### PR TITLE
Add setup script for automatic .NET installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ Some of the design goals include:
 - Avoiding code that prevents AOT compilation on .NET
 
 See [CONTRIBUTING.md](CONTRIBUTING) for more information on how to contribute to this project.
+
+## Environment setup
+
+Run `setup.sh` once after cloning the repository to automatically install the .NET 9 SDK and configure your PATH. The script updates `~/.bashrc` so that the SDK is available in future sessions.
+
+```bash
+./setup.sh
+```

--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ fi
 export PATH="$HOME/.dotnet:$PATH"
 
 # Ensure this script runs on new shell sessions
-SETUP_SOURCE="source $SCRIPT_DIR/setup.sh"
+SETUP_SOURCE="source \"$SCRIPT_DIR/setup.sh\""
 if ! grep -Fq "$SETUP_SOURCE" "$HOME/.bashrc" 2>/dev/null; then
   echo "$SETUP_SOURCE" >> "$HOME/.bashrc"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Install .NET 9 SDK if not already installed
+if ! command -v dotnet >/dev/null || ! dotnet --list-sdks | grep -q '^9\.'; then
+  echo "Installing .NET 9 SDK..."
+  curl -SL https://dot.net/v1/dotnet-install.sh -o "$SCRIPT_DIR/dotnet-install.sh"
+  chmod +x "$SCRIPT_DIR/dotnet-install.sh"
+  "$SCRIPT_DIR/dotnet-install.sh" --channel 9.0 --install-dir "$HOME/.dotnet"
+fi
+
+# Ensure PATH includes the installed SDK
+if ! grep -q 'export PATH="$HOME/.dotnet' "$HOME/.bashrc" 2>/dev/null; then
+  echo 'export PATH="$HOME/.dotnet:$PATH"' >> "$HOME/.bashrc"
+fi
+export PATH="$HOME/.dotnet:$PATH"
+
+# Ensure this script runs on new shell sessions
+SETUP_SOURCE="source $SCRIPT_DIR/setup.sh"
+if ! grep -Fq "$SETUP_SOURCE" "$HOME/.bashrc" 2>/dev/null; then
+  echo "$SETUP_SOURCE" >> "$HOME/.bashrc"
+fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ if ! command -v dotnet >/dev/null || ! dotnet --list-sdks | grep -q '^9\.'; then
 fi
 
 # Ensure PATH includes the installed SDK
-if ! grep -q 'export PATH="$HOME/.dotnet' "$HOME/.bashrc" 2>/dev/null; then
+if ! grep -q 'export PATH="$HOME/.dotnet:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
   echo 'export PATH="$HOME/.dotnet:$PATH"' >> "$HOME/.bashrc"
 fi
 export PATH="$HOME/.dotnet:$PATH"


### PR DESCRIPTION
## Summary
- provide `setup.sh` script for .NET 9 SDK installation and PATH configuration
- document the setup script in the README

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: ValidateAllocations value difference)*


------
https://chatgpt.com/codex/tasks/task_e_6855a68162e88326ae275f105dc470d3