### PR TITLE
Add conditional Assert handler

### DIFF
--- a/touki.tests/Touki/AssertInterpolatedStringHandlerTests.cs
+++ b/touki.tests/Touki/AssertInterpolatedStringHandlerTests.cs
@@ -1,0 +1,34 @@
+namespace Touki;
+
+#if NETFRAMEWORK
+using AssertInterpolatedStringHandler = System.Diagnostics.AssertInterpolatedStringHandler;
+#else
+using AssertInterpolatedStringHandler = System.Diagnostics.Debug.AssertInterpolatedStringHandler;
+#endif
+
+public class AssertInterpolatedStringHandlerTests
+{
+    // The built-in handler in .NET 9 does not support calling the append
+    // methods when the assertion succeeds, so limit these tests to .NET Framework.
+#if NETFRAMEWORK
+    [Fact]
+    public void Constructor_SetsShouldAppend_FalseWhenConditionTrue()
+    {
+        bool shouldAppend;
+        AssertInterpolatedStringHandler handler = new(5, 1, true, out shouldAppend);
+        shouldAppend.Should().BeFalse();
+        handler.AppendLiteral("Hello");
+        handler.ToStringAndClear().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Constructor_SetsShouldAppend_TrueWhenConditionFalse()
+    {
+        bool shouldAppend;
+        AssertInterpolatedStringHandler handler = new(5, 1, false, out shouldAppend);
+        shouldAppend.Should().BeTrue();
+        handler.AppendLiteral("Hello");
+        handler.ToStringAndClear().Should().Be("Hello");
+    }
+#endif
+}

--- a/touki.tests/Touki/DebuggingTests.cs
+++ b/touki.tests/Touki/DebuggingTests.cs
@@ -1,0 +1,22 @@
+namespace Touki;
+
+public class DebuggingTests
+{
+    [Fact]
+    public void Assert_ExpressionNotEvaluated_WhenConditionTrue()
+    {
+        int value = 0;
+        Debugging.Assert(true, $"Value {++value}");
+        value.Should().Be(0);
+    }
+
+#if !DEBUG
+    [Fact]
+    public void Assert_Elided_InRelease()
+    {
+        int value = 0;
+        Debugging.Assert(true, $"Value {++value}");
+        value.Should().Be(0);
+    }
+#endif
+}

--- a/touki/Framework/System/Diagnostics/AssertInterpolatedStringHandler.cs
+++ b/touki/Framework/System/Diagnostics/AssertInterpolatedStringHandler.cs
@@ -1,0 +1,96 @@
+namespace System.Diagnostics;
+
+/// <summary>
+///  Provides an interpolated string handler for <see cref="Debug.Assert(bool)"/> that only formats when the assert fails.
+/// </summary>
+[InterpolatedStringHandler]
+public ref struct AssertInterpolatedStringHandler
+{
+    private Touki.ValueStringBuilder _builder;
+    private readonly bool _shouldAppend;
+
+    /// <summary>Creates an instance of the handler.</summary>
+    /// <param name="literalLength">The length of literal content in the interpolated string.</param>
+    /// <param name="formattedCount">The number of interpolation holes in the interpolated string.</param>
+    /// <param name="condition">The condition Boolean passed to the consuming method.</param>
+    /// <param name="shouldAppend">Indicates whether formatting should proceed.</param>
+    public AssertInterpolatedStringHandler(int literalLength, int formattedCount, bool condition, out bool shouldAppend)
+    {
+        if (condition)
+        {
+            _builder = default;
+            _shouldAppend = shouldAppend = false;
+        }
+        else
+        {
+            _builder = new Touki.ValueStringBuilder(literalLength, formattedCount);
+            _shouldAppend = shouldAppend = true;
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendLiteral(string?)"/>
+    public void AppendLiteral(string? value)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendLiteral(value);
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted{T}(T)"/>
+    public void AppendFormatted<T>(T value)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendFormatted(value);
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted{T}(T,int)"/>
+    public void AppendFormatted<T>(T value, int alignment)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendFormatted(value, alignment);
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted{T}(T,int,string?)"/>
+    public void AppendFormatted<T>(T value, int alignment, string? format)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendFormatted<T>(value, alignment, format);
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted(ReadOnlySpan{char})"/>
+    public void AppendFormatted(scoped ReadOnlySpan<char> value)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendFormatted(value);
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted(ReadOnlySpan{char},int,string?)"/>
+    public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendFormatted(value, alignment, format);
+        }
+    }
+
+    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted(string?)"/>
+    public void AppendFormatted(string? value)
+    {
+        if (_shouldAppend)
+        {
+            _builder.AppendFormatted(value);
+        }
+    }
+
+    /// <summary>Gets the built string and clears the handler.</summary>
+    public string ToStringAndClear() => _shouldAppend ? _builder.ToStringAndClear() : string.Empty;
+}

--- a/touki/Touki/Debugging.cs
+++ b/touki/Touki/Debugging.cs
@@ -1,0 +1,74 @@
+namespace Touki;
+
+/// <summary>
+///  Helper methods that mirror <see cref="Debug"/>.
+/// </summary>
+public static class Debugging
+{
+    /// <inheritdoc cref="Debug.Assert(bool)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition) => Debug.Assert(condition);
+
+    /// <inheritdoc cref="Debug.Assert(bool,string?)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition, string? message) => Debug.Assert(condition, message);
+
+#if NET9_0_OR_GREATER
+    /// <inheritdoc cref="Debug.Assert(bool,ref Debug.AssertInterpolatedStringHandler)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition,
+        [InterpolatedStringHandlerArgument(nameof(condition))] ref Debug.AssertInterpolatedStringHandler message)
+        => Debug.Assert(condition, ref message);
+#else
+    /// <inheritdoc cref="Debug.Assert(bool,string?)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition,
+        [InterpolatedStringHandlerArgument(nameof(condition))] ref System.Diagnostics.AssertInterpolatedStringHandler message)
+    {
+        if (!condition)
+        {
+            Debug.Fail(message.ToStringAndClear());
+        }
+    }
+#endif
+
+    /// <inheritdoc cref="Debug.Assert(bool,string?,string?)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition, string? message, string? detailMessage)
+        => Debug.Assert(condition, message, detailMessage);
+
+#if NET9_0_OR_GREATER
+    /// <inheritdoc cref="Debug.Assert(bool,ref Debug.AssertInterpolatedStringHandler,ref Debug.AssertInterpolatedStringHandler)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition,
+        [InterpolatedStringHandlerArgument(nameof(condition))] ref Debug.AssertInterpolatedStringHandler message,
+        [InterpolatedStringHandlerArgument(nameof(condition))] ref Debug.AssertInterpolatedStringHandler detailMessage)
+        => Debug.Assert(condition, ref message, ref detailMessage);
+#else
+    /// <inheritdoc cref="Debug.Assert(bool,string?,string?)"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition,
+        [InterpolatedStringHandlerArgument(nameof(condition))] ref System.Diagnostics.AssertInterpolatedStringHandler message,
+        [InterpolatedStringHandlerArgument(nameof(condition))] ref System.Diagnostics.AssertInterpolatedStringHandler detailMessage)
+    {
+        if (!condition)
+        {
+            Debug.Fail(message.ToStringAndClear(), detailMessage.ToStringAndClear());
+        }
+    }
+#endif
+
+    /// <inheritdoc cref="Debug.Assert(bool,string?,string,System.Object[])"/>
+    [Conditional("DEBUG")]
+    public static void Assert([DoesNotReturnIf(false)] bool condition, string? message,
+        [StringSyntax(StringSyntaxAttribute.CompositeFormat)] string detailMessageFormat, params object?[] args)
+        => Debug.Assert(condition, message, detailMessageFormat, args);
+
+    /// <inheritdoc cref="Debug.Fail(string?)"/>
+    [Conditional("DEBUG"), DoesNotReturn]
+    public static void Fail(string? message) => Debug.Fail(message);
+
+    /// <inheritdoc cref="Debug.Fail(string?,string?)"/>
+    [Conditional("DEBUG"), DoesNotReturn]
+    public static void Fail(string? message, string? detailMessage) => Debug.Fail(message, detailMessage);
+}


### PR DESCRIPTION
## Summary
- implement `AssertInterpolatedStringHandler` using `ValueStringBuilder`
- expose `Debugging` helper methods for asserts and failures
- test custom handler behavior
- explain why assert handler tests only run for .NET Framework

## Testing
- `dotnet test touki.tests/touki.tests.csproj -c Release -f net9.0 -v minimal`
- `dotnet test touki.tests/touki.tests.csproj -c Release -f net481 -v minimal` *(fails: Could not find 'mono' host)*

------
https://chatgpt.com/codex/tasks/task_e_6856f63600348326baa60b01abad4d55