### PR TITLE
Add Stream ArraySegment extensions

### DIFF
--- a/touki.tests/Touki/StreamExtensionsTests.cs
+++ b/touki.tests/Touki/StreamExtensionsTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class StreamExtensionsTests
+{
+    [Fact]
+    public void StreamExtensions_Read_Write_ArraySegment()
+    {
+        using MemoryStream memory = new();
+        byte[] data = [1, 2, 3, 4, 5];
+
+        // Write using ArraySegment
+        memory.Write(new ArraySegment<byte>(data, 1, 3));
+        memory.Position = 0;
+
+        byte[] readBuffer = new byte[3];
+        int read = memory.Read(new ArraySegment<byte>(readBuffer));
+        read.Should().Be(3);
+        readBuffer.Should().BeEquivalentTo([2, 3, 4]);
+    }
+
+    [Fact]
+    public async Task StreamExtensions_ReadAsync_WriteAsync_ArraySegment()
+    {
+        using MemoryStream memory = new();
+        byte[] data = [6, 7, 8, 9, 10];
+
+        // Write asynchronously using ArraySegment
+        await memory.WriteAsync(new ArraySegment<byte>(data, 2, 2));
+        memory.Position = 0;
+
+        byte[] readBuffer = new byte[2];
+        int read = await memory.ReadAsync(new ArraySegment<byte>(readBuffer));
+        read.Should().Be(2);
+        readBuffer.Should().BeEquivalentTo([8, 9]);
+    }
+
+    [Fact]
+    public void StreamExtensions_DefaultSegment_IsIgnored()
+    {
+        using MemoryStream memory = new();
+
+        memory.Write(default(ArraySegment<byte>));
+        memory.Length.Should().Be(0);
+
+        byte[] data = [1, 2, 3];
+        memory.Write(data);
+        memory.Position = 0;
+
+        long initial = memory.Position;
+        int read = memory.Read(default(ArraySegment<byte>));
+        read.Should().Be(0);
+        memory.Position.Should().Be(initial);
+    }
+
+    [Fact]
+    public async Task StreamExtensions_DefaultSegmentAsync_IsIgnored()
+    {
+        using MemoryStream memory = new();
+
+        await memory.WriteAsync(default(ArraySegment<byte>));
+        memory.Length.Should().Be(0);
+
+        byte[] data = [4, 5];
+        await memory.WriteAsync(data);
+        memory.Position = 0;
+
+        long initial = memory.Position;
+        int read = await memory.ReadAsync(default(ArraySegment<byte>));
+        read.Should().Be(0);
+        memory.Position.Should().Be(initial);
+    }
+}

--- a/touki/Touki/StreamExtensions.cs
+++ b/touki/Touki/StreamExtensions.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Touki;
+
+/// <summary>
+///  Extension methods for <see cref="Stream"/>.
+/// </summary>
+public static class StreamExtensions
+{
+    /// <summary>
+    ///  Reads a sequence of bytes from the current stream and advances the position
+    ///  within the stream by the number of bytes read.
+    /// </summary>
+    /// <param name="stream">The stream to read from.</param>
+    /// <param name="buffer">The buffer to read into.</param>
+    /// <returns>The total number of bytes read into the buffer.</returns>
+    public static int Read(this Stream stream, ArraySegment<byte> buffer)
+        => buffer.Array is byte[] array
+            ? stream.Read(array, buffer.Offset, buffer.Count)
+            : 0;
+
+    /// <summary>
+    ///  Asynchronously reads a sequence of bytes from the current stream and
+    ///  advances the position within the stream by the number of bytes read.
+    /// </summary>
+    /// <param name="stream">The stream to read from.</param>
+    /// <param name="buffer">The buffer to read into.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous read operation.</returns>
+    public static Task<int> ReadAsync(this Stream stream, ArraySegment<byte> buffer, CancellationToken cancellationToken = default)
+        => buffer.Array is byte[] array
+            ? stream.ReadAsync(array, buffer.Offset, buffer.Count, cancellationToken)
+            : Task.FromResult(0);
+
+    /// <summary>
+    ///  Writes a sequence of bytes to the current stream and advances the current
+    ///  position within the stream by the number of bytes written.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    /// <param name="buffer">The buffer to write from.</param>
+    public static void Write(this Stream stream, ArraySegment<byte> buffer)
+    {
+        if (buffer.Array is byte[] array)
+        {
+            stream.Write(array, buffer.Offset, buffer.Count);
+        }
+    }
+
+    /// <summary>
+    ///  Asynchronously writes a sequence of bytes to the current stream and
+    ///  advances the current position within the stream by the number of bytes written.
+    /// </summary>
+    /// <param name="stream">The stream to write to.</param>
+    /// <param name="buffer">The buffer to write from.</param>
+    /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous write operation.</returns>
+    public static Task WriteAsync(this Stream stream, ArraySegment<byte> buffer, CancellationToken cancellationToken = default)
+        => buffer.Array is byte[] array
+            ? stream.WriteAsync(array, buffer.Offset, buffer.Count, cancellationToken)
+            : Task.CompletedTask;
+}


### PR DESCRIPTION
## Summary
- add Stream extension methods for ArraySegment
- test Stream extensions using MemoryStream
- handle default ArraySegment values

## Testing
- `dotnet test --framework net9.0 -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857663be2ec83268c2e5f49752f77a6