### PR TITLE
Add extensions for writing interpolated strings to streams

### DIFF
--- a/touki.perf/Program.cs
+++ b/touki.perf/Program.cs
@@ -8,6 +8,7 @@ internal class Program
 {
     private static void Main(string[] args)
     {
+        // _ = Touki.Strings.Format("The answer is {0}.", 42);
         BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/touki.perf/Program.cs
+++ b/touki.perf/Program.cs
@@ -8,7 +8,7 @@ internal class Program
 {
     private static void Main(string[] args)
     {
-        // _ = Touki.Strings.Format("The answer is {0}.", 42);
+        
         BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/touki.tests/Touki/StreamExtensionsTests.cs
+++ b/touki.tests/Touki/StreamExtensionsTests.cs
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Text;
+
 namespace Touki;
 
 public class StreamExtensionsTests
 {
     [Fact]
-    public void StreamExtensions_Read_Write_ArraySegment()
+    public void Read_Write_ArraySegment()
     {
         using MemoryStream memory = new();
         byte[] data = [1, 2, 3, 4, 5];
@@ -23,7 +25,7 @@ public class StreamExtensionsTests
     }
 
     [Fact]
-    public async Task StreamExtensions_ReadAsync_WriteAsync_ArraySegment()
+    public async Task ReadAsync_WriteAsync_ArraySegment()
     {
         using MemoryStream memory = new();
         byte[] data = [6, 7, 8, 9, 10];
@@ -39,7 +41,7 @@ public class StreamExtensionsTests
     }
 
     [Fact]
-    public void StreamExtensions_DefaultSegment_IsIgnored()
+    public void DefaultSegment_IsIgnored()
     {
         using MemoryStream memory = new();
 
@@ -57,7 +59,7 @@ public class StreamExtensionsTests
     }
 
     [Fact]
-    public async Task StreamExtensions_DefaultSegmentAsync_IsIgnored()
+    public async Task DefaultSegmentAsync_IsIgnored()
     {
         using MemoryStream memory = new();
 
@@ -73,5 +75,142 @@ public class StreamExtensionsTests
         int read = await memory.ReadAsync(new ArraySegment<byte>());
         read.Should().Be(0);
         memory.Position.Should().Be(initial);
+    }
+
+    [Fact]
+    public void WriteFormatted_SimpleString_WritesToMemoryStream()
+    {
+        using MemoryStream stream = new();
+        stream.WriteFormatted($"Hello World!");
+        stream.Position = 0;
+
+        using StreamReader reader = new(stream, Encoding.Unicode);
+        string result = reader.ReadToEnd();
+        result.Should().Be("Hello World!");
+    }
+
+    [Fact]
+    public void WriteFormatted_EmptyBuilder_WritesNothing()
+    {
+        using MemoryStream stream = new();
+        ValueStringBuilder builder = new();
+        stream.WriteFormatted(ref builder);
+
+        stream.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void WriteFormatted_InterpolatedString_WritesToMemoryStream()
+    {
+        using MemoryStream stream = new();
+        string name = "Touki";
+        int version = 42;
+
+        stream.WriteFormatted($"Library: {name}, Version: {version}");
+        stream.Position = 0;
+
+        using StreamReader reader = new(stream, Encoding.Unicode);
+        string result = reader.ReadToEnd();
+        result.Should().Be("Library: Touki, Version: 42");
+    }
+
+    [Fact]
+    public void WriteFormatted_MultipleWrites_AppendToStream()
+    {
+        using MemoryStream stream = new();
+
+        stream.WriteFormatted($"First part. ");
+        stream.WriteFormatted($"Second part.");
+        stream.Position = 0;
+
+        using StreamReader reader = new(stream, Encoding.Unicode);
+        string result = reader.ReadToEnd();
+        result.Should().Be("First part. Second part.");
+    }
+
+    [Fact]
+    public void WriteFormatted_StreamWriterUnicode_WritesCorrectly()
+    {
+        using MemoryStream stream = new();
+        StreamWriter writer = new(stream, Encoding.Unicode);
+
+#pragma warning disable IDE0082 // 'typeof' can be converted to 'nameof'
+        writer.WriteFormatted($"Hello from {typeof(StreamWriter).Name}!");
+#pragma warning restore IDE0082
+        writer.Flush();
+
+        stream.Position = 0;
+        StreamReader reader = new(stream, Encoding.Unicode);
+        string result = reader.ReadToEnd();
+
+        result.Should().Be("Hello from StreamWriter!");
+    }
+
+    [Fact]
+    public void WriteFormatted_StreamWriterUTF8_WritesCorrectly()
+    {
+        using MemoryStream stream = new();
+        StreamWriter writer = new(stream, Encoding.UTF8);
+
+        writer.WriteFormatted($"UTF-{8} Text");
+        writer.Flush();
+
+        stream.Position = 0;
+        StreamReader reader = new(stream, Encoding.UTF8);
+        string result = reader.ReadToEnd();
+
+        result.Should().Be("UTF-8 Text");
+    }
+
+    [Fact]
+    public void WriteFormatted_StreamWriterInterpolatedValues_WritesCorrectly()
+    {
+        using MemoryStream stream = new();
+        StreamWriter writer = new(stream, Encoding.UTF8);
+
+        string name = "StreamWriter";
+        int value = 123;
+        double pi = 3.14159;
+
+        writer.WriteFormatted($"Name: {name}, Value: {value}, Pi: {pi:F2}");
+        writer.Flush();
+
+        stream.Position = 0;
+        StreamReader reader = new(stream, Encoding.UTF8);
+        string result = reader.ReadToEnd();
+
+        result.Should().Be("Name: StreamWriter, Value: 123, Pi: 3.14");
+    }
+
+    [Fact]
+    public void WriteFormatted_StreamWriterMultipleWrites_AppendCorrectly()
+    {
+        using MemoryStream stream = new();
+        StreamWriter writer = new(stream, Encoding.Unicode);
+
+        writer.WriteFormatted($"Part one. ");
+        writer.WriteFormatted($"Part two.");
+        writer.Flush();
+
+        stream.Position = 0;
+        StreamReader reader = new(stream, Encoding.Unicode);
+        string result = reader.ReadToEnd();
+
+        result.Should().Be("Part one. Part two.");
+    }
+
+    [Fact]
+    public void WriteFormatted_StreamWriterEmptyBuilder_WritesNothing()
+    {
+        using MemoryStream stream = new();
+        StreamWriter writer = new(stream, Encoding.UTF8);
+        writer.Flush();
+        long length = stream.Length;
+
+        ValueStringBuilder builder = new();
+        writer.WriteFormatted(ref builder);
+        writer.Flush();
+
+        stream.Length.Should().Be(length);
     }
 }

--- a/touki.tests/Touki/ValueStringBuilderTests.cs
+++ b/touki.tests/Touki/ValueStringBuilderTests.cs
@@ -1782,7 +1782,8 @@ public unsafe class ValueStringBuilderTests
 
         // Test undefined flag combinations
         IntFlagsEnum undefinedCombination = IntFlagsEnum.IntFlag1 | (IntFlagsEnum)64;
-        ULongFlagsEnum undefinedULongCombination = ULongFlagsEnum.ULongFlag2 | (ULongFlagsEnum)128;        builder.AppendFormat("Undefined: {0}, ULongUndefined: {1}",
+        ULongFlagsEnum undefinedULongCombination = ULongFlagsEnum.ULongFlag2 | (ULongFlagsEnum)128;
+        builder.AppendFormat("Undefined: {0}, ULongUndefined: {1}",
             Value.Create(undefinedCombination),
             Value.Create(undefinedULongCombination));
         builder.ToString().Should().Be("Undefined: 65, ULongUndefined: 130");
@@ -1826,7 +1827,8 @@ public unsafe class ValueStringBuilderTests
             Value.Create(ByteFlagsEnum.ByteNone),
             Value.Create(UShortFlagsEnum.UShortNone),
             Value.Create(UIntFlagsEnum.UIntNone),
-            Value.Create(ULongFlagsEnum.ULongNone));builder.ToString().Should().Be("Zeros: SByteZero, ShortZero, IntZero, LongZero, ByteNone, UShortNone, UIntNone, ULongNone");
+            Value.Create(ULongFlagsEnum.ULongNone));
+        builder.ToString().Should().Be("Zeros: SByteZero, ShortZero, IntZero, LongZero, ByteNone, UShortNone, UIntNone, ULongNone");
     }
 
     [Fact]

--- a/touki/Touki/StreamExtensions.cs
+++ b/touki/Touki/StreamExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Touki;
 
 namespace System.IO;
 
@@ -65,4 +66,28 @@ public static class StreamExtensions
         => buffer.Array is byte[] array
             ? stream.WriteAsync(array, buffer.Offset, buffer.Count, cancellationToken)
             : Task.CompletedTask;
+
+    /// <summary>
+    ///  Writes an interpolated string directly to a stream.
+    /// </summary>
+    public static void WriteFormatted(this Stream stream, ref ValueStringBuilder builder)
+    {
+        if (builder.Length > 0)
+        {
+            builder.CopyTo(stream);
+            builder.Clear();
+        }
+    }
+
+    /// <summary>
+    ///  Writes an interpolated string directly to a <see cref="StreamWriter"/>.
+    /// </summary>
+    public static void WriteFormatted(this StreamWriter writer, ref ValueStringBuilder builder)
+    {
+        if (builder.Length > 0)
+        {
+            builder.CopyTo(writer);
+            builder.Clear();
+        }
+    }
 }

--- a/touki/Touki/ValueStringBuilder.cs
+++ b/touki/Touki/ValueStringBuilder.cs
@@ -40,7 +40,7 @@ public ref partial struct ValueStringBuilder
     // byte[] backing array we can call the byte [] virtual on Stream without worrying about type safety issues.
     //
     // We may also be able to use this with GREAT caution via Unsafe.As<byte[], char[]> as a last result. Doing so would
-    // allow a buffer overrun as code would be using the prefixed array info for length and indicies, so we would have
+    // allow a buffer overrun as code would be using the prefixed array info for length and indices, so we would have
     // to be *extremely* careful. If any code would check the length of the array it would get the byte length, not
     // the char length.
     private byte[]? _arrayToReturnToPool;


### PR DESCRIPTION
Adds extension methods to allow writing formatted strings directly to Stream and StreamWriter without allocating an intermediate string.