### PR TITLE
Add MSBuild FileSystemEnumerator

### DIFF
--- a/touki.perf/GlobFiles.cs
+++ b/touki.perf/GlobFiles.cs
@@ -1,0 +1,226 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Reflection;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Build.Globbing;
+using Touki.Io;
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+public class MsBuildEnumeratePerf
+{
+    private const string Directory = @"n:\repos\runtime\";
+    // private const string Filespec = "**/*.cs";
+    private const string Filespec = "**/src/**/*.cs";
+
+    [Benchmark(Baseline = true)]
+    public IReadOnlyList<string> MSBuild()
+    {
+        var results = FileMatcherWrapper.GetFilesSimple(Directory, Filespec);
+        return results;
+    }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumerator()
+    {
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(Directory, Filespec);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    ///  Provides access to internal FileMatcher functionality through reflection.
+    /// </summary>
+    public static class FileMatcherWrapper
+    {
+        // Enum to match internal SearchAction enum
+        public enum SearchAction
+        {
+            RunSearch = 0,
+            StopSearching = 1,
+            IncludeAllFiles = 2
+        }
+
+        /// <summary>
+        /// Result of the GetFiles method containing all returned information.
+        /// </summary>
+        public readonly struct GetFilesResult
+        {
+            /// <summary>List of files found</summary>
+            public string[] FileList { get; }
+
+            /// <summary>Action returned by the search</summary>
+            public SearchAction Action { get; }
+
+            /// <summary>Exclude file specification if any</summary>
+            public string ExcludeFileSpec { get; }
+
+            /// <summary>Glob failure message if any</summary>
+            public string GlobFailure { get; }
+
+            internal GetFilesResult(string[] fileList, SearchAction action, string excludeFileSpec, string globFailure)
+            {
+                FileList = fileList;
+                Action = action;
+                ExcludeFileSpec = excludeFileSpec;
+                GlobFailure = globFailure;
+            }
+        }
+
+        // Cache the reflected members for performance
+        private static readonly FieldInfo s_defaultFieldInfo;
+        private static readonly MethodInfo s_getFilesMethodInfo;
+        private static readonly object s_defaultInstance;
+        private static readonly Type s_searchActionType;
+
+        // Cache the return type information
+        private static readonly Type s_returnTupleType;
+        private static readonly FieldInfo s_fileListField;
+        private static readonly FieldInfo s_searchActionField;
+        private static readonly FieldInfo s_excludeFileSpecField;
+        private static readonly FieldInfo s_globFailureField;
+
+#pragma warning disable CA1810 // Initialize reference type static fields inline
+        static FileMatcherWrapper()
+#pragma warning restore CA1810 // Initialize reference type static fields inline
+        {
+            try
+            {
+                // Get the FileMatcher type
+                Type fileMatcherType = typeof(MSBuildGlob).Assembly.GetType("Microsoft.Build.Shared.FileMatcher")
+                    ?? throw new InvalidOperationException("Could not find FileMatcher type");
+
+                // Find the SearchAction enum type
+                s_searchActionType = fileMatcherType.Assembly.GetType("Microsoft.Build.Shared.SearchAction")
+                    ?? fileMatcherType.Assembly.GetType("Microsoft.Build.Shared.FileMatcher+SearchAction")!;
+
+                if (s_searchActionType is null)
+                {
+                    throw new InvalidOperationException("Could not find SearchAction enum type");
+                }
+
+                // Get the Default static field
+                s_defaultFieldInfo = fileMatcherType.GetField("Default",
+                    BindingFlags.Public | BindingFlags.Static)!;
+
+                if (s_defaultFieldInfo is null)
+                {
+                    throw new InvalidOperationException("Could not find Default field on FileMatcher");
+                }
+
+                // Get the Default instance
+                s_defaultInstance = s_defaultFieldInfo.GetValue(null)!;
+
+                if (s_defaultInstance is null)
+                {
+                    throw new InvalidOperationException("Default instance of FileMatcher is null");
+                }
+
+                // Get the GetFiles method
+                s_getFilesMethodInfo = fileMatcherType.GetMethod("GetFiles",
+                    BindingFlags.NonPublic | BindingFlags.Instance,
+                    null,
+                    [typeof(string), typeof(string), typeof(List<string>)],
+                    null)!;
+
+                if (s_getFilesMethodInfo is null)
+                {
+                    throw new InvalidOperationException(
+                        "Could not find GetFiles(string, string, List<string>) method on FileMatcher");
+                }
+
+                // Cache the return type information
+                s_returnTupleType = s_getFilesMethodInfo.ReturnType;
+
+                // Cache tuple item property getters
+                s_fileListField = s_returnTupleType.GetField("Item1") ??
+                    throw new InvalidOperationException("Could not find Item1 property on return tuple");
+
+                s_searchActionField = s_returnTupleType.GetField("Item2") ??
+                    throw new InvalidOperationException("Could not find Item2 property on return tuple");
+
+                s_excludeFileSpecField = s_returnTupleType.GetField("Item3") ??
+                    throw new InvalidOperationException("Could not find Item3 property on return tuple");
+
+                s_globFailureField = s_returnTupleType.GetField("Item4") ??
+                    throw new InvalidOperationException("Could not find Item4 property on return tuple");
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    "Failed to initialize FileMatcher reflection wrapper", ex);
+            }
+        }
+
+        /// <summary>
+        ///  Wrapper for the internal FileMatcher.GetFiles method using the Default instance.
+        /// </summary>
+        /// <param name="directoryPath">The root directory to search in</param>
+        /// <param name="filespec">The file specification (glob pattern)</param>
+        /// <returns>Result object containing files and additional information</returns>
+        public static GetFilesResult GetFiles(string directoryPath, string filespec)
+        {
+#pragma warning disable CA1510 // Use ArgumentNullException throw helper
+            if (directoryPath is null)
+                throw new ArgumentNullException(nameof(directoryPath));
+            if (filespec is null)
+                throw new ArgumentNullException(nameof(filespec));
+#pragma warning restore CA1510 // Use ArgumentNullException throw helper
+
+            try
+            {
+                // Invoke the method and get the tuple return value
+                object? returnValue = s_getFilesMethodInfo.Invoke(s_defaultInstance, [directoryPath, filespec, null])
+                    ?? throw new InvalidOperationException("GetFiles method returned null");
+
+                // Extract tuple values using cached property info
+
+                // Get Item1 (FileList) - the actual results
+                string[] fileList = (string[])s_fileListField.GetValue(returnValue)!;
+
+                // Get Item2 (SearchAction)
+                object actionValue = s_searchActionField.GetValue(returnValue)!;
+                SearchAction action = (SearchAction)Enum.ToObject(typeof(SearchAction), Convert.ToInt32(actionValue));
+
+                // Get Item3 (ExcludeFileSpec)
+                string excludeFileSpec = (string?)s_excludeFileSpecField.GetValue(returnValue) ?? string.Empty;
+
+                // Get Item4 (GlobFailure)
+                string globFailure = (string?)s_globFailureField.GetValue(returnValue) ?? string.Empty;
+
+                return new GetFilesResult(fileList, action, excludeFileSpec, globFailure);
+            }
+            catch (TargetInvocationException tie)
+            {
+                // Unwrap the inner exception
+                if (tie.InnerException != null)
+                {
+                    throw tie.InnerException;
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Simplified version that returns just the file list.
+        /// </summary>
+        public static string[] GetFilesSimple(string directoryPath, string filespec)
+        {
+            return GetFiles(directoryPath, filespec).FileList;
+        }
+
+        /// <summary>
+        /// Checks if FileMatcher reflection initialization was successful.
+        /// </summary>
+        public static bool IsAvailable => s_getFilesMethodInfo != null && s_defaultInstance != null;
+    }
+}

--- a/touki.perf/Program.cs
+++ b/touki.perf/Program.cs
@@ -8,7 +8,6 @@ internal class Program
 {
     private static void Main(string[] args)
     {
-        
         BenchmarkDotNet.Running.BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/touki.perf/touki.perf.csproj
+++ b/touki.perf/touki.perf.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/touki.tests/GlobalUsings.cs
+++ b/touki.tests/GlobalUsings.cs
@@ -2,4 +2,24 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+#pragma warning disable IDE0005 // Using directive is unnecessary.
+global using System;
+global using System.Collections.Generic;
+global using System.Diagnostics;
+global using System.Diagnostics.CodeAnalysis;
+global using System.IO;
+global using System.Linq;
+global using System.Runtime.CompilerServices;
+global using System.Runtime.InteropServices;
+global using System.Threading;
+global using System.Threading.Tasks;
+
+#if NETFRAMEWORK
+global using Path = Microsoft.IO.Path;
+#else
+global using Path = System.IO.Path;
+#endif
+#pragma warning restore IDE0005
+
+
 global using FluentAssertions;

--- a/touki.tests/Touki/EnumerableTests.cs
+++ b/touki.tests/Touki/EnumerableTests.cs
@@ -9,7 +9,7 @@ namespace Touki;
 public class EnumerableTests
 {
     // Test implementation of Enumerable<T>
-    private class TestEnumerable : Enumerable<int>
+    private class TestEnumerable : EnumerableBase<int>
     {
         private readonly int[] _items;
         private int _index = -1;
@@ -48,7 +48,7 @@ public class EnumerableTests
     }
 
     // Test implementation that throws on MoveNext
-    private class ThrowingEnumerable : Enumerable<int>
+    private class ThrowingEnumerable : EnumerableBase<int>
     {
         public override bool MoveNext() => throw new InvalidOperationException("Test exception");
 

--- a/touki.tests/Touki/Io/FileMatcherWrapper.cs
+++ b/touki.tests/Touki/Io/FileMatcherWrapper.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Reflection;
+using Microsoft.Build.Globbing;
+
+namespace Touki.Io;
+/// <summary>
+///  Provides access to internal FileMatcher functionality through reflection.
+/// </summary>
+public static class FileMatcherWrapper
+{
+    // Enum to match internal SearchAction enum
+    public enum SearchAction
+    {
+        RunSearch = 0,
+        StopSearching = 1,
+        IncludeAllFiles = 2
+    }
+
+    /// <summary>
+    /// Result of the GetFiles method containing all returned information.
+    /// </summary>
+    public readonly struct GetFilesResult
+    {
+        /// <summary>List of files found</summary>
+        public string[] FileList { get; }
+
+        /// <summary>Action returned by the search</summary>
+        public SearchAction Action { get; }
+
+        /// <summary>Exclude file specification if any</summary>
+        public string ExcludeFileSpec { get; }
+
+        /// <summary>Glob failure message if any</summary>
+        public string GlobFailure { get; }
+
+        internal GetFilesResult(string[] fileList, SearchAction action, string excludeFileSpec, string globFailure)
+        {
+            FileList = fileList;
+            Action = action;
+            ExcludeFileSpec = excludeFileSpec;
+            GlobFailure = globFailure;
+        }
+    }
+
+    // Cache the reflected members for performance
+    private static readonly FieldInfo s_defaultFieldInfo;
+    private static readonly MethodInfo s_getFilesMethodInfo;
+    private static readonly object s_defaultInstance;
+    private static readonly Type s_searchActionType;
+
+    // Cache the return type information
+    private static readonly Type s_returnTupleType;
+    private static readonly FieldInfo s_fileListField;
+    private static readonly FieldInfo s_searchActionField;
+    private static readonly FieldInfo s_excludeFileSpecField;
+    private static readonly FieldInfo s_globFailureField;
+
+#pragma warning disable CA1810 // Initialize reference type static fields inline
+    static FileMatcherWrapper()
+#pragma warning restore CA1810 // Initialize reference type static fields inline
+    {
+        try
+        {
+            // Get the FileMatcher type
+            Type fileMatcherType = typeof(MSBuildGlob).Assembly.GetType("Microsoft.Build.Shared.FileMatcher")
+                ?? throw new InvalidOperationException("Could not find FileMatcher type");
+
+            // Find the SearchAction enum type
+            s_searchActionType = fileMatcherType.Assembly.GetType("Microsoft.Build.Shared.SearchAction")
+                ?? fileMatcherType.Assembly.GetType("Microsoft.Build.Shared.FileMatcher+SearchAction")!;
+
+            if (s_searchActionType is null)
+            {
+                throw new InvalidOperationException("Could not find SearchAction enum type");
+            }
+
+            // Get the Default static field
+            s_defaultFieldInfo = fileMatcherType.GetField("Default",
+                BindingFlags.Public | BindingFlags.Static)!;
+
+            if (s_defaultFieldInfo is null)
+            {
+                throw new InvalidOperationException("Could not find Default field on FileMatcher");
+            }
+
+            // Get the Default instance
+            s_defaultInstance = s_defaultFieldInfo.GetValue(null)!;
+
+            if (s_defaultInstance is null)
+            {
+                throw new InvalidOperationException("Default instance of FileMatcher is null");
+            }
+
+            // Get the GetFiles method
+            s_getFilesMethodInfo = fileMatcherType.GetMethod("GetFiles",
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                null,
+                [typeof(string), typeof(string), typeof(List<string>)],
+                null)!;
+
+            if (s_getFilesMethodInfo is null)
+            {
+                throw new InvalidOperationException(
+                    "Could not find GetFiles(string, string, List<string>) method on FileMatcher");
+            }
+
+            // Cache the return type information
+            s_returnTupleType = s_getFilesMethodInfo.ReturnType;
+
+            // Cache tuple item property getters
+            s_fileListField = s_returnTupleType.GetField("Item1") ??
+                throw new InvalidOperationException("Could not find Item1 property on return tuple");
+
+            s_searchActionField = s_returnTupleType.GetField("Item2") ??
+                throw new InvalidOperationException("Could not find Item2 property on return tuple");
+
+            s_excludeFileSpecField = s_returnTupleType.GetField("Item3") ??
+                throw new InvalidOperationException("Could not find Item3 property on return tuple");
+
+            s_globFailureField = s_returnTupleType.GetField("Item4") ??
+                throw new InvalidOperationException("Could not find Item4 property on return tuple");
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException(
+                "Failed to initialize FileMatcher reflection wrapper", ex);
+        }
+    }
+
+    /// <summary>
+    ///  Wrapper for the internal FileMatcher.GetFiles method using the Default instance.
+    /// </summary>
+    /// <param name="directoryPath">The root directory to search in</param>
+    /// <param name="filespec">The file specification (glob pattern)</param>
+    /// <returns>Result object containing files and additional information</returns>
+    public static GetFilesResult GetFiles(string directoryPath, string filespec)
+    {
+#pragma warning disable CA1510 // Use ArgumentNullException throw helper
+        if (directoryPath is null)
+            throw new ArgumentNullException(nameof(directoryPath));
+        if (filespec is null)
+            throw new ArgumentNullException(nameof(filespec));
+#pragma warning restore CA1510 // Use ArgumentNullException throw helper
+
+        try
+        {
+            // Invoke the method and get the tuple return value
+            object? returnValue = s_getFilesMethodInfo.Invoke(s_defaultInstance, [directoryPath, filespec, null])
+                ?? throw new InvalidOperationException("GetFiles method returned null");
+
+            // Extract tuple values using cached property info
+
+            // Get Item1 (FileList) - the actual results
+            string[] fileList = (string[])s_fileListField.GetValue(returnValue)!;
+
+            // Get Item2 (SearchAction)
+            object actionValue = s_searchActionField.GetValue(returnValue)!;
+            SearchAction action = (SearchAction)Enum.ToObject(typeof(SearchAction), Convert.ToInt32(actionValue));
+
+            // Get Item3 (ExcludeFileSpec)
+            string excludeFileSpec = (string?)s_excludeFileSpecField.GetValue(returnValue) ?? string.Empty;
+
+            // Get Item4 (GlobFailure)
+            string globFailure = (string?)s_globFailureField.GetValue(returnValue) ?? string.Empty;
+
+            return new GetFilesResult(fileList, action, excludeFileSpec, globFailure);
+        }
+        catch (TargetInvocationException tie)
+        {
+            // Unwrap the inner exception
+            if (tie.InnerException != null)
+            {
+                throw tie.InnerException;
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Simplified version that returns just the file list.
+    /// </summary>
+    public static string[] GetFilesSimple(string directoryPath, string filespec) =>
+        GetFiles(directoryPath, filespec).FileList;
+
+    /// <summary>
+    /// Checks if FileMatcher reflection initialization was successful.
+    /// </summary>
+    public static bool IsAvailable => s_getFilesMethodInfo != null && s_defaultInstance != null;
+}

--- a/touki.tests/Touki/Io/MSBuildEnumeratorTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumeratorTests.cs
@@ -1,0 +1,503 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+public class MSBuildEnumeratorTests
+{
+    [Fact]
+    public void EnumerateFiles_WithGlobPattern_ReturnsMatchingFiles()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "file1.txt"), "Content 1");
+        File.WriteAllText(Path.Join(tempFolder, "file2.txt"), "Content 2");
+        File.WriteAllText(Path.Join(tempFolder, "file3.md"), "Content 3");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "*.txt");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.EndsWith("file1.txt"));
+        files.Should().Contain(f => f.EndsWith("file2.txt"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "*.txt");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_MatchesDirectoryEnumerate()
+    {
+        // N:\repos\touki\artifacts\x64\Release\touki.tests\net9.0
+        string currentDirectory = Directory.GetCurrentDirectory();
+        string directory = Path.GetFullPath(Path.Join(currentDirectory, "../../../../../Touki"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(directory, "*.cs");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(directory, "*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_MatchesDirectoryEnumerate_Recursive()
+    {
+        // N:\repos\touki\artifacts\x64\Release\touki.tests\net9.0
+        string currentDirectory = Directory.GetCurrentDirectory();
+        string directory = Path.GetFullPath(Path.Join(currentDirectory, "../../../../.."));
+        string[] expected = FileMatcherWrapper.GetFilesSimple(directory, "**/*.cs");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(directory, "**/*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Count.Should().Be(expected.Length);
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithQuestionMarkPattern_MatchesSingleCharacter()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "a.txt"), "Content 1");
+        File.WriteAllText(Path.Join(tempFolder, "b.txt"), "Content 2");
+        File.WriteAllText(Path.Join(tempFolder, "ab.txt"), "Content 3");
+        File.WriteAllText(Path.Join(tempFolder, "abc.txt"), "Content 4");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "?.txt");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.EndsWith("a.txt"));
+        files.Should().Contain(f => f.EndsWith("b.txt"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "?.txt");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithMultipleQuestionMarks_MatchesExactLength()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "ab.txt"), "Content 1");
+        File.WriteAllText(Path.Join(tempFolder, "abc.txt"), "Content 2");
+        File.WriteAllText(Path.Join(tempFolder, "abcd.txt"), "Content 3");
+        File.WriteAllText(Path.Join(tempFolder, "a.txt"), "Content 4");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "???.txt");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(1);
+        files.Should().Contain(f => f.EndsWith("abc.txt"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "???.txt");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithMixedWildcards_MatchesPattern()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "test1.cs"), "Content 1");
+        File.WriteAllText(Path.Join(tempFolder, "test22.cs"), "Content 2");
+        File.WriteAllText(Path.Join(tempFolder, "test333.cs"), "Content 3");
+        File.WriteAllText(Path.Join(tempFolder, "other.cs"), "Content 4");
+        File.WriteAllText(Path.Join(tempFolder, "test.txt"), "Content 5");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "test*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(3);
+        files.Should().Contain(f => f.EndsWith("test1.cs"));
+        files.Should().Contain(f => f.EndsWith("test22.cs"));
+        files.Should().Contain(f => f.EndsWith("test333.cs"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "test*.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithSubdirectoryPattern_MatchesInSpecificDirectory()
+    {
+        using TempFolder tempFolder = new();
+
+        string subDir = Path.Join(tempFolder, "subdir");
+        Directory.CreateDirectory(subDir);
+
+        File.WriteAllText(Path.Join(tempFolder, "file1.txt"), "Content 1");
+        File.WriteAllText(Path.Join(subDir, "file2.txt"), "Content 2");
+        File.WriteAllText(Path.Join(subDir, "file3.txt"), "Content 3");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "subdir/*.txt");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.EndsWith("file2.txt"));
+        files.Should().Contain(f => f.EndsWith("file3.txt"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "subdir/*.txt");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithDeepRecursivePattern_MatchesAllSubdirectories()
+    {
+        using TempFolder tempFolder = new();
+
+        string level1 = Path.Join(tempFolder, "level1");
+        string level2 = Path.Join(level1, "level2");
+        string level3 = Path.Join(level2, "level3");
+
+        Directory.CreateDirectory(level3);
+
+        File.WriteAllText(Path.Join(tempFolder, "root.cs"), "Root");
+        File.WriteAllText(Path.Join(level1, "level1.cs"), "Level1");
+        File.WriteAllText(Path.Join(level2, "level2.cs"), "Level2");
+        File.WriteAllText(Path.Join(level3, "level3.cs"), "Level3");
+        File.WriteAllText(Path.Join(level2, "other.txt"), "Other");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "**/*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(4);
+        files.Should().Contain(f => f.EndsWith("root.cs"));
+        files.Should().Contain(f => f.Contains("level1.cs"));
+        files.Should().Contain(f => f.Contains("level2.cs"));
+        files.Should().Contain(f => f.Contains("level3.cs"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "**/*.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithSpecificDirectoryRecursivePattern_MatchesFromSpecificLevel()
+    {
+        using TempFolder tempFolder = new();
+
+        string src = Path.Join(tempFolder, "src");
+        string tests = Path.Join(tempFolder, "tests");
+        string srcSub = Path.Join(src, "sub");
+
+        Directory.CreateDirectory(srcSub);
+        Directory.CreateDirectory(tests);
+
+        File.WriteAllText(Path.Join(tempFolder, "root.cs"), "Root");
+        File.WriteAllText(Path.Join(src, "main.cs"), "Main");
+        File.WriteAllText(Path.Join(srcSub, "helper.cs"), "Helper");
+        File.WriteAllText(Path.Join(tests, "test.cs"), "Test");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "src/**/*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.Contains("main.cs"));
+        files.Should().Contain(f => f.Contains("helper.cs"));
+        files.Should().NotContain(f => f.Contains("root.cs"));
+        files.Should().NotContain(f => f.Contains("test.cs"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "src/**/*.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithComplexPattern_MatchesCombinedWildcards()
+    {
+        using TempFolder tempFolder = new();
+
+        string subDir = Path.Join(tempFolder, "components");
+        Directory.CreateDirectory(subDir);
+
+        File.WriteAllText(Path.Join(subDir, "Button.cs"), "Component");
+        File.WriteAllText(Path.Join(subDir, "Button.test.cs"), "Test");
+        File.WriteAllText(Path.Join(subDir, "Input.cs"), "Component");
+        File.WriteAllText(Path.Join(subDir, "Input.test.cs"), "Test");
+        File.WriteAllText(Path.Join(subDir, "Dialog.tsx"), "React");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "components/*.test.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.Contains("Button.test.cs"));
+        files.Should().Contain(f => f.Contains("Input.test.cs"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "components/*.test.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithNoMatches_ReturnsEmpty()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "file1.txt"), "Content 1");
+        File.WriteAllText(Path.Join(tempFolder, "file2.md"), "Content 2");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().BeEmpty();
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "*.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithExactFileName_MatchesSpecificFile()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "Program.cs"), "Content 1");
+        File.WriteAllText(Path.Join(tempFolder, "Program.txt"), "Content 2");
+        File.WriteAllText(Path.Join(tempFolder, "Other.cs"), "Content 3");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "Program.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(1);
+        files.Should().Contain(f => f.EndsWith("Program.cs"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "Program.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithNestedRecursivePattern_MatchesDeepPaths()
+    {
+        using TempFolder tempFolder = new();
+
+        string nested = Path.Join(tempFolder, "a", "b", "c", "d");
+        Directory.CreateDirectory(nested);
+
+        File.WriteAllText(Path.Join(tempFolder, "root.txt"), "Root");
+        File.WriteAllText(Path.Join(nested, "deep.txt"), "Deep");
+        File.WriteAllText(Path.Join(Path.Join(tempFolder, "a"), "intermediate.txt"), "Intermediate");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "**/deep.txt");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(1);
+        files.Should().Contain(f => f.EndsWith("deep.txt"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "**/deep.txt");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithMultipleExtensionPattern_MatchesVariousExtensions()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "file.c"), "C Code");
+        File.WriteAllText(Path.Join(tempFolder, "file.h"), "Header");
+        File.WriteAllText(Path.Join(tempFolder, "file.cpp"), "C++ Code");
+        File.WriteAllText(Path.Join(tempFolder, "file.txt"), "Text");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "file.?");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.EndsWith("file.c"));
+        files.Should().Contain(f => f.EndsWith("file.h"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "file.?");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithDirectoryNamePattern_MatchesDirectoryNames()
+    {
+        using TempFolder tempFolder = new();
+
+        string testDir = Path.Join(tempFolder, "Test");
+        string testsDir = Path.Join(tempFolder, "Tests");
+        string otherDir = Path.Join(tempFolder, "Other");
+
+        Directory.CreateDirectory(testDir);
+        Directory.CreateDirectory(testsDir);
+        Directory.CreateDirectory(otherDir);
+
+        File.WriteAllText(Path.Join(testDir, "file.cs"), "Test File");
+        File.WriteAllText(Path.Join(testsDir, "file.cs"), "Tests File");
+        File.WriteAllText(Path.Join(otherDir, "file.cs"), "Other File");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "Test*/*.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "Test*/*.cs");
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.Contains("Test") && f.EndsWith("file.cs"));
+        files.Should().Contain(f => f.Contains("Tests") && f.EndsWith("file.cs"));
+
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithEmptyDirectory_ReturnsEmpty()
+    {
+        using TempFolder tempFolder = new();
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "*.*");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().BeEmpty();
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "*.*");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithStarStarAtEnd_MatchesAllFilesRecursively()
+    {
+        using TempFolder tempFolder = new();
+
+        string subDir = Path.Join(tempFolder, "sub");
+        Directory.CreateDirectory(subDir);
+
+        File.WriteAllText(Path.Join(tempFolder, "root.txt"), "Root");
+        File.WriteAllText(Path.Join(subDir, "nested.txt"), "Nested");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "**");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "**");
+
+        files.Should().HaveCount(2);
+        files.Should().Contain(f => f.EndsWith("root.txt"));
+        files.Should().Contain(f => f.Contains("sub\\nested.txt"));
+
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithCaseVariations_MatchesBasedOnPlatform()
+    {
+        using TempFolder tempFolder = new();
+
+        File.WriteAllText(Path.Join(tempFolder, "file.txt"), "Lower");
+        File.WriteAllText(Path.Join(tempFolder, "FILE.TXT"), "Upper");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "file.txt");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        // On Windows, should match both due to case insensitivity
+        // On Linux, should only match the exact case
+        bool isWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+        if (isWindows)
+        {
+            files.Should().HaveCountGreaterOrEqualTo(1);
+        }
+        else
+        {
+            files.Should().HaveCount(1);
+            files.Should().Contain(f => f.EndsWith("file.txt"));
+        }
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "file.txt");
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [Fact]
+    public void EnumerateFiles_WithDoubleStarAtStart_MatchesFromAnyLevel()
+    {
+        using TempFolder tempFolder = new();
+
+        string level1 = Path.Join(tempFolder, "level1");
+        string level2 = Path.Join(level1, "level2");
+        Directory.CreateDirectory(level2);
+
+        File.WriteAllText(Path.Join(tempFolder, "target.cs"), "Root target");
+        File.WriteAllText(Path.Join(level1, "target.cs"), "Level1 target");
+        File.WriteAllText(Path.Join(level2, "target.cs"), "Level2 target");
+        File.WriteAllText(Path.Join(level2, "other.txt"), "Other file");
+
+        List<string> files = [];
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(tempFolder, "**/target.cs");
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().HaveCount(3);
+        files.Should().Contain(f => f.EndsWith("target.cs"));
+
+        IReadOnlyList<string> expected = FileMatcherWrapper.GetFilesSimple(tempFolder, "**/target.cs");
+        files.Should().BeEquivalentTo(expected);
+    }
+}

--- a/touki.tests/Touki/SimpleServiceProviderTests.cs
+++ b/touki.tests/Touki/SimpleServiceProviderTests.cs
@@ -4,6 +4,8 @@
 
 namespace Touki;
 
+#pragma warning disable CA2263 // Prefer the generic overload for GetService
+
 public class SimpleServiceProviderTests
 {
     // Test interfaces and classes for service registration
@@ -237,3 +239,5 @@ public class SimpleServiceProviderTests
         public CustomService(int id) => Id = id;
     }
 }
+
+#pragma warning restore CA2263 // Prefer the generic overload for GetService

--- a/touki.tests/touki.tests.csproj
+++ b/touki.tests/touki.tests.csproj
@@ -12,7 +12,11 @@
     <!-- Main project builds against 4.72 -->
     <DependencyTargetFramework Condition="'$(TargetFramework)' == 'net481'">net472</DependencyTargetFramework>
 
-    <ImplicitUsings>enable</ImplicitUsings>
+    <!--
+     We don't want to have implicit usings as we're retargeting System.IO to Microsoft.IO
+     in our GlobalUsings.cs file for .NET 4.7.2.
+    -->
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -35,6 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.Build" Version="17.14.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/touki/Framework/Touki/ArgumentNullAdapter.cs
+++ b/touki/Framework/Touki/ArgumentNullAdapter.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+internal static class ArgumentNullAdapter
+{
+    public static void ThrowIfNull<T>(T? value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : class
+    {
+        if (value is null)
+        {
+            ThrowNull(paramName);
+        }
+    }
+
+    [DoesNotReturn]
+    private static void ThrowNull(string? paramName) =>
+        throw new ArgumentNullException(paramName, "Value cannot be null.");
+}

--- a/touki/Framework/Touki/ArgumentOutOfRangeAdapter.cs
+++ b/touki/Framework/Touki/ArgumentOutOfRangeAdapter.cs
@@ -20,5 +20,5 @@ internal static class ArgumentOutOfRangeAdapter
 
     [DoesNotReturn]
     private static void ThrowNegative<T>(T value, string? paramName) =>
-    throw new ArgumentOutOfRangeException(paramName, value, null);
+        throw new ArgumentOutOfRangeException(paramName, value, null);
 }

--- a/touki/GlobalUsings.cs
+++ b/touki/GlobalUsings.cs
@@ -32,10 +32,12 @@ global using DriveNotFoundException = System.IO.DriveNotFoundException;
 global using Marshal = System.Runtime.InteropServices.Marshal;
 
 #if NETFRAMEWORK || NET6_0
+global using ArgumentNull = Touki.ArgumentNullAdapter;
 global using ArgumentOutOfRange = Touki.ArgumentOutOfRangeAdapter;
 global using ObjectDisposed = Touki.ObjectDisposedAdapter;
 global using Overflow = Touki.OverflowAdapter;
 #else
+global using ArgumentNull = System.ArgumentNullException;
 global using ArgumentOutOfRange = System.ArgumentOutOfRangeException;
 global using ObjectDisposed = System.ObjectDisposedException;
 #endif

--- a/touki/Touki/EnumerableBase.cs
+++ b/touki/Touki/EnumerableBase.cs
@@ -9,7 +9,7 @@ namespace Touki;
 /// <summary>
 ///  Simple enumerable base class.
 /// </summary>
-public abstract class Enumerable<T> : DisposableBase, IEnumerable<T>, IEnumerator<T>
+public abstract class EnumerableBase<T> : DisposableBase, IEnumerable<T>, IEnumerator<T>
 {
     /// <inheritdoc cref="IEnumerator.MoveNext"/>
     public abstract bool MoveNext();

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -1,0 +1,483 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Enumerates files that match a glob pattern with zero allocations until matches are found.
+/// </summary>
+/// <remarks>
+///  <para>The following wildcard patterns are supported:
+///   <list type="table">
+///    <listheader>
+///     <term>Pattern</term>
+///     <description>Description</description>
+///    </listheader>
+///    <item>
+///     <term>*</term>
+///     <description>Matches zero or more characters within a file or directory name</description>
+///    </item>
+///    <item>
+///     <term>**</term>
+///     <description>Matches zero or more directories (recursive wildcard)</description>
+///    </item>
+///    <item>
+///     <term>?</term>
+///     <description>Matches a single character</description>
+///    </item>
+///   </list>
+///  </para>
+/// </remarks>
+public sealed class MSBuildEnumerator : FileSystemEnumerator<string>
+{
+    private static readonly EnumerationOptions s_defaultOptions = new()
+    {
+        MatchType = MatchType.Simple,
+        MatchCasing = MatchCasing.PlatformDefault,
+        RecurseSubdirectories = true
+    };
+
+    private static readonly char[] s_wildcardChars = ['*', '?'];
+
+    private readonly string _projectDirectory;
+    private readonly bool _stripProjectDirectory;
+    private readonly int _projectDirectoryLength;
+
+    private readonly bool _alwaysRecurse;
+    private readonly StringSegment _directorySpec;
+    private readonly StringSegment _fileNameSpec;
+    private readonly List<Segment> _specSegments = [];
+    private readonly string _startDirectory;
+
+    private readonly MatchType _matchType;
+    private readonly MatchCasing _matchCasing;
+
+    // Cache for current directory being processed - valid until OnDirectoryFinished is called
+    private bool _cacheValid;
+    private bool _cachedCanMatch;
+    private bool _cachedFullyMatches;
+
+    private readonly struct Segment
+    {
+        public StringSegment Spec { get; }
+        public bool IsAnyDirectory { get; }
+
+        public Segment(StringSegment spec)
+        {
+            Spec = spec;
+            IsAnyDirectory = spec.Equals("**");
+        }
+
+        public static implicit operator ReadOnlySpan<char>(Segment segment) => segment.Spec.AsSpan();
+        public static implicit operator Segment(StringSegment segment) => new(segment);
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="MSBuildEnumerator"/> class.
+    /// </summary>
+    private MSBuildEnumerator(
+        string fileSpec,
+        string fullPathSpec,
+        string? projectDirectory,
+        string startDirectory,
+        EnumerationOptions? options = null)
+        : base(startDirectory, options ?? s_defaultOptions)
+    {
+        _startDirectory = startDirectory;
+
+        if (projectDirectory is null)
+        {
+            _stripProjectDirectory = false;
+            _projectDirectory = string.Empty;
+            _projectDirectoryLength = 0;
+        }
+        else
+        {
+            _projectDirectory = projectDirectory;
+            _projectDirectoryLength = projectDirectory.Length;
+            if (!Path.EndsInDirectorySeparator(_projectDirectory))
+            {
+                _projectDirectoryLength += 1;
+            }
+
+            // In MSBuild, this uses Path.IsRooted, which is not technically correct.
+            // There is also a case if the fileSpec is something like "**\C:\foo\bar\baz.cs"
+            // where it would not be stripped, but that doesn't seem to be by design.
+            _stripProjectDirectory = !Path.IsPathFullyQualified(fileSpec);
+        }
+
+        _matchType = options?.MatchType ?? MatchType.Simple;
+        _matchCasing = options?.MatchCasing ?? MatchCasing.PlatformDefault;
+
+        if (_matchCasing == MatchCasing.PlatformDefault)
+        {
+#if NETFRAMEWORK
+            _matchCasing = MatchCasing.CaseInsensitive;
+#else
+            _matchCasing = OperatingSystem.IsWindows()
+                || OperatingSystem.IsMacOS()
+                || OperatingSystem.IsIOS()
+                || OperatingSystem.IsTvOS()
+                || OperatingSystem.IsWatchOS()
+                    ? MatchCasing.CaseInsensitive
+                    : MatchCasing.CaseSensitive;
+#endif
+        }
+
+        Debug.Assert(!Path.EndsInDirectorySeparator(startDirectory));
+
+        // Don't want to include the trailing separator in the start of the file spec.
+        _directorySpec = new(fullPathSpec, startDirectory.Length + 1);
+
+        StringSegment remainingDirectorySpec = _directorySpec;
+
+        // Split the remaining directory spec on the directory separator char and put the segments into _specSegments.
+
+        int nextSeparator;
+        while (true)
+        {
+            nextSeparator = remainingDirectorySpec.IndexOf(Path.DirectorySeparatorChar);
+            if (nextSeparator < 0)
+            {
+                _fileNameSpec = remainingDirectorySpec;
+                break;
+            }
+
+            StringSegment segment = remainingDirectorySpec[..nextSeparator];
+            int currentCount = _specSegments.Count;
+            if (currentCount == 0 || !_specSegments[currentCount - 1].Equals("**"))
+            {
+                // If the last segment was not a "**" or this is the first segment, we can just add it.
+                _specSegments.Add(segment);
+            }
+
+            remainingDirectorySpec = remainingDirectorySpec[(nextSeparator + 1)..];
+        }
+
+        if (_specSegments.Count == 0)
+        {
+            if (_fileNameSpec.Equals("**"))
+            {
+                // Special case of "**" as the file spec, which means we match everything recursively.
+                _alwaysRecurse = true;
+                _fileNameSpec = "*";
+            }
+
+            return;
+        }
+
+        if (_specSegments.Count == 1 && _specSegments[0].IsAnyDirectory)
+        {
+            // If the only segment is "**", we should simply match anything recursively. Optimized case for "**/*.cs"
+            _alwaysRecurse = true;
+        }
+
+        if (_fileNameSpec.Equals("**"))
+        {
+            _fileNameSpec = "*";
+            if (!_specSegments[^1].IsAnyDirectory)
+            {
+                _specSegments.Add(new("**"));
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="MSBuildEnumerator"/> class.
+    /// </summary>
+    public static MSBuildEnumerator Create(string? projectDirectory, string fileSpec, EnumerationOptions? options = null)
+    {
+        ArgumentNull.ThrowIfNull(fileSpec);
+
+        // Ensure we're fully normalized
+        string rootDirectory = projectDirectory is null
+            ? Path.GetFullPath(Environment.CurrentDirectory)
+            : Path.GetFullPath(projectDirectory);
+
+        string fullPathSpec = Path.GetFullPath(fileSpec, rootDirectory);
+
+        ReadOnlySpan<char> fullPath = fullPathSpec.AsSpan();
+        int firstWildcard = fullPath.IndexOfAny(s_wildcardChars);
+        if (firstWildcard > 0)
+        {
+            fullPath = fullPath[..firstWildcard];
+        }
+
+        int lastSeparator = fullPath.LastIndexOf(Path.DirectorySeparatorChar);
+        if (lastSeparator < 0)
+        {
+            throw new ArgumentException("Did not resolve to a full path.", nameof(fileSpec));
+        }
+
+        string startDirectory = fullPath[..lastSeparator].ToString();
+
+        return new MSBuildEnumerator(fileSpec, fullPathSpec, projectDirectory, startDirectory, options);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnDirectoryFinished(ReadOnlySpan<char> directory)
+    {
+        // Clear the cache when we finish processing a directory
+        _cacheValid = false;
+    }
+
+    /// <inheritdoc/>
+    protected override string TransformEntry(ref FileSystemEntry entry)
+    {
+        if (!_stripProjectDirectory)
+        {
+            // If we're not stripping the project directory, we can just return the full path.
+            return entry.ToFullPath();
+        }
+
+        if (entry.Directory.Length <= _projectDirectoryLength)
+        {
+            // If the entry is in the base directory, we can just return the file name.
+            return entry.FileName.ToString();
+        }
+
+        return $"{entry.Directory[_projectDirectoryLength..]}{Path.DirectorySeparatorChar}{entry.FileName}";
+    }
+
+    /// <inheritdoc/>
+    protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry)
+    {
+        if (_alwaysRecurse)
+        {
+            // Optimized case for "**/*.cs"
+            return true;
+        }
+
+        // Get the relative path from start directory to this directory
+        ReadOnlySpan<char> relativePath = GetRelativeDirectoryPath(entry.Directory);
+
+        // Check if recursing into this directory would match the pattern
+        // Pass the entry filename as the final segment to avoid string allocation
+        return DoesDirectoryPathMatch(relativePath, entry.FileName, out _);
+    }
+
+    /// <inheritdoc/>
+    protected override bool ShouldIncludeEntry(ref FileSystemEntry entry)
+    {
+        if (entry.IsDirectory)
+        {
+            return false;
+        }
+
+        // Get the relative path from start directory to this file's directory
+        ReadOnlySpan<char> relativePath = GetRelativeDirectoryPath(entry.Directory);
+
+        // Check if the current directory fully matches the pattern and the file name matches
+        // Use cached result since we'll be called multiple times for files in the same directory
+        return GetCachedDirectoryMatchState(relativePath).FullyMatches && MatchSpec(entry.FileName, _fileNameSpec);
+    }
+
+    private ReadOnlySpan<char> GetRelativeDirectoryPath(ReadOnlySpan<char> fullDirectory) =>
+        // Remove the start directory prefix to get the relative path
+        fullDirectory.Length <= _startDirectory.Length ? default : fullDirectory[(_startDirectory.Length + 1)..];
+
+    private bool DoesDirectoryPathMatch(ReadOnlySpan<char> relativePath, out bool fullyMatches)
+        => DoesDirectoryPathMatch(relativePath, default, out fullyMatches);
+
+    private bool DoesDirectoryPathMatch(ReadOnlySpan<char> relativePath, ReadOnlySpan<char> finalSegment, out bool fullyMatches)
+    {
+        if (_specSegments.Count == 0)
+        {
+            // No directory segments to match - this means the pattern was just a filename or "**"
+            // If _alwaysRecurse is true (pattern was "**"), match all directories
+            // Otherwise, only match if we're at the root
+            fullyMatches = _alwaysRecurse || relativePath.IsEmpty;
+            return true; // Always can match when no directory segments
+        }
+
+        return MatchDirectorySegments(relativePath, finalSegment, out fullyMatches);
+    }
+
+    private bool MatchDirectorySegments(ReadOnlySpan<char> relativePath, ReadOnlySpan<char> finalSegment, out bool fullyMatches)
+    {
+        // If no relative path, we're at the start directory
+        if (relativePath.IsEmpty)
+        {
+            // If we have a final segment, we need to consider it for matching
+            if (!finalSegment.IsEmpty)
+            {
+                return MatchSegments(finalSegment, default, out fullyMatches);
+            }
+
+            // We match if we have no segments or if the first segment is "**"
+            bool canMatch = _specSegments.Count == 0 || _specSegments[0].IsAnyDirectory;
+            fullyMatches = canMatch; // At root, can match and fully matches are the same
+            return canMatch;
+        }
+
+        return MatchSegments(relativePath, finalSegment, out fullyMatches);
+    }
+
+    private bool MatchSegments(ReadOnlySpan<char> relativePath, ReadOnlySpan<char> finalSegment, out bool fullyMatches)
+    {
+        SpanReader<char> reader = new(relativePath);
+
+        int specIndex = 0;
+
+        while (specIndex < _specSegments.Count && !reader.End)
+        {
+            Segment currentSpec = _specSegments[specIndex];
+
+            if (currentSpec.IsAnyDirectory)
+            {
+                // "**" matches zero or more directory segments
+                specIndex++;
+
+                if (specIndex >= _specSegments.Count)
+                {
+                    // "**" is the last segment, it matches everything remaining
+                    fullyMatches = true;
+                    return true;
+                }
+
+                // Try to match the next spec segment with any remaining path segment
+                Segment nextSpec = _specSegments[specIndex];
+                bool foundMatch = false;
+
+                // Try matching from each remaining segment position
+                while (!reader.End)
+                {
+                    if (reader.TrySplit(Path.DirectorySeparatorChar, out ReadOnlySpan<char> segment))
+                    {
+                        if (MatchSpec(segment, nextSpec.Spec.AsSpan()))
+                        {
+                            specIndex++;
+                            foundMatch = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        // No more separators, check the remaining unread data
+                        if (MatchSpec(reader.Unread, nextSpec.Spec.AsSpan()))
+                        {
+                            reader.Advance(reader.Unread.Length);
+                            specIndex++;
+                            foundMatch = true;
+                        }
+
+                        break;
+                    }
+                }
+
+                if (!foundMatch)
+                {
+                    fullyMatches = false;
+                    return false;
+                }
+            }
+            else
+            {
+                // Regular segment, must match exactly
+                if (!reader.TrySplit(Path.DirectorySeparatorChar, out ReadOnlySpan<char> segment))
+                {
+                    // No more separators, check the remaining unread data
+                    segment = reader.Unread;
+                    reader.Advance(segment.Length);
+                }
+
+                if (!MatchSpec(segment, currentSpec.Spec.AsSpan()))
+                {
+                    fullyMatches = false;
+                    return false;
+                }
+
+                specIndex++;
+            }
+        }
+
+        // If we have a final segment to process, handle it now
+        if (!finalSegment.IsEmpty && specIndex < _specSegments.Count)
+        {
+            Segment currentSpec = _specSegments[specIndex];
+
+            if (currentSpec.IsAnyDirectory)
+            {
+                // "**" matches the final segment
+                specIndex++;
+
+                // If there are more spec segments after "**", try to match them with the final segment
+                if (specIndex < _specSegments.Count)
+                {
+                    Segment nextSpec = _specSegments[specIndex];
+                    if (MatchSpec(finalSegment, nextSpec.Spec.AsSpan()))
+                    {
+                        specIndex++;
+                    }
+                    else
+                    {
+                        fullyMatches = false;
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                // Regular segment, must match the final segment
+                if (!MatchSpec(finalSegment, currentSpec.Spec.AsSpan()))
+                {
+                    fullyMatches = false;
+                    return false;
+                }
+
+                specIndex++;
+            }
+        }
+
+        // Check if we've matched appropriately
+        // For partial match (recursion), we succeed if:
+        // 1. We've consumed all path segments and haven't exceeded spec segments, OR
+        // 2. The remaining spec segments start with "**"
+        bool hasUnprocessedFinalSegment = !finalSegment.IsEmpty && specIndex < _specSegments.Count;
+        bool canMatch = reader.End
+            && !hasUnprocessedFinalSegment
+            && specIndex <= _specSegments.Count
+            && (specIndex == _specSegments.Count || _specSegments[specIndex].IsAnyDirectory);
+
+        // For full match (file inclusion), we need to have consumed all spec segments
+        // or the remaining spec segments are all "**"
+        int tempSpecIndex = specIndex;
+        while (tempSpecIndex < _specSegments.Count && _specSegments[tempSpecIndex].IsAnyDirectory)
+        {
+            tempSpecIndex++;
+        }
+
+        fullyMatches = reader.End && finalSegment.IsEmpty && tempSpecIndex >= _specSegments.Count;
+
+        return canMatch;
+    }
+
+    private bool MatchSpec(ReadOnlySpan<char> name, ReadOnlySpan<char> spec) => _matchType switch
+    {
+        MatchType.Win32 => FileSystemName.MatchesWin32Expression(
+            spec,
+            name,
+            ignoreCase: _matchCasing == MatchCasing.CaseInsensitive),
+        _ => FileSystemName.MatchesSimpleExpression(
+            spec,
+            name,
+            ignoreCase: _matchCasing == MatchCasing.CaseInsensitive)
+    };
+
+    private (bool CanMatch, bool FullyMatches) GetCachedDirectoryMatchState(ReadOnlySpan<char> relativePath)
+    {
+        if (_cacheValid)
+        {
+            return (_cachedCanMatch, _cachedFullyMatches);
+        }
+
+        bool canMatch = DoesDirectoryPathMatch(relativePath, out bool fullyMatches);
+
+        _cacheValid = true;
+        _cachedCanMatch = canMatch;
+        _cachedFullyMatches = fullyMatches;
+
+        return (canMatch, fullyMatches);
+    }
+}

--- a/touki/Touki/Io/TempFolder.cs
+++ b/touki/Touki/Io/TempFolder.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Simple temporary folder implementation that is automatically deleted when disposed.
+/// </summary>
+public sealed class TempFolder : DisposableBase
+{
+    /// <summary>
+    ///  The path of the temporary folder.
+    /// </summary>
+    public string TempPath { get; } = CreateTempFolder();
+
+    private static string CreateTempFolder()
+    {
+        string path = Path.Join(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    /// <summary>
+    ///  Implicit conversion from <see cref="TempFolder"/> to <see cref="string"/> that returns the path of the temporary folder.
+    /// </summary>
+    public static implicit operator string(TempFolder folder) => folder.TempPath;
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (!disposing)
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.Delete(TempPath, recursive: true);
+        }
+        catch
+        {
+        }
+    }
+}

--- a/touki/Touki/StringSegment.cs
+++ b/touki/Touki/StringSegment.cs
@@ -1,0 +1,270 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+/// <summary>
+///  Span like string wrapper that allows using like a span but also storing as a field in a class.
+/// </summary>
+public readonly struct StringSegment : IEquatable<StringSegment>
+{
+    private readonly string _value;
+    private readonly int _start;
+    private readonly int _length;
+
+    /// <summary>
+    ///  Gets the length of the segment.
+    /// </summary>
+    public int Length => _length;
+
+    /// <summary>
+    ///  Gets a value indicating whether the segment is empty.
+    /// </summary>
+    public bool IsEmpty => _length == 0;
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="StringSegment"/> struct with an empty value.
+    /// </summary>
+    public StringSegment()
+    {
+        _value = string.Empty;
+        _start = 0;
+        _length = 0;
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="StringSegment"/> struct.
+    /// </summary>
+    /// <param name="value">The string to wrap.</param>
+    public StringSegment(string value)
+    {
+        _value = value;
+        _start = 0;
+        _length = value.Length;
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="StringSegment"/> struct.
+    /// </summary>
+    /// <param name="value">The <see langword="string"/> to wrap.</param>
+    /// <param name="start">The starting position in the <see langword="string"/>.</param>
+    /// <param name="length">The length of the segment.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  Thrown if <paramref name="start"/> or <paramref name="length"/> are negative, or if
+    ///  <paramref name="start"/> + <paramref name="length"/> exceeds the length of <paramref name="value"/>.
+    /// </exception>
+    public StringSegment(string value, int start, int length)
+    {
+        if (value is null)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start), "Start and length must be 0 for a null string");
+        }
+
+        if (start < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(start), "Start cannot be negative");
+        }
+
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(length), "Length cannot be negative");
+        }
+
+        if (start > value.Length - length && (start != 0 || length != 0))
+        {
+            throw new ArgumentOutOfRangeException(nameof(start), "Start and length exceed the bounds of the string");
+        }
+
+        _value = value;
+        _start = start;
+        _length = length;
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="StringSegment"/> struct.
+    /// </summary>
+    /// <param name="value">The <see langword="string"/> to wrap.</param>
+    /// <param name="start">The starting position in the <see langword="string"/>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  Thrown if <paramref name="start"/> is negative, or exceeds the length of <paramref name="value"/>.
+    /// </exception>
+    public StringSegment(string value, int start)
+        : this(value, start, value.Length - start)
+    {
+    }
+
+    /// <summary>
+    ///  Gets the character at the specified index.
+    /// </summary>
+    /// <param name="index">The index.</param>
+    /// <returns>The character at the specified index.</returns>
+    /// <exception cref="IndexOutOfRangeException">
+    ///  Thrown if <paramref name="index"/> is negative or greater than or equal to <see cref="Length"/>.
+    /// </exception>
+    public char this[int index] => _value![_start + index];
+
+    /// <summary>
+    ///  Gets a segment from a range of this segment.
+    /// </summary>
+    /// <param name="range">The range.</param>
+    /// <returns>A new <see cref="StringSegment"/> that represents the specified range.</returns>
+    public StringSegment this[Range range]
+    {
+        get
+        {
+            (int offset, int length) = range.GetOffsetAndLength(_length);
+            return new StringSegment(_value, _start + offset, length);
+        }
+    }
+
+    /// <summary>
+    ///  Slices the segment to create a new segment starting at a specified index.
+    /// </summary>
+    /// <param name="start">The start index.</param>
+    /// <returns>A new <see cref="StringSegment"/> that starts at the specified index.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  Thrown when <paramref name="start"/> is negative or greater than <see cref="Length"/>.
+    /// </exception>
+    public StringSegment Slice(int start)
+    {
+        return (uint)start > (uint)_length
+            ? throw new ArgumentOutOfRangeException(nameof(start))
+            : new StringSegment(_value, _start + start, _length - start);
+    }
+
+    /// <summary>
+    ///  Slices the segment to create a new segment starting at a specified index with the specified length.
+    /// </summary>
+    /// <param name="start">The start index.</param>
+    /// <param name="length">The length of the new segment.</param>
+    /// <returns>A new <see cref="StringSegment"/> that starts at the specified index and has the specified length.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  Thrown when <paramref name="start"/> or <paramref name="length"/> are negative, or if
+    ///  <paramref name="start"/> + <paramref name="length"/> exceeds <see cref="Length"/>.
+    /// </exception>
+    public StringSegment Slice(int start, int length) =>
+        (uint)start > (uint)_length || (uint)length > (uint)(_length - start)
+            ? throw new ArgumentOutOfRangeException(nameof(start))
+            : new StringSegment(_value, _start + start, length);
+
+    /// <summary>
+    ///  Returns the index of the given <see langword="char"/> or -1 if not found.
+    /// </summary>
+    public int IndexOf(char value)
+    {
+        int index = _value.IndexOf(value, _start, _length);
+        return index < 0 ? -1 : index - _start;
+    }
+
+    /// <summary>
+    ///  Creates a span over this segment.
+    /// </summary>
+    /// <returns>A span that represents the segment.</returns>
+    public ReadOnlySpan<char> AsSpan() => _value.AsSpan(_start, _length);
+
+    /// <summary>
+    ///  Creates a span over a portion of this segment.
+    /// </summary>
+    /// <param name="start">The start index.</param>
+    /// <returns>A span that represents the specified portion of the segment.</returns>
+    public ReadOnlySpan<char> AsSpan(int start) => (uint)start > (uint)_length
+        ? throw new ArgumentOutOfRangeException(nameof(start))
+        : _value.AsSpan(_start + start, _length - start);
+
+    /// <summary>
+    ///  Creates a span over a portion of this segment.
+    /// </summary>
+    /// <param name="start">The start index.</param>
+    /// <param name="length">The length of the span.</param>
+    /// <returns>A span that represents the specified portion of the segment.</returns>
+    public ReadOnlySpan<char> AsSpan(int start, int length) =>
+        (uint)start > (uint)_length || (uint)length > (uint)(_length - start)
+            ? throw new ArgumentOutOfRangeException(nameof(start))
+            : _value.AsSpan(_start + start, length);
+
+    /// <summary>
+    ///  Returns a <see langword="string"/> that represents the current segment.
+    /// </summary>
+    /// <returns>A <see langword="string"/> that represents the current segment.</returns>
+    public override string ToString() => _length == 0
+        ? string.Empty
+        : _start switch
+        {
+            0 when _length == _value.Length => _value,
+            _ => _value.Substring(_start, _length)
+        };
+
+    /// <summary>
+    ///  Implicitly converts a <see cref="StringSegment"/> to a <see cref="ReadOnlySpan{T}"/> of <see cref="char"/>.
+    /// </summary>
+    /// <param name="segment">The segment to convert.</param>
+    public static implicit operator ReadOnlySpan<char>(StringSegment segment) => segment.AsSpan();
+
+    /// <summary>
+    ///  Implicitly converts a <see cref="string"/> to a <see cref="StringSegment"/>.
+    /// </summary>
+    /// <param name="value">The string to convert.</param>
+    public static implicit operator StringSegment(string value) => new StringSegment(value);
+
+    /// <summary>
+    ///  Gets a value indicating whether two segments are equal.
+    /// </summary>
+    /// <param name="other">The segment to compare with.</param>
+    /// <returns><see langword="true"/> if the segments are equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(StringSegment other) => _length == other._length && AsSpan().SequenceEqual(other.AsSpan());
+
+    /// <summary>
+    ///  Gets a value indicating whether the segment equals the specified span.
+    /// </summary>
+    /// <param name="other">The span to compare with.</param>
+    /// <returns><see langword="true"/> if the values are equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(ReadOnlySpan<char> other) => _length == other.Length && AsSpan().SequenceEqual(other);
+
+    /// <summary>
+    ///  Gets a value indicating whether the segment equals the specified <see langword="string"/>.
+    /// </summary>
+    /// <param name="other">The span to compare with.</param>
+    /// <returns><see langword="true"/> if the values are equal; otherwise, <see langword="false"/>.</returns>
+    public bool Equals(string other) => _length == other.Length && AsSpan().SequenceEqual(other.AsSpan());
+
+    /// <summary>
+    ///  Gets a value indicating whether the segment equals the specified object.
+    /// </summary>
+    /// <param name="obj">The object to compare with.</param>
+    /// <returns><see langword="true"/> if the segment equals the specified object; otherwise, <see langword="false"/>.</returns>
+    public override bool Equals(object? obj) => obj is StringSegment other && Equals(other);
+
+    /// <summary>
+    ///  Gets the hash code for the segment.
+    /// </summary>
+    /// <returns>A hash code for the segment.</returns>
+    public override int GetHashCode()
+    {
+        ReadOnlySpan<char> span = AsSpan();
+        int hash = 0;
+
+        for (int i = 0; i < span.Length; i++)
+        {
+            hash = unchecked((hash * 31) + span[i]);
+        }
+
+        return hash;
+    }
+
+    /// <summary>
+    ///  Gets a value indicating whether two segments are equal.
+    /// </summary>
+    /// <param name="left">The first segment.</param>
+    /// <param name="right">The second segment.</param>
+    /// <returns><see langword="true"/> if the segments are equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator ==(StringSegment left, StringSegment right) => left.Equals(right);
+
+    /// <summary>
+    ///  Gets a value indicating whether two segments are not equal.
+    /// </summary>
+    /// <param name="left">The first segment.</param>
+    /// <param name="right">The second segment.</param>
+    /// <returns><see langword="true"/> if the segments are not equal; otherwise, <see langword="false"/>.</returns>
+    public static bool operator !=(StringSegment left, StringSegment right) => !left.Equals(right);
+}

--- a/touki/Touki/ValueStringBuilder.cs
+++ b/touki/Touki/ValueStringBuilder.cs
@@ -552,6 +552,11 @@ public ref partial struct ValueStringBuilder
         }
     }
 
+    /// <summary>
+    ///  Implicitly converts a <see cref="ValueStringBuilder"/> to a <see cref="string"/>.
+    /// </summary>
+    public static implicit operator ReadOnlySpan<char>(ValueStringBuilder builder) => builder._chars[..builder._position];
+
 #pragma warning disable IDE0251 // Member can be made readonly
 
     /// <summary>


### PR DESCRIPTION
Adds a MSBuild style FileSystemEnumerator that enumerates with significantly better performance and far lower allocations.

- Added `Microsoft.Build` package reference in tests.
- Renamed `Enumerable` to `EnumerableBase`
- Added  `StringSegment` and `TempFolder`
- Added tests for `MSBuildEnumerator` in `MSBuildEnumeratorTests.cs`.