### PR TITLE
ValueStringBuilder cleanup

### DIFF
--- a/touki.perf/StringFormattingAs8DigitHex.cs
+++ b/touki.perf/StringFormattingAs8DigitHex.cs
@@ -3,10 +3,13 @@
 // See LICENSE file in the project root for full license information
 
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Touki;
 
 namespace touki.perf;
 
 [MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
 public class StringFormattingAs8DigitHex
 {
     private readonly int _value = 42;
@@ -22,6 +25,13 @@ public class StringFormattingAs8DigitHex
     {
         // Using "X8" to format the integer as an 8-digit hexadecimal string.
         return string.Format("The answer is {0:X8}.", _value);
+    }
+
+    [Benchmark]
+    public string StringsFormat()
+    {
+        // Using "X8" to format the integer as an 8-digit hexadecimal string.
+        return Strings.Format("The answer is {0:X8}.", _value);
     }
 
     [Benchmark]

--- a/touki/Framework/Touki/ValueStringBuilder.cs
+++ b/touki/Framework/Touki/ValueStringBuilder.cs
@@ -11,7 +11,7 @@ public ref partial struct ValueStringBuilder
     private readonly Span<char> Remaining
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _chars[_position..];
+        get => _chars[_length..];
     }
 
     private bool TryAppendFormattedPrimitives<T>(T value, ReadOnlySpan<char> format, IFormatProvider? formatProvider)
@@ -37,7 +37,7 @@ public ref partial struct ValueStringBuilder
 
             if (Number.TryFormatInt32(Unsafe.As<T, int>(ref value), 0xFF, format, formatProvider, Remaining, out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -50,7 +50,7 @@ public ref partial struct ValueStringBuilder
 
             if (Number.TryFormatInt32(Unsafe.As<T, int>(ref value), 0xFFFF, format, formatProvider, Remaining, out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -63,7 +63,7 @@ public ref partial struct ValueStringBuilder
 
             if (Number.TryFormatInt32(Unsafe.As<T, int>(ref value), ~0, format, formatProvider, Remaining, out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -84,7 +84,7 @@ public ref partial struct ValueStringBuilder
 
             if (Number.TryFormatUInt32(Unsafe.As<T, uint>(ref value), format, formatProvider, Remaining, out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -97,7 +97,7 @@ public ref partial struct ValueStringBuilder
 
             if (Number.TryFormatInt64(Unsafe.As<T, long>(ref value), format, formatProvider, Remaining, out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -110,7 +110,7 @@ public ref partial struct ValueStringBuilder
 
             if (Number.TryFormatUInt64(Unsafe.As<T, ulong>(ref value), format, formatProvider, Remaining, out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -128,7 +128,7 @@ public ref partial struct ValueStringBuilder
                 Remaining,
                 out int charsWritten))
             {
-                _position += charsWritten;
+                _length += charsWritten;
                 return true;
             }
 
@@ -219,7 +219,7 @@ public ref partial struct ValueStringBuilder
         bool firstTime = true;
         ulong saveResult = result;
 
-        int startPosition = _position;
+        int startPosition = _length;
 
         // We will not optimize this code further to keep it maintainable. There are some boundary checks that can be applied
         // to minimize the comparsions required. This code works the same for the best/worst case. In general the number of
@@ -249,7 +249,7 @@ public ref partial struct ValueStringBuilder
         // We were unable to represent this number as a bitwise or of valid flags
         if (result != 0)
         {
-            _position = startPosition;
+            _length = startPosition;
             bool success = signed
                 ? TryAppendFormattedPrimitives((long)value, default, default)
                 : TryAppendFormattedPrimitives(value, default, default);


### PR DESCRIPTION
Refactored `ValueStringBuilder.cs` to replace the `_position` field with `_length`, improving internal logic for character management and introducing new methods for slicing and span handling.