### PR TITLE
Refactor file and directory matching logic

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # CoPilot instructions for this repository
 
 # Coding
-- Use modern C# features where appropriate.
+- Use the latest C# features (C# 13) where applicable.
 - Always use C# keywords for types (e.g., `int`, `string`, `bool`) instead of their aliases (e.g., `Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
 - Avoid using `var` - always use explicit type declarations.
@@ -34,6 +34,7 @@
 - Use `<inheritdoc/>` and `<inheritdoc cref="..."/>` to inherit documentation from base classes, interfaces where applicable.
 - For method overloads, use `<inheritdoc cref="MethodName"/>` to inherit documentation from the method with the most arguments,
   overriding tags where they differ.
+- Use see langword tags for language keywords in comments (e.g. `<see langword='true'/>` instead of `true`).
 
 # Line breaks and white space
 - Never put multiple statements on a single line.

--- a/touki.tests/TestSupport/NoAssertContext.cs
+++ b/touki.tests/TestSupport/NoAssertContext.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Concurrent;
+
+namespace System;
+
+/// <summary>
+///  Use (within a using) to eat asserts.
+/// </summary>
+public sealed class NoAssertContext : IDisposable
+{
+    // For any given thread we don't need to lock to decide how to route messages, as any messages for that
+    // given thread will not happen while we're in the constructor or dispose method on that thread. That
+    // means we can safely check to see if we've hooked our thread without locking (outside of using a
+    // concurrent collection to make sure the collection is in a known state).
+    //
+    // We do, however need to lock around hooking/unhooking our custom listener to make sure that we
+    // are rerouting correctly if multiple threads are creating/disposing this class concurrently.
+
+    private static readonly Lock s_lock = new();
+    private static bool s_hooked;
+    private static bool s_hasDefaultListener;
+    private static bool s_hasThrowingListener;
+
+    private static readonly ConcurrentDictionary<int, int> s_suppressedThreads = new();
+
+    // "Default" is the listener that terminates the process when debug assertions fail.
+    private static readonly TraceListener? s_defaultListener = Trace.Listeners["Default"];
+    private static readonly NoAssertListener s_noAssertListener = new();
+
+    public NoAssertContext()
+    {
+        s_suppressedThreads.AddOrUpdate(Environment.CurrentManagedThreadId, 1, (key, oldValue) => oldValue + 1);
+
+        // Lock to make sure we are hooked properly if two threads come into the constructor/dispose at the same time.
+        lock (s_lock)
+        {
+            if (!s_hooked)
+            {
+                // Hook our custom listener first so we don't lose assertions from other threads when
+                // we disconnect the default listener.
+                Trace.Listeners.Add(s_noAssertListener);
+                if (s_defaultListener is not null && Trace.Listeners.Contains(s_defaultListener))
+                {
+                    s_hasDefaultListener = true;
+                    Trace.Listeners.Remove(s_defaultListener);
+                }
+
+                if (Trace.Listeners.OfType<ThrowingTraceListener>().FirstOrDefault() is { } throwingTraceListener)
+                {
+                    s_hasThrowingListener = true;
+                    Trace.Listeners.Remove(throwingTraceListener);
+                }
+
+                s_hooked = true;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+
+        int currentThread = Environment.CurrentManagedThreadId;
+        if (s_suppressedThreads.TryRemove(currentThread, out int count))
+        {
+            if (count > 1)
+            {
+                // We're in a nested assert context on a given thread, re-add with a decremented count.
+                // This doesn't need to be atomic as we're currently on the thread that would care about
+                // being rerouted.
+                s_suppressedThreads.TryAdd(currentThread, --count);
+            }
+        }
+
+        lock (s_lock)
+        {
+            if (s_hooked && s_suppressedThreads.IsEmpty)
+            {
+                // We're the first to hit the need to unhook. Add the default listener back first to
+                // ensure we don't lose any asserts from other threads.
+                if (s_hasDefaultListener)
+                {
+                    Trace.Listeners.Add(s_defaultListener!);
+                }
+
+                if (s_hasThrowingListener)
+                {
+                    Trace.Listeners.Add(ThrowingTraceListener.Instance);
+                }
+
+                Trace.Listeners.Remove(s_noAssertListener);
+                s_hooked = false;
+            }
+        }
+    }
+
+#pragma warning disable CA1821 // Remove empty Finalizers
+    ~NoAssertContext()
+#pragma warning restore CA1821
+    {
+        // We need this class to be used in a using to effectively rationalize about a test.
+        throw new InvalidOperationException($"Did not dispose {nameof(NoAssertContext)}");
+    }
+
+    private class NoAssertListener : TraceListener
+    {
+        public NoAssertListener()
+            : base(typeof(NoAssertListener).FullName)
+        {
+        }
+
+        private static TraceListener? DefaultListener => s_hasThrowingListener
+            ? ThrowingTraceListener.Instance
+            : s_hasDefaultListener ? s_defaultListener : null;
+
+        public override void Fail(string? message)
+        {
+            if (!s_suppressedThreads.TryGetValue(Environment.CurrentManagedThreadId, out _))
+            {
+                DefaultListener?.Fail(message);
+            }
+        }
+
+        public override void Fail(string? message, string? detailMessage)
+        {
+            if (!s_suppressedThreads.TryGetValue(Environment.CurrentManagedThreadId, out _))
+            {
+                DefaultListener?.Fail(message, detailMessage);
+            }
+        }
+
+        // Write and WriteLine are virtual
+
+        public override void Write(string? message)
+        {
+            if (!s_suppressedThreads.TryGetValue(Environment.CurrentManagedThreadId, out _))
+            {
+                DefaultListener?.Write(message);
+            }
+        }
+
+        public override void WriteLine(string? message)
+        {
+            if (!s_suppressedThreads.TryGetValue(Environment.CurrentManagedThreadId, out _))
+            {
+                DefaultListener?.WriteLine(message);
+            }
+        }
+    }
+}

--- a/touki.tests/TestSupport/ThrowingTraceListener.cs
+++ b/touki.tests/TestSupport/ThrowingTraceListener.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System;
+
+public sealed class ThrowingTraceListener : TraceListener
+{
+    public static ThrowingTraceListener Instance { get; } = new();
+
+    public override void Fail(string? message, string? detailMessage)
+    {
+        throw new InvalidOperationException(
+            $"{(string.IsNullOrEmpty(message) ? "Assertion failed" : message)}{(string.IsNullOrEmpty(detailMessage)
+                ? ""
+                : $"{Environment.NewLine}{detailMessage}")}");
+    }
+
+    public override void Write(object? o)
+    {
+    }
+
+    public override void Write(object? o, string? category)
+    {
+    }
+
+    public override void Write(string? message)
+    {
+    }
+
+    public override void Write(string? message, string? category)
+    {
+    }
+
+    public override void WriteLine(object? o)
+    {
+    }
+
+    public override void WriteLine(object? o, string? category)
+    {
+    }
+
+    public override void WriteLine(string? message)
+    {
+    }
+
+    public override void WriteLine(string? message, string? category)
+    {
+    }
+}

--- a/touki.tests/Touki/Collections/EmptyListTests.cs
+++ b/touki.tests/Touki/Collections/EmptyListTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Collections;
+
+public class EmptyListTests
+{
+    [Fact]
+    public void Instance_RequestedMultipleTimes_ReturnsSameInstance()
+    {
+        EmptyList<int>.Instance.Should().BeSameAs(EmptyList<int>.Instance);
+        EmptyList<string>.Instance.Should().BeSameAs(EmptyList<string>.Instance);
+    }
+
+    [Fact]
+    public void Indexer_Get_ThrowsArgumentOutOfRangeException()
+    {
+        EmptyList<int> list = EmptyList<int>.Instance;
+
+        Action act = () => _ = list[0];
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("index");
+    }
+
+    [Fact]
+    public void Indexer_Set_ThrowsArgumentOutOfRangeException()
+    {
+        EmptyList<int> list = EmptyList<int>.Instance;
+
+        Action act = () => list[0] = 42;
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("index");
+    }
+
+    [Fact]
+    public void IsReadOnly_Get_ReturnsTrue()
+    {
+        EmptyList<int>.Instance.IsReadOnly.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnsafeValues_Get_ReturnsEmptySpan()
+    {
+        EmptyList<int>.Instance.UnsafeValues.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Values_Get_ReturnsEmptySpan()
+    {
+        EmptyList<int>.Instance.Values.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Count_Get_ReturnsZero()
+    {
+        EmptyList<int>.Instance.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Add_AnyItem_ThrowsNotImplementedException()
+    {
+        Action act = () => EmptyList<int>.Instance.Add(42);
+        act.Should().Throw<NotImplementedException>();
+    }
+
+    [Fact]
+    public void Clear_Called_DoesNotThrow()
+    {
+        Action act = () => EmptyList<int>.Instance.Clear();
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CopyTo_ArrayWithNonZeroIndex_ThrowsArgumentOutOfRangeException()
+    {
+        int[] array = new int[1];
+        Action act = () => EmptyList<int>.Instance.CopyTo(array, 1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CopyTo_ArrayWithZeroIndex_DoesNotThrow()
+    {
+        int[] array = [];
+        Action act = () => EmptyList<int>.Instance.CopyTo(array, 0);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void CopyTo_SystemArrayWithNonZeroIndex_ThrowsArgumentOutOfRangeException()
+    {
+        Array array = new int[1];
+        Action act = () => EmptyList<int>.Instance.CopyTo(array, 1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CopyTo_SystemArrayWithZeroIndex_DoesNotThrow()
+    {
+        Array array = Array.Empty<int>();
+        Action act = () => EmptyList<int>.Instance.CopyTo(array, 0);
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void IndexOf_AnyItem_ReturnsMinusOne()
+    {
+        EmptyList<int>.Instance.IndexOf(42).Should().Be(-1);
+    }
+
+    [Fact]
+    public void Insert_AnyItemAtAnyIndex_ThrowsInvalidOperationException()
+    {
+        Action act = () => EmptyList<int>.Instance.Insert(0, 42);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void RemoveAt_AnyIndex_ThrowsInvalidOperationException()
+    {
+        Action act = () => EmptyList<int>.Instance.RemoveAt(0);
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/touki.tests/Touki/Io/EnumeratorMock.cs
+++ b/touki.tests/Touki/Io/EnumeratorMock.cs
@@ -13,11 +13,11 @@ internal sealed class EnumeratorMock
     }
 
     private readonly string _root;
-    private readonly MSBuildSpec _spec;
+    private readonly MatchMSBuild _spec;
     private readonly DirectoryNode _rootNode = new();
     private readonly List<string> _included = [];
 
-    public EnumeratorMock(string root, IEnumerable<string> files, MSBuildSpec spec)
+    public EnumeratorMock(string root, IEnumerable<string> files, MatchMSBuild spec)
     {
         _root = root;
         _spec = spec;
@@ -65,7 +65,7 @@ internal sealed class EnumeratorMock
             // Process files in current directory
             foreach (string file in currentNode.Files)
             {
-                if (_spec.ShouldIncludeFile(currentPath.AsSpan(), file.AsSpan()))
+                if (_spec.MatchesFile(currentPath.AsSpan(), file.AsSpan()))
                 {
                     _included.Add(Path.GetRelativePath(_root, Path.Join(currentPath, file)));
                 }
@@ -76,13 +76,13 @@ internal sealed class EnumeratorMock
             {
                 string name = pair.Key;
                 DirectoryNode child = pair.Value;
-                if (_spec.ShouldRecurseIntoDirectory(currentPath.AsSpan(), name.AsSpan()))
+                if (_spec.MatchesDirectory(currentPath.AsSpan(), name.AsSpan()))
                 {
                     directoryQueue.Enqueue((child, Path.Join(currentPath, name)));
                 }
             }
 
-            _spec.InvalidateCache();
+            _spec.DirectoryFinished();
         }
 
         return _included;

--- a/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
@@ -1,0 +1,825 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Collections;
+
+namespace Touki.Io;
+
+public class MSBuildSpecificationTests
+{
+    private static string Sep(string path) => Paths.ChangeAlternateDirectorySeparators(path);
+
+    [Theory]
+    [InlineData("file.txt", "", "", "file.txt", false)]
+    [InlineData("**", "", "**", "*", true)]
+    [InlineData("*.txt", "", "", "*.txt", true)]
+    [InlineData("a/b/file.txt", "a/b", "", "file.txt", false)]
+    [InlineData("a/b/*.txt", "a/b", "", "*.txt", true)]
+    [InlineData("a/*/file.txt", "a", "*", "file.txt", true)]
+    [InlineData("a/**/file.txt", "a", "**", "file.txt", true)]
+    [InlineData("a/?/file.txt", "a", "?", "file.txt", true)]
+    [InlineData("*/file.txt", "", "*", "file.txt", true)]
+    [InlineData("**/file.txt", "", "**", "file.txt", true)]
+    [InlineData("a/b/**", "a/b", "**", "*", true)]
+    [InlineData("**/b/**", "", "**/b/**", "*", true)]
+    public void MSBuildSpecification_ParsesCorrectly(
+        string original,
+        string expectedFixed,
+        string expectedWildCard,
+        string expectedFileName,
+        bool expectedAnyWildCards)
+    {
+        MSBuildSpecification spec = new(original);
+
+        expectedFixed = expectedFixed.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        expectedWildCard = expectedWildCard.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        expectedFileName = expectedFileName.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        spec.Original.ToString().Should().Be(original);
+        spec.Normalized.ToString().Should().Be(original.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
+        spec.FixedPath.ToString().Should().Be(expectedFixed);
+        spec.WildPath.ToString().Should().Be(expectedWildCard);
+        spec.FileName.ToString().Should().Be(expectedFileName);
+        spec.HasAnyWildCards.Should().Be(expectedAnyWildCards);
+    }
+
+    [Theory]
+    [InlineData("a\\b\\file.txt", "a/b/file.txt")]
+    [InlineData("a/b\\file.txt", "a/b/file.txt")]
+    [InlineData("\\a\\b\\file.txt", "/a/b/file.txt")]
+    public void MSBuildSpecification_NormalizesPaths(string original, string expected)
+    {
+        expected = expected.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        MSBuildSpecification spec = new(original);
+        spec.Normalized.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("a/**/**/b", "a/**/b")]
+    [InlineData("a/**/**/**/b", "a/**/b")]
+    [InlineData("**/**", "**")]
+    [InlineData("**/**/", "**/")]
+    [InlineData("a/**/**", "a/**")]
+    [InlineData("a/**/**/", "a/**/")]
+    [InlineData("/a/**/**/b", "/a/**/b")]
+    [InlineData("/a/**/**/b/", "/a/**/b/")]
+    [InlineData("a\\**\\**\\b", "a/**/b")]
+    [InlineData("a/**\\**/b", "a/**/b")]
+    [InlineData("a/**/c/**/b", "a/**/c/**/b")]
+    public void MSBuildSpecification_NormalizesDuplicateRecursiveWildcards(string original, string expected)
+    {
+        expected = expected.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        MSBuildSpecification spec = new(original);
+        spec.Normalized.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("file.txt", "file.txt")]
+    [InlineData("a/b/c.txt", "a/b/c.txt")]
+    public void MSBuildSpecification_ToString_ReturnsNormalized(string original, string expected)
+    {
+        expected = expected.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+
+        MSBuildSpecification spec = new(original);
+        spec.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("./file.txt", "", "", "file.txt", false)]
+    [InlineData("../file.txt", "..", "", "file.txt", false)]
+    [InlineData("a/./file.txt", "a", "", "file.txt", false)]
+    [InlineData("a/../file.txt", "", "", "file.txt", false)]
+    [InlineData("a/b/../../file.txt", "", "", "file.txt", false)]
+    [InlineData("a/./b/c/file.txt", "a/b/c", "", "file.txt", false)]
+    [InlineData("a/b/c/./../file.txt", "a/b", "", "file.txt", false)]
+    [InlineData("a//b///file.txt", "a/b", "", "file.txt", false)]
+    // It is unclear what to really do in the next case
+    [InlineData("a/b/file.txt/", "a/b/file.txt", "", "", false)]
+    [InlineData("a/b/./", "a/b", "", "", false)]
+    [InlineData("./*/file.txt", "", "*", "file.txt", true)]
+    [InlineData("../*/file.txt", "..", "*", "file.txt", true)]
+    [InlineData("a/./**/file.txt", "a", "**", "file.txt", true)]
+    [InlineData("a/../**/file.txt", "", "**", "file.txt", true)]
+    [InlineData("a/b/../../*/file.txt", "", "*", "file.txt", true)]
+    [InlineData("a/./b/*/c/*.txt", "a/b", "*/c", "*.txt", true)]
+    [InlineData("a//b//*/file.txt", "a/b", "*", "file.txt", true)]
+    [InlineData("a/b/**/", "a/b", "**", "*", true)]
+    [InlineData("./a/../**", "", "**", "*", true)]
+    public void MSBuildSpecification_ParsesNonNormalizedPaths(
+        string original,
+        string expectedFixed,
+        string expectedWildCard,
+        string expectedFileName,
+        bool expectedAnyWildCards)
+    {
+        MSBuildSpecification spec = new(original);
+
+        expectedFixed = Sep(expectedFixed);
+        expectedWildCard = Sep(expectedWildCard);
+        expectedFileName = Sep(expectedFileName);
+
+        spec.Original.ToString().Should().Be(original);
+        spec.FixedPath.ToString().Should().Be(expectedFixed);
+        spec.WildPath.ToString().Should().Be(expectedWildCard);
+        spec.FileName.ToString().Should().Be(expectedFileName);
+        spec.HasAnyWildCards.Should().Be(expectedAnyWildCards);
+    }
+
+    [Theory]
+    [InlineData("C:/path/file.txt", true, false)]
+    [InlineData("/absolute/path/file.txt", false, false)]
+    [InlineData("//server/share/file.txt", true, false)]
+    [InlineData("relative/path/file.txt", false, true)]
+    [InlineData("./relative/path/file.txt", false, true)]
+    [InlineData("../parent/path/file.txt", false, false)]
+    [InlineData("C:relative/file.txt", false, false)] // Drive-relative path
+    public void MSBuildSpecification_SetsPathQualificationPropertiesCorrectly(
+        string path,
+        bool expectedIsFullyQualified,
+        bool expectedIsNestedRelative)
+    {
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+#endif
+
+        MSBuildSpecification spec = new(path);
+
+        spec.IsFullyQualified.Should().Be(expectedIsFullyQualified);
+        spec.IsNestedRelative.Should().Be(expectedIsNestedRelative);
+    }
+
+    [Theory]
+    [InlineData("file.txt", false, true)]
+    [InlineData("folder/file.txt", false, true)]
+    [InlineData("../file.txt", false, false)]
+    [InlineData("../../file.txt", false, false)]
+    [InlineData("folder/../file.txt", false, true)] // Normalized doesn't contain '..'
+    [InlineData("C:/folder/file.txt", true, false)]
+    public void MSBuildSpecification_HandlesSpecialPathsCorrectly(
+        string path,
+        bool expectedIsFullyQualified,
+        bool expectedIsNestedRelative)
+    {
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+#endif
+
+        MSBuildSpecification spec = new(path);
+
+        spec.IsFullyQualified.Should().Be(expectedIsFullyQualified);
+        spec.IsNestedRelative.Should().Be(expectedIsNestedRelative);
+    }
+
+    [Fact]
+    public void IsNestedRelative_ReturnsTrue_ForPathsBelow_CurrentDirectory()
+    {
+        // These paths are guaranteed to be below the current directory
+        new MSBuildSpecification("file.txt").IsNestedRelative.Should().BeTrue();
+        new MSBuildSpecification("./file.txt").IsNestedRelative.Should().BeTrue();
+        new MSBuildSpecification("folder/file.txt").IsNestedRelative.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNestedRelative_ReturnsFalse_ForPathsNotGuaranteedToBeBelow_CurrentDirectory()
+    {
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+#endif
+
+        // These paths may navigate outside the current directory
+        new MSBuildSpecification("../file.txt").IsNestedRelative.Should().BeFalse();
+        new MSBuildSpecification("C:/file.txt").IsNestedRelative.Should().BeFalse();
+        new MSBuildSpecification("C:file.txt").IsNestedRelative.Should().BeFalse(); // Drive-relative
+        new MSBuildSpecification("/root/file.txt").IsNestedRelative.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("C:/file.txt", true)]
+    [InlineData("C:\\file.txt", true)]
+    [InlineData("\\\\server\\share\\file.txt", true)]
+    public void IsFullyQualified_WindowsSpecificPaths(string path, bool expected)
+    {
+#if NET
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+#endif
+
+        MSBuildSpecification spec = new(path);
+        spec.IsFullyQualified.Should().Be(expected);
+    }
+
+#if NET
+    [Theory]
+    [InlineData("/root/file.txt", true)]
+    [InlineData("~/file.txt", false)] // Not fully qualified, needs expansion
+    public void IsFullyQualified_UnixSpecificPaths(string path, bool expected)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        MSBuildSpecification spec = new(path);
+        spec.IsFullyQualified.Should().Be(expected);
+    }
+#endif
+
+    // TODO: Add Windows specific tests for UNCs.
+
+    [Theory]
+    [InlineData("**", true)]
+    [InlineData("**/", true)]
+    [InlineData("/**/", true)]
+    [InlineData("a/**", true)]
+    [InlineData("a/**/", true)]
+    [InlineData("a/b/**", true)]
+    [InlineData("**/file.txt", true)]
+    [InlineData("a/**/file.txt", true)]
+    [InlineData("a/*/file.txt", false)]
+    [InlineData("a/?/file.txt", false)]
+    [InlineData("a/?/**/file.txt", false)]
+    [InlineData("a/b/*.txt", false)]
+    [InlineData("a/b/**/c", true)]
+    public void SimpleRecursiveMatch_IsSetCorrectly(string pattern, bool expected)
+    {
+        MSBuildSpecification spec = new(pattern);
+        spec.IsSimpleRecursiveMatch.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Unescape_ReturnsOriginalSegment_WhenNoEscapeCharacters()
+    {
+        StringSegment original = "file.txt";
+        StringSegment result = MSBuildSpecification.Unescape(original);
+        result.Should().Be(original);
+    }
+
+    [Theory]
+    [InlineData("file%2A.txt", "file*.txt")]
+    [InlineData("file%3F.txt", "file?.txt")]
+    [InlineData("file%25.txt", "file%.txt")]
+    [InlineData("file%20name.txt", "file name.txt")]
+    [InlineData("file%invalidhex.txt", "file%invalidhex.txt")]
+    [InlineData("file%2", "file%2")]
+    [InlineData("file%", "file%")]
+    public void Unescape_HandlesEscapeSequences(string escaped, string expected)
+    {
+        StringSegment result = MSBuildSpecification.Unescape(escaped);
+        result.ToString().Should().Be(expected);
+    }
+
+    [Fact]
+    public void Normalize_NoSeparators_ReturnsOriginalSegment()
+    {
+        StringSegment segment = new("HelloWorld");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.Should().Be(segment);
+    }
+
+    [Fact]
+    public void Normalize_SingleForwardSlash_NormalizesToPlatformSeparator()
+    {
+        StringSegment segment = new("Hello/World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_SingleBackslash_NormalizesToPlatformSeparator()
+    {
+        StringSegment segment = new(@"Hello\World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_ConsecutiveForwardSlashes_CollapsesToSingle()
+    {
+        StringSegment segment = new("Hello////World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_ConsecutiveBackslashes_CollapsesToSingle()
+    {
+        StringSegment segment = new(@"Hello\\\\World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_MixedSeparators_NormalizesCorrectly()
+    {
+        StringSegment segment = new(@"Hello\/\/\World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_LeadingSeparator_Preserved()
+    {
+        StringSegment segment = new("/Hello/World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("/Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_TrailingSeparator_Preserved()
+    {
+        StringSegment segment = new("Hello/World/");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World/"));
+    }
+
+    [Fact]
+    public void Normalize_MultipleSeparatorsInPath_AllNormalized()
+    {
+        StringSegment segment = new("path/to/some/file.txt");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("path/to/some/file.txt"));
+    }
+
+    [Fact]
+    public void Normalize_EmptySegment_ReturnsEmptySegment()
+    {
+        StringSegment segment = new("");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Normalize_MixedConsecutiveSeparators()
+    {
+        StringSegment segment = new("Hello/\\//\\World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_LeadingWhitespace_IsTrimmed()
+    {
+        StringSegment segment = new("  Hello/World");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_TrailingWhitespace_IsTrimmed()
+    {
+        StringSegment segment = new("Hello/World  ");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_LeadingAndTrailingWhitespace_IsTrimmed()
+    {
+        StringSegment segment = new("  Hello/World  ");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/World"));
+    }
+
+    [Fact]
+    public void Normalize_WhitespaceBetweenSeparators_IsPreserved()
+    {
+        StringSegment segment = new("Hello/ World/Test");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello/ World/Test"));
+    }
+
+    [Fact]
+    public void Normalize_OnlyWhitespace_ReturnsEmptySegment()
+    {
+        StringSegment segment = new("   ");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Normalize_WhitespaceAroundSeparators_IsPreserved()
+    {
+        StringSegment segment = new("Hello / World \\ Test");
+        StringSegment result = MSBuildSpecification.Normalize(segment);
+
+        result.ToString().Should().Be(Sep("Hello / World / Test"));
+    }
+
+    [Fact]
+    public void Split_EmptyString_ReturnsEmptyList()
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split("", ignoreCase: false);
+        specs.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Split_SingleSpec_ReturnsSingleItem()
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split("file.txt", ignoreCase: false);
+        specs.Count.Should().Be(1);
+        specs[0].Normalized.ToString().Should().Be("file.txt");
+    }
+
+    [Fact]
+    public void Split_MultipleSpecs_ReturnsMultipleItems()
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split(
+            Paths.ChangeAlternateDirectorySeparators("file.txt;*.cs;docs/**"),
+            ignoreCase: false);
+
+        specs.Count.Should().Be(3);
+        specs[0].Normalized.ToString().Should().Be("file.txt");
+        specs[1].Normalized.ToString().Should().Be("*.cs");
+        specs[2].Normalized.ToString().Should().Be(Paths.ChangeAlternateDirectorySeparators("docs/**"));
+    }
+
+    [Fact]
+    public void Split_WithEmptySegments_IgnoresEmptySegments()
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split("file.txt;;*.cs;", ignoreCase: false);
+        specs.Count.Should().Be(2);
+        specs[0].Normalized.ToString().Should().Be("file.txt");
+        specs[1].Normalized.ToString().Should().Be("*.cs");
+    }
+
+    [Fact]
+    public void Split_WithDuplicates_SkipsDuplicates()
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split("file.txt;file.txt;*.cs", ignoreCase: false);
+        specs.Count.Should().Be(2);
+        specs[0].Normalized.ToString().Should().Be("file.txt");
+        specs[1].Normalized.ToString().Should().Be("*.cs");
+    }
+
+    [Fact]
+    public void Split_CaseInsensitive_SkipsCaseInsensitiveDuplicates()
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split("file.txt;FILE.txt;*.cs", ignoreCase: true);
+        specs.Count.Should().Be(2);
+        specs[0].Normalized.ToString().Should().Be("file.txt");
+        specs[1].Normalized.ToString().Should().Be("*.cs");
+    }
+
+    [Fact]
+    public void Split_EmptyInput_ReturnsEmptySegments()
+    {
+        StringSegment specs = new("");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+        splitSpecs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Split_SingleWildcardSpec_ReturnsWildcardSpec()
+    {
+        StringSegment specs = new("*.txt");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["*.txt"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_SingleLiteralSpec_ReturnsLiteralSpec()
+    {
+        StringSegment specs = new("file.txt");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["file.txt"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_MultipleWildcardSpecs_ReturnsFirstAndList()
+    {
+        StringSegment specs = new("*.txt;*.cs;*.md");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["*.txt", "*.cs", "*.md"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_MultipleLiteralSpecs_ReturnsFirstAndList()
+    {
+        StringSegment specs = new("file1.txt;file2.txt;file3.txt");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["file1.txt", "file2.txt", "file3.txt"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_MixedSpecs_SeparatesCorrectly()
+    {
+        StringSegment specs = new("file1.txt;*.cs;file2.txt;*.md");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["file1.txt", "*.cs", "file2.txt", "*.md"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_DuplicateSpecs_DeduplicatesSpecs()
+    {
+        StringSegment specs = new("file.txt;file.txt;*.cs;*.cs");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["file.txt", "*.cs"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_CaseSensitiveDuplicates_WithIgnoreCaseFalse_KeepsBoth()
+    {
+        StringSegment specs = new("FILE.TXT;file.txt;*.CS;*.cs");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["FILE.TXT", "file.txt", "*.CS", "*.cs"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_CaseSensitiveDuplicates_WithIgnoreCaseTrue_DeduplicatesSpecs()
+    {
+        StringSegment specs = new("FILE.TXT;file.txt;*.CS;*.cs");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: true);
+
+        splitSpecs.Should().Equal(["FILE.TXT", "*.CS"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_DifferentSeparators_NormalizesSeparators()
+    {
+        StringSegment specs = new($"path/to/file.txt;path{Path.DirectorySeparatorChar}to{Path.DirectorySeparatorChar}other.txt");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Select(s => s.ToString()).Should().Equal(
+            [
+                $"path{Path.DirectorySeparatorChar}to{Path.DirectorySeparatorChar}file.txt",
+                $"path{Path.DirectorySeparatorChar}to{Path.DirectorySeparatorChar}other.txt"
+            ]);
+
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_ConsecutiveSeparators_CollapsesToSingle()
+    {
+        StringSegment specs = new("path//to////file.txt");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Select(s => s.ToString()).Should().Equal([Sep("path/to/file.txt")]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_EmptySegments_SkipsEmptySegments()
+    {
+        StringSegment specs = new(";file.txt;;*.cs;");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().Equal(["file.txt", "*.cs"]);
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_OnlySemicolons_ReturnsEmptySegments()
+    {
+        StringSegment specs = new(";;;;");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Should().BeEmpty();
+        splitSpecs.Dispose();
+    }
+
+    [Fact]
+    public void Split_MultipleWildcardTypes()
+    {
+        StringSegment specs = new("file?.txt;dir*/file.txt;**/*.cs");
+        var splitSpecs = MSBuildSpecification.Split(specs, ignoreCase: false);
+
+        splitSpecs.Select(s => s.ToString()).Should().Equal(
+            [
+                "file?.txt",
+                $"dir*{Path.DirectorySeparatorChar}file.txt",
+                $"**{Path.DirectorySeparatorChar}*.cs"
+            ]);
+
+        splitSpecs.Dispose();
+    }
+
+
+    public static TheoryData<string, bool, string[]> SplitData { get; } = new()
+    {
+        {
+            "file.txt;*.cs;docs/**",
+            true,
+            new[] { "file.txt", "*.cs", Sep("docs/**") }
+        },
+        { "file.txt;;*.cs;", true, new[] { "file.txt", "*.cs" } },
+        { "file.txt;file.txt;*.cs", true, new[] { "file.txt", "*.cs" } },
+        { "file.txt;FILE.txt;*.cs", true, new[] { "file.txt", "*.cs" } },
+        { "", true, Array.Empty<string>() },
+        {
+            // This is the actual exclude spec for "**/*.cs" currently
+            @"bin\Debug\/**;obj\Debug\/**;bin\/**;obj\/**;**/*.user;**/*.*proj;**/*.sln;**/*.slnx;**/*.vssscc;**/.DS_Store",
+            true,
+            new[]
+            {
+                Sep(@"bin/**"),
+                Sep(@"obj/**"),
+                Sep("**/*.user"),
+                Sep("**/*.*proj"),
+                Sep("**/*.sln"),
+                Sep("**/*.slnx"),
+                Sep("**/*.vssscc"),
+                Sep("**/.DS_Store")
+            }
+        },
+        {
+            @"bin\/**;obj\/**;bin\Debug\/**;obj\Debug\/**;",
+            true,
+            new[]
+            {
+                Sep(@"bin/**"),
+                Sep(@"obj/**"),
+            }
+        }
+    };
+
+    [Theory]
+    [MemberData(nameof(SplitData))]
+    public void Split_ReturnsExpectedResults(string input, bool ignoreCase, string[] expected)
+    {
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split(input, ignoreCase: ignoreCase);
+        specs.Count.Should().Be(expected.Length);
+        for (int i = 0; i < expected.Length; i++)
+        {
+            specs[i].Normalized.ToString().Should().Be(expected[i]);
+        }
+    }
+
+    [Fact]
+    public void UnescapeSegment_NoEscapeCharacters_ReturnsSameSegment()
+    {
+        string original = "HelloWorld";
+        StringSegment segment = new(original);
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.ToString().Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void UnescapeSegment_ValidEscapeSequences_Unescapes()
+    {
+        StringSegment segment = new("Hello%20World%2A%3F%25");
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.Should().Be("Hello World*?%");
+    }
+
+    [Fact]
+    public void UnescapeSegment_InvalidEscapeSequences_LeftAsIs()
+    {
+        string original = "Hello%2World%G%";
+        StringSegment segment = new(original);
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.ToString().Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void UnescapeSegment_EmptyString_ReturnsEmptySegment()
+    {
+        StringSegment segment = new(string.Empty);
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnescapeSegment_IncompleteEscapeSequence_PreservesOriginal()
+    {
+        string original = "Hello%World";
+        StringSegment segment = new(original);
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.ToString().Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void UnescapeSegment_EscapeSequencesAtBoundaries_Unescapes()
+    {
+        StringSegment segment = new("%20Hello%20");
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.Should().Be(" Hello ");
+    }
+
+    [Fact]
+    public void UnescapeSegment_EscapeSequenceWithControlCharacters_Unescapes()
+    {
+        StringSegment segment = new("Hello%0AWorld%09Tab");
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.Should().Be("Hello\nWorld\tTab");
+    }
+
+    [Fact]
+    public void UnescapeSegment_LongSegmentWithEscapes_Unescapes()
+    {
+        // Create a segment longer than 256 chars with escapes to test buffer handling
+        string longString = new string('a', 250) + "%20%25%2A";
+        StringSegment segment = new(longString);
+        StringSegment result = MSBuildSpecification.Unescape(segment);
+
+        result.Should().Be(new string('a', 250) + " %*");
+    }
+
+
+    [Fact]
+    public void Equals_SameOriginalString_ReturnsTrue()
+    {
+        MSBuildSpecification spec1 = new("file.txt");
+        MSBuildSpecification spec2 = new("file.txt");
+
+        spec1.Equals(spec2).Should().BeTrue();
+        spec1.Equals("file.txt").Should().BeTrue();
+        spec1.Equals(new StringSegment("file.txt")).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentCase_ReturnsTrue()
+    {
+        MSBuildSpecification spec1 = new("file.txt");
+        MSBuildSpecification spec2 = new("FILE.TXT");
+
+        spec1.Equals(spec2).Should().BeTrue();
+        spec1.Equals("FILE.TXT").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_DifferentPaths_ReturnsFalse()
+    {
+        MSBuildSpecification spec1 = new("file.txt");
+        MSBuildSpecification spec2 = new("file.cs");
+
+        spec1.Equals(spec2).Should().BeFalse();
+        spec1.Equals("file.cs").Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_SameOriginalString_ReturnsSameHashCode()
+    {
+        MSBuildSpecification spec1 = new("file.txt");
+        MSBuildSpecification spec2 = new("file.txt");
+
+        spec1.GetHashCode().Should().Be(spec2.GetHashCode());
+    }
+
+    [Fact]
+    public void ImplicitConversions_WorkAsExpected()
+    {
+        MSBuildSpecification specFromString = "file.txt";
+        specFromString.Original.ToString().Should().Be("file.txt");
+
+        MSBuildSpecification specFromSegment = new StringSegment("file.txt");
+        specFromSegment.Original.ToString().Should().Be("file.txt");
+
+        StringSegment segmentFromSpec = new MSBuildSpecification("file.txt");
+        segmentFromSpec.ToString().Should().Be("file.txt");
+
+        string stringFromSpec = (string)new MSBuildSpecification("file.txt");
+        stringFromSpec.Should().Be("file.txt");
+    }
+}

--- a/touki.tests/Touki/Io/MatchAnyTests.cs
+++ b/touki.tests/Touki/Io/MatchAnyTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+public class MatchAnyTests
+{
+    [Theory]
+    [InlineData("temp", "temp", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("temp", "TEMP", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    [InlineData("temp", "TEMP", MatchType.Simple, MatchCasing.CaseInsensitive, true)]
+    [InlineData("temp*", "tempdir", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("temp*", "other", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    public void MatchAnyDirectory_MatchesDirectory_ReturnsExpectedResult(
+        string pattern,
+        string directoryName,
+        MatchType matchType,
+        MatchCasing matchCasing,
+        bool expectedResult)
+    {
+        IEnumerationMatcher matcher = new MatchAnyDirectory(
+            pattern,
+            matchType,
+            matchCasing);
+
+        matcher.MatchesDirectory("".AsSpan(), directoryName.AsSpan()).Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void MatchAnyDirectory_WithMultipleSpecs_MatchesAny()
+    {
+        MatchAnyDirectory matcher = new(
+            "docs",
+            MatchType.Simple,
+            MatchCasing.CaseSensitive);
+
+        matcher.AddSpec("src");
+        matcher.AddSpec("build*");
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory("".AsSpan(), "docs".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "src".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "build".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "build-output".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "tests".AsSpan()).Should().BeFalse();
+        iMatcher.MatchesDirectory("".AsSpan(), "SRC".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchAnyDirectory_AddSpec_HandlesDuplicates()
+    {
+        MatchAnyDirectory matcher = new(
+            "src",
+            MatchType.Simple,
+            MatchCasing.CaseInsensitive);
+
+        matcher.AddSpec("docs").Should().BeTrue();
+        matcher.AddSpec("src").Should().BeFalse();
+        matcher.AddSpec("SRC").Should().BeFalse();
+        matcher.AddSpec("docs").Should().BeFalse();
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory("".AsSpan(), "src".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "SRC".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "docs".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesDirectory("".AsSpan(), "build".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchAnyDirectory_MatchesFile_AlwaysReturnsFalse()
+    {
+        IEnumerationMatcher matcher = new MatchAnyDirectory(
+            "any",
+            MatchType.Simple,
+            MatchCasing.CaseSensitive);
+
+        bool result = matcher.MatchesFile("".AsSpan(), "file.txt".AsSpan());
+
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("file.txt", "file.txt", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("file.txt", "FILE.TXT", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    [InlineData("file.txt", "FILE.TXT", MatchType.Simple, MatchCasing.CaseInsensitive, true)]
+    [InlineData("*.txt", "file.txt", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("*.txt", "file.doc", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    public void MatchAnyFile_MatchesFile_ReturnsExpectedResult(
+        string pattern,
+        string fileName,
+        MatchType matchType,
+        MatchCasing matchCasing,
+        bool expectedResult)
+    {
+        // Create the matcher
+        IEnumerationMatcher matcher = new MatchAnyFile(
+            pattern,
+            matchType,
+            matchCasing);
+
+        matcher.MatchesFile("".AsSpan(), fileName.AsSpan()).Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void MatchAnyFile_WithMultipleSpecs_MatchesAny()
+    {
+        MatchAnyFile matcher = new(
+            "*.txt",
+            MatchType.Simple,
+            MatchCasing.CaseSensitive);
+
+        matcher.AddSpec("*.log");
+        matcher.AddSpec("data.csv");
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile("".AsSpan(), "file1.txt".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesFile("".AsSpan(), "file2.log".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesFile("".AsSpan(), "data.csv".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesFile("".AsSpan(), "file3.doc".AsSpan()).Should().BeFalse();
+        iMatcher.MatchesFile("".AsSpan(), "other.dat".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchAnyFile_AddSpec_HandlesDuplicates()
+    {
+        MatchAnyFile matcher = new(
+            "*.txt",
+            MatchType.Simple,
+            MatchCasing.CaseInsensitive);
+
+        matcher.AddSpec("*.log").Should().BeTrue();
+        matcher.AddSpec("*.txt").Should().BeFalse();
+        matcher.AddSpec("*.TXT").Should().BeFalse();
+        matcher.AddSpec("*.log").Should().BeFalse();
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile("".AsSpan(), "file.txt".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesFile("".AsSpan(), "FILE.TXT".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesFile("".AsSpan(), "file.log".AsSpan()).Should().BeTrue();
+        iMatcher.MatchesFile("".AsSpan(), "file.csv".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchAnyFile_MatchesDirectory_AlwaysReturnsTrue()
+    {
+        IEnumerationMatcher matcher = new MatchAnyFile(
+            "any",
+            MatchType.Simple,
+            MatchCasing.CaseSensitive);
+
+        matcher.MatchesDirectory("".AsSpan(), "dir".AsSpan()).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("/root", "file.txt", "/root", "file.txt", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("/root", "file.txt", "/root/subdir", "file.txt", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("/root", "file.txt", "/other", "file.txt", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    [InlineData("/root", "*.txt", "/root", "file.txt", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("/root", "*.txt", "/root", "file.doc", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    public void MatchAnyFileAfter_MatchesFile_ReturnsExpectedResult(
+        string rootPath,
+        string pattern,
+        string currentDir,
+        string fileName,
+        MatchType matchType,
+        MatchCasing matchCasing,
+        bool expectedResult)
+    {
+        IEnumerationMatcher matcher = new MatchAnyFile(
+            pattern,
+            rootPath,
+            matchType,
+            matchCasing);
+
+        matcher.MatchesFile(currentDir.AsSpan(), fileName.AsSpan()).Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void MatchAnyFile_MatchesDirectory_ReturnsExpectedResult()
+    {
+        IEnumerationMatcher matcher = new MatchAnyFile(
+            "*.txt",
+            "/root",
+            MatchType.Simple,
+            MatchCasing.CaseSensitive);
+
+        matcher.MatchesDirectory("/root".AsSpan(), "subdir".AsSpan()).Should().BeTrue();
+        matcher.DirectoryFinished();
+        matcher.MatchesDirectory("/foo".AsSpan(), "subdir".AsSpan()).Should().BeFalse();
+    }
+
+
+    [Theory]
+    [InlineData("/root", "subdir", "/root", "subdir", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("/root", "subdir", "/root/parent", "subdir", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("/root", "subdir", "/other", "subdir", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    [InlineData("/root", "sub*", "/root", "subdir", MatchType.Simple, MatchCasing.CaseSensitive, true)]
+    [InlineData("/root", "sub*", "/root", "other", MatchType.Simple, MatchCasing.CaseSensitive, false)]
+    public void MatchAnyDirectory_MatchesDirectory_WithRoot_ReturnsExpectedResult(
+        string rootPath,
+        string pattern,
+        string currentDir,
+        string dirName,
+        MatchType matchType,
+        MatchCasing matchCasing,
+        bool expectedResult)
+    {
+        IEnumerationMatcher matcher = new MatchAnyDirectory(
+            pattern,
+            rootPath,
+            matchType,
+            matchCasing);
+
+        matcher.MatchesDirectory(currentDir.AsSpan(), dirName.AsSpan()).Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void MatchAnyDirectoryAfter_MatchesFile_AlwaysReturnsFalse()
+    {
+        IEnumerationMatcher matcher = new MatchAnyDirectory(
+            "/root",
+            "subdir",
+            MatchType.Simple,
+            MatchCasing.CaseSensitive);
+
+        matcher.MatchesFile("/root".AsSpan(), "file.txt".AsSpan()).Should().BeFalse();
+    }
+}

--- a/touki.tests/Touki/Io/MatchSetTests.cs
+++ b/touki.tests/Touki/Io/MatchSetTests.cs
@@ -1,0 +1,305 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+public class MatchSetTests
+{
+    [Fact]
+    public void Constructor_NullMatcher_ThrowsArgumentNullException()
+    {
+        Action action = () => new MatchSet(null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddInclude_NullMatcher_ThrowsArgumentNullException()
+    {
+        using MatchSet matchSet = new(new MockMatcher());
+        Action action = () => matchSet.AddInclude(null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void AddExclude_NullMatcher_ThrowsArgumentNullException()
+    {
+        using MatchSet matchSet = new(new MockMatcher());
+        Action action = () => matchSet.AddExclude(null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void MatchesDirectory_SingleInclude_Matches()
+    {
+        using IEnumerationMatcher matcher = new MatchSet(
+            new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        matcher.MatchesDirectory(string.Empty, "src").Should().BeTrue();
+        matcher.MatchesDirectory(string.Empty, "docs").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_SingleInclude_Matches()
+    {
+        using IEnumerationMatcher matcher = new MatchSet(
+            new MatchAnyFile("*.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        matcher.MatchesFile(string.Empty, "file.txt").Should().BeTrue();
+        matcher.MatchesFile(string.Empty, "file.doc").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_MultipleIncludes_MatchesAny()
+    {
+        using MatchSet matcher = new(new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddInclude(new MatchAnyDirectory("docs", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory(string.Empty, "src").Should().BeTrue();
+        iMatcher.MatchesDirectory(string.Empty, "docs").Should().BeTrue();
+        iMatcher.MatchesDirectory(string.Empty, "build").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_MultipleIncludes_MatchesAny()
+    {
+        using MatchSet matcher = new(new MatchAnyFile("*.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddInclude(new MatchAnyFile("*.log", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile(string.Empty, "file.txt").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "file.log").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "file.doc").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_ExcludeOverridesInclude()
+    {
+        using MatchSet matcher = new(new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddExclude(new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory(string.Empty, "src").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_ExcludeOverridesInclude()
+    {
+        using MatchSet matcher = new(new MatchAnyFile("*.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddExclude(new MatchAnyFile("important.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile(string.Empty, "file.txt").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "important.txt").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_ExcludeWithoutInclude_NoMatch()
+    {
+        using MatchSet matcher = new(new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddExclude(new MatchAnyDirectory("docs", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory(string.Empty, "src").Should().BeTrue();
+        iMatcher.MatchesDirectory(string.Empty, "docs").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_ExcludeWithoutInclude_NoMatch()
+    {
+        using MatchSet matcher = new(new MatchAnyFile("*.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddExclude(new MatchAnyFile("*.log", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile(string.Empty, "file.txt").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "file.log").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_NoIncludesMatch_ReturnsFalse()
+    {
+        using MatchSet matcher = new(new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddInclude(new MatchAnyDirectory("docs", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory(string.Empty, "build").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_NoIncludesMatch_ReturnsFalse()
+    {
+        using MatchSet matcher = new(new MatchAnyFile("*.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddInclude(new MatchAnyFile("*.log", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile(string.Empty, "file.doc").Should().BeFalse();
+    }
+
+    [Fact]
+    public void DirectoryFinished_CallsDirectoryFinishedOnAllMatchers()
+    {
+        MockMatcher include1 = new();
+        MockMatcher include2 = new();
+        MockMatcher exclude1 = new();
+        MockMatcher exclude2 = new();
+
+        using MatchSet matcher = new(include1);
+        matcher.AddInclude(include2);
+        matcher.AddExclude(exclude1);
+        matcher.AddExclude(exclude2);
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.DirectoryFinished();
+
+        include1.DirectoryFinishedCount.Should().Be(1);
+        include2.DirectoryFinishedCount.Should().Be(1);
+        exclude1.DirectoryFinishedCount.Should().Be(1);
+        exclude2.DirectoryFinishedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void DirectoryFinished_NoExcludes_CallsDirectoryFinishedOnIncludes()
+    {
+        MockMatcher include1 = new();
+        MockMatcher include2 = new();
+
+        using MatchSet matcher = new(include1);
+        matcher.AddInclude(include2);
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.DirectoryFinished();
+
+        include1.DirectoryFinishedCount.Should().Be(1);
+        include2.DirectoryFinishedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public void Dispose_DoesNotDisposeMatchers()
+    {
+        MockMatcher include1 = new();
+        MockMatcher include2 = new();
+        MockMatcher exclude1 = new();
+        MockMatcher exclude2 = new();
+
+        MatchSet matcher = new(include1);
+        matcher.AddInclude(include2);
+        matcher.AddExclude(exclude1);
+        matcher.AddExclude(exclude2);
+
+        matcher.Dispose();
+
+        include1.IsDisposed.Should().BeFalse();
+        include2.IsDisposed.Should().BeFalse();
+        exclude1.IsDisposed.Should().BeFalse();
+        exclude2.IsDisposed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_ComplexScenario_WorksCorrectly()
+    {
+        using MatchSet matcher = new(new MatchAnyDirectory("src", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddInclude(new MatchAnyDirectory("test*", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddExclude(new MatchAnyDirectory("test-utils", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory(string.Empty, "src").Should().BeTrue();
+        iMatcher.MatchesDirectory(string.Empty, "tests").Should().BeTrue();
+        iMatcher.MatchesDirectory(string.Empty, "test-utils").Should().BeFalse();
+        iMatcher.MatchesDirectory(string.Empty, "docs").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_ComplexScenario_WorksCorrectly()
+    {
+        using MatchSet matcher = new(new MatchAnyFile("*.cs", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddInclude(new MatchAnyFile("*.txt", MatchType.Simple, MatchCasing.CaseSensitive));
+        matcher.AddExclude(new MatchAnyFile("*Test*", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile(string.Empty, "Program.cs").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "readme.txt").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "TestFile.cs").Should().BeFalse();
+        iMatcher.MatchesFile(string.Empty, "Test.txt").Should().BeFalse();
+        iMatcher.MatchesFile(string.Empty, "file.doc").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_WithMockMatchers_EvaluatesCorrectly()
+    {
+        MockMatcher include1 = new() { OnMatchesDirectory = (_, name) => name == "include1" };
+        MockMatcher include2 = new() { OnMatchesDirectory = (_, name) => name == "include2" };
+        MockMatcher exclude1 = new() { OnMatchesDirectory = (_, name) => name == "exclude1" };
+        MockMatcher exclude2 = new() { OnMatchesDirectory = (_, name) => name == "include1" }; // Excludes include1
+
+        using MatchSet matcher = new(include1);
+        matcher.AddInclude(include2);
+        matcher.AddExclude(exclude1);
+        matcher.AddExclude(exclude2);
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesDirectory(string.Empty, "include1").Should().BeFalse(); // Excluded by exclude2
+        iMatcher.MatchesDirectory(string.Empty, "include2").Should().BeTrue();
+        iMatcher.MatchesDirectory(string.Empty, "exclude1").Should().BeFalse();
+        iMatcher.MatchesDirectory(string.Empty, "other").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_WithMockMatchers_EvaluatesCorrectly()
+    {
+        MockMatcher include1 = new() { OnMatchesFile = (_, name) => name == "file1.txt" };
+        MockMatcher include2 = new() { OnMatchesFile = (_, name) => name == "file2.txt" };
+        MockMatcher exclude1 = new() { OnMatchesFile = (_, name) => name == "excluded.txt" };
+        MockMatcher exclude2 = new() { OnMatchesFile = (_, name) => name == "file1.txt" }; // Excludes file1.txt
+
+        using MatchSet matcher = new(include1);
+        matcher.AddInclude(include2);
+        matcher.AddExclude(exclude1);
+        matcher.AddExclude(exclude2);
+
+        IEnumerationMatcher iMatcher = matcher;
+        iMatcher.MatchesFile(string.Empty, "file1.txt").Should().BeFalse(); // Excluded by exclude2
+        iMatcher.MatchesFile(string.Empty, "file2.txt").Should().BeTrue();
+        iMatcher.MatchesFile(string.Empty, "excluded.txt").Should().BeFalse();
+        iMatcher.MatchesFile(string.Empty, "other.txt").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesDirectory_EmptyStrings_HandledCorrectly()
+    {
+        // Should never see an empty string, just make sure it doesn't throw.
+        using NoAssertContext context = new();
+        using IEnumerationMatcher matcher = new MatchSet(
+            new MatchAnyDirectory("", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        matcher.MatchesDirectory(string.Empty, string.Empty).Should().BeFalse();
+        matcher.MatchesDirectory(string.Empty, "anydir").Should().BeFalse();
+    }
+
+    [Fact]
+    public void MatchesFile_EmptyStrings_HandledCorrectly()
+    {
+        // Should never see an empty string, just make sure it doesn't throw.
+        using NoAssertContext context = new();
+        using IEnumerationMatcher matcher = new MatchSet(
+            new MatchAnyFile("", MatchType.Simple, MatchCasing.CaseSensitive));
+
+        matcher.MatchesFile(string.Empty, string.Empty).Should().BeFalse();
+        matcher.MatchesFile(string.Empty, "anyfile.txt").Should().BeFalse();
+    }
+
+    private sealed class MockMatcher : IEnumerationMatcher
+    {
+        public int DirectoryFinishedCount { get; private set; }
+        public bool IsDisposed { get; private set; }
+        public Func<string, string, bool> OnMatchesDirectory { get; set; } = (_, _) => false;
+        public Func<string, string, bool> OnMatchesFile { get; set; } = (_, _) => false;
+
+        public void DirectoryFinished() => DirectoryFinishedCount++;
+        public void Dispose() => IsDisposed = true;
+        public bool MatchesDirectory(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> directoryName) =>
+            OnMatchesDirectory(currentDirectory.ToString(), directoryName.ToString());
+        public bool MatchesFile(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> fileName) =>
+            OnMatchesFile(currentDirectory.ToString(), fileName.ToString());
+    }
+}

--- a/touki.tests/Touki/Io/VirtualPathTests.cs
+++ b/touki.tests/Touki/Io/VirtualPathTests.cs
@@ -5,86 +5,86 @@
 namespace Touki.Io;
 
 /// <summary>
-///  Tests for <see cref="VirtualPath"/>.
+///  Tests for <see cref="PathSegmentEnumerator"/>.
 /// </summary>
 public class VirtualPathTests
 {
     [Fact]
     public void VirtualPath_SinglePath_ConstructsCorrectly()
     {
-        VirtualPath path = new($"test{Path.DirectorySeparatorChar}path".AsSpan());
+        PathSegmentEnumerator path = new(Paths.ChangeAlternateDirectorySeparators("test/path"));
 
         path.Length.Should().Be(9);
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_TwoPaths_WithoutSeparators_ConstructsCorrectly()
     {
-        VirtualPath path = new("first".AsSpan(), "second".AsSpan());
+        PathSegmentEnumerator path = new("first", "second");
 
         path.Length.Should().Be(12); // 5 + 6 + 1 (virtual separator)
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_TwoPaths_FirstEndsWithSeparator_ConstructsCorrectly()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}".AsSpan(), "second".AsSpan());
+        PathSegmentEnumerator path = new(Paths.ChangeAlternateDirectorySeparators("first/"), "second");
 
         path.Length.Should().Be(12); // 6 + 6 (no virtual separator needed)
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_TwoPaths_SecondStartsWithSeparator_ConstructsCorrectly()
     {
-        VirtualPath path = new("first".AsSpan(), $"{Path.DirectorySeparatorChar}second".AsSpan());
+        PathSegmentEnumerator path = new("first", Paths.ChangeAlternateDirectorySeparators("/second"));
 
         path.Length.Should().Be(12); // 5 + 7 (no virtual separator needed)
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_TwoPaths_BothHaveSeparators_ConstructsCorrectly()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}".AsSpan(), $"{Path.DirectorySeparatorChar}second".AsSpan());
+        PathSegmentEnumerator path = new($"first{Path.DirectorySeparatorChar}", $"{Path.DirectorySeparatorChar}second");
 
         path.Length.Should().Be(13); // 6 + 7 (no virtual separator needed)
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_EmptyFirstPath_ConstructsCorrectly()
     {
-        VirtualPath path = new("".AsSpan(), "second".AsSpan());
+        PathSegmentEnumerator path = new("", "second");
 
         path.Length.Should().Be(6);
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_EmptySecondPath_ConstructsCorrectly()
     {
-        VirtualPath path = new("first".AsSpan(), "".AsSpan());
+        PathSegmentEnumerator path = new("first", "");
 
         path.Length.Should().Be(5);
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_BothPathsEmpty_ConstructsCorrectly()
     {
-        VirtualPath path = new("".AsSpan(), "".AsSpan());
+        PathSegmentEnumerator path = new("", "");
 
         path.Length.Should().Be(0);
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_Indexer_FirstPath_ReturnsCorrectCharacters()
     {
-        VirtualPath path = new("hello".AsSpan(), "world".AsSpan());
+        PathSegmentEnumerator path = new("hello", "world");
 
         path[0].Should().Be('h');
         path[1].Should().Be('e');
@@ -96,7 +96,7 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_Indexer_VirtualSeparator_ReturnsDirectorySeparator()
     {
-        VirtualPath path = new("hello".AsSpan(), "world".AsSpan());
+        PathSegmentEnumerator path = new("hello", "world");
 
         path[5].Should().Be(Path.DirectorySeparatorChar);
     }
@@ -104,7 +104,7 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_Indexer_SecondPath_ReturnsCorrectCharacters()
     {
-        VirtualPath path = new("hello".AsSpan(), "world".AsSpan());
+        PathSegmentEnumerator path = new("hello", "world");
 
         path[6].Should().Be('w');
         path[7].Should().Be('o');
@@ -116,7 +116,7 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_Indexer_WithExistingSeparators_ReturnsCorrectCharacters()
     {
-        VirtualPath path = new($"hello{Path.DirectorySeparatorChar}".AsSpan(), $"{Path.DirectorySeparatorChar}world".AsSpan());
+        PathSegmentEnumerator path = new($"hello{Path.DirectorySeparatorChar}", $"{Path.DirectorySeparatorChar}world");
 
         path[0].Should().Be('h');
         path[5].Should().Be(Path.DirectorySeparatorChar);
@@ -127,209 +127,211 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_MoveNextSegment_SingleSegment_ReturnsSegment()
     {
-        VirtualPath path = new("hello".AsSpan());
+        PathSegmentEnumerator path = new("hello");
 
-        bool result = path.MoveNextSegment();
+        bool result = path.MoveNext();
 
         result.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("hello");
+        path.Current.ToString().Should().Be("hello");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_NoMoreSegments_ReturnsFalse()
     {
-        VirtualPath path = new("hello".AsSpan());
+        PathSegmentEnumerator path = new("hello");
 
-        path.MoveNextSegment(); // First call
-        bool result = path.MoveNextSegment(); // Second call
+        path.MoveNext(); // First call
+        bool result = path.MoveNext(); // Second call
 
         result.Should().BeFalse();
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_MultipleSegments_ReturnsEachSegment()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}third".AsSpan());
+        PathSegmentEnumerator path = new($"first{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}third");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
 
-        bool result3 = path.MoveNextSegment();
+        bool result3 = path.MoveNext();
         result3.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("third");
+        path.Current.ToString().Should().Be("third");
 
-        bool result4 = path.MoveNextSegment();
+        bool result4 = path.MoveNext();
         result4.Should().BeFalse();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_TwoPaths_ReturnsAllSegments()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}second".AsSpan(), $"third{Path.DirectorySeparatorChar}fourth".AsSpan());
+        PathSegmentEnumerator path = new($"first{Path.DirectorySeparatorChar}second", $"third{Path.DirectorySeparatorChar}fourth");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
 
-        bool result3 = path.MoveNextSegment();
+        bool result3 = path.MoveNext();
         result3.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("third");
+        path.Current.ToString().Should().Be("third");
 
-        bool result4 = path.MoveNextSegment();
+        bool result4 = path.MoveNext();
         result4.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("fourth");
+        path.Current.ToString().Should().Be("fourth");
 
-        bool result5 = path.MoveNextSegment();
+        bool result5 = path.MoveNext();
         result5.Should().BeFalse();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_LeadingSeparators_SkipsSeparators()
     {
-        VirtualPath path = new($"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}first{Path.DirectorySeparatorChar}second".AsSpan());
+        PathSegmentEnumerator path = new($"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}first{Path.DirectorySeparatorChar}second");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_TrailingSeparators_IgnoresTrailingSeparators()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}".AsSpan());
+        PathSegmentEnumerator path = new($"first{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
 
-        bool result3 = path.MoveNextSegment();
+        bool result3 = path.MoveNext();
         result3.Should().BeFalse();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_ConsecutiveSeparators_SkipsEmptySegments()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}third".AsSpan());
+        PathSegmentEnumerator path = new($"first{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}third");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
 
-        bool result3 = path.MoveNextSegment();
+        bool result3 = path.MoveNext();
         result3.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("third");
+        path.Current.ToString().Should().Be("third");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_OnlySeparators_ReturnsFalse()
     {
-        VirtualPath path = new($"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}".AsSpan());
+        PathSegmentEnumerator path = new($"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}");
 
-        bool result = path.MoveNextSegment();
+        bool result = path.MoveNext();
 
         result.Should().BeFalse();
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_EmptyPath_ReturnsFalse()
     {
-        VirtualPath path = new("".AsSpan());
+        PathSegmentEnumerator path = new("");
 
-        bool result = path.MoveNextSegment();
+        bool result = path.MoveNext();
 
         result.Should().BeFalse();
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_CrossingBoundary_ReturnsCorrectSegments()
     {
-        VirtualPath path = new("first".AsSpan(), "second".AsSpan());
+        PathSegmentEnumerator path = new("first", "second");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_FirstPathWithTrailingSeparator_HandlesCorrectly()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}".AsSpan(), "second".AsSpan());
+        PathSegmentEnumerator path = new($"first{Path.DirectorySeparatorChar}", "second");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_SecondPathWithLeadingSeparator_HandlesCorrectly()
     {
-        VirtualPath path = new("first".AsSpan(), $"{Path.DirectorySeparatorChar}second".AsSpan());
+        PathSegmentEnumerator path = new("first", $"{Path.DirectorySeparatorChar}second");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("first");
+        path.Current.ToString().Should().Be("first");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("second");
+        path.Current.ToString().Should().Be("second");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_SegmentSpanningBoundary_HandlesCorrectly()
     {
         // This tests when a segment would span across the virtual boundary
-        VirtualPath path = new("path".AsSpan(), "segment".AsSpan());
+        PathSegmentEnumerator path = new("path", "segment");
 
-        bool result1 = path.MoveNextSegment();
+        bool result1 = path.MoveNext();
         result1.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("path");
+        path.Current.ToString().Should().Be("path");
 
-        bool result2 = path.MoveNextSegment();
+        bool result2 = path.MoveNext();
         result2.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("segment");
+        path.Current.ToString().Should().Be("segment");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_ComplexPath_ReturnsAllSegments()
     {
-        VirtualPath path = new($"a{Path.DirectorySeparatorChar}b{Path.DirectorySeparatorChar}c".AsSpan(), $"d{Path.DirectorySeparatorChar}e{Path.DirectorySeparatorChar}f".AsSpan());
+        PathSegmentEnumerator path = new(
+            Paths.ChangeAlternateDirectorySeparators("a/b/c"),
+            Paths.ChangeAlternateDirectorySeparators("d/e/f"));
 
         List<string> segments = [];
-        while (path.MoveNextSegment())
+        while (path.MoveNext())
         {
-            segments.Add(path.CurrentSegment.ToString());
+            segments.Add(path.Current.ToString());
         }
 
         segments.Should().BeEquivalentTo(["a", "b", "c", "d", "e", "f"]);
@@ -338,12 +340,12 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_MoveNextSegment_OnlyFirstPath_ReturnsFirstPathSegments()
     {
-        VirtualPath path = new($"first{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}third".AsSpan(), "".AsSpan());
+        PathSegmentEnumerator path = new(Paths.ChangeAlternateDirectorySeparators("first/second/third"), "");
 
         List<string> segments = [];
-        while (path.MoveNextSegment())
+        while (path.MoveNext())
         {
-            segments.Add(path.CurrentSegment.ToString());
+            segments.Add(path.Current.ToString());
         }
 
         segments.Should().BeEquivalentTo(["first", "second", "third"]);
@@ -352,12 +354,12 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_MoveNextSegment_OnlySecondPath_ReturnsSecondPathSegments()
     {
-        VirtualPath path = new("".AsSpan(), $"first{Path.DirectorySeparatorChar}second{Path.DirectorySeparatorChar}third".AsSpan());
+        PathSegmentEnumerator path = new("", Paths.ChangeAlternateDirectorySeparators("first/second/third"));
 
         List<string> segments = [];
-        while (path.MoveNextSegment())
+        while (path.MoveNext())
         {
-            segments.Add(path.CurrentSegment.ToString());
+            segments.Add(path.Current.ToString());
         }
 
         segments.Should().BeEquivalentTo(["first", "second", "third"]);
@@ -366,12 +368,14 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_MoveNextSegment_SingleCharacterSegments_HandlesCorrectly()
     {
-        VirtualPath path = new($"a{Path.DirectorySeparatorChar}b".AsSpan(), $"c{Path.DirectorySeparatorChar}d".AsSpan());
+        PathSegmentEnumerator path = new(
+            Paths.ChangeAlternateDirectorySeparators($"a/b"),
+            Paths.ChangeAlternateDirectorySeparators($"c/d"));
 
         List<string> segments = [];
-        while (path.MoveNextSegment())
+        while (path.MoveNext())
         {
-            segments.Add(path.CurrentSegment.ToString());
+            segments.Add(path.Current.ToString());
         }
 
         segments.Should().BeEquivalentTo(["a", "b", "c", "d"]);
@@ -383,12 +387,12 @@ public class VirtualPathTests
     [InlineData("first", "second", "first", "second")]
     public void VirtualPath_MoveNextSegment_VariousInputs_ReturnsExpectedSegments(string firstPath, string secondPath, params string[] expectedSegments)
     {
-        VirtualPath path = new(firstPath.AsSpan(), secondPath.AsSpan());
+        PathSegmentEnumerator path = new(firstPath.AsSpan(), secondPath.AsSpan());
 
         List<string> actualSegments = [];
-        while (path.MoveNextSegment())
+        while (path.MoveNext())
         {
-            actualSegments.Add(path.CurrentSegment.ToString());
+            actualSegments.Add(path.Current.ToString());
         }
 
         actualSegments.Should().BeEquivalentTo(expectedSegments);
@@ -401,21 +405,21 @@ public class VirtualPathTests
         string sep = Path.DirectorySeparatorChar.ToString();
 
         // Test "a/b", "c/d" -> ["a", "b", "c", "d"]
-        VirtualPath path1 = new($"a{sep}b".AsSpan(), $"c{sep}d".AsSpan());
+        PathSegmentEnumerator path1 = new($"a{sep}b", $"c{sep}d");
         List<string> segments1 = [];
-        while (path1.MoveNextSegment())
+        while (path1.MoveNext())
         {
-            segments1.Add(path1.CurrentSegment.ToString());
+            segments1.Add(path1.Current.ToString());
         }
 
         segments1.Should().BeEquivalentTo(["a", "b", "c", "d"]);
 
         // Test "///a///", "///b///" -> ["a", "b"]
-        VirtualPath path2 = new($"{sep}{sep}{sep}a{sep}{sep}{sep}".AsSpan(), $"{sep}{sep}{sep}b{sep}{sep}{sep}".AsSpan());
+        PathSegmentEnumerator path2 = new($"{sep}{sep}{sep}a{sep}{sep}{sep}", $"{sep}{sep}{sep}b{sep}{sep}{sep}");
         List<string> segments2 = [];
-        while (path2.MoveNextSegment())
+        while (path2.MoveNext())
         {
-            segments2.Add(path2.CurrentSegment.ToString());
+            segments2.Add(path2.Current.ToString());
         }
         segments2.Should().BeEquivalentTo(["a", "b"]);
     }
@@ -423,56 +427,58 @@ public class VirtualPathTests
     [Fact]
     public void VirtualPath_CurrentSegment_BeforeFirstMove_ReturnsEmpty()
     {
-        VirtualPath path = new($"test{Path.DirectorySeparatorChar}path".AsSpan());
+        PathSegmentEnumerator path = new($"test{Path.DirectorySeparatorChar}path");
 
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_CurrentSegment_AfterLastMove_ReturnsEmpty()
     {
-        VirtualPath path = new("test".AsSpan());
+        PathSegmentEnumerator path = new("test");
 
-        path.MoveNextSegment();
-        path.MoveNextSegment(); // This should return false
+        path.MoveNext();
+        path.MoveNext(); // This should return false
 
-        path.CurrentSegment.IsEmpty.Should().BeTrue();
+        path.Current.IsEmpty.Should().BeTrue();
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_RecursiveCall_HandlesCorrectly()
     {
         // Test the recursive call for separator skipping
-        VirtualPath path = new($"{Path.DirectorySeparatorChar}test".AsSpan());
+        PathSegmentEnumerator path = new($"{Path.DirectorySeparatorChar}test");
 
-        bool result = path.MoveNextSegment();
+        bool result = path.MoveNext();
 
         result.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("test");
+        path.Current.ToString().Should().Be("test");
     }
 
     [Fact]
     public void VirtualPath_MoveNextSegment_MultipleRecursiveCalls_HandlesCorrectly()
     {
         // Test multiple recursive calls for consecutive separators
-        VirtualPath path = new($"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}test".AsSpan());
+        PathSegmentEnumerator path = new(Paths.ChangeAlternateDirectorySeparators("////test"));
 
-        bool result = path.MoveNextSegment();
+        bool result = path.MoveNext();
 
         result.Should().BeTrue();
-        path.CurrentSegment.ToString().Should().Be("test");
+        path.Current.ToString().Should().Be("test");
     }
 
     [Fact]
     public void VirtualPath_Documentation_Example()
     {
         // Example from documentation: combining two path segments
-        VirtualPath path = new($"src{Path.DirectorySeparatorChar}main".AsSpan(), $"components{Path.DirectorySeparatorChar}Button.cs".AsSpan());
+        PathSegmentEnumerator path = new(
+            Paths.ChangeAlternateDirectorySeparators("src/main"),
+            Paths.ChangeAlternateDirectorySeparators("components/Button.cs"));
 
         List<string> segments = [];
-        while (path.MoveNextSegment())
+        while (path.MoveNext())
         {
-            segments.Add(path.CurrentSegment.ToString());
+            segments.Add(path.Current.ToString());
         }
 
         segments.Should().BeEquivalentTo(["src", "main", "components", "Button.cs"]);

--- a/touki/Framework/Touki/Io/EnumerationMatcherExtensions.cs
+++ b/touki/Framework/Touki/Io/EnumerationMatcherExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Convenience methods for working with <see cref="IEnumerationMatcher"/>.
+/// </summary>
+public static class EnumerationMatcherExtensions
+{
+    /// <inheritdoc cref="IEnumerationMatcher.MatchesDirectory(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+    public static bool MatchesDirectory(
+        this IEnumerationMatcher matcher,
+        string currentDirectory,
+        string directoryName) => matcher.MatchesDirectory(currentDirectory.AsSpan(), directoryName.AsSpan());
+
+    /// <inheritdoc cref="IEnumerationMatcher.MatchesFile(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+    public static bool MatchesFile(
+        this IEnumerationMatcher matcher,
+        string currentDirectory,
+        string fileName) => matcher.MatchesFile(currentDirectory.AsSpan(), fileName.AsSpan());
+}

--- a/touki/Touki/Collections/EmptyList.cs
+++ b/touki/Touki/Collections/EmptyList.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Collections;
+
+/// <summary>
+///  Empty, read-only list.
+/// </summary>
+public sealed class EmptyList<T> : ContiguousList<T> where T : notnull
+{
+    private EmptyList()
+    {
+    }
+
+    /// <summary>
+    ///  Gets the singleton instance of the <see cref="EmptyList{T}"/> class.
+    /// </summary>
+    public static EmptyList<T> Instance { get; } = new();
+
+    /// <inheritdoc/>
+    public override T this[int index]
+    {
+        get => throw new ArgumentOutOfRangeException(nameof(index));
+        set => throw new ArgumentOutOfRangeException(nameof(index));
+    }
+
+    /// <inheritdoc/>
+    public override bool IsReadOnly => true;
+
+    /// <inheritdoc/>
+    public override Span<T> UnsafeValues => [];
+
+    /// <inheritdoc/>
+    public override ReadOnlySpan<T> Values => [];
+
+    /// <inheritdoc/>
+    public override int Count => 0;
+
+    /// <inheritdoc/>
+    public override void Add(T item) => throw new NotImplementedException();
+
+    /// <inheritdoc/>
+    public override void Clear() { }
+
+    /// <inheritdoc/>
+    public override void CopyTo(T[] array, int arrayIndex) => ArgumentOutOfRange.ThrowIfNotEqual(arrayIndex, 0);
+
+    /// <inheritdoc/>
+    public override void CopyTo(Array array, int index) => ArgumentOutOfRange.ThrowIfNotEqual(index, 0);
+
+    /// <inheritdoc/>
+    public override int IndexOf(T item) => -1;
+
+    /// <inheritdoc/>
+    public override void Insert(int index, T item) => throw new InvalidOperationException();
+
+    /// <inheritdoc/>
+    public override void RemoveAt(int index) => throw new InvalidOperationException();
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing) { }
+}

--- a/touki/Touki/Collections/ListBase.cs
+++ b/touki/Touki/Collections/ListBase.cs
@@ -49,13 +49,19 @@ public abstract partial class ListBase<T> : DisposableBase, IList<T>, IReadOnlyL
     /// <inheritdoc/>
     public bool Contains(T item) => IndexOf(item) >= 0;
 
+    /// <inheritdoc cref="Contains(T)"/>
+    /// <inheritdoc cref="IndexOf(T, IEqualityComparer{T})"/>
+    public bool Contains(T item, IEqualityComparer<T> comparer) => IndexOf(item, comparer) >= 0;
+
     /// <inheritdoc/>
     public abstract void CopyTo(T[] array, int arrayIndex);
 
     /// <inheritdoc/>
     public abstract int IndexOf(T item);
 
-    /// <inheritdoc/>
+    /// <inheritdoc cref="IndexOf(T)"/>
+    /// <param name="comparer">The comparer to use.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="comparer"/> is null.</exception>
     public virtual int IndexOf(T item, IEqualityComparer<T> comparer)
     {
         // .NET 10 is getting a number of extensions for IEqualityComparer for spans, which will

--- a/touki/Touki/Collections/ValueEnumerator.cs
+++ b/touki/Touki/Collections/ValueEnumerator.cs
@@ -17,7 +17,9 @@ public ref struct ValueEnumerator<TEnumerator, TValue>
 #endif
 {
     // When TEnumerator is a value type, the JIT will devirtualize the calls to it (no boxing).
+#pragma warning disable IDE0044 // Add readonly modifier - must be mutable to support MoveNext and Reset.
     private TEnumerator _enumerator;
+#pragma warning restore IDE0044
 
     /// <summary>
     ///  Constructs a new instance of the <see cref="ValueEnumerator{TEnumerator, TValue}"/> struct.

--- a/touki/Touki/Io/IEnumerationMatcher.cs
+++ b/touki/Touki/Io/IEnumerationMatcher.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Represents a specification for matching files and directories.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is designed to faciliate composition with <see cref="FileSystemEnumerator{TResult}"/>s.
+///   As such, names should always be passed breadth-first when enumerating directories.
+///  </para>
+/// </remarks>
+public interface IEnumerationMatcher : IDisposable
+{
+    /// <summary>
+    ///  The current directory has finished processing. Any further calls to <see cref="MatchesFile"/>
+    ///  or <see cref="MatchesDirectory"/> will now have a different current directory.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Typically used to invalidate cached directory match state.
+    ///  </para>
+    /// </remarks>
+    void DirectoryFinished();
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if the specified <paramref name="directoryName"/> is a match and should (or
+    ///  should not) be recursed into from the specified <paramref name="currentDirectory"/>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Recursion is breadth-first, returning `true` from this method will put the directory at the end of the queue
+    ///   to be processed.
+    ///  </para>
+    /// </remarks>
+    bool MatchesDirectory(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> directoryName);
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if the specified <paramref name="fileName"/> should (or should not)
+    ///  be included in the results.
+    /// </summary>
+    bool MatchesFile(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> fileName);
+}

--- a/touki/Touki/Io/MSBuildEnumerator.SingleSpec.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.SingleSpec.cs
@@ -7,45 +7,45 @@ namespace Touki.Io;
 public abstract partial class MSBuildEnumerator
 {
     /// <summary>
-    ///  Enumerator for the simplest scenario where a single <see cref="MSBuildSpec"/> is used.
+    ///  Enumerator for the simplest scenario where a single <see cref="MatchMSBuild"/> is used.
     /// </summary>
     private sealed class SingleSpec : MSBuildEnumerator
     {
-        private readonly MSBuildSpec _spec;
+        private readonly IEnumerationMatcher _matcher;
 
         /// <summary>
         ///  Initializes a new instance of the <see cref="SingleSpec"/> class.
         /// </summary>
         public SingleSpec(
-            MSBuildSpec includeSpec,
+            IEnumerationMatcher includeMatcher,
             string? projectDirectory,
             bool stripProjectDirectory,
             string startDirectory,
             EnumerationOptions options)
             : base(projectDirectory, stripProjectDirectory, startDirectory, options)
         {
-            _spec = includeSpec;
+            _matcher = includeMatcher;
         }
 
         /// <inheritdoc/>
         protected override void OnDirectoryFinished(ReadOnlySpan<char> directory) =>
             // Clear the cache when we finish processing a directory
-            _spec.InvalidateCache();
+            _matcher.DirectoryFinished();
 
         /// <inheritdoc/>
         protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry) =>
-            _spec.ShouldRecurseIntoDirectory(entry.Directory, entry.FileName);
+            _matcher.MatchesDirectory(entry.Directory, entry.FileName);
 
         /// <inheritdoc/>
         protected override bool ShouldIncludeEntry(ref FileSystemEntry entry) =>
-            !entry.IsDirectory && _spec.ShouldIncludeFile(entry.Directory, entry.FileName);
+            !entry.IsDirectory && _matcher.MatchesFile(entry.Directory, entry.FileName);
 
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-                _spec.Dispose();
+                _matcher.Dispose();
             }
 
             base.Dispose(disposing);

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -112,7 +112,7 @@ public abstract partial class MSBuildEnumerator : FileSystemEnumerator<string>
         string startDirectory = fullPath[..lastSeparator].ToString();
 
         return new SingleSpec(
-            new MSBuildSpec(fullPathSpec, startDirectory, options.MatchType, options.MatchCasing),
+            new MatchMSBuild(fullPathSpec, startDirectory, options.MatchType, options.MatchCasing),
             projectDirectory,
             !Path.IsPathFullyQualified(fileSpec),
             startDirectory,

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -215,7 +215,7 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
         // Handle empty filename edge cases
 
         if (IsSimpleRecursiveMatch
-            || (WildPath.Length > 2 && WildPath[^3] == Path.PathSeparator && WildPath[^2] == '*' && WildPath[^1] == '*'))
+            || (WildPath.Length > 2 && WildPath[^3] == Path.DirectorySeparatorChar && WildPath[^2] == '*' && WildPath[^1] == '*'))
         {
             // Wildcard is "**" or ends with "**", so the filename is "*".
             // (This would potentially happen with "foo/bar/**/").

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -1,0 +1,543 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Collections;
+
+namespace Touki.Io;
+
+/// <summary>
+///  An MSBuild specification used in an item include or an exclude.
+/// </summary>
+public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment>, IEquatable<MSBuildSpecification>
+{
+    private static readonly string s_redundantWildCard = $"**{Path.DirectorySeparatorChar}**";
+
+    /// <summary>
+    ///  The specification as it was originally provided.
+    /// </summary>
+    public StringSegment Original { get; }
+
+    /// <summary>
+    ///  The normalized specification.
+    /// </summary>
+    public StringSegment Normalized { get; }
+
+    /// <summary>
+    ///  The fixed directory part of the specification, if any, which is the part before any wildcards.
+    /// </summary>
+    public StringSegment FixedPath { get; }
+
+    /// <summary>
+    ///  The wildcard directory part of the specification, if any, which is the part where wildcards are used outside
+    ///  of the filename itself.
+    /// </summary>
+    public StringSegment WildPath { get; }
+
+    /// <summary>
+    ///  The file name part of the specification. This is the part after the last directory separator.
+    /// </summary>
+    public StringSegment FileName { get; }
+
+    /// <summary>
+    ///  <see langword="true"/> if the specification contains any wildcards.
+    ///  May be in <see cref="WildPath"/> or <see cref="FileName"/>, or both.
+    /// </summary>
+    public bool HasAnyWildCards { get; }
+
+    /// <summary>
+    ///  <see langword="true"/> if the <see cref="WildPath"/> is "**", meaning that it will match all subdirectories
+    ///  once the primary <see cref="FixedPath"/> (if any) is matched.
+    /// </summary>
+    public bool IsSimpleRecursiveMatch { get; }
+
+    /// <summary>
+    ///  <see langword="true"/> if the <see cref="Normalized"/> path is a nested relative path. This means that the path
+    ///  is not <see cref="IsFullyQualified"/> but is guaranteed to be below the current directory when combined.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The path can still be relative, but start with '..' or be drive relative (e.g. 'C:file.txt') and not
+    ///   satisfy this requirement. You can directly compare two specs that are <see cref="IsNestedRelative"/>.
+    ///   See remarks on <see cref="IsFullyQualified"/> for more information on other comparisons.
+    ///  </para>
+    /// </remarks>
+    public bool IsNestedRelative { get; }
+
+    /// <summary>
+    ///  <see langword="true"/> if the <see cref="Normalized"/> path is rooted and will not change with the current directory.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   In effect this means that the path is completely normalized and can be compared directly against any normalized
+    ///   full path (something that has been passed to <see cref="Path.GetFullPath(string)"/> or other <see cref="IsFullyQualified"/>
+    ///   specs. When this isn't <see langword="true"/> and <see cref="Normalized"/> is not <see cref="IsNestedRelative"/>
+    ///   it is unsafe to compare without first resolving against the current directory with <see cref="Path.GetFullPath(string)"/>,
+    ///   or <see cref="Path.GetFullPath(string, string)"/>.
+    ///  </para>
+    /// </remarks>
+    public bool IsFullyQualified { get; }
+
+    /// <inheritdoc cref="MSBuildSpecification(StringSegment)"/>
+    public MSBuildSpecification(string original) : this(new StringSegment(original)) { }
+
+    /// <summary>
+    ///  Constructs a new <see cref="MSBuildSpecification"/> from the given original specification.
+    /// </summary>
+    public MSBuildSpecification(StringSegment original) : this(original, Normalize(original))
+    {
+    }
+
+    internal MSBuildSpecification(StringSegment original, StringSegment normalized)
+    {
+        if (normalized.IsEmpty)
+        {
+            throw new ArgumentException("Normalized specification cannot be empty.", nameof(normalized));
+        }
+
+        Original = original;
+        Normalized = normalized;
+
+        Debug.Assert(Normalized.Equals(Normalize(Original)));
+
+        IsFullyQualified = Path.IsPathFullyQualified(Normalized.AsSpan());
+        IsNestedRelative = !IsFullyQualified
+            && !Path.IsPathRooted(Normalized.AsSpan())
+            && !(Normalized.StartsWith("..")
+                && (Normalized.Length == 2 || (Normalized.Length > 2 && Normalized[2] == Path.DirectorySeparatorChar)));
+
+        int lastSeparator = Normalized.LastIndexOf(Path.DirectorySeparatorChar);
+        int firstWildCard = Normalized.IndexOfAny('*', '?');
+
+        HasAnyWildCards = firstWildCard >= 0;
+
+        // Split into segments without separators between them.
+
+        if (lastSeparator < 1)
+        {
+            // No separator, only special case is "**"
+            FixedPath = default;
+
+            if (Normalized == "**")
+            {
+                goto SimpleRecursiveMatch;
+            }
+            else
+            {
+                WildPath = default;
+                FileName = Normalized;
+            }
+
+            return;
+        }
+
+        if (!HasAnyWildCards)
+        {
+            // No wildcards, split the fixed path and filename and exit.
+            WildPath = default;
+            FixedPath = Normalized[..lastSeparator];
+            FileName = Normalized[(lastSeparator + 1)..];
+            return;
+        }
+
+        FileName = Normalized[(lastSeparator + 1)..];
+        bool trailingWildDirectory = FileName == "**";
+
+        if (firstWildCard > lastSeparator)
+        {
+            // No wildcards before the last separator, the filename contains the wildcard (e.g. "foo/bar/*.txt").
+            // Everything else is fixed, unless we have a trailing wild directory (e.g. "foo/bar/**").
+            FixedPath = Normalized[..lastSeparator];
+
+            if (trailingWildDirectory)
+            {
+                goto SimpleRecursiveMatch;
+            }
+            else
+            {
+                WildPath = default;
+            }
+
+            return;
+        }
+
+        // Handle cases where wildcards appear in the path
+
+        StringSegment preWildCard = Normalized[..firstWildCard];
+        int lastSeparatorBeforeWildCard = preWildCard.LastIndexOf(Path.DirectorySeparatorChar);
+
+        if (lastSeparatorBeforeWildCard < 0)
+        {
+            // No separator before the first wildcard, so nothing is fixed (e.g. "*/foo/*.txt" or "**/foo/*.txt").
+            FixedPath = default;
+
+            if (trailingWildDirectory)
+            {
+                // Trailing wild directory (e.g. "*/foo/**" or "**/foo/**").
+                WildPath = Normalized;
+                FileName = "*";
+                IsSimpleRecursiveMatch = WildPath == "**";
+                return;
+            }
+            else
+            {
+                // Normal all wild scenario (e.g. "*/foo/*.txt" or "**/foo/*.txt")
+                WildPath = Normalized[..^(FileName.Length + 1)];
+            }
+        }
+        else
+        {
+            // We have a fixed part and a wildcard part
+            FixedPath = Normalized[..lastSeparatorBeforeWildCard];
+
+            if (trailingWildDirectory)
+            {
+                // Trailing wild directory (e.g. "foo/bar*/**").
+                WildPath = Normalized[(lastSeparatorBeforeWildCard + 1)..];
+                FileName = "*";
+                IsSimpleRecursiveMatch = WildPath == "**";
+                return;
+            }
+            else
+            {
+                // Normal case with wildcards in the path (e.g. "foo/bar*/baz/*.txt").
+                WildPath = Normalized.Slice(FixedPath.Length + 1, Normalized.Length - FileName.Length - FixedPath.Length - 2);
+            }
+        }
+
+        IsSimpleRecursiveMatch = WildPath == "**";
+
+        if (!FileName.IsEmpty)
+        {
+            return;
+        }
+
+        // Handle empty filename edge cases
+
+        if (IsSimpleRecursiveMatch
+            || (WildPath.Length > 2 && WildPath[^3] == Path.PathSeparator && WildPath[^2] == '*' && WildPath[^1] == '*'))
+        {
+            // Wildcard is "**" or ends with "**", so the filename is "*".
+            // (This would potentially happen with "foo/bar/**/").
+            FileName = "*";
+        }
+
+        return;
+
+    SimpleRecursiveMatch:
+        // If we reach here, it means that the specification is a simple recursive match (e.g. "**").
+        // This is a special case where the entire path is just "**", so we set the wild path to "**" and the filename to "*".
+        WildPath = "**";
+        FileName = "*";
+        IsSimpleRecursiveMatch = true;
+    }
+
+    /// <summary>
+    ///  Unescapes the given <paramref name="specification"/> if needed. `%` is used to escape special characters
+    ///  in MSBuild strings, such as `*`, `?`, and `%`.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This method will allocate a new string for the segment if needed.
+    ///  </para>
+    /// </remarks>
+    public static StringSegment Unescape(StringSegment specification)
+    {
+        // Don't bother if the segment doesn't contain an escape character.
+        if (!specification.Contains('%'))
+        {
+            return specification;
+        }
+
+        // Path segments should never be over 256 characters, so we shouldn't need to stack allocate more than this.
+        using ValueStringBuilder builder = new(stackalloc char[256]);
+
+        // Iterate through the segment and unescape characters as needed. Escape sequences are of the form `%XX` where
+        // `XX` is the hexadecimal representation of the character. Invalid escape sequences are left as is.
+        for (int i = 0; i < specification.Length; i++)
+        {
+            char c = specification[i];
+            if (c != '%'
+                || i + 2 >= specification.Length
+                || !specification[i + 1].TryDecodeHexDigit(out int firstDigit)
+                || !specification[i + 2].TryDecodeHexDigit(out int secondDigit))
+            {
+                builder.Append(c);
+            }
+            else
+            {
+                // Valid escape sequence, decode it.
+                builder.Append((char)((firstDigit << 4) + secondDigit));
+                i += 2;
+            }
+        }
+
+        // It is possible that all of the escapes are "invalid", so check if we've actually built anything different.
+        return builder.Length < specification.Length ? builder.ToString() : specification;
+    }
+
+
+    /// <summary>
+    ///  Simplify a path by converting backslashes to forward slashes on Unix systems, collapsing
+    ///  consecutive directory separators into a single separator, trimming whitespace, and removing any
+    ///  redundant path segments (".", "..", and duplicate "**").
+    /// </summary>
+    /// <param name="specification">The path specification to normalize.</param>
+    /// <remarks>
+    ///  <para>
+    ///   Multiple specifications (separated by ';') must be split first for this to work correctly.
+    ///  </para>
+    /// </remarks>
+    public static StringSegment Normalize(StringSegment specification)
+    {
+        // TODO: What is the behavior of a trailing separator in MSBuild? Is "Foo\" the same as "Foo" or is it
+        // expected to be the same as "Foo\*"?
+
+        specification = specification.Trim();
+
+        char separatorToReplace = Path.DirectorySeparatorChar == '\\' ? '/' : '\\';
+
+        ValueStringBuilder replaceBuilder = new(stackalloc char[Paths.MaxShortPath]);
+
+        if (specification.Contains(separatorToReplace))
+        {
+            replaceBuilder.Append(specification);
+            replaceBuilder.Replace(separatorToReplace, Path.DirectorySeparatorChar);
+            ReadOnlySpan<char> currentState = replaceBuilder;
+            replaceBuilder.Length = 0;
+            Paths.RemoveRelativeSegments(currentState, ref replaceBuilder);
+            RemoveDuplicateMatchAnyDirectory(ref replaceBuilder);
+            return replaceBuilder.ToStringAndDispose();
+        }
+        else
+        {
+            if (specification.IndexOf(Path.DirectorySeparatorChar) < 0)
+            {
+                // No path segments to normalize, return the original segment.
+                return specification;
+            }
+
+            bool modified = Paths.RemoveRelativeSegments(specification, ref replaceBuilder);
+            modified |= RemoveDuplicateMatchAnyDirectory(ref replaceBuilder);
+
+            if (modified)
+            {
+                return replaceBuilder.ToStringAndDispose();
+            }
+            else
+            {
+                // No changes made, return the original segment.
+                replaceBuilder.Dispose();
+                return specification;
+            }
+        }
+
+        static bool RemoveDuplicateMatchAnyDirectory(ref ValueStringBuilder builder)
+        {
+            ReadOnlySpan<char> redundantWildCard = s_redundantWildCard.AsSpan();
+            ReadOnlySpan<char> original = builder.AsSpan();
+            int index = original.IndexOf(redundantWildCard, StringComparison.Ordinal);
+
+            if (index == -1)
+            {
+                return false;
+            }
+
+            ValueStringBuilder replaceBuilder = new(stackalloc char[Paths.MaxShortPath]);
+            if (original[0] == Path.DirectorySeparatorChar)
+            {
+                // If the first character is a separator, we need to keep it.
+                replaceBuilder.Append(Path.DirectorySeparatorChar);
+            }
+
+            bool foundMatchAny = false;
+
+            PathSegmentEnumerator enumerator = new(original);
+            while (enumerator.MoveNext())
+            {
+                ReadOnlySpan<char> current = enumerator.Current;
+                if (current.SequenceEqual("**".AsSpan()))
+                {
+                    if (foundMatchAny)
+                    {
+                        // Skip this match any directory, we already have one.
+                        continue;
+                    }
+
+                    foundMatchAny = true;
+                }
+                else
+                {
+                    foundMatchAny = false;
+                }
+
+                replaceBuilder.Append(current);
+                replaceBuilder.Append(Path.DirectorySeparatorChar);
+            }
+
+            if (!Path.EndsInDirectorySeparator(original))
+            {
+                replaceBuilder.Length--;
+            }
+
+            builder.Clear();
+            builder.Append(replaceBuilder.AsSpan());
+            return true;
+        }
+    }
+
+    /// <summary>
+    ///  Splits semicolon-separated MSBuild specifications and buckets them into wildcard and literal versions.
+    /// </summary>
+    /// <param name="specs">
+    ///  The possibly semicolon-separated MSBuild specification to split. In MSBuild this is processed unescaped, but
+    ///  the logic would still work here if you wanted escaped `*` and `?` characters to be treated as literals in
+    ///  matches ("/foo/bar?.text" is a valid file name on Unix).
+    /// </param>
+    /// <returns>
+    ///  The list of split specifications. Each specification is normalized, meaning that backslashes are converted to
+    ///  forward slashes on Unix and vice versa on Windows. Consecutive separators will be collapsed to a single
+    ///  separator. Duplicate specifications will be removed, including some that are effectively duplicate, such as
+    ///  "bin/**" and "bin/Debug/**" (the latter is a subdirectory of the former, so it will be replaced).
+    /// </returns>
+    public static ListBase<MSBuildSpecification> Split(
+        StringSegment specs,
+        bool ignoreCase)
+    {
+        SingleOptimizedList<MSBuildSpecification> splitSpecs = [];
+
+        // MSBuild normally validates specifications after it splits each one into fixed, wildcard, and file parts.
+        // None of the validation is strictly necessary, but would be done here if we wanted to roughly match.
+        // Things that are considered "invalid: should be put in the literalSpecs even if they contain wildcards.
+        //
+        // What MSBuild considers invalid:
+        //
+        //  - InvalidPathCharacters - not needed anymore, the only illegal character is null.
+        //  - A colon after the second character - not a real risk unless you create a `Uri` and breaks Unix paths.
+        //  - `...` - this isn't needed either, there is no risk with this.
+        //  - `**` not between separators - a lot of pain for not much gain, so we don't do this.
+
+        StringSegment right = specs;
+
+        while (right.TrySplit(';', out StringSegment left, out right))
+        {
+            if (left.IsEmpty)
+            {
+                // Skip empty segments.
+                continue;
+            }
+
+            // Normalize the spec. This will collapse any consecutive separators into a single separator and reduce
+            // unnecessary segments like "." and "..". MSBuild doesn't fully do this at this stage. For performance we
+            // want to dedupe the segments, which can done more efficiently if we normalize first. This will also
+            // improve performance further downstream as we can be more efficient with additional comparisons.
+
+            StringSegment normalized = Normalize(left);
+            bool found = false;
+
+            for (int i = 0; i < splitSpecs.Count; i++)
+            {
+                if (splitSpecs[i].Normalized.Equals(normalized, ignoreCase))
+                {
+                    // Already present.
+                    found = true;
+                    break;
+                }
+            }
+
+            if (found)
+            {
+                // Skip duplicates.
+                continue;
+            }
+
+            MSBuildSpecification newSpec = new(left, normalized);
+            if (!newSpec.IsSimpleRecursiveMatch)
+            {
+                splitSpecs.Add(newSpec);
+                continue;
+            }
+
+            // Looking for duplicates akin to "bin\Debug\/**" and "bin\/**"
+            for (int i = 0; i < splitSpecs.Count; i++)
+            {
+                MSBuildSpecification current = splitSpecs[i];
+                if (!current.IsSimpleRecursiveMatch
+                    || !current.FileName.Equals(newSpec.FileName, ignoreCase))
+                {
+                    continue;
+                }
+
+                if (current.FixedPath.Length > newSpec.FixedPath.Length)
+                {
+                    if (Paths.IsSameOrSubdirectory(newSpec.FixedPath, current.FixedPath, ignoreCase))
+                    {
+                        // Current is a subdirectory of the new, replace it.
+                        splitSpecs[i] = newSpec;
+                        found = true;
+                        break;
+                    }
+                }
+                else if (Paths.IsSameOrSubdirectory(current.FixedPath, newSpec.FixedPath, ignoreCase))
+                {
+                    // New is a subdirectory of the current, we can skip this.
+                    // We already have a simple recursive match for this fixed path.
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                splitSpecs.Add(newSpec);
+            }
+        }
+
+        return splitSpecs;
+    }
+
+    /// <summary>
+    ///  Implicitly converts a <see langword="string"/> to a <see cref="MSBuildSpecification"/>.
+    /// </summary>
+    /// <param name="specification">The string specification to convert.</param>
+    public static implicit operator MSBuildSpecification(string specification) => new MSBuildSpecification(specification);
+
+    /// <summary>
+    ///  Explicitly converts a <see cref="MSBuildSpecification"/> to a <see langword="string"/>.
+    /// </summary>
+    /// <param name="specification">The string specification to convert.</param>
+    public static explicit operator string(MSBuildSpecification specification) => (string)specification.Normalized;
+
+    /// <summary>
+    ///  Implicitly converts a <see cref="StringSegment"/> to a <see cref="MSBuildSpecification"/>.
+    /// </summary>
+    /// <param name="specification">The string specification to convert.</param>
+    public static implicit operator MSBuildSpecification(StringSegment specification) => new MSBuildSpecification(specification);
+
+    /// <summary>
+    ///  Implicitly converts a <see cref="MSBuildSpecification"/> to a <see cref="StringSegment"/>.
+    /// </summary>
+    /// <param name="specification">The string specification to convert.</param>
+    public static implicit operator StringSegment(MSBuildSpecification specification) => specification.Normalized;
+
+    /// <inheritdoc/>
+    public override string ToString() => Normalized.ToString();
+
+    /// <inheritdoc cref="Equals(object?)"/>
+    public bool Equals(string? other) => other is not null && Original.Equals(other, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc cref="Equals(object?)"/>
+    public bool Equals(MSBuildSpecification? other) =>
+        other is not null && Original.Equals(other.Original, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc cref="Equals(object?)"/>
+    public bool Equals(StringSegment other) =>
+        Original.Equals(other, StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is MSBuildSpecification other && Equals(other)
+        || obj is string str && Equals(str);
+
+    /// <inheritdoc/>
+    public override int GetHashCode() => Original.GetHashCode();
+}

--- a/touki/Touki/Io/MatchAnyBase.cs
+++ b/touki/Touki/Io/MatchAnyBase.cs
@@ -92,7 +92,8 @@ public abstract class MatchAnyBase : DisposableBase, IEnumerationMatcher
     protected virtual bool MatchesDirectory(ReadOnlySpan<char> directoryName) => true;
 
     /// <summary>
-    ///  Returns true if the given <paramref name="name"/> 
+    ///  Returns true if the given <paramref name="name"/> matches any of the expressions in <see cref="_expressions"/>
+    ///  using the specified <see cref="MatchCasing"/> and <see cref="MatchType"/>.
     /// </summary>
     protected bool MatchesName(ReadOnlySpan<char> name)
     {

--- a/touki/Touki/Io/MatchAnyBase.cs
+++ b/touki/Touki/Io/MatchAnyBase.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Collections;
+
+namespace Touki.Io;
+
+/// <summary>
+///  Base class for simple matches that match any file or directory name.
+/// </summary>
+public abstract class MatchAnyBase : DisposableBase, IEnumerationMatcher
+{
+    private readonly MatchType _matchType;
+    private protected readonly MatchCasing _matchCasing;
+    private readonly StringSegment _rootPath;
+
+    private readonly SingleOptimizedList<StringSegment> _expressions = [];
+
+    private bool? _nestingMatched;
+
+    /// <summary>
+    ///  Constructs a new <see cref="MatchAnyBase"/> with a single name expression.
+    /// </summary>
+    /// <param name="expression">The primary expression to match.</param>
+    /// <param name="rootPath">The root path that must match, can be empty for all paths.</param>
+    /// <param name="matchType">The type of match to perform.</param>
+    /// <param name="matchCasing">How to match casing.</param>
+    public MatchAnyBase(
+        StringSegment expression,
+        StringSegment rootPath,
+        MatchType matchType,
+        MatchCasing matchCasing)
+    {
+        _matchType = matchType;
+        _matchCasing = Paths.GetFinalCasing(matchCasing);
+        _rootPath = rootPath;
+        AddSpec(expression);
+    }
+
+    /// <inheritdoc cref="MatchAnyBase(StringSegment, StringSegment, MatchType, MatchCasing)"/>
+    public MatchAnyBase(
+        StringSegment expression,
+        MatchType matchType,
+        MatchCasing matchCasing) : this(expression, default, matchType, matchCasing)
+    {
+    }
+
+    /// <summary>
+    ///  Adds another name expression to match.
+    /// </summary>
+    /// <param name="expression">The name matching expression to add.</param>
+    /// <returns><see langword="true"/> if the expression was added, <see langword="false"/> if it was a duplicate.</returns>
+    public bool AddSpec(StringSegment expression)
+    {
+        Debug.Assert(!expression.IsEmpty);
+        Debug.Assert(expression.IndexOf(Path.DirectorySeparatorChar) == -1);
+
+        if (_expressions.Contains(
+            expression,
+            _matchCasing == MatchCasing.CaseInsensitive
+                ? StringSegmentComparer.OrdinalIgnoreCase
+                : StringSegmentComparer.Ordinal))
+        {
+            // Already contains this expression, no need to add it again.
+            return false;
+        }
+
+        _expressions.Add(expression);
+        return true;
+    }
+
+    void IEnumerationMatcher.DirectoryFinished()
+    {
+        _nestingMatched = null;
+        DirectoryFinished();
+    }
+
+    /// <inheritdoc cref="IEnumerationMatcher.DirectoryFinished"/>
+    public virtual void DirectoryFinished() { }
+
+    bool IEnumerationMatcher.MatchesFile(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> fileName) =>
+        MatchesRoot(currentDirectory) && MatchesFile(fileName);
+
+    /// <inheritdoc cref="IEnumerationMatcher.MatchesFile(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+    protected virtual bool MatchesFile(ReadOnlySpan<char> fileName) => true;
+
+    bool IEnumerationMatcher.MatchesDirectory(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> directoryName) =>
+        MatchesRoot(currentDirectory) && MatchesDirectory(directoryName);
+
+    /// <inheritdoc cref="IEnumerationMatcher.MatchesDirectory(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+    protected virtual bool MatchesDirectory(ReadOnlySpan<char> directoryName) => true;
+
+    /// <summary>
+    ///  Returns true if the given <paramref name="name"/> 
+    /// </summary>
+    protected bool MatchesName(ReadOnlySpan<char> name)
+    {
+        for (int i = 0; i < _expressions.Count; i++)
+        {
+            if (Paths.MatchesExpression(name, _expressions[i], _matchCasing, _matchType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool MatchesRoot(ReadOnlySpan<char> currentDirectory)
+    {
+        if (_rootPath.IsEmpty)
+        {
+            // No root path means we match everything.
+            return true;
+        }
+
+        if (_nestingMatched.HasValue)
+        {
+            return _nestingMatched.Value;
+        }
+
+        _nestingMatched = currentDirectory.StartsWith(_rootPath);
+        return _nestingMatched.Value;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _expressions.Dispose();
+        }
+    }
+}

--- a/touki/Touki/Io/MatchAnyDirectory.cs
+++ b/touki/Touki/Io/MatchAnyDirectory.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Matcher that matches any directory.
+/// </summary>
+public sealed class MatchAnyDirectory : MatchAnyBase
+{
+    /// <summary>
+    ///  Constructs a new <see cref="MatchAnyFile"/> with a primary file name expression.
+    /// </summary>
+    /// <inheritdoc/>
+    public MatchAnyDirectory(
+        StringSegment expression,
+        StringSegment rootPath,
+        MatchType matchType,
+        MatchCasing matchCasing) : base(expression, rootPath, matchType, matchCasing)
+    {
+    }
+
+    /// <summary>
+    ///  Constructs a new <see cref="MatchAnyDirectory"/> with a single directory name expression.
+    /// </summary>
+    public MatchAnyDirectory(StringSegment expression, MatchType matchType, MatchCasing matchCasing)
+        : base(expression, matchType, matchCasing)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override bool MatchesFile(ReadOnlySpan<char> fileName) => false;
+
+    /// <inheritdoc/>
+    protected override bool MatchesDirectory(ReadOnlySpan<char> directoryName) => MatchesName(directoryName);
+}

--- a/touki/Touki/Io/MatchAnyDirectory.cs
+++ b/touki/Touki/Io/MatchAnyDirectory.cs
@@ -10,7 +10,7 @@ namespace Touki.Io;
 public sealed class MatchAnyDirectory : MatchAnyBase
 {
     /// <summary>
-    ///  Constructs a new <see cref="MatchAnyFile"/> with a primary file name expression.
+    ///  Constructs a new <see cref="MatchAnyDirectory"/> with a primary directory name expression.
     /// </summary>
     /// <inheritdoc/>
     public MatchAnyDirectory(

--- a/touki/Touki/Io/MatchAnyFile.cs
+++ b/touki/Touki/Io/MatchAnyFile.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Matcher that matches any file.
+/// </summary>
+public sealed class MatchAnyFile : MatchAnyBase
+{
+    /// <summary>
+    ///  Constructs a new <see cref="MatchAnyFile"/> with a primary file name expression.
+    /// </summary>
+    /// <inheritdoc/>
+    public MatchAnyFile(
+        StringSegment expression,
+        StringSegment rootPath,
+        MatchType matchType,
+        MatchCasing matchCasing) : base(expression, rootPath, matchType, matchCasing)
+    {
+    }
+
+    /// <summary>
+    ///  Constructs a new <see cref="MatchAnyFile"/> with a primary file name expression.
+    /// </summary>
+    /// <inheritdoc/>
+    public MatchAnyFile(
+        StringSegment expression,
+        MatchType matchType,
+        MatchCasing matchCasing) : base(expression, matchType, matchCasing)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override bool MatchesFile(ReadOnlySpan<char> fileName) => MatchesName(fileName);
+}

--- a/touki/Touki/Io/MatchEnumerator.cs
+++ b/touki/Touki/Io/MatchEnumerator.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+
+namespace Touki.Io;
+
+/// <summary>
+///  File system enumerator that matches files and directories based on a specified matcher.
+/// </summary>
+public sealed class MatchEnumerator : FileSystemEnumerator<string>
+{
+    private readonly IEnumerationMatcher _matcher;
+    private readonly FindTransform? _findTransform;
+
+    /// <summary>
+    ///  Default options for the enumerator.
+    /// </summary>
+    private static EnumerationOptions DefaultOptions { get; } = new()
+    {
+        MatchType = MatchType.Simple,
+        MatchCasing = MatchCasing.PlatformDefault,
+        IgnoreInaccessible = true,
+        RecurseSubdirectories = true
+    };
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="MatchEnumerator"/> class.
+    /// </summary>
+    public MatchEnumerator(
+        string directory,
+        IEnumerationMatcher matcher,
+        FindTransform? transform = null)
+        : this(directory, matcher, transform, DefaultOptions)
+    {
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="MatchEnumerator"/> class.
+    /// </summary>
+    public MatchEnumerator(
+        string directory,
+        IEnumerationMatcher matcher,
+        FindTransform? transform,
+        EnumerationOptions options)
+        : base(directory, options)
+    {
+        ArgumentNull.ThrowIfNull(directory);
+        ArgumentNull.ThrowIfNull(matcher);
+        _matcher = matcher;
+        _findTransform = transform;
+    }
+
+    /// <inheritdoc/>
+    protected override bool ShouldIncludeEntry(ref FileSystemEntry entry) =>
+        _matcher.MatchesFile(entry.Directory, entry.FileName);
+
+    /// <inheritdoc/>
+    protected override bool ShouldRecurseIntoEntry(ref FileSystemEntry entry) =>
+        _matcher.MatchesDirectory(entry.Directory, entry.FileName);
+
+    /// <inheritdoc/>
+    protected override void OnDirectoryFinished(ReadOnlySpan<char> directory) => _matcher.DirectoryFinished();
+
+    /// <inheritdoc/>
+    protected override string TransformEntry(ref FileSystemEntry entry) =>
+        _findTransform?.Invoke(ref entry) ?? entry.ToFullPath();
+
+    /// <summary>
+    /// Delegate for transforming raw find data into a result.
+    /// </summary>
+    public delegate string FindTransform(ref FileSystemEntry entry);
+}

--- a/touki/Touki/Io/MatchSet.cs
+++ b/touki/Touki/Io/MatchSet.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Collections;
+
+namespace Touki.Io;
+
+/// <summary>
+///  A set of matchers that can include and exclude matches for enumeration.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Excludes are processed before includes, meaning that if an exclude matcher matches, the include matchers will
+///   not be considered. This optimizes the matching process by allowing for early exits when a subdirectory does
+///   not match.
+///  </para>
+/// </remarks>
+public sealed class MatchSet : DisposableBase, IEnumerationMatcher
+{
+    private readonly SingleOptimizedList<IEnumerationMatcher> _includes = [];
+    private SingleOptimizedList<IEnumerationMatcher>? _excludes;
+
+    /// <summary>
+    ///  Constructs a new <see cref="MatchSet"/> with the specified primary match.
+    /// </summary>
+    public MatchSet(IEnumerationMatcher includeMatcher)
+    {
+        ArgumentNull.ThrowIfNull(includeMatcher);
+        _includes.Add(includeMatcher);
+    }
+
+    /// <summary>
+    ///  Adds an include matcher to the set.
+    /// </summary>
+    /// <param name="includeMatcher">If no excludes have been processed, this matcher will be considered for matches.</param>
+    public void AddInclude(IEnumerationMatcher includeMatcher)
+    {
+        ArgumentNull.ThrowIfNull(includeMatcher);
+        _includes.Add(includeMatcher);
+    }
+
+    /// <summary>
+    ///  Adds an exclude matcher to the set.
+    /// </summary>
+    /// <param name="excludematcher">This matcher will be considered to block consideration for matching.</param>
+    public void AddExclude(IEnumerationMatcher excludematcher)
+    {
+        ArgumentNull.ThrowIfNull(excludematcher);
+        _excludes ??= [];
+        _excludes.Add(excludematcher);
+    }
+
+    void IEnumerationMatcher.DirectoryFinished()
+    {
+        foreach (IEnumerationMatcher matcher in _includes)
+        {
+            matcher.DirectoryFinished();
+        }
+
+        if (_excludes is { } excludes)
+        {
+            foreach (IEnumerationMatcher matcher in excludes)
+            {
+                matcher.DirectoryFinished();
+            }
+        }
+    }
+
+    bool IEnumerationMatcher.MatchesDirectory(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> directoryName)
+    {
+        if (_excludes is { } excludes)
+        {
+            foreach (IEnumerationMatcher matcher in excludes)
+            {
+                if (matcher.MatchesDirectory(currentDirectory, directoryName))
+                {
+                    // Excluded
+                    return false;
+                }
+            }
+        }
+
+        foreach (IEnumerationMatcher matcher in _includes)
+        {
+            if (matcher.MatchesDirectory(currentDirectory, directoryName))
+            {
+                // Matched
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    bool IEnumerationMatcher.MatchesFile(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> fileName)
+    {
+        if (_excludes is { } excludes)
+        {
+            foreach (IEnumerationMatcher matcher in excludes)
+            {
+                if (matcher.MatchesFile(currentDirectory, fileName))
+                {
+                    // Excluded
+                    return false;
+                }
+            }
+        }
+
+        foreach (IEnumerationMatcher matcher in _includes)
+        {
+            if (matcher.MatchesFile(currentDirectory, fileName))
+            {
+                // Matched
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _includes.Dispose();
+            _excludes?.Dispose();
+        }
+    }
+}

--- a/touki/Touki/Text/StringSegment.cs
+++ b/touki/Touki/Text/StringSegment.cs
@@ -182,9 +182,19 @@ public readonly struct StringSegment :
     /// <summary>
     ///  Splits on the next separator, or returns the entire segment if no separator is found.
     /// </summary>
-    /// <returns>
-    ///  <see langword="false"/> if the current segment is empty, otherwise <see langword="true"/>.
-    /// </returns>
+    /// <param name="left">The left side of the split.</param>
+    /// <param name="right">The right side of the split, if any.</param>
+    /// <returns><see langword="false"/> if the current segment is empty, otherwise <see langword="true"/>.</returns>
+    /// <remarks>
+    ///  <para>
+    ///   Example usage:
+    ///   <code>
+    ///    <![CDATA[StringSegment right = segment;
+    ///    while (right.TrySplit(';', out StringSegment left, out right)) { /* Do something with left */ }
+    ///    ]]>
+    ///   </code>
+    ///  </para>
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TrySplit(char delimiter, out StringSegment left, out StringSegment right)
     {


### PR DESCRIPTION
Renamed `MSBuildSpec` to `MatchMSBuild` and updated methods accordingly. Introduced `IEnumerationMatcher` interface for improved matching flexibility. Added `MatchAnyDirectory` and `MatchAnyFile` classes for specific matching behaviors.