### PR TITLE
StringSegment related tweaks

### DIFF
--- a/touki.perf/StringFormattingDateTime.cs
+++ b/touki.perf/StringFormattingDateTime.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Touki;
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StringFormattingDateTime
+{
+    private readonly DateTime _value = DateTime.Now;
+
+    [Benchmark(Baseline = true)]
+    public string StringFormat()
+    {
+        return string.Format("The time was {0}.", _value);
+    }
+
+    [Benchmark]
+    public string StringInterpolation()
+    {
+        return $"The time was {_value}.";
+    }
+
+    [Benchmark]
+    public string StringsFormat()
+    {
+        return Strings.Format("The time was {0}.", _value);
+    }
+}

--- a/touki.perf/StringSegmentFormatting.cs
+++ b/touki.perf/StringSegmentFormatting.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Touki;
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StringSegmentFormatting
+{
+    private readonly StringSegment _valueOne = new("Hello World!", 0, 5);
+    private readonly StringSegment _valueTwo = new("Hello Universe!", 6, 9);
+
+    [Benchmark(Baseline = true)]
+    public string StringFormat()
+    {
+        return string.Format("{0} {1}", _valueOne, _valueTwo);
+    }
+
+    [Benchmark]
+    public string StringInterpolation()
+    {
+        return $"{_valueOne} {_valueTwo}";
+    }
+
+    [Benchmark]
+    public string StringsFormat()
+    {
+        return Strings.Format("{0} {1}", _valueOne, _valueTwo);
+    }
+}

--- a/touki.tests/Touki/StreamExtensionsTests.cs
+++ b/touki.tests/Touki/StreamExtensionsTests.cs
@@ -4,6 +4,7 @@
 
 using System.Text;
 using Touki.Io;
+using Touki.Text;
 #if NETFRAMEWORK
 using System.IO;
 #endif

--- a/touki.tests/Touki/Text/StringBuilderExtensionsTests.cs
+++ b/touki.tests/Touki/Text/StringBuilderExtensionsTests.cs
@@ -4,7 +4,7 @@
 
 using System.Text;
 
-namespace Touki;
+namespace Touki.Text;
 
 /// <summary>
 ///  Tests for <see cref="StringBuilderExtensions"/> AppendFormatted methods.

--- a/touki.tests/Touki/Text/ValueStringBuilderEnumTests.cs
+++ b/touki.tests/Touki/Text/ValueStringBuilderEnumTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Text;
 
 /// <summary>
 /// Tests for ValueStringBuilder enum formatting with all integer backing types.

--- a/touki.tests/Touki/Text/ValueStringBuilderTests.cs
+++ b/touki.tests/Touki/Text/ValueStringBuilderTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information
 
 using System.Text;
+using Touki.Text;
 
 namespace Touki;
 

--- a/touki.tests/Touki/Value/StoringStringSegment.cs
+++ b/touki.tests/Touki/Value/StoringStringSegment.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.ValueTests;
+
+public class StoringStringSegment
+{
+    public static TheoryData<StringSegment> StringSegmentData => new()
+    {
+        { new StringSegment("Hello, World!") },
+        { new StringSegment("Hello, World!", 7, 5) },
+        { new StringSegment(string.Empty) },
+        { default }
+    };
+
+    [Theory]
+    [MemberData(nameof(StringSegmentData))]
+    public void StringSegmentImplicit(StringSegment segment)
+    {
+        Value value = segment;
+        Assert.Equal(segment, value.As<StringSegment>());
+        Assert.Equal(typeof(StringSegment), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(StringSegmentData))]
+    public void StringSegmentCreate(StringSegment segment)
+    {
+        Value value;
+        using (MemoryWatch.Create)
+        {
+            value = Value.Create(segment);
+        }
+
+        Assert.Equal(segment, value.As<StringSegment>());
+        Assert.Equal(typeof(StringSegment), value.Type);
+    }
+
+    [Theory]
+    [MemberData(nameof(StringSegmentData))]
+    public void StringSegmentInOut(StringSegment segment)
+    {
+        Value value = segment;
+        bool success = value.TryGetValue(out StringSegment result);
+        Assert.True(success);
+        Assert.Equal(segment, result);
+
+        Assert.Equal(segment, value.As<StringSegment>());
+        Assert.Equal(segment, (StringSegment)value);
+    }
+
+    [Fact]
+    public void NestedSegments()
+    {
+        string text = "Hello, World! How are you?";
+        StringSegment fullSegment = new(text);
+        StringSegment worldSegment = new(text, 7, 5); // "World"
+        StringSegment howSegment = new(text, 14, 3);  // "How"
+
+        Value value1 = fullSegment;
+        Value value2 = worldSegment;
+        Value value3 = howSegment;
+
+        Assert.Equal(fullSegment, value1.As<StringSegment>());
+        Assert.Equal(worldSegment, value2.As<StringSegment>());
+        Assert.Equal(howSegment, value3.As<StringSegment>());
+
+        // Ensure the segments maintain their correct positions
+        Assert.Equal("Hello, World! How are you?", fullSegment.ToString());
+        Assert.Equal("World", worldSegment.ToString());
+        Assert.Equal("How", howSegment.ToString());
+
+        // Verify the retrieved segments have the same properties
+        StringSegment retrieved2 = value2.As<StringSegment>();
+        Assert.Equal(7, retrieved2._startIndex);
+        Assert.Equal(5, retrieved2._length);
+        Assert.Equal(text, retrieved2.Value);
+    }
+
+    [Fact]
+    public void DefaultStringSegment()
+    {
+        StringSegment defaultSegment = default;
+        Value value = defaultSegment;
+
+        Assert.Equal(typeof(StringSegment), value.Type);
+        Assert.Equal(defaultSegment, value.As<StringSegment>());
+        Assert.Equal(string.Empty, value.As<StringSegment>().Value);
+        Assert.Equal(0, value.As<StringSegment>()._startIndex);
+        Assert.Equal(0, value.As<StringSegment>()._length);
+    }
+
+    [Fact]
+    public void OutAsObject()
+    {
+        StringSegment segment = new("Test Segment", 0, 4); // "Test"
+        Value value = segment;
+
+        object o = value.As<object>();
+        Assert.Equal(typeof(StringSegment), o.GetType());
+        Assert.Equal(segment, (StringSegment)o);
+        Assert.Equal("Test", ((StringSegment)o).ToString());
+    }
+
+    [Fact]
+    public void EmptyStringSegment()
+    {
+        StringSegment emptySegment = new(string.Empty);
+        Value value = emptySegment;
+
+        Assert.Equal(typeof(StringSegment), value.Type);
+        Assert.Equal(emptySegment, value.As<StringSegment>());
+        Assert.True(value.As<StringSegment>().IsEmpty);
+    }
+
+    [Fact]
+    public void StringSegmentRoundTrip()
+    {
+        string original = "This is a test of string segments";
+        StringSegment[] segments =
+        [
+            new StringSegment(original),
+            new StringSegment(original, 10, 4),  // "test"
+            new StringSegment(original, 0, 4),   // "This"
+            new StringSegment(original, 18, 8)   // "segments"
+        ];
+
+        foreach (StringSegment segment in segments)
+        {
+            Value value = segment;
+            StringSegment roundTripped = value.As<StringSegment>();
+
+            Assert.Equal(segment.Value, roundTripped.Value);
+            Assert.Equal(segment._startIndex, roundTripped._startIndex);
+            Assert.Equal(segment._length, roundTripped._length);
+            Assert.Equal(segment.ToString(), roundTripped.ToString());
+        }
+    }
+}

--- a/touki/Framework/System/Diagnostics/AssertInterpolatedStringHandler.cs
+++ b/touki/Framework/System/Diagnostics/AssertInterpolatedStringHandler.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics;
 [InterpolatedStringHandler]
 public ref struct AssertInterpolatedStringHandler
 {
-    private Touki.ValueStringBuilder _builder;
+    private Touki.Text.ValueStringBuilder _builder;
     private readonly bool _shouldAppend;
 
     /// <summary>Creates an instance of the handler.</summary>
@@ -27,12 +27,12 @@ public ref struct AssertInterpolatedStringHandler
         }
         else
         {
-            _builder = new Touki.ValueStringBuilder(literalLength, formattedCount);
+            _builder = new Touki.Text.ValueStringBuilder(literalLength, formattedCount);
             _shouldAppend = shouldAppend = true;
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendLiteral(string?)"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendLiteral(string?)"/>
     public void AppendLiteral(string? value)
     {
         if (_shouldAppend)
@@ -41,7 +41,7 @@ public ref struct AssertInterpolatedStringHandler
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted{T}(T)"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendFormatted{T}(T, Touki.StringSpan)"/>
     public void AppendFormatted<T>(T value)
     {
         if (_shouldAppend)
@@ -50,7 +50,7 @@ public ref struct AssertInterpolatedStringHandler
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted{T}(T,int)"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendFormatted{T}(T,int)"/>
     public void AppendFormatted<T>(T value, int alignment)
     {
         if (_shouldAppend)
@@ -59,7 +59,7 @@ public ref struct AssertInterpolatedStringHandler
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted{T}(T, int, Touki.StringSpan)"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendFormatted{T}(T, int, Touki.StringSpan)"/>
     public void AppendFormatted<T>(T value, int alignment, string? format)
     {
         if (_shouldAppend)
@@ -68,7 +68,7 @@ public ref struct AssertInterpolatedStringHandler
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted(ReadOnlySpan{char})"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendFormatted(ReadOnlySpan{char})"/>
     public void AppendFormatted(scoped ReadOnlySpan<char> value)
     {
         if (_shouldAppend)
@@ -77,7 +77,7 @@ public ref struct AssertInterpolatedStringHandler
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted(ReadOnlySpan{char},int,string?)"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendFormatted(ReadOnlySpan{char},int,string?)"/>
     public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null)
     {
         if (_shouldAppend)
@@ -86,7 +86,7 @@ public ref struct AssertInterpolatedStringHandler
         }
     }
 
-    /// <inheritdoc cref="Touki.ValueStringBuilder.AppendFormatted(string?)"/>
+    /// <inheritdoc cref="Touki.Text.ValueStringBuilder.AppendFormatted(string?)"/>
     public void AppendFormatted(string? value)
     {
         if (_shouldAppend)

--- a/touki/Framework/System/Globalization/DateTimeFormat.cs
+++ b/touki/Framework/System/Globalization/DateTimeFormat.cs
@@ -7,6 +7,7 @@
 
 using System.Globalization;
 using Touki;
+using Touki.Text;
 using Touki.Framework.Resources;
 
 namespace System;

--- a/touki/Framework/System/Globalization/HebrewNumber.cs
+++ b/touki/Framework/System/Globalization/HebrewNumber.cs
@@ -5,7 +5,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Touki;
+using Touki.Text;
 
 namespace System.Globalization;
 

--- a/touki/Framework/System/Number.Formatting.cs
+++ b/touki/Framework/System/Number.Formatting.cs
@@ -9,6 +9,7 @@ using System.Buffers.Text;
 using System.Globalization;
 using Touki;
 using Touki.Resources;
+using Touki.Text;
 
 namespace System;
 

--- a/touki/Framework/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/touki/Framework/System/Runtime/CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -8,6 +8,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Touki;
+using Touki.Text;
 
 namespace System.Runtime.CompilerServices;
 
@@ -49,8 +50,11 @@ public ref struct DefaultInterpolatedStringHandler
     /// <inheritdoc cref="ValueStringBuilder.Append(string)"/>
     public void AppendLiteral(string s) => _builder.Append(s);
 
-    /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T)"/>
+    /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, StringSpan)"/>
     public void AppendFormatted<T>(T value) => _builder.AppendFormatted(value);
+
+    /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, StringSpan)"/>
+    public void AppendFormatted(Value value) => _builder.AppendFormatted(value);
 
     /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, string?)"/>
     public void AppendFormatted<T>(T value, string? format) => _builder.AppendFormatted(value, format);

--- a/touki/GlobalSuppressions.cs
+++ b/touki/GlobalSuppressions.cs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.Cache`1.t_localItem")]
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.ValueStringBuilder.t_values")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.Text.ValueStringBuilder.t_values")]
 
 #if NETFRAMEWORK
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.EnumExtensions.t_params")]

--- a/touki/Resources/SR.resx
+++ b/touki/Resources/SR.resx
@@ -1,64 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema
-
-    Version 1.3
-
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
-    associated with the data types.
-
-    Example:
-
-    ... ado.net/XML headers & schema ...
-    <resheader name="resmimetype">text/microsoft-resx</resheader>
-    <resheader name="version">1.3</resheader>
-    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="Name1">this is my long string</data>
-    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-      [base64 mime encoded serialized .NET Framework object]
-    </data>
-    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-      [base64 mime encoded string representing a byte array form of the .NET Framework object]
-    </data>
-
-    There are any number of "resheader" rows that contain simple 
-    name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
-    mimetype set.
-
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
-    extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
-    read any of the formats listed below.
-
-    mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
-      : System.Serialization.Formatters.Binary.BinaryFormatter
-      : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
-      : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-      : and then encoded with base64 encoding.
-
-    mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
-      : using a System.ComponentModel.TypeConverter
-      : and then encoded with base64 encoding.
-  -->
-  
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
@@ -103,5 +44,8 @@
   </data>
   <data name="DestinationArrayTooSmall" xml:space="preserve">
     <value>Destination array is not long enough to copy all the items in the collection.</value>
+  </data>
+  <data name="ErrorString" xml:space="preserve">
+    <value>Error: </value>
   </data>
 </root>

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information
 
 using Touki.Collections;
+using Touki.Text;
 
 namespace Touki.Io;
 

--- a/touki/Touki/Io/Paths.cs
+++ b/touki/Touki/Io/Paths.cs
@@ -7,6 +7,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Touki.Text;
+
 namespace Touki.Io;
 
 /// <summary>

--- a/touki/Touki/Io/StreamExtensions.cs
+++ b/touki/Touki/Io/StreamExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 #if !NET
 using System.IO;
 #endif
+using Touki.Text;
 
 namespace Touki.Io;
 

--- a/touki/Touki/Text/StringBuilderExtensions.cs
+++ b/touki/Touki/Text/StringBuilderExtensions.cs
@@ -4,7 +4,7 @@
 
 using System.Text;
 
-namespace Touki;
+namespace Touki.Text;
 
 /// <summary>
 ///  Extensions for <see cref="StringBuilder"/> to provide additional functionality.

--- a/touki/Touki/Text/Strings.cs
+++ b/touki/Touki/Text/Strings.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Touki.Text;
+
 namespace Touki;
 
 /// <summary>

--- a/touki/Touki/Text/ValueStringBuilder.cs
+++ b/touki/Touki/Text/ValueStringBuilder.cs
@@ -10,7 +10,7 @@
 using System.Buffers;
 using System.Globalization;
 
-namespace Touki;
+namespace Touki.Text;
 
 /// <summary>
 ///  String builder struct that can be used to build strings in a memory-efficient way.

--- a/touki/Touki/Value.cs
+++ b/touki/Touki/Value.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Touki.Text;
+
 namespace Touki;
 
 /// <summary>
@@ -57,7 +59,7 @@ public readonly partial struct Value
     /// </summary>
     /// <param name="value">The <see langword="string"/> value to convert.</param>
     /// <returns>A <see cref="Value"/> containing the specified <see langword="string"/> value.</returns>
-    public static implicit operator Value(string value) => new(value);
+    public static implicit operator Value(string value) => new((object)value);
 
     /// <summary>
     ///  Gets the type of the value stored in this instance.
@@ -86,7 +88,7 @@ public readonly partial struct Value
 
                 if (_union.UInt64 != 0)
                 {
-                    Debug.Assert(type.IsArray);
+                    Debug.Assert(type.IsArray || type == typeof(string));
 
                     // We have an ArraySegment
                     if (type == typeof(byte[]))
@@ -96,6 +98,10 @@ public readonly partial struct Value
                     else if (type == typeof(char[]))
                     {
                         type = typeof(ArraySegment<char>);
+                    }
+                    else if (type == typeof(string))
+                    {
+                        type = typeof(StringSegment);
                     }
                     else
                     {
@@ -956,6 +962,40 @@ public readonly partial struct Value
     public static explicit operator DateTime?(in Value value) => value.As<DateTime?>();
     #endregion
 
+    #region StringSegment
+    /// <summary>
+    ///  Creates a new <see cref="Value"/> instance with the specified <see cref="StringSegment"/> value.
+    /// </summary>
+    /// <param name="segment">The <see cref="StringSegment"/> value to store.</param>
+    private Value(in StringSegment segment)
+    {
+        _object = segment.Value;
+        if (segment._startIndex == 0 && segment._length == 0)
+        {
+            _union.UInt64 = ulong.MaxValue;
+        }
+        else
+        {
+            _union.Segment = (segment._startIndex, segment._length);
+        }
+    }
+
+    /// <summary>
+    ///  Implicitly converts a <see cref="StringSegment"/> value to a <see cref="Value"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="StringSegment"/> value to convert.</param>
+    /// <returns>A <see cref="Value"/> containing the specified <see cref="StringSegment"/> value.</returns>
+    public static implicit operator Value(in StringSegment value) => new(value);
+
+    /// <summary>
+    ///  Explicitly converts a <see cref="Value"/> to a <see cref="StringSegment"/>.
+    /// </summary>
+    /// <param name="value">The <see cref="Value"/> to convert.</param>
+    /// <returns>The <see cref="StringSegment"/> value stored in the <see cref="Value"/>.</returns>
+    /// <exception cref="InvalidCastException">The stored value is not an <see cref="StringSegment"/>.</exception>
+    public static explicit operator StringSegment(in Value value) => value.As<StringSegment>();
+    #endregion
+
     #region ArraySegment
     /// <summary>
     ///  Creates a new <see cref="Value"/> instance with the specified <see cref="ArraySegment{Byte}"/> value.
@@ -982,24 +1022,24 @@ public readonly partial struct Value
     }
 
     /// <summary>
-    ///  Implicitly converts an ArraySegment&lt;byte&gt; value to a <see cref="Value"/>.
+    ///  Implicitly converts an <see cref="ArraySegment{Byte}"/> value to a <see cref="Value"/>.
     /// </summary>
-    /// <param name="value">The ArraySegment&lt;byte&gt; value to convert.</param>
-    /// <returns>A <see cref="Value"/> containing the specified ArraySegment&lt;byte&gt; value.</returns>
+    /// <param name="value">The <see cref="ArraySegment{Byte}"/> value to convert.</param>
+    /// <returns>A <see cref="Value"/> containing the specified <see cref="ArraySegment{Byte}"/> value.</returns>
     public static implicit operator Value(ArraySegment<byte> value) => new(value);
 
     /// <summary>
-    ///  Explicitly converts a <see cref="Value"/> to an ArraySegment&lt;byte&gt;.
+    ///  Explicitly converts a <see cref="Value"/> to an <see cref="ArraySegment{Byte}"/>.
     /// </summary>
     /// <param name="value">The <see cref="Value"/> to convert.</param>
-    /// <returns>The ArraySegment&lt;byte&gt; value stored in the <see cref="Value"/>.</returns>
-    /// <exception cref="InvalidCastException">The stored value is not an ArraySegment&lt;byte&gt;.</exception>
+    /// <returns>The <see cref="ArraySegment{Byte}"/> value stored in the <see cref="Value"/>.</returns>
+    /// <exception cref="InvalidCastException">The stored value is not an <see cref="ArraySegment{Byte}"/>.</exception>
     public static explicit operator ArraySegment<byte>(in Value value) => value.As<ArraySegment<byte>>();
 
     /// <summary>
-    ///  Creates a new <see cref="Value"/> instance with the specified ArraySegment&lt;char&gt; value.
+    ///  Creates a new <see cref="Value"/> instance with the specified <see cref="ArraySegment{Char}"/> value.
     /// </summary>
-    /// <param name="segment">The ArraySegment&lt;char&gt; value to store.</param>
+    /// <param name="segment">The <see cref="ArraySegment{Char}"/> value to store.</param>
     /// <exception cref="ArgumentNullException">The array of the segment is null.</exception>
     private Value(ArraySegment<char> segment)
     {
@@ -1021,18 +1061,18 @@ public readonly partial struct Value
     }
 
     /// <summary>
-    ///  Implicitly converts an ArraySegment&lt;char&gt; value to a <see cref="Value"/>.
+    ///  Implicitly converts an <see cref="ArraySegment{Char}"/> value to a <see cref="Value"/>.
     /// </summary>
-    /// <param name="value">The ArraySegment&lt;char&gt; value to convert.</param>
-    /// <returns>A <see cref="Value"/> containing the specified ArraySegment&lt;char&gt; value.</returns>
+    /// <param name="value">The <see cref="ArraySegment{Char}"/> value to convert.</param>
+    /// <returns>A <see cref="Value"/> containing the specified <see cref="ArraySegment{Char}"/> value.</returns>
     public static implicit operator Value(ArraySegment<char> value) => new(value);
 
     /// <summary>
-    ///  Explicitly converts a <see cref="Value"/> to an ArraySegment&lt;char&gt;.
+    ///  Explicitly converts a <see cref="Value"/> to an <see cref="ArraySegment{Char}"/>.
     /// </summary>
     /// <param name="value">The <see cref="Value"/> to convert.</param>
-    /// <returns>The ArraySegment&lt;char&gt; value stored in the <see cref="Value"/>.</returns>
-    /// <exception cref="InvalidCastException">The stored value is not an ArraySegment&lt;char&gt;.</exception>
+    /// <returns>The <see cref="ArraySegment{Char}"/> value stored in the <see cref="Value"/>.</returns>
+    /// <exception cref="InvalidCastException">The stored value is not an <see cref="ArraySegment{Char}"/>.</exception>
     public static explicit operator ArraySegment<char>(in Value value) => value.As<ArraySegment<char>>();
     #endregion
 
@@ -1146,6 +1186,8 @@ public readonly partial struct Value
             return new(Unsafe.As<T, ArraySegment<byte>>(ref Unsafe.AsRef(in value)));
         if (typeof(T) == typeof(ArraySegment<char>))
             return new(Unsafe.As<T, ArraySegment<char>>(ref Unsafe.AsRef(in value)));
+        if (typeof(T) == typeof(StringSegment))
+            return new(Unsafe.As<T, StringSegment>(ref Unsafe.AsRef(in value)));
 
         if (typeof(T).IsEnum)
         {
@@ -1247,6 +1289,22 @@ public readonly partial struct Value
         {
             value = t;
             result = true;
+        }
+        else if (typeof(T) == typeof(StringSegment))
+        {
+            ulong bits = _union.UInt64;
+            if (bits != 0 && _object is string str)
+            {
+                StringSegment segment = bits != ulong.MaxValue
+                    ? new(str, _union.Segment.Offset, _union.Segment.Count)
+                    : new(str, 0, 0);
+                value = Unsafe.As<StringSegment, T>(ref segment);
+                result = true;
+            }
+            else
+            {
+                value = default!;
+            }
         }
         else if (typeof(T) == typeof(ArraySegment<byte>))
         {
@@ -1430,6 +1488,20 @@ public readonly partial struct Value
         {
             value = default!;
         }
+        else if (typeof(T) == typeof(string))
+        {
+            if (_union.UInt64 == 0 && _object is string str)
+            {
+                value = (T)(object)str;
+                result = true;
+            }
+            else
+            {
+                // Don't allow "implicit" cast to string if we stored a segment.
+                value = default!;
+                result = false;
+            }
+        }
         else if (typeof(T) == typeof(char[]))
         {
             if (_union.UInt64 == 0 && _object is char[])
@@ -1464,6 +1536,13 @@ public readonly partial struct Value
             if (_object is TypeFlag flag)
             {
                 value = (T)flag.ToObject(this);
+                result = true;
+            }
+            else if (_union.UInt64 != 0 && _object is string stringValue)
+            {
+                value = _union.UInt64 != ulong.MaxValue
+                    ? (T)(object)new StringSegment(stringValue, _union.Segment.Offset, _union.Segment.Count)
+                    : (T)(object)new StringSegment(stringValue, 0, 0);
                 result = true;
             }
             else if (_union.UInt64 != 0 && _object is char[] chars)
@@ -1565,11 +1644,11 @@ public readonly partial struct Value
             }
             else
             {
-                // Need to special case ArraySegment<byte> and ArraySegment<char>
+                // Need to special case ArraySegment<byte>, ArraySegment<char>, and StringSegment
 
-                Debug.Assert(objectType.IsArray);
+                Debug.Assert(objectType.IsArray || objectType == typeof(StringSegment));
 
-                // We have an ArraySegment
+                // We have an ArraySegment or StringSegment
                 if (objectType == typeof(byte[]))
                 {
                     destination.AppendFormatted(As<ArraySegment<byte>>(), format);
@@ -1577,6 +1656,10 @@ public readonly partial struct Value
                 else if (objectType == typeof(char[]))
                 {
                     destination.AppendFormatted(As<ArraySegment<char>>(), format);
+                }
+                else if (objectType == typeof(string))
+                {
+                    destination.AppendFormatted(As<StringSegment>(), format);
                 }
                 else
                 {


### PR DESCRIPTION
- Handle StringSegment in Value.
- Change StringSegment to work when created via `default`
- Add ISpanFormattable to StringSegment.
- Move ValueStringBuilder to `Touki.Text`.
- Avoid boxing on .NET Framework when formatting ISpanFormattable structs.
- Add more tests.