### PR TITLE
Simplify DateTimeOffset storage in Value

### DIFF
--- a/touki.perf/GlobalUsings.cs
+++ b/touki.perf/GlobalUsings.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+global using BenchmarkDotNet.Attributes;
+global using BenchmarkDotNet.Jobs;
+global using Touki;

--- a/touki.perf/MsBuildEnumeratePerf.cs
+++ b/touki.perf/MsBuildEnumeratePerf.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
 using Touki.Io;
 
 namespace touki.perf;

--- a/touki.perf/StoreArray.cs
+++ b/touki.perf/StoreArray.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StoreArray
+{
+    private static readonly byte[] s_byteArray = new byte[10];
+    private static readonly ArraySegment<byte> s_byteSegment = new(s_byteArray);
+    private static readonly ArraySegment<byte> s_emptyByteSegment = new(s_byteArray, 0, 0);
+
+    [Benchmark(Baseline = true)]
+    public byte[] InOutByteArray()
+    {
+        Value value = Value.Create(s_byteArray);
+        value.TryGetValue(out byte[] result);
+        return result;
+    }
+
+    [Benchmark]
+    public ArraySegment<byte> InOutByteSegment()
+    {
+        Value value = s_byteSegment;
+        value.TryGetValue(out ArraySegment<byte> result);
+        return result;
+    }
+
+    [Benchmark]
+    public ArraySegment<byte> InOutEmptyByteSegment()
+    {
+        Value value = s_emptyByteSegment;
+        value.TryGetValue(out ArraySegment<byte> result);
+        return result;
+    }
+}

--- a/touki.perf/StoreDateTime.cs
+++ b/touki.perf/StoreDateTime.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+// [SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StoreDateTime
+{
+    private static readonly DateTime s_now = DateTime.Now;
+    private static readonly DateTimeOffset s_offsetUtc = DateTime.UtcNow;
+    private static readonly DateTimeOffset s_offset = DateTime.Now;
+
+    [Benchmark(Baseline = true)]
+    public DateTime InOutDateTime()
+    {
+        Value value = s_now;
+        value.TryGetValue(out DateTime result);
+        return result;
+    }
+
+    [Benchmark]
+    public DateTimeOffset InOutDateTimeOffsetUTC()
+    {
+        Value value = s_offsetUtc;
+        value.TryGetValue(out DateTimeOffset result);
+        return result;
+    }
+
+    [Benchmark]
+    public DateTimeOffset InOutDateTimeOffset()
+    {
+        Value value = s_offset;
+        value.TryGetValue(out DateTimeOffset result);
+        return result;
+    }
+}

--- a/touki.perf/StoreEnum.cs
+++ b/touki.perf/StoreEnum.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StoreEnum
+{
+    [Benchmark(Baseline = true)]
+    public DayOfWeek TryOut()
+    {
+        Value value = Value.Create(DayOfWeek.Monday);
+        value.TryGetValue(out DayOfWeek result);
+        return result;
+    }
+}

--- a/touki.perf/StoreInteger.cs
+++ b/touki.perf/StoreInteger.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StoreInteger
+{
+    [Benchmark]
+    public int As()
+    {
+        Value value = 42;
+        return value.As<int>();
+    }
+
+    [Benchmark]
+    public int TryGet()
+    {
+        Value value = 42;
+        value.TryGetValue(out int result);
+        return result;
+    }
+}

--- a/touki.perf/StoreLong.cs
+++ b/touki.perf/StoreLong.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StoreLong
+{
+    [Benchmark]
+    public long As()
+    {
+        Value value = 42L;
+        return value.As<long>();
+    }
+
+    [Benchmark(Baseline = true)]
+    public long TryGet()
+    {
+        Value value = 42L;
+        value.TryGetValue(out long result);
+        return result;
+    }
+
+    [Benchmark]
+    public long CastOut()
+    {
+        Value value = 42L;
+        return (long)value;
+    }
+}

--- a/touki.perf/StoreNullableLong.cs
+++ b/touki.perf/StoreNullableLong.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class StoreNullableLong
+{
+    [Benchmark(Baseline = true)]
+    public long? InOutNullable()
+    {
+        long? @long = 42;
+        Value value = @long;
+        value.TryGetValue(out long? result);
+        return result;
+    }
+
+    [Benchmark]
+    public long? InLongOutNullable()
+    {
+        long @long = 42;
+        Value value = @long;
+        value.TryGetValue(out long? result);
+        return result;
+    }
+
+    [Benchmark]
+    public long InNullableOut()
+    {
+        long? @long = 42;
+        Value value = @long;
+        value.TryGetValue(out long result);
+        return result;
+    }
+
+    [Benchmark]
+    public long? CastInNullableOutNullable()
+    {
+        long? @long = 42;
+        Value value = @long;
+        return (long?)value;
+    }
+
+    [Benchmark]
+    public long? CastInOutNullable()
+    {
+        long @long = 42;
+        Value value = @long;
+        return (long?)value;
+    }
+
+    [Benchmark]
+    public long CastInNullableOut()
+    {
+        long? @long = 42;
+        Value value = @long;
+        return (long)value;
+    }
+}

--- a/touki.perf/StringFormatting.cs
+++ b/touki.perf/StringFormatting.cs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki.perf/StringFormattingAs8DigitHex.cs
+++ b/touki.perf/StringFormattingAs8DigitHex.cs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki.perf/StringFormattingDateTime.cs
+++ b/touki.perf/StringFormattingDateTime.cs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki.perf/StringFormattingEnum.cs
+++ b/touki.perf/StringFormattingEnum.cs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki.perf/StringFormattingFlagsEnum.cs
+++ b/touki.perf/StringFormattingFlagsEnum.cs
@@ -2,9 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki.perf/StringSegmentFormatting.cs
+++ b/touki.perf/StringSegmentFormatting.cs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki.perf/StringsHashPerf.cs
+++ b/touki.perf/StringsHashPerf.cs
@@ -2,10 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
-using Touki;
-
 namespace touki.perf;
 
 [MemoryDiagnoser]

--- a/touki/Framework/System/Globalization/DateTimeFormat.cs
+++ b/touki/Framework/System/Globalization/DateTimeFormat.cs
@@ -135,14 +135,6 @@ internal static class DateTimeFormat
     private const char JapaneseEraStart = '\u5143';
     private const string Gmt = "GMT";
 
-    // Number of 100ns (10E-7 second) ticks per time unit
-    private const long TicksPerMillisecond = 10000;
-    private const long TicksPerSecond = TicksPerMillisecond * 1000;
-    private const long TicksPerMinute = TicksPerSecond * 60;
-    private const long TicksPerHour = TicksPerMinute * 60;
-    private const long TicksPerDay = TicksPerHour * 24;
-
-
     private static DateTimeFormatInfo InvariantFormatInfo { get; } = CultureInfo.InvariantCulture.DateTimeFormat;
     private static string[] InvariantAbbreviatedMonthNames { get; } = InvariantFormatInfo.AbbreviatedMonthNames;
     private static string[] InvariantAbbreviatedDayNames { get; } = InvariantFormatInfo.AbbreviatedDayNames;
@@ -509,7 +501,7 @@ internal static class DateTimeFormat
                     tokenLen = ParseRepeatPattern(format, i, ch);
                     if (tokenLen <= MaxSecondsFractionDigits)
                     {
-                        long fraction = dateTime.Ticks % TicksPerSecond;
+                        long fraction = dateTime.Ticks % TimeSpan.TicksPerSecond;
                         fraction /= (long)Math.Pow(10, 7 - tokenLen);
                         if (ch == 'f')
                         {
@@ -790,7 +782,7 @@ internal static class DateTimeFormat
         if (dateTimeFormat)
         {
             // No offset. The instance is a DateTime and the output should be the local time zone
-            if (timeOnly && dateTime.Ticks < TicksPerDay)
+            if (timeOnly && dateTime.Ticks < TimeSpan.TicksPerDay)
             {
                 // For time only format and a time only input, the time offset on 0001/01/01 is less
                 // accurate than the system's current offset because of daylight saving time.
@@ -950,7 +942,7 @@ internal static class DateTimeFormat
         if (format.Length == 0)
         {
             bool timeOnlySpecialCase = false;
-            if (dateTime.Ticks < TicksPerDay)
+            if (dateTime.Ticks < TimeSpan.TicksPerDay)
             {
                 // If the time is less than 1 day, consider it as time of day.
                 // Just print out the short time format.

--- a/touki/Touki/Value.PackedDateTimeOffset.cs
+++ b/touki/Touki/Value.PackedDateTimeOffset.cs
@@ -34,8 +34,6 @@ public readonly partial struct Value
 
         private readonly ulong _data;
 
-        // public const long TicksPerHour = TicksPerMinute * 60;        // 36,000,000,000
-
         private PackedDateTimeOffset(ulong data) => _data = data;
 
         public static bool TryCreate(ulong ticks, short offsetMinutes, out PackedDateTimeOffset packed)
@@ -47,14 +45,13 @@ public readonly partial struct Value
                 && offsetMinutes >= MinOffsetMinutes
                 && offsetMinutes <= MaxOffsetMinutes)
             {
-                offsetMinutes += PositiveShiftMinutes; // Shift to make all values positive
-                int quotient = Math.DivRem(offsetMinutes + PositiveShiftMinutes, IncrementMinutes, out int remainder);
+                // Shift to make all values positive
+                offsetMinutes += PositiveShiftMinutes;
+                int quotient = Math.DivRem(offsetMinutes, IncrementMinutes, out int remainder);
 
                 // Validate: no remainder (30-min increment)
                 if (remainder == 0)
                 {
-                    // offsetMinutes += PositiveShiftMinutes; // Shift to make all values positive
-                    // int quotient = offsetMinutes / IncrementMinutes;
                     ulong data = ((ulong)quotient << MinuteShift);
                     data |= (ticks - BaseTicks);
                     packed = new(data);

--- a/touki/Touki/Value.PackedDateTimeOffset.cs
+++ b/touki/Touki/Value.PackedDateTimeOffset.cs
@@ -8,52 +8,55 @@ public readonly partial struct Value
 {
     private readonly struct PackedDateTimeOffset
     {
-        // HHHHHMMT TTT...
-        //
-        // HHHHH   - hour bits 1-31
-        // MM      - minutes flag
-        // T       - ticks bit
-        //            00 - :00
-        //            01 - :15
-        //            10 - :30
-        //            11 - :45
+        // The maximum supported number of minutes is +/- 14 hours, but everything goes between -12:00 and +14:00 and
+        // almost all offsets are on :30 minute intervals.
 
-        // Base local tick time 1800 [DateTime(1800, 1, 1).Ticks]
-        private const ulong BaseTicks = 567709344000000000;
+        // Windows NT epoch is January 1, 1601. Unix epoch is January 1, 1970. The Gregorian calendar was introduced
+        // in 1582 (adopted by Britain in 1752). While it is sort of strange to have an offset that goes back that far,
+        // if we do, we still go forward 914 years from 1582 to 2496 (which is well beyond the current date).
+        //
+        // Our updated algorithm (which exludes offsets that do not fall on 30 minute intervals) gives us 914 years of
+        // "ticks" to work with (we did have 457).
+        private const ulong BaseTicks = 498283488000000000;
         private const ulong MaxTicks = BaseTicks + TickMask;
 
-        // Hours go from -14 to 14. We add 14 to get our number to store.
-        private const int HourOffset = 14;
+        private const ulong TickMask = 0b00000011_11111111_11111111_11111111__11111111_11111111_11111111_11111111;
 
-        private const ulong TickMask    = 0b00000001_11111111_11111111_11111111__11111111_11111111_11111111_11111111;
-        private const ulong MinuteMask  = 0b00000110_00000000_00000000_00000000__00000000_00000000_00000000_00000000;
-        private const ulong HourMask    = 0b11111000_00000000_00000000_00000000__00000000_00000000_00000000_00000000;
+        // Range constants
+        private const int MinOffsetMinutes = -840;  // UTC-14:00
+        private const int MaxOffsetMinutes = 840;   // UTC+14:00
+        private const int PositiveShiftMinutes = 840; // Shift to make all values positive
 
-        private const int MinuteShift = 57;
-        private const int HourShift = 59;
+        private const int MinuteShift = 58;
+
+        // Validation constants
+        private const int IncrementMinutes = 30;    // 30-minute intervals
 
         private readonly ulong _data;
 
+        // public const long TicksPerHour = TicksPerMinute * 60;        // 36,000,000,000
+
         private PackedDateTimeOffset(ulong data) => _data = data;
 
-        public static bool TryCreate(DateTimeOffset dateTime, TimeSpan offset, out PackedDateTimeOffset packed)
+        public static bool TryCreate(ulong ticks, short offsetMinutes, out PackedDateTimeOffset packed)
         {
             bool result = false;
             packed = default;
 
-            ulong ticks = (ulong)dateTime.Ticks;
-            if (ticks is > BaseTicks and < MaxTicks)
+            if ((ticks is > BaseTicks and < MaxTicks)
+                && offsetMinutes >= MinOffsetMinutes
+                && offsetMinutes <= MaxOffsetMinutes)
             {
-                int minutes = offset.Minutes;
-                if (minutes % 15 == 0)
-                {
-                    ulong data = (ulong)(minutes / 15) << MinuteShift;
-                    int hours = offset.Hours + HourOffset;
+                offsetMinutes += PositiveShiftMinutes; // Shift to make all values positive
+                int quotient = Math.DivRem(offsetMinutes + PositiveShiftMinutes, IncrementMinutes, out int remainder);
 
-                    // Only valid offset hours are -14 to 14
-                    Debug.Assert(hours is >= 0 and <= 28);
-                    data |= (ulong)hours << HourShift;
-                    data |= ticks - BaseTicks;
+                // Validate: no remainder (30-min increment)
+                if (remainder == 0)
+                {
+                    // offsetMinutes += PositiveShiftMinutes; // Shift to make all values positive
+                    // int quotient = offsetMinutes / IncrementMinutes;
+                    ulong data = ((ulong)quotient << MinuteShift);
+                    data |= (ticks - BaseTicks);
                     packed = new(data);
                     result = true;
                 }
@@ -64,12 +67,12 @@ public readonly partial struct Value
 
         public DateTimeOffset Extract()
         {
-            TimeSpan offset = new(
-                (int)(((_data & HourMask) >> HourShift) - HourOffset),
-                (int)((_data & MinuteMask) >> MinuteShift),
-                0);
+            DateTimeOffset dateTimeOffset = default;
+            ref DateTimeOffsetAccessor accessor = ref Unsafe.As<DateTimeOffset, DateTimeOffsetAccessor>(ref dateTimeOffset);
+            accessor._dateTime._dateTimeData = (_data & TickMask) + BaseTicks;
+            accessor._offsetMinutes = (short)(((int)(_data >> MinuteShift) * IncrementMinutes) - PositiveShiftMinutes);
 
-            return new((long)((_data & TickMask) + BaseTicks), offset);
+            return dateTimeOffset;
         }
     }
 }

--- a/touki/Touki/Value.cs
+++ b/touki/Touki/Value.cs
@@ -840,7 +840,7 @@ public readonly partial struct Value
     {
         ref DateTimeOffsetAccessor accessor = ref Unsafe.As<DateTimeOffset, DateTimeOffsetAccessor>(ref value);
         short offsetMinutes = accessor._offsetMinutes;
-        ulong ticks = accessor._dateTime._dateTimeData;
+        ulong ticks = accessor._dateTime._dateTimeData & DateTimeAccessor.TicksMask;
 
         if (offsetMinutes == 0)
         {
@@ -871,6 +871,7 @@ public readonly partial struct Value
     [StructLayout(LayoutKind.Auto)]
     private struct DateTimeAccessor
     {
+        internal const ulong TicksMask = 0x3FFFFFFFFFFFFFFF;
         internal ulong _dateTimeData;
     }
 


### PR DESCRIPTION
Only stash 30 minute divisible offsets to gain another bit to store ticks. Hack directly into the data as well. Speeds up storage on .NET Framework by about 40%.

Also add Value perf tests.