### PR TITLE
Add polyfill-dotnet-api and pre-pr-self-review agent skills

### DIFF
--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -89,7 +89,54 @@ customization file. The PR review history showed each of these caught a real bug
 - The CI job runs on `ubuntu-latest`. PowerShell is preinstalled; no `pip`
   step is needed.
 
-## 7. Whitespace (applies to every file in scope)
+## 7. Relative Markdown links must resolve in this branch
+
+The CI link check is **offline lychee** &mdash; it only follows links that
+resolve to files in the current working tree. A link to a file that exists
+on the canonical repo's `main` but not in your branch will fail.
+
+- **Before opening a PR with agent-file changes, run
+  [`tools/Test-AgentFileLinks.ps1`](../../../tools/Test-AgentFileLinks.ps1).**
+  Without arguments, it scans every Markdown file in CI's lychee scope and
+  reports any relative link whose target doesn't exist on disk:
+
+  ```pwsh
+  pwsh tools/Test-AgentFileLinks.ps1
+  ```
+
+  The script auto-detects the PR base ref when used with `-ChangedOnly`:
+  it picks `upstream/main` if a remote literally named `upstream` exists
+  (the fork-PR workflow, where `origin` is your fork and `upstream` is the
+  canonical repo) and `origin/main` otherwise (working directly on a clone
+  of the canonical repo). Override with `-Base <ref>` if needed:
+
+  ```pwsh
+  # Audit only files changed on this branch vs the auto-detected base.
+  pwsh tools/Test-AgentFileLinks.ps1 -ChangedOnly
+
+  # Override the base explicitly.
+  pwsh tools/Test-AgentFileLinks.ps1 -Base origin/feature
+  ```
+
+- **If you cite files added by a different in-flight or just-merged PR,
+  rebase your branch on the canonical `main`** (`upstream/main` from a
+  fork, or `origin/main` from a direct clone) so those files exist
+  locally. PR #110's review feedback was triggered by exactly this
+  scenario: the branch predated PR #109 (which added the polyfill files),
+  so every cross-reference to `ConvertExtensions.cs`, `RandomExtensions.cs`,
+  `StringExtensions.cs`, `EncodingExtensions.cs`, `HashCodeExtensions.cs`,
+  `CryptographicOperations.cs`, `SpanExtensions.StartsEndsWith.cs`,
+  `StartsWithPerf.cs`, and `StringExtensionsConcatTests.cs` failed lychee
+  even though those files existed on the canonical `main`.
+- The lychee check runs against the merged tree on `main` only after a
+  push, so a stale branch can still ship broken links into your PR. Treat
+  rebase-then-link-audit as a single step before pushing any agent-file
+  change that references code added elsewhere.
+- Don't downgrade a real link to backticks just to silence the checker.
+  Either fix the link or rebase. Backtick references work as a last resort
+  when the file truly does not exist in any branch yet.
+
+## 8. Whitespace (applies to every file in scope)
 
 - No trailing whitespace.
 - No whitespace-only lines (a "blank" line must be truly empty).

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -9,6 +9,14 @@ Follow these steps in order. Stop and ask the user if any check is ambiguous;
 do not force-push, rewrite history, or delete branches without explicit
 confirmation.
 
+Before running this workflow, walk through the
+[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist &mdash; it
+catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
+that have repeatedly cost a review round-trip on this repo. If the change
+polyfills a .NET API for .NET Framework, the
+[`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) skill defines the
+design rules the self-review then validates against.
+
 ## 1. Inspect repository state
 
 Run these (read-only) checks first:

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -12,7 +12,17 @@ is excluded from the modern build, so it only ever runs on the older RyuJIT. Tre
 This skill captures decisions distilled from real benchmarks under
 [touki.perf/](../../../touki.perf/). Always validate with the
 [performance-testing](../performance-testing/SKILL.md) skill workflow before
-committing a change.
+committing a change. Run the
+[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist before
+opening a PR &mdash; in particular &sect;5 (allocation-free over raw speed)
+and &sect;7 (perf claims must name the JIT and be measured) apply directly
+to changes guided by this skill.
+
+For the broader "how do I polyfill API X for net472?" question (which
+packages to prefer, when to hand-roll), see the
+[`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) skill. This
+skill picks up after that decision is already made and the polyfill
+lives in `touki/Framework/`.
 
 ## What is and isn't available on `net481`
 

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -16,6 +16,17 @@ available to perf code).
 Note: code under `touki/Framework/` is only compiled for the .NET Framework target.
 References to those types from a benchmark must be guarded with `#if NETFRAMEWORK`.
 
+**Related skills:**
+
+- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) &mdash; reasons
+  to add a polyfill (and therefore a benchmark) in the first place.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) &mdash;
+  decisions about specialization, unrolling, and BCL-delegation on net481 that the
+  benchmarks here exist to validate.
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; requires a benchmark
+  in `touki.perf/` (or an explicit "not measured" note) for any perf claim that
+  drives a code change in `touki/Framework/`.
+
 ## 1. Authoring a benchmark
 
 ### File and class layout

--- a/.agents/skills/polyfill-dotnet-api/SKILL.md
+++ b/.agents/skills/polyfill-dotnet-api/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: polyfill-dotnet-api
+description: Polyfill a modern .NET BCL API for .NET Framework. Use when asked to "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", or any time a member is missing on net472 and present on net10. Picks the right source (Microsoft-shipped package vs PolySharp source-gen vs hand-rolled `touki/Framework/` polyfill) and captures the recurring design gotchas.
+---
+
+# Polyfill a .NET API for .NET Framework
+
+`touki` multi-targets `$(DotNetCoreVersion)` (currently `net10.0`) and
+`$(DotNetFrameworkVersion)` (currently `net472`). Files under
+[`touki/Framework/`](../../../touki/Framework/) compile **only** for the
+.NET Framework target (excluded from the modern build by
+[touki.csproj](../../../touki/touki.csproj)). Tests run on `net481` but
+exercise the `net472` polyfill assembly.
+
+Work the source list below in order; stop at the first hit. Don't add a
+hand polyfill for something a Microsoft package or PolySharp already
+ships.
+
+**Related skills:**
+[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) (this skill feeds
+into &sect;5 / &sect;6 / &sect;7 there),
+[`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
+(net481 RyuJIT shape once hand-rolling),
+[`performance-testing`](../performance-testing/SKILL.md) (benchmark
+required for any perf trade-off).
+
+## Source preference order
+
+### 1. Microsoft-shipped NuGet packages
+
+Probe before polyfilling: write a tiny `#if NETFRAMEWORK` snippet in
+`touki.tests/Framework/` that calls the candidate API and try a `net472`
+build. If it compiles, a referenced package already supplies the member;
+delete the probe.
+
+| Package | Covers | Referenced |
+| --- | --- | --- |
+| `System.Memory` | `Span<T>` / `ReadOnlySpan<T>` / `Memory<T>`, base `MemoryExtensions`, `MemoryMarshal`, `Unsafe`, `BinaryPrimitives`, `ArrayPool<T>` | yes |
+| `Microsoft.Bcl.Memory` | `Range`, `Index`, newer `MemoryExtensions` (`Count`, `CommonPrefixLength`, `ContainsAnyExcept`, `IsWhiteSpace`) | yes |
+| `Microsoft.Bcl.HashCode` | `HashCode` | yes |
+| `Microsoft.IO.Redist` | .NET 6 `System.IO` (via `global using Microsoft.IO;`) | yes |
+| `Microsoft.Bcl.AsyncInterfaces` | `IAsyncEnumerable<T>`, `IAsyncDisposable`, async-returning interfaces | not yet |
+| `Microsoft.Bcl.TimeProvider` | `TimeProvider`, `ITimer` | not yet |
+| `Microsoft.Bcl.Numerics` | `Half`, `BigInteger` additions | not yet |
+
+When adding a new package, place the `<PackageReference>` inside the
+`Condition="'$(TargetFramework)' == '$(DotNetFrameworkVersion)'"`
+ItemGroup &mdash; never unconditional.
+
+### 2. PolySharp source-generated polyfills
+
+[PolySharp](https://github.com/Sergio0694/PolySharp) (referenced for the
+.NET Framework target only) supplies **language / compiler attributes**,
+not runtime types. Use it for `IsExternalInit`, `RequiredMember`,
+`CompilerFeatureRequired`, `CallerArgumentExpression`,
+`ModuleInitializerAttribute`, `SkipLocalsInit`, and the nullable
+attributes (`NotNullWhen`, `MaybeNullWhen`, `MemberNotNull`,
+`DoesNotReturn`, ...).
+
+The repo enables:
+
+```xml
+<PolySharpUsePublicAccessibilityForGeneratedTypes>true</PolySharpUsePublicAccessibilityForGeneratedTypes>
+<PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+```
+
+Don't hand-write attribute polyfills; PolySharp generates them.
+
+### 3. Hand-rolled polyfill in `touki/Framework/`
+
+Last resort, when a runtime member (instance method, static helper,
+ctor) isn't supplied by a package and isn't an attribute. Polyfill only
+when there's a real caller; "completeness" polyfills bloat the surface.
+
+- **Mirror the BCL namespace.** `System.Convert` &rarr;
+  `touki/Framework/System/ConvertExtensions.cs`. `System.Text.Encoding`
+  &rarr; `touki/Framework/System/Text/EncodingExtensions.cs`. Callers
+  hit the polyfill via the same `using` they already had.
+- **Use C# 14 `extension` blocks** (e.g. `extension(Encoding encoding) { ... }`)
+  rather than static-class extension methods. Lookup picks the BCL
+  member on modern .NET and the polyfill on net472. See
+  [ConvertExtensions.cs](../../../touki/Framework/System/ConvertExtensions.cs).
+- **Don't `#if NETFRAMEWORK` inside `touki/Framework/`** &mdash; the
+  whole folder is already framework-only.
+
+## Design rules every hand polyfill must satisfy
+
+### Behavior parity
+
+- Match the BCL exception type **and** message family
+  (`ArgumentNullException` vs `NullReferenceException` is an observable
+  diff; same for span "destination too short" cases).
+- Read modern .NET docs / reference source for edge cases
+  (empty / null / zero-length-destination / overflow inputs).
+- For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
+  only take a fast path when `typeof(BaseType) == obj.GetType()`;
+  subclasses dispatch through the virtual member. See
+  [RandomExtensions.NextBytes](../../../touki/Framework/System/RandomExtensions.cs).
+- Stateful types (`HashCode`, `Random`): match the documented contract,
+  not observable cross-runtime output. `HashCode` is process-local.
+
+### Allocations
+
+The point of a span overload is to skip the array overload's
+allocation. Allocating a temp `T[]` to delegate to the BCL throws that
+benefit away. **Default allocation-free even at 5&ndash;15% throughput
+cost**; document the trade-off in `<remarks>`. Use existing helpers
+before inventing new ones:
+
+- **`stackalloc` + [`BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs)**
+  for small bounded buffers that may grow into `ArrayPool<T>`.
+- **`ArrayPool<T>.Shared.Rent` / `Return`** for unbounded buffers
+  (clear on return only when `T` contains references); see
+  [`ArrayPoolList<T>`](../../../touki/Touki/Collections/ArrayPoolList.cs).
+- **Pinned write into `new string('\0', length)`** for `string`-returning
+  methods (`Convert.ToHexString`, `string.Concat(ROS<char>...)`).
+- **Pinned `unsafe` pass-through to BCL `T*` overloads** when no span
+  variant exists; see
+  [EncodingExtensions](../../../touki/Framework/System/Text/EncodingExtensions.cs).
+  Watch the empty-span null-pinnable foot-gun (Gotchas &sect;1).
+- **`MemoryMarshal.AsBytes` / `AsRef` / `GetReference`** for zero-copy
+  reinterpretation.
+
+### Reflecting into BCL internals
+
+**Last-resort tool. Never write reflection-based polyfill code without
+explicit user approval.** The default answer is "allocate instead."
+
+Consider asking only when both hold:
+
+- Win is **substantial** (order of magnitude, or removes a per-call
+  allocation from a documented hot path).
+- No supported alternative exists (no Microsoft package, no
+  `MemoryMarshal`/`Unsafe` route, no `extension`-blockable surface).
+
+When asking, surface: which BCL member, the perf/alloc delta vs the
+supported alternative, the fragility (private members can change in
+servicing updates), and any security/trust implications. If approved,
+isolate in one internal helper, cache `MethodInfo`/`FieldInfo` once,
+and comment which BCL surface is targeted and why.
+
+### Argument validation
+
+- `ArgumentNullException.ThrowIfNull(arg)` &mdash; the polyfill at
+  [`ArgumentNullExtensions`](../../../touki/Framework/Touki/Exceptions/ArgumentNullExtensions.cs)
+  covers net472.
+- `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when available;
+  fall back to `(uint)x > (uint)max`.
+- Mirror the BCL exception type. Don't introduce custom exception types.
+
+### Length / overflow
+
+Wrap any sum of input lengths used to size an allocation in `checked()`.
+Unchecked overflow allocates the wrong-sized buffer and surfaces failure
+later from `CopyTo`.
+[`StringExtensions.Concat`](../../../touki/Framework/System/StringExtensions.cs)
+is the reference pattern.
+
+### Coexistence with future BCL polyfills
+
+C# 14 `extension` blocks add members to an existing type, not new types.
+A future Microsoft `Convert.ToHexString` on net472 wins lookup over the
+extension; the polyfill goes silently inert. No `extern alias` needed.
+
+The exception is when the polyfill defines a **new type** in `System.*`
+(e.g.
+[CryptographicOperations](../../../touki/Framework/System/Security/Cryptography/CryptographicOperations.cs)).
+A future Microsoft polyfill for that exact type collides (CS0436/CS0433)
+and callers need `extern alias`. Prefer extension members over new
+`System.*` types when feasible.
+
+## Gotchas seen in past PRs
+
+The [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist
+enforces these; this section explains *why*.
+
+1. **Empty-span pinning yields `null`.**
+   `MemoryMarshal.GetReference(default(ROS<T>))` is a null ref, so
+   `fixed (T* p = ...)` produces a null pointer, and net481 BCL `T*`
+   overloads typically throw `ArgumentNullException` instead of the
+   canonical "destination too short". Handle empty source / empty
+   destination separately before pinning. See
+   [EncodingExtensions.GetBytes](../../../touki/Framework/System/Text/EncodingExtensions.cs).
+
+2. **`Unsafe.As<T,...>(ref param)` mis-reads negative-signed primitives
+   in Release on net481.** RyuJIT can keep the parameter in a register
+   or smaller-than-`int` slot, so reinterpret reads the wrong byte
+   (`StartsWith((sbyte)0)` over `[-1, 0, 1]` returns the wrong answer).
+   Either copy to a definite local first (`T local = value;`), or skip
+   Unsafe entirely &mdash; per
+   [StartsWithPerf](../../../touki.perf/StartsWithPerf.cs),
+   `value.Equals(span[0])` via `IEquatable<T>` already beats Unsafe on
+   net481.
+
+3. **`Random.NextBytes(byte[])` is native on net481; the obvious
+   managed span loop is slower per byte** (loses to `byte[]` + copy by
+   ~1.2&times; on big buffers despite saving the alloc). Use a pinned
+   pointer loop and only on the type-exact fast path; subclasses go
+   through the array overload. See
+   [RandomExtensions](../../../touki/Framework/System/RandomExtensions.cs).
+
+4. **`HashCode` is process-local.** No cross-runtime parity contract;
+   only assert within-process determinism.
+
+5. **`net472` vs `net481` phrasing.** Polyfill assembly TFM is `net472`
+   (`$(DotNetFrameworkVersion)`); test TFM is `net481` for richer GC
+   APIs but consumes the `net472` polyfill. Don't call the polyfill
+   "net481-only" in commits or PR descriptions.
+
+## Workflow
+
+1. Probe to confirm the API is missing; pick the highest source from
+   the order above that supplies it.
+2. If hand-rolling, place under `touki/Framework/<BclNamespace>/` using
+   `extension(...)` blocks (only declare a new type when the BCL
+   surface itself is a brand-new type).
+3. Add tests under [`touki.tests/`](../../../touki.tests/) running on
+   both TFMs. Identical observable behavior to modern BCL for matching
+   inputs.
+4. Run [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) before
+   invoking [`create-pr`](../create-pr/SKILL.md).
+
+## Examples in this repo
+
+| API | Source | File |
+| --- | --- | --- |
+| `Span<T>.IndexOf` / `Contains` | `System.Memory` | &mdash; |
+| `HashCode` | `Microsoft.Bcl.HashCode` | &mdash; |
+| `IsExternalInit`, `CallerArgumentExpression` | PolySharp | &mdash; |
+| `ROS<T>.StartsWith(T)` (single element) | hand | [SpanExtensions.StartsEndsWith.cs](../../../touki/Framework/Touki/SpanExtensions.StartsEndsWith.cs) |
+| `Convert.ToHexString` / `FromHexString` | hand | [ConvertExtensions.cs](../../../touki/Framework/System/ConvertExtensions.cs) |
+| `Random.NextBytes(Span<byte>)` | hand | [RandomExtensions.cs](../../../touki/Framework/System/RandomExtensions.cs) |
+| `string.Concat(ROS<char>...)` | hand | [StringExtensions.cs](../../../touki/Framework/System/StringExtensions.cs) |
+| `HashCode.AddBytes(ROS<byte>)` | hand | [HashCodeExtensions.cs](../../../touki/Framework/System/HashCodeExtensions.cs) |
+| `CryptographicOperations.FixedTimeEquals` | hand | [CryptographicOperations.cs](../../../touki/Framework/System/Security/Cryptography/CryptographicOperations.cs) |
+| `Encoding.GetBytes(ROS<char>, Span<byte>)` ... | hand | [EncodingExtensions.cs](../../../touki/Framework/System/Text/EncodingExtensions.cs) |

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: pre-pr-self-review
+description: Self-review checklist before opening a PR. Use before invoking `create-pr`, when reviewing your own draft, or when a reviewer flags issues that should have been caught earlier. Codifies recurring mistakes from this repo's polyfill work: missing tests for new public surface, unchecked length sums, null-pointer foot-guns from `MemoryMarshal.GetReference` on empty spans, drift from `ArgumentNullException.ThrowIfNull` and `checked()` conventions, TFM phrasing errors, and stale PR descriptions.
+---
+
+# Pre-PR self-review
+
+Run this checklist before invoking the [`create-pr`](../create-pr/SKILL.md)
+skill. Each item is a question your code or PR body must answer. Update
+the skill whenever a reviewer flags something not yet listed.
+
+**Related skills:**
+
+- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) &mdash; the
+  source-preference and design rules for adding a new polyfill that
+  this checklist then validates.
+- [`create-pr`](../create-pr/SKILL.md) &mdash; the workflow this checklist
+  precedes.
+- [`performance-testing`](../performance-testing/SKILL.md) &mdash; benchmark
+  authoring required by &sect;7 when a perf claim drives a code change.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
+  &mdash; net481 RyuJIT tradeoffs cited in &sect;5 and &sect;7.
+- [`agent-files-review`](../agent-files-review/SKILL.md) &mdash; for any
+  changes under `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`.
+
+## 1. Tests cover every new branch
+
+For each new `public` (or `InternalsVisibleTo`-internal) member:
+
+- Search the test projects for the symbol; no hits = missing test.
+- Polyfills under `touki/Framework/`: tests run on both TFMs. Wrap
+  polyfill-only paths (subclass fallbacks, null-receiver guards) in
+  `#if NETFRAMEWORK`.
+- Runtime type-check fast paths (`typeof(T) == obj.GetType()`): test
+  the fast path *and* a subclass override.
+- Generic primitive specializations: every specialized branch needs a
+  test. Don't rely on `byte`/`int` covering `bool`/`sbyte`/`short`/
+  `ushort`/`uint`/`long`/`ulong` &mdash; each has independent ref
+  reinterpretation.
+- Security-sensitive APIs (`FixedTimeEquals`, hex decode): cover equal,
+  differing-content, length mismatch, both empty, one empty, and a long
+  span where only the last byte differs.
+- Allocating APIs (`Concat`, `ToHexString`): include an
+  `OverflowException` test on the length sum (see &sect;3).
+
+## 2. Empty / null spans before `unsafe` interop
+
+`MemoryMarshal.GetReference(default(ReadOnlySpan<T>))` is a null ref.
+`fixed (T* p = &nullRef)` produces a null pointer, and BCL `T*` overloads
+on net481 typically throw `ArgumentNullException` instead of the canonical
+"destination too short" / "source empty" exception the modern span
+overloads produce.
+
+Before pinning:
+
+- Both empty &rarr; return the zero-length result without pinning.
+- Source non-empty, destination empty &rarr; pass a stack-allocated
+  non-null pointer with length 0
+  (`byte stack = 0; return Foo(src, &stack, 0);`).
+- Source empty &rarr; return the empty result without pinning.
+- Cross-check the resulting exception type against the modern BCL.
+
+## 3. Multi-input length sums are `checked()`
+
+Any public API summing lengths before allocating wraps the sum in
+`checked()`. Unchecked overflow allocates the wrong-sized buffer and
+fails later from `CopyTo`. See
+[touki.tests/System/StringExtensionsConcatTests.cs](../../../touki.tests/System/StringExtensionsConcatTests.cs)
+for the canonical `OverflowException` test pattern.
+
+## 4. Throw helpers
+
+- Null guards use `ArgumentNullException.ThrowIfNull(arg)` &mdash; the
+  polyfill at
+  [touki/Framework/Touki/Exceptions/ArgumentNullExtensions.cs](../../../touki/Framework/Touki/Exceptions/ArgumentNullExtensions.cs)
+  covers net472.
+- Range checks use `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when
+  available; fall back to `(uint)x > (uint)max`.
+- Match the BCL exception type for parity. New custom exception types
+  are almost never the right answer in a polyfill.
+
+## 5. Span overloads prefer fewer allocations over raw speed
+
+The whole reason callers reach for a span overload is to avoid the
+allocation the array overload makes. A polyfill that allocates a temp
+`T[]` to delegate to the BCL has thrown that benefit away.
+
+**Default to allocation-free, even if 5&ndash;15% slower.** Document
+the trade-off in `<remarks>` so callers understand the choice.
+
+Strategies used elsewhere in this repo (look here before inventing a
+new one):
+
+- **`stackalloc` for small bounded buffers.** Always pair with
+  [`Touki.Buffers.BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs)
+  so the buffer transparently grows into an `ArrayPool<T>` rental if it
+  doesn't fit. Usage: `using BufferScope<char> buffer = new(stackalloc char[64]);`
+- **`ArrayPool<T>.Shared.Rent` / `Return`** for unbounded buffers. See
+  [`Touki.Collections.ArrayPoolList<T>`](../../../touki/Touki/Collections/ArrayPoolList.cs)
+  for the rental + clear-on-return pattern (clear only when `T` contains
+  references).
+- **Pinned write into `new string('\0', length)`.** Allocates one final
+  string with no temp `char[]`; see
+  [`StringExtensions.Concat`](../../../touki/Framework/System/StringExtensions.cs)
+  and `Convert.ToHexString` for the `fixed (char* p = result)` pattern.
+- **Pinned `unsafe` pass-through to BCL `T*` overloads** when the BCL
+  doesn't expose a span variant. See
+  [`EncodingExtensions`](../../../touki/Framework/System/Text/EncodingExtensions.cs).
+- **`MemoryMarshal.AsBytes` / `AsRef` / `GetArrayDataReference`** to
+  reinterpret without copying.
+- **Type-exact runtime check + inline path for the base type**, with
+  fallback through the virtual member for subclasses (see
+  [`RandomExtensions.NextBytes`](../../../touki/Framework/System/RandomExtensions.cs)).
+- **`InternalsVisibleTo` to the test project** so you can test
+  internal helpers directly without exposing them in the public API.
+
+If the only way to be allocation-free is to call an `internal` BCL API,
+allocate &mdash; do not reflect into the BCL.
+
+## 6. Behavior parity with the modern BCL
+
+- Read modern .NET docs / reference source for edge cases (empty / null
+  inputs, length-zero destination, exception types and message family).
+- Mirror the BCL exception type and message family for observable cases.
+- For stateful types (`HashCode`, `Random`), document any deviation in
+  `<remarks>`. `HashCode` is process-local in the BCL too &mdash;
+  within-process determinism is the only contract.
+- For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
+  the polyfill's fast path applies only when
+  `typeof(T) == obj.GetType()`; subclasses must dispatch through the
+  virtual member.
+
+## 7. Performance claims name the JIT and are measured
+
+State which JIT &mdash; **net481 RyuJIT** (no tiered JIT, no PGO, no
+`EqualityComparer<T>.Default` intrinsic, weaker inlining) vs **modern
+.NET RyuJIT** (.NET 6+, tiered, PGO, devirtualizes
+`EqualityComparer<T>.Default`). Unqualified "RyuJIT does X" claims are
+wrong about half the time on this repo. The
+[`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
+skill catalogues which optimizations actually win on net481.
+
+For code changes in `touki/Framework/` driven by a perf claim:
+
+- Add a benchmark in `touki.perf/` per the
+  [`performance-testing`](../performance-testing/SKILL.md) skill, *or*
+- State explicitly in the commit / PR / `<remarks>` that you have not
+  measured.
+
+If a polyfill is slower than the array-taking BCL it shadows, quantify
+the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
+
+## 8. PR description matches reality
+
+- TFM phrasing: the polyfill TFM is `$(DotNetFrameworkVersion)` =
+  `net472`. The test project's `net481` TFM is just where it runs. Do
+  not call the polyfill "net481-only".
+- File list, test counts, and perf numbers all reflect the *current*
+  diff. Re-run after every commit; do not paste numbers from an earlier
+  iteration.
+- "Deliberately deferred" entries match what's actually absent from
+  the working tree.
+
+## 9. Final audit before staging
+
+- `git status --short` &mdash; delete leftover probe / scratch files;
+  confirm every listed file belongs in the change set.
+- `git diff --check` &mdash; whitespace.
+- Build both TFMs.
+- Run `dotnet test` in **both Debug and Release**. Release-mode RyuJIT
+  inlining surfaces bugs Debug doesn't &mdash; e.g.
+  `Unsafe.As<T, ...>(ref param)` mis-reads negative-signed-primitive
+  parameters on net481, but only in Release.
+- Stage **by path**, never `git add -A` / `git add .` when the working
+  tree spans more than one logical change. If topics are intermingled,
+  ask before staging.
+
+## 10. Failing CI is a stop, not a sprint
+
+When a build / test / CI run fails on a PR:
+
+1. Diagnose.
+2. Prepare the fix in the working tree.
+3. Describe what changed, why, and any risks.
+4. **Stop and wait for explicit approval before commit/push.**
+
+Stacked rapid-fire fix commits are how perf regressions and unrelated
+sweep-ups get into history.
+
+## 11. Update this skill
+
+If a reviewer flags something not in this checklist, add it. If the
+review touched `.agents/` files, also update via the
+[`agent-files-review`](../agent-files-review/SKILL.md) workflow so the
+validator and CI mirror stay in sync.

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -166,6 +166,18 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
 - `git status --short` &mdash; delete leftover probe / scratch files;
   confirm every listed file belongs in the change set.
 - `git diff --check` &mdash; whitespace.
+- **Rebase onto the canonical `main` if the branch trails it.** Use
+  `upstream/main` when working from a fork (the canonical repo lives at
+  `upstream`), `origin/main` when cloning the canonical repo directly.
+  Recently-merged sister PRs may have introduced files this PR
+  cross-references; running off a stale base point makes those links look
+  broken to the offline lychee check that gates `.agents/**`, `AGENTS.md`,
+  and `*.instructions.md` changes. PR #110 lost a review round to exactly
+  this.
+- For changes that touch `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`,
+  also run `pwsh tools/Test-AgentFileLinks.ps1` (see
+  [`agent-files-review`](../agent-files-review/SKILL.md) &sect;7 for
+  options including `-ChangedOnly` and `-Base`).
 - Build both TFMs.
 - Run `dotnet test` in **both Debug and Release**. Release-mode RyuJIT
   inlining surfaces bugs Debug doesn't &mdash; e.g.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -156,6 +156,11 @@ Treat them as hard requirements.
 - PowerShell is the terminal environment for building and testing.
 - Check `GlobalUsings.cs` for global usings and don't add unnecessary usings.
 - Write XML documentation for public APIs.
+- When adding a polyfill for a modern .NET API on .NET Framework, follow the
+  [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
+  prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,
+  `Microsoft.IO.Redist`), then PolySharp source-gen for compiler attributes,
+  and only hand-roll under `touki/Framework/` as a last resort.
 
 ## Path-specific instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,11 @@ Treat them as hard requirements.
 - PowerShell is the terminal environment for building and testing.
 - Check `GlobalUsings.cs` for global usings and don't add unnecessary usings.
 - Write XML documentation for public APIs.
+- When adding a polyfill for a modern .NET API on .NET Framework, follow the
+  [`polyfill-dotnet-api`](.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
+  prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,
+  `Microsoft.IO.Redist`), then PolySharp source-gen for compiler attributes,
+  and only hand-roll under `touki/Framework/` as a last resort.
 
 ## Path-specific instructions
 

--- a/tools/Test-AgentFileLinks.ps1
+++ b/tools/Test-AgentFileLinks.ps1
@@ -1,0 +1,208 @@
+<#
+.SYNOPSIS
+    Verify that relative Markdown links in the agent customization files point
+    at files present in the current working tree.
+
+.DESCRIPTION
+    Mirrors what the offline lychee link check enforces in
+    .github/workflows/agent-files.yml. The CI step is a
+    "links must resolve in the merged tree" gate; this script lets you run the
+    same gate locally before pushing so a stale branch doesn't ship broken
+    links into a PR.
+
+    By default, scans every Markdown file in lychee's CI scope:
+
+      AGENTS.md
+      .github/copilot-instructions.md
+      .github/instructions/**/*.md
+      .github/prompts/**/*.md
+      .github/agents/**/*.md
+      .agents/**/*.md
+      docs/agent-customization.md
+
+    For each Markdown link of the form `](target)` that is not an external URL,
+    `mailto:`, or pure in-page anchor, the script resolves the target relative
+    to the containing file's directory (after stripping any `#fragment`) and
+    reports any that don't exist on disk.
+
+.PARAMETER ChangedOnly
+    Restrict the scan to files changed on the current branch versus the
+    auto-detected base ref. The base is `upstream/main` when a remote literally
+    named `upstream` exists (the fork-PR workflow) and `origin/main` otherwise
+    (the work-on-canonical-clone workflow). Use this when you only want to
+    audit your own diff.
+
+.PARAMETER Base
+    Override the base ref used by -ChangedOnly. Implies -ChangedOnly.
+
+.EXAMPLE
+    pwsh tools/Test-AgentFileLinks.ps1
+    Scans every agent file in CI's lychee scope.
+
+.EXAMPLE
+    pwsh tools/Test-AgentFileLinks.ps1 -ChangedOnly
+    Scans only the agent-scope files changed on this branch vs upstream/main
+    (or origin/main when no upstream remote exists).
+
+.EXAMPLE
+    pwsh tools/Test-AgentFileLinks.ps1 -Base origin/feature-branch
+    Compare against an explicit ref.
+#>
+[CmdletBinding()]
+param(
+    [switch]$ChangedOnly,
+    [string]$Base
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+function Get-RepoRelativePath([string]$Path) {
+    $full = (Resolve-Path -LiteralPath $Path).Path
+    $rootWithSep = $RepoRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+    if ($full.StartsWith($rootWithSep, [System.StringComparison]::OrdinalIgnoreCase)) {
+        return $full.Substring($rootWithSep.Length).Replace('\', '/')
+    }
+    return $full.Replace('\', '/')
+}
+
+# Files in CI's lychee scope. Keep in sync with .github/workflows/agent-files.yml.
+# Each entry is either a single file or @{ Dir = <relative dir>; Filter = <glob> }
+# for recursive scans.
+$ScopeEntries = @(
+    'AGENTS.md',
+    '.github/copilot-instructions.md',
+    'docs/agent-customization.md',
+    @{ Dir = '.github/instructions'; Filter = '*.md' },
+    @{ Dir = '.github/prompts'; Filter = '*.md' },
+    @{ Dir = '.github/agents'; Filter = '*.md' },
+    @{ Dir = '.agents'; Filter = '*.md' }
+)
+
+function Resolve-BaseRef() {
+    if ($Base) { return $Base }
+    $remotes = git -C $RepoRoot remote 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Not a git repository (or git is not on PATH)."
+    }
+    if ($remotes -contains 'upstream') { return 'upstream/main' }
+    if ($remotes -contains 'origin') { return 'origin/main' }
+    throw "Cannot resolve a base ref: neither 'upstream' nor 'origin' remote is configured. Pass -Base explicitly."
+}
+
+function Get-ScopeFiles() {
+    $results = [System.Collections.Generic.List[string]]::new()
+    foreach ($entry in $ScopeEntries) {
+        if ($entry -is [string]) {
+            $full = Join-Path $RepoRoot $entry
+            if (Test-Path -LiteralPath $full) {
+                $results.Add((Resolve-Path -LiteralPath $full).Path) | Out-Null
+            }
+        }
+        else {
+            $dir = Join-Path $RepoRoot $entry.Dir
+            if (-not (Test-Path -LiteralPath $dir)) { continue }
+            $found = Get-ChildItem -LiteralPath $dir -Recurse -File -Filter $entry.Filter -ErrorAction SilentlyContinue
+            foreach ($f in $found) { $results.Add($f.FullName) | Out-Null }
+        }
+    }
+    return $results | Sort-Object -Unique
+}
+
+function Get-ChangedScopeFiles([string]$BaseRef) {
+    $diffOutput = git -C $RepoRoot diff --name-only $BaseRef -- 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "git diff against '$BaseRef' failed: $diffOutput"
+    }
+    $allScope = Get-ScopeFiles
+    $allScopeSet = [System.Collections.Generic.HashSet[string]]::new(
+        [string[]]$allScope,
+        [System.StringComparer]::OrdinalIgnoreCase)
+
+    $changed = [System.Collections.Generic.List[string]]::new()
+    foreach ($rel in $diffOutput) {
+        if (-not $rel) { continue }
+        $abs = (Join-Path $RepoRoot $rel)
+        if (-not (Test-Path -LiteralPath $abs)) { continue }
+        $absResolved = (Resolve-Path -LiteralPath $abs).Path
+        if ($allScopeSet.Contains($absResolved)) {
+            $changed.Add($absResolved) | Out-Null
+        }
+    }
+    return $changed | Sort-Object -Unique
+}
+
+function Test-FileLinks([string]$Path) {
+    $broken = [System.Collections.Generic.List[string]]::new()
+    $dir = Split-Path -Parent $Path
+    $linkRegex = [regex]'\]\(([^)]+)\)'
+    $lineNumber = 0
+    $inFence = $false
+    foreach ($line in Get-Content -LiteralPath $Path) {
+        $lineNumber++
+        # Toggle fenced code block on lines that open with ``` (or ~~~), with
+        # an optional language tag. Anything inside is treated as code, not
+        # markdown, mirroring lychee's markdown-aware link extraction.
+        if ($line -match '^\s*(```|~~~)') {
+            $inFence = -not $inFence
+            continue
+        }
+        if ($inFence) { continue }
+        # Strip inline code spans (`...`) so links inside them aren't matched.
+        $stripped = [regex]::Replace($line, '`[^`]*`', '')
+        foreach ($linkMatch in $linkRegex.Matches($stripped)) {
+            $target = $linkMatch.Groups[1].Value.Trim()
+            if (-not $target) { continue }
+            # External URLs, mailto, in-page anchors, absolute repo paths: skip.
+            if ($target -match '^(https?:|mailto:|tel:|ftp:|#|/)') { continue }
+            # Strip any fragment.
+            $candidatePath = ($target -split '#', 2)[0]
+            if (-not $candidatePath) { continue }
+            $resolved = Join-Path $dir $candidatePath
+            if (-not (Test-Path -LiteralPath $resolved)) {
+                $rel = Get-RepoRelativePath -Path $Path
+                $broken.Add("${rel}:${lineNumber}: ${target}") | Out-Null
+            }
+        }
+    }
+    return $broken
+}
+
+if ($Base) { $ChangedOnly = $true }
+
+if ($ChangedOnly) {
+    $baseRef = Resolve-BaseRef
+    Write-Host "Scanning files changed vs ${baseRef}..."
+    $files = Get-ChangedScopeFiles -BaseRef $baseRef
+} else {
+    Write-Host "Scanning all agent customization files in CI's lychee scope..."
+    $files = Get-ScopeFiles
+}
+
+if (-not $files -or $files.Count -eq 0) {
+    Write-Host "No files in scope to scan."
+    exit 0
+}
+
+$allBroken = [System.Collections.Generic.List[string]]::new()
+foreach ($file in $files) {
+    foreach ($entry in (Test-FileLinks -Path $file)) {
+        $allBroken.Add($entry) | Out-Null
+    }
+}
+
+if ($allBroken.Count -gt 0) {
+    Write-Host ""
+    Write-Host "Broken relative links:" -ForegroundColor Red
+    foreach ($entry in $allBroken) {
+        Write-Host "  $entry" -ForegroundColor Red
+    }
+    Write-Host ""
+    Write-Host "$($allBroken.Count) broken link(s) in $($files.Count) scanned file(s)." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "All relative links resolve. ($($files.Count) file(s) scanned.)" -ForegroundColor Green
+exit 0


### PR DESCRIPTION
Adds two new agent skills capturing review feedback and the polyfill workflow that have been recurring across recent PRs.

## New skills

### `polyfill-dotnet-api`

Triggers when asked to "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", or any time a member is missing on net472 and present on net10.

Defines the source-preference order:

1. **Microsoft-shipped NuGet packages** (`System.Memory`, `Microsoft.Bcl.Memory`, `Microsoft.Bcl.HashCode`, `Microsoft.IO.Redist`, plus candidates not yet referenced).
2. **PolySharp source-gen** for compiler attributes (`IsExternalInit`, `CallerArgumentExpression`, nullable annotations).
3. **Hand-rolled** under `touki/Framework/` only when nothing else supplies the runtime member.

Captures design rules drawn from review feedback on PRs #107 / #108 / #109:

- Behavior parity (BCL exception type and message family).
- Allocation-first defaults; standard helpers (`BufferScope<T>`, `ArrayPoolList<T>`, pinned `new string('\0', n)`, `MemoryMarshal.AsBytes`).
- `ArgumentNullException.ThrowIfNull` convention (covered downlevel by the existing `ArgumentNullExtensions` polyfill).
- `checked()` length sums for allocation sizes.
- Coexistence with future BCL polyfills (extension blocks vs new `System.*` types).
- Reflecting into BCL internals is **last-resort and requires explicit user approval** &mdash; never written silently; default answer is "allocate instead".

Documents recurring gotchas: empty-span pinning yielding null pointers; `Unsafe.As<T,...>(ref param)` mis-reading negative-signed primitives in Release on net481; `Random.NextBytes(byte[])` native sampler beating obvious managed loops; `HashCode` process-locality; `net472`-vs-`net481` phrasing.

### `pre-pr-self-review`

Triggers before invoking `create-pr`. 11-step checklist covering:

1. Tests cover every new branch (including primitive-specialization branches and subclass-fallback paths).
2. Empty-span / null-pinnable handling before `unsafe` interop.
3. `checked()` length sums.
4. `ArgumentNullException.ThrowIfNull` and friends.
5. Span overloads prefer fewer allocations over raw speed (with the helper inventory).
6. Behavior parity with the modern BCL.
7. Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT) and are measured.
8. PR description matches reality (TFM phrasing, file list, test counts, perf numbers).
9. Final audit: `git status --short`, build both TFMs, run `dotnet test` in **both Debug and Release**, stage by path.
10. Failing CI is a stop, not a sprint &mdash; diagnose, prepare fix, describe, **wait for explicit approval before commit/push**.
11. Self-update: add new lessons as reviewers find them.

## Cross-links

- `create-pr` gains a forward-link to `pre-pr-self-review` and `polyfill-dotnet-api` near the top.
- `framework-jit-optimization` extended intro to point at both new skills.
- `performance-testing` "Related skills" block leads with `polyfill-dotnet-api`, then `framework-jit-optimization`, then `pre-pr-self-review`.
- `AGENTS.md` "General guidance" gains one bullet pointing at `polyfill-dotnet-api`.
- `.github/copilot-instructions.md` regenerated by the validator to match.

## Validation

`pwsh tools/Validate-AgentFiles.ps1` passes (frontmatter, mirror sync, dir-name match, whitespace, trailing newline).