### PR TITLE
Enable TreatWarningsAsErrors and fix surfaced diagnostics

### DIFF
--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: address-pr-feedback
+description: Address feedback on an existing pull request &mdash; review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
+---
+
+# Address PR feedback
+
+This skill is the post-PR counterpart to [`create-pr`](../create-pr/SKILL.md).
+The crucial difference between the two:
+
+- In `create-pr` the user asked you to publish work, so the request itself
+  authorizes the push at the end of the workflow.
+- In this skill the user asked you to *respond to feedback*. That
+  authorizes editing files and **nothing more**.
+
+The
+["Working with the user on changes"](../../../AGENTS.md#working-with-the-user-on-changes)
+section of AGENTS.md is the source of truth for the commit/push approval
+rule. Re-read it at the start of every invocation; this skill is the
+decision-point reminder, not a replacement.
+
+## Recognizing approval
+
+Skim the most recent user message for an explicit publishing verb before
+you stage, commit, or push. Pattern-match the words, do not infer intent.
+
+**Approval** &mdash; verbs that authorize publishing the current change:
+`commit`, `push`, `update the PR`, `ship it`, `go ahead`, `send it`, or
+direct synonyms in context.
+
+**Not approval** &mdash; everything else, including these phrasings that
+have caused violations on this repo:
+
+- "Address the review comments."
+- "Fix the comments / fix the CI failure."
+- "Look at Copilot's feedback / see what they said."
+- "See what you can do about this."
+- "Try a different approach."
+- "What about &lt;suggestion&gt;?"
+- A reviewer (human or Copilot) leaving a new comment.
+- A failing check on the PR.
+
+If you are uncertain whether a phrase is approval, **it is not approval**.
+Stop and ask.
+
+## Workflow
+
+1. **Fetch the feedback.** Use the GitHub PR tools (or
+   `Invoke-RestMethod` against
+   `api.github.com/repos/<owner>/<repo>/pulls/<N>/comments`) to read review
+   comments. Read PR-level conversation comments and check-run logs too if
+   relevant.
+2. **Plan the response.** Decide which comments require code changes,
+   which are out of scope, and which you disagree with. For comments you
+   disagree with, plan a written response rather than silently overriding.
+3. **Edit files.** Make the code changes. Run the build and any relevant
+   tests. The applicable validation rules are still
+   [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; a follow-up
+   round needs the same checks as the initial PR.
+4. **Stop. Describe.** Summarize what you changed, why, and what (if
+   anything) you chose not to act on. Do **not** run `git add`, `git
+   commit`, or `git push`.
+5. **Wait** for an explicit publishing verb (see "Recognizing approval"
+   above).
+6. **Only then** stage by path, commit with a message that summarizes the
+   round of changes, and push. The staging/commit/push mechanics are the
+   same as in [`create-pr`](../create-pr/SKILL.md) §3&ndash;§4.
+
+## When you've already violated the rule
+
+Acknowledge the violation directly without minimizing. Do **not** push a
+follow-up commit to "fix" the situation without explicit approval &mdash;
+that compounds the failure. The user decides whether to revert,
+force-push, or leave the commit in place.
+
+## Related
+
+- [AGENTS.md](../../../AGENTS.md) &mdash; the rule itself.
+- [`create-pr`](../create-pr/SKILL.md) &mdash; opening the initial PR
+  (different approval semantics).
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; validation
+  checklist that applies to both initial and follow-up rounds.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -134,6 +134,11 @@ Tell the user:
 - The base the PR targets (`upstream/main` or `origin/main`).
 - The PR URL (from `gh pr create` output) or the compare URL fallback.
 
+Once the PR exists, this skill is done. Subsequent rounds of edits in
+response to review comments, requested changes, or CI failures go through
+the [`address-pr-feedback`](../address-pr-feedback/SKILL.md) skill, which
+has different commit/push approval semantics.
+
 ## Guardrails
 
 - Never commit directly to `main`, even if the user is currently on it —

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -16,6 +16,8 @@ the skill whenever a reviewer flags something not yet listed.
   this checklist then validates.
 - [`create-pr`](../create-pr/SKILL.md) &mdash; the workflow this checklist
   precedes.
+- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) &mdash; the
+  follow-up workflow that re-runs this checklist after review comments.
 - [`performance-testing`](../performance-testing/SKILL.md) &mdash; benchmark
   authoring required by &sect;7 when a perf claim drives a code change.
 - [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)

--- a/.editorconfig
+++ b/.editorconfig
@@ -1626,11 +1626,13 @@ end_of_line = crlf
 # in fact used by the extension members.
 #
 # By convention every file that declares an `extension(...)` block in this
-# repo is named `*Extensions.cs`, so the glob below covers them. If/when the
-# analyzer learns to see through extension types, narrow or delete this
-# section. Other analyzer false positives produced by extension types should
-# be added here as additional `dotnet_diagnostic.*.severity = none` lines.
+# repo has `Extensions` in its name, so the glob below covers them
+# (including partial-class splits such as `MemoryExtensions.Trim.cs` and
+# `StringExtensions_DotNetFoundation.cs`). If/when the analyzer learns to
+# see through extension types, narrow or delete this section. Other analyzer
+# false positives produced by extension types should be added here as
+# additional `dotnet_diagnostic.*.severity = none` lines.
 
-[**/*Extensions.cs]
+[**/*Extensions*.cs]
 dotnet_diagnostic.IDE0051.severity = none
 dotnet_diagnostic.IDE0052.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -1625,14 +1625,19 @@ end_of_line = crlf
 # ("private member assigned but never read") diagnostics for helpers that are
 # in fact used by the extension members.
 #
-# By convention every file that declares an `extension(...)` block in this
-# repo has `Extensions` in its name, so the glob below covers them
-# (including partial-class splits such as `MemoryExtensions.Trim.cs` and
-# `StringExtensions_DotNetFoundation.cs`). If/when the analyzer learns to
-# see through extension types, narrow or delete this section. Other analyzer
-# false positives produced by extension types should be added here as
-# additional `dotnet_diagnostic.*.severity = none` lines.
+# By convention single-file extension types are named `*Extensions.cs`, so
+# the first glob below covers them. The second glob lists the multi-file
+# partial-class splits where at least one partial declares an `extension(...)`
+# block; only those exact filenames are included so non-extension siblings
+# in the same family (e.g. `MemoryExtensions.TryWrite.cs`,
+# `SpanExtensions.SpanSplitEnumeratorMode.cs`) keep IDE0051/IDE0052 active.
+# If/when the analyzer learns to see through extension types, narrow or
+# delete this section.
 
-[**/*Extensions*.cs]
+[**/*Extensions.cs]
+dotnet_diagnostic.IDE0051.severity = none
+dotnet_diagnostic.IDE0052.severity = none
+
+[**/{MemoryExtensions.Trim,SpanExtensions.EnumerateLines,SpanExtensions.InRange,SpanExtensions.Replace,SpanExtensions.Search,SpanExtensions.Sort,SpanExtensions.SpanSplitEnumerator,SpanExtensions.SplitRanges,SpanExtensions.StartsEndsWith,StringExtensions_DotNetFoundation}.cs]
 dotnet_diagnostic.IDE0051.severity = none
 dotnet_diagnostic.IDE0052.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -39,8 +39,14 @@
     <!-- Surface .editorconfig IDE rules (unused usings, type simplification, etc.) as build diagnostics. -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
-    <!-- Treat all compiler/analyzer warnings as build errors so style and correctness issues fail fast. -->
+    <!--
+      Treat all compiler/analyzer warnings as build errors so style and correctness issues fail fast.
+      Exclude the NuGet audit / deprecation codes (NU1900-NU1904) so an upstream package advisory
+      cannot break CI without a source change. The advisories still appear as warnings in the build
+      log; act on them by upgrading or replacing the package, not by ignoring them.
+    -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,6 +38,9 @@
 
     <!-- Surface .editorconfig IDE rules (unused usings, type simplification, etc.) as build diagnostics. -->
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!-- Treat all compiler/analyzer warnings as build errors so style and correctness issues fail fast. -->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- Common repo directories -->

--- a/touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs
+++ b/touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs
@@ -15,7 +15,7 @@ public static class CryptographicOperations
     /// <remarks>
     ///  <para>
     ///   The runtime of this method is independent of the contents of the inputs (assuming
-    ///   equal lengths). Use this method instead of <see cref="MemoryExtensions.SequenceEqual{T}(ReadOnlySpan{T}, ReadOnlySpan{T})"/>
+    ///   equal lengths). Use this method instead of <c>MemoryExtensions.SequenceEqual</c>
     ///   or equivalent to avoid timing side channels when comparing security tokens.
     ///  </para>
     /// </remarks>

--- a/touki/Framework/Polyfills/System/CharExtensions.cs
+++ b/touki/Framework/Polyfills/System/CharExtensions.cs
@@ -4,6 +4,10 @@
 
 namespace System;
 
+/// <summary>
+///  Polyfills for <see cref="char"/> static APIs added in modern .NET, exposed
+///  to .NET Framework via C# extension types.
+/// </summary>
 public static partial class CharExtensions
 {
     extension(char)

--- a/touki/Framework/Polyfills/System/SpanExtensions.EnumerateLines.cs
+++ b/touki/Framework/Polyfills/System/SpanExtensions.EnumerateLines.cs
@@ -4,6 +4,11 @@
 
 namespace System;
 
+/// <summary>
+///  Polyfills for <see cref="Span{T}"/> and <see cref="ReadOnlySpan{T}"/>
+///  instance APIs added in modern .NET, exposed to .NET Framework via C#
+///  extension types.
+/// </summary>
 public static partial class SpanExtensions
 {
     extension(ReadOnlySpan<char> span)

--- a/touki/Framework/Polyfills/System/SpanExtensions.Replace.cs
+++ b/touki/Framework/Polyfills/System/SpanExtensions.Replace.cs
@@ -2,6 +2,15 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+// CS8500 ("takes the address of, gets the size of, or declares a pointer to
+// a managed type") fires on every `fixed (T* ...)` and `(<primitive>*)p` cast
+// in this file. Each one is statically dominated by an `if (typeof(T) ==
+// typeof(<primitive>))` runtime check, which guarantees `T` is an unmanaged
+// primitive on every path that reaches the pointer. The compiler cannot see
+// through the typeof check, so the warning is structurally unavoidable here
+// without rewriting the specialization in a way that defeats its purpose.
+#pragma warning disable CS8500
+
 namespace System;
 
 public static partial class SpanExtensions

--- a/touki/Framework/Polyfills/System/SpanExtensions.Search.cs
+++ b/touki/Framework/Polyfills/System/SpanExtensions.Search.cs
@@ -5,6 +5,15 @@
 // Algorithms in this file are adapted from dotnet/runtime (MIT licensed).
 // https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
 
+// CS8500 ("takes the address of, gets the size of, or declares a pointer to
+// a managed type") fires on every `fixed (T* ...)` and `(<primitive>*)p` cast
+// in this file. Each one is statically dominated by an `if (typeof(T) ==
+// typeof(<primitive>))` runtime check, which guarantees `T` is an unmanaged
+// primitive on every path that reaches the pointer. The compiler cannot see
+// through the typeof check, so the warning is structurally unavoidable here
+// without rewriting the specialization in a way that defeats its purpose.
+#pragma warning disable CS8500
+
 namespace System;
 
 public static partial class SpanExtensions

--- a/touki/Touki/Text/StringSegment.cs
+++ b/touki/Touki/Text/StringSegment.cs
@@ -24,7 +24,7 @@ namespace Touki.Text;
 ///   <see cref="StringComparison.CurrentCulture"/>.
 ///  </para>
 ///  <para>
-///   <see cref="ReadOnlyMemory{T}"/> (created via <see cref="System.MemoryExtensions.AsMemory(string?)"/>) provides
+///   <see cref="ReadOnlyMemory{T}"/> (created via <c>MemoryExtensions.AsMemory</c>) provides
 ///   some functionality similar to <see cref="StringSegment"/>, but it is not as optimized for <see langword="string"/>
 ///   operations. This struct leverages <see langword="string"/> methods to get good performance on .NET Framework.
 ///  </para>


### PR DESCRIPTION
## Summary

Promote all compiler / analyzer warnings to build errors and fix everything that surfaced. Builds on the previous `EnforceCodeStyleInBuild` PR by closing the remaining "warnings get silently shipped" gap.

## Changes

### Build infrastructure

- **[Directory.Build.props](Directory.Build.props)** &mdash; add `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`. CS, CA, and IDE diagnostics whose `.editorconfig` severity is `warning` now fail the build instead of being advisory.
- **[.editorconfig](.editorconfig)** &mdash; broaden the extension-type analyzer suppression glob from `**/*Extensions.cs` to `**/*Extensions*.cs`. The previous glob missed partial-class splits like `MemoryExtensions.Trim.cs`, `SpanExtensions.Search.cs`, `StringExtensions_DotNetFoundation.cs`, etc., causing IDE0051 false positives to leak through. Comment updated to spell out the convention.

### Diagnostic fixes surfaced by the new flag

- **CS1574 (unresolvable cref) &mdash; real bugs**:
  - [CryptographicOperations.cs](touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs) referenced `MemoryExtensions.SequenceEqual{T}(ReadOnlySpan{T}, ReadOnlySpan{T})`, which doesn't exist on net472. Replaced with a `<c>...</c>` tag.
  - [StringSegment.cs](touki/Touki/Text/StringSegment.cs) referenced `MemoryExtensions.AsMemory(string?)`, which doesn't exist with that nullable annotation on net472. Same treatment.
- **CS1591 (missing XML on public type)**: added type-level `<summary>` to the primary partial declarations in [CharExtensions.cs](touki/Framework/Polyfills/System/CharExtensions.cs) and [SpanExtensions.EnumerateLines.cs](touki/Framework/Polyfills/System/SpanExtensions.EnumerateLines.cs). All other partials inherit from these.

### Targeted suppression: CS8500

[SpanExtensions.Replace.cs](touki/Framework/Polyfills/System/SpanExtensions.Replace.cs) and [SpanExtensions.Search.cs](touki/Framework/Polyfills/System/SpanExtensions.Search.cs) contain ~16 `fixed (T* p = span)` sites where `T` is unconstrained generic. Each is statically dominated by `if (typeof(T) == typeof(<primitive>))`, so the pointer is safe at runtime &mdash; but the compiler can't see through the typeof check. CS8500 ("takes the address of, gets the size of, or declares a pointer to a managed type") is structurally unavoidable without rewriting the specialization in a way that defeats the inlining/JIT-elision purpose of the pattern.

I considered several scopes for the suppression and picked the narrowest one that's still readable:

- ~~`<NoWarn>CS8500</NoWarn>`~~ in `touki.csproj` &mdash; rejected, too broad (entire library).
- ~~`dotnet_diagnostic.CS8500.severity = none`~~ in `.editorconfig` &mdash; rejected, separates the suppression from the code that motivates it.
- ~~Per `fixed` block~~ &mdash; would add ~32 lines of identical pragma noise.
- ~~Per method~~ &mdash; still 9 copies of the same justification comment.
- **File-top `#pragma warning disable CS8500` with a justification comment** &mdash; chosen. Suppression travels with the code, comment explains the typeof-guarded invariant once per file.

There's no upstream Roslyn issue to track. CS8500 is firing on real `fixed (T*)` code that we wrote for these polyfills; modern .NET just doesn't compile those files because the BCL provides `Vector128<T>` / span intrinsics instead.

## Verification

```
dotnet build touki.slnx -c Debug --no-incremental
Build succeeded.
    0 Warning(s)
    0 Error(s)

dotnet test -c Release touki.slnx
Passed: 3113 (net10.0)
Passed: 3301 (net481)
Failed: 0
```

## Notes

- Test (`touki.tests/.editorconfig`) and benchmark (`touki.perf/.editorconfig`) projects already set CS1591 = `none` in their own configs, so missing XML docs in tests/benchmarks remain non-failing &mdash; only library code is held to the new bar.
- Followup observation: the `**/*Extensions*.cs` glob is now load-bearing for all extension-type files. New partials (e.g. `FooExtensions.SomeFeature.cs`) are covered automatically; new non-Extensions files with `extension(...)` blocks would need to be added explicitly.
