### PR TITLE
Polyfill remaining static exception throw helpers

### DIFF
--- a/touki.tests/System/ArgumentExceptionExtensionsTests.cs
+++ b/touki.tests/System/ArgumentExceptionExtensionsTests.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class ArgumentExceptionExtensionsTests
+{
+    [Fact]
+    public void ThrowIfNullOrEmpty_Null_ThrowsArgumentNull()
+    {
+        string? value = null;
+        Action action = () => ArgumentException.ThrowIfNullOrEmpty(value);
+        action.Should().Throw<ArgumentNullException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNullOrEmpty_Empty_ThrowsArgument()
+    {
+        string value = string.Empty;
+        Action action = () => ArgumentException.ThrowIfNullOrEmpty(value);
+        action.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNullOrEmpty_WhiteSpace_DoesNotThrow()
+    {
+        ArgumentException.ThrowIfNullOrEmpty("  ");
+    }
+
+    [Fact]
+    public void ThrowIfNullOrEmpty_NonEmpty_DoesNotThrow()
+    {
+        ArgumentException.ThrowIfNullOrEmpty("x");
+    }
+
+    [Fact]
+    public void ThrowIfNullOrWhiteSpace_Null_ThrowsArgumentNull()
+    {
+        string? value = null;
+        Action action = () => ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        action.Should().Throw<ArgumentNullException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNullOrWhiteSpace_Empty_ThrowsArgument()
+    {
+        string value = string.Empty;
+        Action action = () => ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        action.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNullOrWhiteSpace_WhiteSpaceOnly_ThrowsArgument()
+    {
+        string value = " \t\r\n";
+        Action action = () => ArgumentException.ThrowIfNullOrWhiteSpace(value);
+        action.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNullOrWhiteSpace_NonWhiteSpace_DoesNotThrow()
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(" x ");
+    }
+}

--- a/touki.tests/System/ArgumentOutOfRangeExtensionsTests.cs
+++ b/touki.tests/System/ArgumentOutOfRangeExtensionsTests.cs
@@ -30,6 +30,38 @@ public class ArgumentOutOfRangeExtensionsTests
     }
 
     [Fact]
+    public void ThrowIfZero_Ulong_Zero_Throws()
+    {
+        ulong value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfZero_Nint_Zero_Throws()
+    {
+        nint value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfZero_Nuint_Zero_Throws()
+    {
+        nuint value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfZero_Float_Zero_Throws()
+    {
+        float value = 0f;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
     public void ThrowIfZero_Double_Zero_Throws()
     {
         double value = 0;
@@ -58,6 +90,22 @@ public class ArgumentOutOfRangeExtensionsTests
     {
         ArgumentOutOfRangeException.ThrowIfNegative(0L);
         ArgumentOutOfRangeException.ThrowIfNegative(1L);
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Nint_Negative_Throws()
+    {
+        nint value = -1;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegative(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Float_Negative_Throws()
+    {
+        float value = -0.1f;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegative(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
     }
 
     [Fact]
@@ -96,6 +144,22 @@ public class ArgumentOutOfRangeExtensionsTests
     public void ThrowIfNegativeOrZero_Long_Positive_DoesNotThrow()
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(1L);
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Nint_Zero_Throws()
+    {
+        nint value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Float_Negative_Throws()
+    {
+        float value = -1f;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
     }
 
     [Fact]

--- a/touki.tests/System/ArgumentOutOfRangeExtensionsTests.cs
+++ b/touki.tests/System/ArgumentOutOfRangeExtensionsTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class ArgumentOutOfRangeExtensionsTests
+{
+    [Fact]
+    public void ThrowIfZero_Long_Zero_Throws()
+    {
+        long value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfZero_Long_NonZero_DoesNotThrow()
+    {
+        ArgumentOutOfRangeException.ThrowIfZero(1L);
+        ArgumentOutOfRangeException.ThrowIfZero(-1L);
+    }
+
+    [Fact]
+    public void ThrowIfZero_Uint_Zero_Throws()
+    {
+        uint value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfZero_Double_Zero_Throws()
+    {
+        double value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfZero_Decimal_Zero_Throws()
+    {
+        decimal value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Long_Negative_Throws()
+    {
+        long value = -1;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegative(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Long_ZeroOrPositive_DoesNotThrow()
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(0L);
+        ArgumentOutOfRangeException.ThrowIfNegative(1L);
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Double_Negative_Throws()
+    {
+        double value = -0.1;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegative(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Decimal_Negative_Throws()
+    {
+        decimal value = -1m;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegative(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Long_Zero_Throws()
+    {
+        long value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Long_Negative_Throws()
+    {
+        long value = -1;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Long_Positive_DoesNotThrow()
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(1L);
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Double_Zero_Throws()
+    {
+        double value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Decimal_Zero_Throws()
+    {
+        decimal value = 0;
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value);
+        action.Should().Throw<ArgumentOutOfRangeException>().WithParameterName(nameof(value));
+    }
+}

--- a/touki.tests/System/ObjectDisposedExtensionsTests.cs
+++ b/touki.tests/System/ObjectDisposedExtensionsTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class ObjectDisposedExtensionsTests
+{
+    private sealed class Sample { }
+
+    [Fact]
+    public void ThrowIf_FalseWithInstance_DoesNotThrow()
+    {
+        ObjectDisposedException.ThrowIf(false, new Sample());
+    }
+
+    [Fact]
+    public void ThrowIf_TrueWithInstance_ThrowsWithTypeName()
+    {
+        Action action = () => ObjectDisposedException.ThrowIf(true, new Sample());
+        action.Should().Throw<ObjectDisposedException>()
+            .Which.ObjectName.Should().Be(typeof(Sample).FullName);
+    }
+
+    [Fact]
+    public void ThrowIf_FalseWithType_DoesNotThrow()
+    {
+        ObjectDisposedException.ThrowIf(false, typeof(Sample));
+    }
+
+    [Fact]
+    public void ThrowIf_TrueWithType_ThrowsWithTypeName()
+    {
+        Action action = () => ObjectDisposedException.ThrowIf(true, typeof(Sample));
+        action.Should().Throw<ObjectDisposedException>()
+            .Which.ObjectName.Should().Be(typeof(Sample).FullName);
+    }
+}

--- a/touki/Framework/Polyfills/System/ArgumentExceptionExtensions.cs
+++ b/touki/Framework/Polyfills/System/ArgumentExceptionExtensions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Framework.Resources;
+
+namespace System;
+
+/// <summary>
+///  Helper to allow using new patterns for throwing <see cref="ArgumentException"/>s.
+/// </summary>
+public static class ArgumentExceptionExtensions
+{
+    extension(ArgumentException)
+    {
+        /// <summary>
+        ///  Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>,
+        ///  or an <see cref="ArgumentException"/> if it is empty.
+        /// </summary>
+        /// <param name="argument">The string argument to validate as non-null and non-empty.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        public static void ThrowIfNullOrEmpty(
+            [NotNull] string? argument,
+            [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+
+            if (argument.Length == 0)
+            {
+                throw new ArgumentException(SRF.Argument_EmptyString, paramName);
+            }
+        }
+
+        /// <summary>
+        ///  Throws an <see cref="ArgumentNullException"/> if <paramref name="argument"/> is <see langword="null"/>,
+        ///  or an <see cref="ArgumentException"/> if it is empty or consists only of white-space characters.
+        /// </summary>
+        /// <param name="argument">The string argument to validate.</param>
+        /// <param name="paramName">The name of the parameter with which <paramref name="argument"/> corresponds.</param>
+        public static void ThrowIfNullOrWhiteSpace(
+            [NotNull] string? argument,
+            [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+        {
+            if (argument is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                throw new ArgumentException(SRF.Argument_EmptyOrWhiteSpaceString, paramName);
+            }
+        }
+    }
+}

--- a/touki/Framework/Polyfills/System/ArgumentOutOfRangeExtensions.cs
+++ b/touki/Framework/Polyfills/System/ArgumentOutOfRangeExtensions.cs
@@ -116,6 +116,132 @@ public static class ArgumentOutOfRangeExtensions
                 ThrowNegativeOrZero(value, paramName);
         }
 
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(long value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(uint value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(ulong value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(nint value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(nuint value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(float value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(double value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfZero(int, string?)"/>
+        public static void ThrowIfZero(decimal value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value == 0)
+                ThrowZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegative(int, string?)"/>
+        public static void ThrowIfNegative(long value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+                ThrowNegative(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegative(int, string?)"/>
+        public static void ThrowIfNegative(nint value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+                ThrowNegative(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegative(int, string?)"/>
+        public static void ThrowIfNegative(float value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+                ThrowNegative(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegative(int, string?)"/>
+        public static void ThrowIfNegative(double value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+                ThrowNegative(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegative(int, string?)"/>
+        public static void ThrowIfNegative(decimal value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value < 0)
+                ThrowNegative(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegativeOrZero(int, string?)"/>
+        public static void ThrowIfNegativeOrZero(long value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value <= 0)
+                ThrowNegativeOrZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegativeOrZero(int, string?)"/>
+        public static void ThrowIfNegativeOrZero(nint value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value <= 0)
+                ThrowNegativeOrZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegativeOrZero(int, string?)"/>
+        public static void ThrowIfNegativeOrZero(float value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value <= 0)
+                ThrowNegativeOrZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegativeOrZero(int, string?)"/>
+        public static void ThrowIfNegativeOrZero(double value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value <= 0)
+                ThrowNegativeOrZero(value, paramName);
+        }
+
+        /// <inheritdoc cref="ThrowIfNegativeOrZero(int, string?)"/>
+        public static void ThrowIfNegativeOrZero(decimal value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        {
+            if (value <= 0)
+                ThrowNegativeOrZero(value, paramName);
+        }
+
         /// <summary>Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is equal to <paramref name="other"/>.</summary>
         /// <param name="value">The argument to validate as not equal to <paramref name="other"/>.</param>
         /// <param name="other">The value to compare with <paramref name="value"/>.</param>

--- a/touki/Framework/Polyfills/System/ObjectDisposedExtensions.cs
+++ b/touki/Framework/Polyfills/System/ObjectDisposedExtensions.cs
@@ -11,7 +11,11 @@ public static class ObjectDisposedExtensions
 {
     extension(ObjectDisposedException)
     {
-        /// <summary>Throws an <see cref="ObjectDisposedException"/> if <paramref name="condition"/> is true.</summary>
+        /// <summary>
+        ///  Throws an <see cref="ObjectDisposedException"/> if <paramref name="condition"/> is <see langword="true"/>.
+        /// </summary>
+        /// <param name="condition">The condition to evaluate.</param>
+        /// <param name="instance">The object whose type's name is used to construct the exception's message.</param>
         public static void ThrowIf([DoesNotReturnIf(true)] bool condition, object instance)
         {
             if (condition)
@@ -19,9 +23,26 @@ public static class ObjectDisposedExtensions
                 ThrowObjectDisposed(instance);
             }
         }
+
+        /// <summary>
+        ///  Throws an <see cref="ObjectDisposedException"/> if <paramref name="condition"/> is <see langword="true"/>.
+        /// </summary>
+        /// <param name="condition">The condition to evaluate.</param>
+        /// <param name="type">The type whose name is used to construct the exception's message.</param>
+        public static void ThrowIf([DoesNotReturnIf(true)] bool condition, Type type)
+        {
+            if (condition)
+            {
+                ThrowObjectDisposed(type);
+            }
+        }
     }
 
     [DoesNotReturn]
     private static void ThrowObjectDisposed(object instance) =>
         throw new ObjectDisposedException(instance?.GetType().FullName);
+
+    [DoesNotReturn]
+    private static void ThrowObjectDisposed(Type type) =>
+        throw new ObjectDisposedException(type?.FullName);
 }

--- a/touki/Framework/Resources/SRF.resx
+++ b/touki/Framework/Resources/SRF.resx
@@ -129,6 +129,12 @@
   <data name="Argument_DestinationTooShort" xml:space="preserve">
     <value>Destination is too short.</value>
   </data>
+  <data name="Argument_EmptyOrWhiteSpaceString" xml:space="preserve">
+    <value>The value cannot be an empty string or composed entirely of whitespace.</value>
+  </data>
+  <data name="Argument_EmptyString" xml:space="preserve">
+    <value>The value cannot be an empty string.</value>
+  </data>
   <data name="Argument_HasToBeArrayClass" xml:space="preserve">
     <value>Must be an array type.</value>
   </data>


### PR DESCRIPTION
Fills in the static `Throw*` / `ThrowIf*` helpers on BCL exception classes that were missing from the .NET Framework polyfill surface. Survey via apisof.net confirmed the BCL surface stabilized in net8.0 — no new helpers in net9.0 / net10.0.

## Changes

- **`ArgumentException`** (new file `ArgumentExceptionExtensions.cs`)
  - `ThrowIfNullOrEmpty(string?, string?)` (net7.0)
  - `ThrowIfNullOrWhiteSpace(string?, string?)` (net8.0)
- **`ObjectDisposedException`**
  - Added `ThrowIf(bool, Type)` overload (net7.0) alongside the existing `(bool, object)` overload
- **`ArgumentOutOfRangeException`** — primitive overloads of the net8.0 generic API
  - `ThrowIfZero`: `long`, `uint`, `ulong`, `nint`, `nuint`, `float`, `double`, `decimal`
  - `ThrowIfNegative`: `long`, `nint`, `float`, `double`, `decimal`
  - `ThrowIfNegativeOrZero`: same as `ThrowIfNegative`
  - `INumberBase<T>` is unavailable on net472, so the generic signature is matched via overloads — same approach used by the existing `int` overload.
- **Resources** — added `Argument_EmptyString` and `Argument_EmptyOrWhiteSpaceString` to `SRF.resx`.

## Tests

New tests in `touki.tests/System/`:
- `ArgumentExceptionExtensionsTests`
- `ObjectDisposedExtensionsTests`
- `ArgumentOutOfRangeExtensionsTests`

Tests run on both target frameworks: exercising the BCL on `net10.0` and the polyfill on `net481`. `dotnet test -c Release` passes (3139 net10.0 / 3327 net481).