### PR TITLE
Polyfill Math, double, and float .NET Core APIs for net472

### DIFF
--- a/touki.tests/System/DoubleExtensionsTests.cs
+++ b/touki.tests/System/DoubleExtensionsTests.cs
@@ -2,31 +2,68 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+#pragma warning disable xUnit1025 // duplicate InlineData (xUnit doesn't distinguish 0.0 from -0.0)
+
 namespace Touki;
 
 public class DoubleExtensionsTests
 {
+    private const double MinNormal = 2.2250738585072014e-308;
+    private const double MaxSubnormal = 2.2250738585072009e-308;
+    private const double NegativeZero = -0.0;
+    private const double NegativeMinNormal = -2.2250738585072014e-308;
+    private const double NegativeMaxSubnormal = -2.2250738585072009e-308;
+    private const double NegativeEpsilon = -double.Epsilon;
+
+    // The BCL test files exercise this canonical 15-row table for each predicate.
+    // -0.0 cases are handled in dedicated [Fact] tests because xUnit's InlineData
+    // can't distinguish 0.0 from -0.0.
+
+    // ---- IsFinite ----
+
     [Theory]
-    [InlineData(0.0, true)]
-    [InlineData(1.0, true)]
-    [InlineData(-1.0, true)]
-    [InlineData(double.MaxValue, true)]
-    [InlineData(double.Epsilon, true)]
-    [InlineData(double.PositiveInfinity, false)]
     [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, true)]
+    [InlineData(-1.0, true)]
+    [InlineData(NegativeMinNormal, true)]
+    [InlineData(NegativeMaxSubnormal, true)]
+    [InlineData(NegativeEpsilon, true)]
     [InlineData(double.NaN, false)]
+    [InlineData(0.0, true)]
+    [InlineData(double.Epsilon, true)]
+    [InlineData(MaxSubnormal, true)]
+    [InlineData(MinNormal, true)]
+    [InlineData(1.0, true)]
+    [InlineData(double.MaxValue, true)]
+    [InlineData(double.PositiveInfinity, false)]
     public void IsFinite_ReturnsExpected(double value, bool expected)
     {
         double.IsFinite(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsFinite_NegativeZero_ReturnsTrue()
+    {
+        double.IsFinite(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsNegative ----
+
     [Theory]
-    [InlineData(0.0, false)]
-    [InlineData(1.0, false)]
-    [InlineData(-1.0, true)]
-    [InlineData(double.NaN, true)]
-    [InlineData(double.PositiveInfinity, false)]
     [InlineData(double.NegativeInfinity, true)]
+    [InlineData(double.MinValue, true)]
+    [InlineData(-1.0, true)]
+    [InlineData(NegativeMinNormal, true)]
+    [InlineData(NegativeMaxSubnormal, true)]
+    [InlineData(NegativeEpsilon, true)]
+    [InlineData(double.NaN, true)]
+    [InlineData(0.0, false)]
+    [InlineData(double.Epsilon, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, false)]
+    [InlineData(1.0, false)]
+    [InlineData(double.MaxValue, false)]
+    [InlineData(double.PositiveInfinity, false)]
     public void IsNegative_ReturnsExpected(double value, bool expected)
     {
         double.IsNegative(value).Should().Be(expected);
@@ -35,100 +72,234 @@ public class DoubleExtensionsTests
     [Fact]
     public void IsNegative_NegativeZero_ReturnsTrue()
     {
-        double negativeZero = BitConverter.Int64BitsToDouble(unchecked((long)0x8000_0000_0000_0000UL));
-        double.IsNegative(negativeZero).Should().BeTrue();
+        double.IsNegative(NegativeZero).Should().BeTrue();
     }
 
+    // ---- IsNormal ----
+
     [Theory]
-    [InlineData(1.0, true)]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, true)]
     [InlineData(-1.0, true)]
+    [InlineData(NegativeMinNormal, true)]
+    [InlineData(NegativeMaxSubnormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(double.NaN, false)]
     [InlineData(0.0, false)]
     [InlineData(double.Epsilon, false)]
-    [InlineData(double.NaN, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, true)]
+    [InlineData(1.0, true)]
+    [InlineData(double.MaxValue, true)]
     [InlineData(double.PositiveInfinity, false)]
     public void IsNormal_ReturnsExpected(double value, bool expected)
     {
         double.IsNormal(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsNormal_NegativeZero_ReturnsFalse()
+    {
+        double.IsNormal(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsSubnormal ----
+
     [Theory]
-    [InlineData(1.0, false)]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, false)]
+    [InlineData(-1.0, false)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeMaxSubnormal, true)]
+    [InlineData(NegativeEpsilon, true)]
+    [InlineData(double.NaN, false)]
     [InlineData(0.0, false)]
     [InlineData(double.Epsilon, true)]
-    [InlineData(double.NaN, false)]
+    [InlineData(MaxSubnormal, true)]
+    [InlineData(MinNormal, false)]
+    [InlineData(1.0, false)]
+    [InlineData(double.MaxValue, false)]
     [InlineData(double.PositiveInfinity, false)]
     public void IsSubnormal_ReturnsExpected(double value, bool expected)
     {
         double.IsSubnormal(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsSubnormal_NegativeZero_ReturnsFalse()
+    {
+        double.IsSubnormal(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsPositive ----
+
     [Theory]
-    [InlineData(0.0, true)]
-    [InlineData(1.0, true)]
-    [InlineData(-1.0, false)]
-    [InlineData(double.NaN, false)]
-    [InlineData(double.PositiveInfinity, true)]
     [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, false)]
+    [InlineData(-1.0, false)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeMaxSubnormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(double.NaN, false)]
+    [InlineData(0.0, true)]
+    [InlineData(double.Epsilon, true)]
+    [InlineData(MaxSubnormal, true)]
+    [InlineData(MinNormal, true)]
+    [InlineData(1.0, true)]
+    [InlineData(double.MaxValue, true)]
+    [InlineData(double.PositiveInfinity, true)]
     public void IsPositive_ReturnsExpected(double value, bool expected)
     {
         double.IsPositive(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsPositive_NegativeZero_ReturnsFalse()
+    {
+        double.IsPositive(NegativeZero).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsPositive_NegativeNaN_ReturnsFalse()
+    {
+        double negNaN = BitConverter.Int64BitsToDouble(unchecked((long)0xFFF8000000000000UL));
+        double.IsPositive(negNaN).Should().BeFalse();
+    }
+
+    // ---- IsRealNumber ----
+    // Always true except NaN.
+
     [Theory]
-    [InlineData(0.0, true)]
-    [InlineData(1.5, true)]
-    [InlineData(double.PositiveInfinity, true)]
     [InlineData(double.NegativeInfinity, true)]
+    [InlineData(-1.0, true)]
     [InlineData(double.NaN, false)]
+    [InlineData(0.0, true)]
+    [InlineData(1.0, true)]
+    [InlineData(double.PositiveInfinity, true)]
     public void IsRealNumber_ReturnsExpected(double value, bool expected)
     {
         double.IsRealNumber(value).Should().Be(expected);
     }
 
+    // ---- IsInteger ----
+
     [Theory]
-    [InlineData(0.0, true)]
-    [InlineData(1.0, true)]
-    [InlineData(-3.0, true)]
-    [InlineData(1.5, false)]
-    [InlineData(double.PositiveInfinity, false)]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, true)]
+    [InlineData(-1.0, true)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeMaxSubnormal, false)]
+    [InlineData(NegativeEpsilon, false)]
     [InlineData(double.NaN, false)]
+    [InlineData(0.0, true)]
+    [InlineData(double.Epsilon, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, false)]
+    [InlineData(1.0, true)]
+    [InlineData(double.MaxValue, true)]
+    [InlineData(double.PositiveInfinity, false)]
     public void IsInteger_ReturnsExpected(double value, bool expected)
     {
         double.IsInteger(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsInteger_NegativeZero_ReturnsTrue()
+    {
+        double.IsInteger(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsEvenInteger ----
+    // Note: BCL says double.MinValue and double.MaxValue are even (they're enormous integers
+    // whose lowest bits are zero by the FP representation).
+
     [Theory]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, true)]
+    [InlineData(-1.0, false)]
+    [InlineData(-2.0, true)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeMaxSubnormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(double.NaN, false)]
     [InlineData(0.0, true)]
-    [InlineData(2.0, true)]
-    [InlineData(-4.0, true)]
+    [InlineData(double.Epsilon, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, false)]
     [InlineData(1.0, false)]
-    [InlineData(1.5, false)]
+    [InlineData(2.0, true)]
+    [InlineData(double.MaxValue, true)]
+    [InlineData(double.PositiveInfinity, false)]
     public void IsEvenInteger_ReturnsExpected(double value, bool expected)
     {
         double.IsEvenInteger(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsEvenInteger_NegativeZero_ReturnsTrue()
+    {
+        double.IsEvenInteger(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsOddInteger ----
+
     [Theory]
-    [InlineData(1.0, true)]
-    [InlineData(-3.0, true)]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, false)]
+    [InlineData(-1.0, true)]
+    [InlineData(-2.0, false)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeMaxSubnormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(double.NaN, false)]
     [InlineData(0.0, false)]
+    [InlineData(double.Epsilon, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, false)]
+    [InlineData(1.0, true)]
     [InlineData(2.0, false)]
+    [InlineData(double.MaxValue, false)]
+    [InlineData(double.PositiveInfinity, false)]
     public void IsOddInteger_ReturnsExpected(double value, bool expected)
     {
         double.IsOddInteger(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsOddInteger_NegativeZero_ReturnsFalse()
+    {
+        double.IsOddInteger(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsPow2 ----
+
     [Theory]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.MinValue, false)]
+    [InlineData(-1.0, false)]
+    [InlineData(-2.0, false)] // negative 2^1 is NOT a pow2 (sign-bit set).
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(double.NaN, false)]
+    [InlineData(0.0, false)]
+    [InlineData(double.Epsilon, true)]   // 2^-1074
+    [InlineData(MinNormal, true)]        // 2^-1022
+    [InlineData(0.5, true)]
     [InlineData(1.0, true)]
     [InlineData(2.0, true)]
     [InlineData(4.0, true)]
-    [InlineData(0.5, true)]
     [InlineData(3.0, false)]
-    [InlineData(0.0, false)]
-    [InlineData(-2.0, false)]
-    [InlineData(double.NaN, false)]
+    [InlineData(1.5, false)]
+    [InlineData(double.MaxValue, false)]
+    [InlineData(double.PositiveInfinity, false)]
     public void IsPow2_ReturnsExpected(double value, bool expected)
     {
         double.IsPow2(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsPow2_NegativeZero_ReturnsFalse()
+    {
+        double.IsPow2(NegativeZero).Should().BeFalse();
     }
 }

--- a/touki.tests/System/DoubleExtensionsTests.cs
+++ b/touki.tests/System/DoubleExtensionsTests.cs
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class DoubleExtensionsTests
+{
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(1.0, true)]
+    [InlineData(-1.0, true)]
+    [InlineData(double.MaxValue, true)]
+    [InlineData(double.Epsilon, true)]
+    [InlineData(double.PositiveInfinity, false)]
+    [InlineData(double.NegativeInfinity, false)]
+    [InlineData(double.NaN, false)]
+    public void IsFinite_ReturnsExpected(double value, bool expected)
+    {
+        double.IsFinite(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, false)]
+    [InlineData(1.0, false)]
+    [InlineData(-1.0, true)]
+    [InlineData(double.NaN, true)]
+    [InlineData(double.PositiveInfinity, false)]
+    [InlineData(double.NegativeInfinity, true)]
+    public void IsNegative_ReturnsExpected(double value, bool expected)
+    {
+        double.IsNegative(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsNegative_NegativeZero_ReturnsTrue()
+    {
+        double negativeZero = BitConverter.Int64BitsToDouble(unchecked((long)0x8000_0000_0000_0000UL));
+        double.IsNegative(negativeZero).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(1.0, true)]
+    [InlineData(-1.0, true)]
+    [InlineData(0.0, false)]
+    [InlineData(double.Epsilon, false)]
+    [InlineData(double.NaN, false)]
+    [InlineData(double.PositiveInfinity, false)]
+    public void IsNormal_ReturnsExpected(double value, bool expected)
+    {
+        double.IsNormal(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1.0, false)]
+    [InlineData(0.0, false)]
+    [InlineData(double.Epsilon, true)]
+    [InlineData(double.NaN, false)]
+    [InlineData(double.PositiveInfinity, false)]
+    public void IsSubnormal_ReturnsExpected(double value, bool expected)
+    {
+        double.IsSubnormal(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(1.0, true)]
+    [InlineData(-1.0, false)]
+    [InlineData(double.NaN, false)]
+    [InlineData(double.PositiveInfinity, true)]
+    [InlineData(double.NegativeInfinity, false)]
+    public void IsPositive_ReturnsExpected(double value, bool expected)
+    {
+        double.IsPositive(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(1.5, true)]
+    [InlineData(double.PositiveInfinity, true)]
+    [InlineData(double.NegativeInfinity, true)]
+    [InlineData(double.NaN, false)]
+    public void IsRealNumber_ReturnsExpected(double value, bool expected)
+    {
+        double.IsRealNumber(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(1.0, true)]
+    [InlineData(-3.0, true)]
+    [InlineData(1.5, false)]
+    [InlineData(double.PositiveInfinity, false)]
+    [InlineData(double.NaN, false)]
+    public void IsInteger_ReturnsExpected(double value, bool expected)
+    {
+        double.IsInteger(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0.0, true)]
+    [InlineData(2.0, true)]
+    [InlineData(-4.0, true)]
+    [InlineData(1.0, false)]
+    [InlineData(1.5, false)]
+    public void IsEvenInteger_ReturnsExpected(double value, bool expected)
+    {
+        double.IsEvenInteger(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1.0, true)]
+    [InlineData(-3.0, true)]
+    [InlineData(0.0, false)]
+    [InlineData(2.0, false)]
+    public void IsOddInteger_ReturnsExpected(double value, bool expected)
+    {
+        double.IsOddInteger(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1.0, true)]
+    [InlineData(2.0, true)]
+    [InlineData(4.0, true)]
+    [InlineData(0.5, true)]
+    [InlineData(3.0, false)]
+    [InlineData(0.0, false)]
+    [InlineData(-2.0, false)]
+    [InlineData(double.NaN, false)]
+    public void IsPow2_ReturnsExpected(double value, bool expected)
+    {
+        double.IsPow2(value).Should().Be(expected);
+    }
+}

--- a/touki.tests/System/MathExtensionsTests.cs
+++ b/touki.tests/System/MathExtensionsTests.cs
@@ -94,9 +94,28 @@ public class MathExtensionsTests
     }
 
     [Fact]
+    public void Acosh_LargeValue_DoesNotOverflow()
+    {
+        // d*d would overflow for d=1e308; result must be finite (~ Log(2*1e308)).
+        double result = Math.Acosh(1e308);
+        result.Should().BeGreaterThan(0.0);
+        double.IsFinite(result).Should().BeTrue();
+    }
+
+    [Fact]
     public void Asinh_OfZero_IsZero()
     {
         Math.Asinh(0.0).Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Asinh_LargeMagnitude_DoesNotOverflow()
+    {
+        double pos = Math.Asinh(1e308);
+        double neg = Math.Asinh(-1e308);
+        double.IsFinite(pos).Should().BeTrue();
+        double.IsFinite(neg).Should().BeTrue();
+        neg.Should().Be(-pos);
     }
 
     [Fact]
@@ -118,6 +137,15 @@ public class MathExtensionsTests
     public void Cbrt_Negative_ReturnsNegative()
     {
         Math.Cbrt(-8.0).Should().BeApproximately(-2.0, 1e-12);
+    }
+
+    [Fact]
+    public void Cbrt_NegativeZero_PreservesSign()
+    {
+        double negativeZero = BitConverter.Int64BitsToDouble(unchecked((long)0x8000_0000_0000_0000UL));
+        double result = Math.Cbrt(negativeZero);
+        result.Should().Be(0.0);
+        double.IsNegative(result).Should().BeTrue();
     }
 
     [Fact]

--- a/touki.tests/System/MathExtensionsTests.cs
+++ b/touki.tests/System/MathExtensionsTests.cs
@@ -2,10 +2,17 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+#pragma warning disable xUnit1025 // duplicate InlineData (xUnit doesn't distinguish 0.0 from -0.0)
+
 namespace Touki;
 
 public class MathExtensionsTests
 {
+    // BCL test files use 2^-50 instead of 2^-52 for cross-platform libm tolerance.
+    private const double CrossPlatformMachineEpsilon = 8.8817841970012523e-16;
+
+    // ---- Clamp ----
+
     [Theory]
     [InlineData(5, 0, 10, 5)]
     [InlineData(-5, 0, 10, 0)]
@@ -15,13 +22,6 @@ public class MathExtensionsTests
     public void Clamp_Int_ReturnsExpected(int value, int min, int max, int expected)
     {
         Math.Clamp(value, min, max).Should().Be(expected);
-    }
-
-    [Fact]
-    public void Clamp_MinGreaterThanMax_Throws()
-    {
-        Action action = () => Math.Clamp(0, 10, 5);
-        action.Should().Throw<ArgumentException>();
     }
 
     [Theory]
@@ -47,96 +47,255 @@ public class MathExtensionsTests
         Math.Clamp(0.5m, 0m, 1m).Should().Be(0.5m);
     }
 
+    // Mirror of BCL Clamp_MinGreaterThanMax_ThrowsArgumentException across all overloads.
     [Fact]
-    public void DivRem_Long_ReturnsTuple()
+    public void Clamp_MinGreaterThanMax_AllTypes_Throw()
     {
-        (long q, long r) = Math.DivRem(17L, 5L);
-        q.Should().Be(3L);
-        r.Should().Be(2L);
+        ((Action)(() => Math.Clamp((sbyte)1, (sbyte)2, (sbyte)1))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp((byte)1, (byte)2, (byte)1))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp((short)1, (short)2, (short)1))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp((ushort)1, (ushort)2, (ushort)1))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1, 2, 1))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1u, 2u, 1u))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1L, 2L, 1L))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1UL, 2UL, 1UL))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1f, 2f, 1f))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1.0, 2.0, 1.0))).Should().Throw<ArgumentException>();
+        ((Action)(() => Math.Clamp(1m, 2m, 1m))).Should().Throw<ArgumentException>();
+    }
+
+    // ---- DivRem (tuple-returning overloads) ----
+
+    [Theory]
+    [InlineData((sbyte)sbyte.MaxValue, (sbyte)sbyte.MaxValue, (sbyte)1, (sbyte)0)]
+    [InlineData((sbyte)sbyte.MaxValue, (sbyte)2, (sbyte)63, (sbyte)1)]
+    [InlineData((sbyte)80, (sbyte)22, (sbyte)3, (sbyte)14)]
+    [InlineData((sbyte)80, (sbyte)-22, (sbyte)-3, (sbyte)14)]
+    [InlineData((sbyte)-80, (sbyte)22, (sbyte)-3, (sbyte)-14)]
+    [InlineData((sbyte)-80, (sbyte)-22, (sbyte)3, (sbyte)-14)]
+    [InlineData((sbyte)0, (sbyte)1, (sbyte)0, (sbyte)0)]
+    public void DivRem_Sbyte_ReturnsTuple(sbyte dividend, sbyte divisor, sbyte expectedQuotient, sbyte expectedRemainder)
+    {
+        (sbyte q, sbyte r) = Math.DivRem(dividend, divisor);
+        q.Should().Be(expectedQuotient);
+        r.Should().Be(expectedRemainder);
     }
 
     [Fact]
-    public void DivRem_Byte_ReturnsTuple()
+    public void DivRem_Sbyte_ZeroDivisor_Throws()
     {
-        (byte q, byte r) = Math.DivRem((byte)17, (byte)5);
-        q.Should().Be((byte)3);
-        r.Should().Be((byte)2);
+        ((Action)(() => Math.DivRem((sbyte)1, (sbyte)0))).Should().Throw<DivideByZeroException>();
+    }
+
+    [Theory]
+    [InlineData((byte)byte.MaxValue, (byte)byte.MaxValue, (byte)1, (byte)0)]
+    [InlineData((byte)byte.MaxValue, (byte)2, (byte)127, (byte)1)]
+    [InlineData((byte)52, (byte)5, (byte)10, (byte)2)]
+    [InlineData((byte)100, (byte)33, (byte)3, (byte)1)]
+    [InlineData((byte)0, (byte)1, (byte)0, (byte)0)]
+    public void DivRem_Byte_ReturnsTuple(byte dividend, byte divisor, byte expectedQuotient, byte expectedRemainder)
+    {
+        (byte q, byte r) = Math.DivRem(dividend, divisor);
+        q.Should().Be(expectedQuotient);
+        r.Should().Be(expectedRemainder);
     }
 
     [Fact]
-    public void DivRem_Sbyte_ReturnsTuple()
+    public void DivRem_Byte_ZeroDivisor_Throws()
     {
-        (sbyte q, sbyte r) = Math.DivRem((sbyte)-17, (sbyte)5);
-        q.Should().Be((sbyte)-3);
-        r.Should().Be((sbyte)-2);
+        ((Action)(() => Math.DivRem((byte)1, (byte)0))).Should().Throw<DivideByZeroException>();
+    }
+
+    [Theory]
+    [InlineData((short)short.MaxValue, (short)2, (short)16383, (short)1)]
+    [InlineData((short)12345, (short)22424, (short)0, (short)12345)]
+    [InlineData((short)300, (short)22, (short)13, (short)14)]
+    [InlineData((short)-300, (short)-22, (short)13, (short)-14)]
+    [InlineData((short)13952, (short)2000, (short)6, (short)1952)]
+    public void DivRem_Short_ReturnsTuple(short dividend, short divisor, short expectedQuotient, short expectedRemainder)
+    {
+        (short q, short r) = Math.DivRem(dividend, divisor);
+        q.Should().Be(expectedQuotient);
+        r.Should().Be(expectedRemainder);
     }
 
     [Fact]
-    public void DivRem_Short_ReturnsTuple()
+    public void DivRem_Short_ZeroDivisor_Throws()
     {
-        (short q, short r) = Math.DivRem((short)17, (short)5);
-        q.Should().Be((short)3);
-        r.Should().Be((short)2);
+        ((Action)(() => Math.DivRem((short)1, (short)0))).Should().Throw<DivideByZeroException>();
+    }
+
+    [Theory]
+    [InlineData((ushort)ushort.MaxValue, (ushort)2, (ushort)32767, (ushort)1)]
+    [InlineData((ushort)51474, (ushort)31474, (ushort)1, (ushort)20000)]
+    [InlineData((ushort)10000, (ushort)333, (ushort)30, (ushort)10)]
+    public void DivRem_Ushort_ReturnsTuple(ushort dividend, ushort divisor, ushort expectedQuotient, ushort expectedRemainder)
+    {
+        (ushort q, ushort r) = Math.DivRem(dividend, divisor);
+        q.Should().Be(expectedQuotient);
+        r.Should().Be(expectedRemainder);
     }
 
     [Fact]
-    public void DivRem_Ushort_ReturnsTuple()
+    public void DivRem_Ushort_ZeroDivisor_Throws()
     {
-        (ushort q, ushort r) = Math.DivRem((ushort)17, (ushort)5);
-        q.Should().Be((ushort)3);
-        r.Should().Be((ushort)2);
+        ((Action)(() => Math.DivRem((ushort)1, (ushort)0))).Should().Throw<DivideByZeroException>();
+    }
+
+    [Theory]
+    [InlineData(9223372036854775807L, 2000L, 4611686018427387L, 1807L)]
+    [InlineData(-9223372036854775808L, -2000L, 4611686018427387L, -1808L)]
+    [InlineData(9223372036854775807L, -2000L, -4611686018427387L, 1807L)]
+    [InlineData(13952L, 2000L, 6L, 1952L)]
+    [InlineData(-14032L, 2000L, -7L, -32L)]
+    public void DivRem_Long_ReturnsTuple(long dividend, long divisor, long expectedQuotient, long expectedRemainder)
+    {
+        (long q, long r) = Math.DivRem(dividend, divisor);
+        q.Should().Be(expectedQuotient);
+        r.Should().Be(expectedRemainder);
     }
 
     [Fact]
-    public void Acosh_OfOne_IsZero()
+    public void DivRem_Long_ZeroDivisor_Throws()
     {
-        Math.Acosh(1.0).Should().Be(0.0);
+        ((Action)(() => Math.DivRem(1L, 0L))).Should().Throw<DivideByZeroException>();
+    }
+
+    // ---- Acosh ----
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.NaN)]
+    [InlineData(-1.0, double.NaN)]
+    [InlineData(0.0, double.NaN)]
+    [InlineData(0.5, double.NaN)]
+    [InlineData(0.99999999, double.NaN)]
+    [InlineData(double.NaN, double.NaN)]
+    [InlineData(1.0, 0.0)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity)]
+    public void Acosh_EdgeCases_ReturnsExpected(double value, double expected)
+    {
+        double actual = Math.Acosh(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
+    }
+
+    [Theory]
+    [InlineData(1.5430806348152438, 1.0)]
+    [InlineData(2.5091784786580568, 1.5707963267948966)]   // (pi / 2)
+    [InlineData(11.591953275521521, 3.1415926535897932)]   // (pi)
+    public void Acosh_KnownValues_MatchBcl(double value, double expected)
+    {
+        Math.Acosh(value).Should().BeApproximately(expected, CrossPlatformMachineEpsilon * 10);
     }
 
     [Fact]
     public void Acosh_LargeValue_DoesNotOverflow()
     {
-        // d*d would overflow for d=1e308; result must be finite (~ Log(2*1e308)).
         double result = Math.Acosh(1e308);
-        result.Should().BeGreaterThan(0.0);
         double.IsFinite(result).Should().BeTrue();
+        result.Should().BeGreaterThan(0.0);
     }
 
-    [Fact]
-    public void Asinh_OfZero_IsZero()
-    {
-        Math.Asinh(0.0).Should().Be(0.0);
-    }
+    // ---- Asinh ----
 
-    [Fact]
-    public void Asinh_LargeMagnitude_DoesNotOverflow()
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.NegativeInfinity)]
+    [InlineData(double.NaN, double.NaN)]
+    [InlineData(0.0, 0.0)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity)]
+    public void Asinh_EdgeCases_ReturnsExpected(double value, double expected)
     {
-        double pos = Math.Asinh(1e308);
-        double neg = Math.Asinh(-1e308);
-        double.IsFinite(pos).Should().BeTrue();
-        double.IsFinite(neg).Should().BeTrue();
-        neg.Should().Be(-pos);
-    }
-
-    [Fact]
-    public void Atanh_OfZero_IsZero()
-    {
-        Math.Atanh(0.0).Should().Be(0.0);
+        double actual = Math.Asinh(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
     }
 
     [Theory]
-    [InlineData(8.0, 2.0)]
-    [InlineData(27.0, 3.0)]
-    [InlineData(0.0, 0.0)]
-    public void Cbrt_Positive_ReturnsExpected(double value, double expected)
+    [InlineData(1.1752011936438015, 1.0)]
+    [InlineData(2.3012989023072949, 1.5707963267948966)]   // (pi / 2)
+    [InlineData(11.548739357257748, 3.1415926535897932)]   // (pi)
+    public void Asinh_KnownValues_MatchBcl(double value, double expected)
     {
-        Math.Cbrt(value).Should().BeApproximately(expected, 1e-12);
+        Math.Asinh(value).Should().BeApproximately(expected, CrossPlatformMachineEpsilon * 10);
     }
 
-    [Fact]
-    public void Cbrt_Negative_ReturnsNegative()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(0.5)]
+    [InlineData(123.456)]
+    [InlineData(1e308)]
+    public void Asinh_OddSymmetry_NegEqualsNegated(double value)
     {
-        Math.Cbrt(-8.0).Should().BeApproximately(-2.0, 1e-12);
+        Math.Asinh(-value).Should().Be(-Math.Asinh(value));
+    }
+
+    // ---- Atanh ----
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.NaN)]
+    [InlineData(-1.5, double.NaN)]
+    [InlineData(-1.0, double.NegativeInfinity)]
+    [InlineData(0.0, 0.0)]
+    [InlineData(1.0, double.PositiveInfinity)]
+    [InlineData(1.5, double.NaN)]
+    [InlineData(double.PositiveInfinity, double.NaN)]
+    [InlineData(double.NaN, double.NaN)]
+    public void Atanh_EdgeCases_ReturnsExpected(double value, double expected)
+    {
+        double actual = Math.Atanh(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
+    }
+
+    [Theory]
+    [InlineData(0.76159415595576489, 1.0)]
+    [InlineData(0.91715233566727435, 1.5707963267948966)]   // (pi / 2)
+    public void Atanh_KnownValues_MatchBcl(double value, double expected)
+    {
+        Math.Atanh(value).Should().BeApproximately(expected, CrossPlatformMachineEpsilon * 10);
+    }
+
+    // ---- Cbrt ----
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.NegativeInfinity)]
+    [InlineData(-8.0, -2.0)]
+    [InlineData(-1.0, -1.0)]
+    [InlineData(0.0, 0.0)]
+    [InlineData(1.0, 1.0)]
+    [InlineData(8.0, 2.0)]
+    [InlineData(27.0, 3.0)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity)]
+    [InlineData(double.NaN, double.NaN)]
+    public void Cbrt_EdgeCases_ReturnsExpected(double value, double expected)
+    {
+        double actual = Math.Cbrt(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().BeApproximately(expected, CrossPlatformMachineEpsilon * 10);
+        }
     }
 
     [Fact]
@@ -148,83 +307,235 @@ public class MathExtensionsTests
         double.IsNegative(result).Should().BeTrue();
     }
 
-    [Fact]
-    public void BitDecrement_PositiveZero_ReturnsNegativeEpsilon()
+    // ---- BitDecrement / BitIncrement ----
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.NegativeInfinity)]
+    [InlineData(double.PositiveInfinity, double.MaxValue)]
+    [InlineData(double.NaN, double.NaN)]
+    [InlineData(1.0, 0.99999999999999989)]
+    [InlineData(0.0, -double.Epsilon)]
+    public void BitDecrement_EdgeCases_ReturnsExpected(double value, double expected)
     {
-        Math.BitDecrement(0.0).Should().Be(-double.Epsilon);
+        double actual = Math.BitDecrement(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
+    }
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.MinValue)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity)]
+    [InlineData(double.NaN, double.NaN)]
+    [InlineData(1.0, 1.0000000000000002)]
+    public void BitIncrement_EdgeCases_ReturnsExpected(double value, double expected)
+    {
+        double actual = Math.BitIncrement(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
     }
 
     [Fact]
     public void BitIncrement_NegativeZero_ReturnsEpsilon()
     {
-        Math.BitIncrement(-0.0).Should().Be(double.Epsilon);
+        double negativeZero = BitConverter.Int64BitsToDouble(unchecked((long)0x8000_0000_0000_0000UL));
+        Math.BitIncrement(negativeZero).Should().Be(double.Epsilon);
     }
 
     [Fact]
-    public void BitIncrement_PositiveInfinity_ReturnsPositiveInfinity()
+    public void BitIncrement_BitDecrement_AreInverse()
     {
-        Math.BitIncrement(double.PositiveInfinity).Should().Be(double.PositiveInfinity);
+        double[] values = [1.0, 2.0, -3.0, 1e-100, 1e100];
+        foreach (double v in values)
+        {
+            Math.BitIncrement(Math.BitDecrement(v)).Should().Be(v);
+            Math.BitDecrement(Math.BitIncrement(v)).Should().Be(v);
+        }
     }
 
-    [Fact]
-    public void CopySign_PositiveAndNegative_TakesSignOfSecond()
-    {
-        Math.CopySign(5.0, -1.0).Should().Be(-5.0);
-        Math.CopySign(-5.0, 1.0).Should().Be(5.0);
-    }
-
-    [Fact]
-    public void FusedMultiplyAdd_Basic_Computes()
-    {
-        Math.FusedMultiplyAdd(2.0, 3.0, 4.0).Should().Be(10.0);
-    }
-
-    [Fact]
-    public void ILogB_PowersOfTwo_ReturnExponent()
-    {
-        Math.ILogB(1.0).Should().Be(0);
-        Math.ILogB(2.0).Should().Be(1);
-        Math.ILogB(0.5).Should().Be(-1);
-    }
-
-    [Fact]
-    public void ILogB_Zero_ReturnsIntMinValue()
-    {
-        Math.ILogB(0.0).Should().Be(int.MinValue);
-    }
+    // ---- CopySign ----
 
     [Theory]
+    [InlineData(5.0, -1.0, -5.0)]
+    [InlineData(-5.0, 1.0, 5.0)]
+    [InlineData(5.0, double.NegativeInfinity, -5.0)]
+    [InlineData(5.0, double.PositiveInfinity, 5.0)]
+    [InlineData(double.PositiveInfinity, -1.0, double.NegativeInfinity)]
+    [InlineData(double.NegativeInfinity, 1.0, double.PositiveInfinity)]
+    public void CopySign_EdgeCases_ReturnsExpected(double x, double y, double expected)
+    {
+        Math.CopySign(x, y).Should().Be(expected);
+    }
+
+    [Fact]
+    public void CopySign_NegativeNaNSign_PropagatesSignBit()
+    {
+        double negNaN = BitConverter.Int64BitsToDouble(unchecked((long)0xFFF8000000000000UL));
+        double result = Math.CopySign(5.0, negNaN);
+        double.IsNegative(result).Should().BeTrue();
+        result.Should().Be(-5.0);
+    }
+
+    // ---- FusedMultiplyAdd ----
+
+    [Theory]
+    [InlineData(2.0, 3.0, 4.0, 10.0)]
+    [InlineData(0.0, double.PositiveInfinity, 1.0, double.NaN)]
+    public void FusedMultiplyAdd_EdgeCases_ReturnsExpected(double x, double y, double z, double expected)
+    {
+        double actual = Math.FusedMultiplyAdd(x, y, z);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
+    }
+
+    [Fact]
+    public void FusedMultiplyAdd_NaNInput_ReturnsNaN()
+    {
+        double.IsNaN(Math.FusedMultiplyAdd(double.NaN, 1.0, 1.0)).Should().BeTrue();
+        double.IsNaN(Math.FusedMultiplyAdd(1.0, double.NaN, 1.0)).Should().BeTrue();
+        double.IsNaN(Math.FusedMultiplyAdd(1.0, 1.0, double.NaN)).Should().BeTrue();
+    }
+
+    // ---- ILogB ----
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, int.MaxValue)]
+    [InlineData(double.PositiveInfinity, int.MaxValue)]
+    [InlineData(double.NaN, int.MaxValue)]
+    [InlineData(0.0, int.MinValue)]
+    [InlineData(1.0, 0)]
+    [InlineData(2.0, 1)]
+    [InlineData(0.5, -1)]
+    [InlineData(8.0, 3)]
+    [InlineData(0.125, -3)]
+    [InlineData(double.Epsilon, -1074)]
+    [InlineData(double.MaxValue, 1023)]
+    public void ILogB_EdgeCases_ReturnsExpected(double value, int expected)
+    {
+        Math.ILogB(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ILogB_NegativeZero_ReturnsIntMinValue()
+    {
+        double negativeZero = BitConverter.Int64BitsToDouble(unchecked((long)0x8000_0000_0000_0000UL));
+        Math.ILogB(negativeZero).Should().Be(int.MinValue);
+    }
+
+    // ---- Log2 ----
+
+    [Theory]
+    [InlineData(double.NegativeInfinity, double.NaN)]
+    [InlineData(-1.0, double.NaN)]
+    [InlineData(0.0, double.NegativeInfinity)]
     [InlineData(1.0, 0.0)]
     [InlineData(2.0, 1.0)]
     [InlineData(8.0, 3.0)]
-    public void Log2_PowersOfTwo_ReturnExponent(double value, double expected)
+    [InlineData(0.5, -1.0)]
+    [InlineData(double.PositiveInfinity, double.PositiveInfinity)]
+    [InlineData(double.NaN, double.NaN)]
+    public void Log2_EdgeCases_ReturnsExpected(double value, double expected)
     {
-        Math.Log2(value).Should().BeApproximately(expected, 1e-12);
+        double actual = Math.Log2(value);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().BeApproximately(expected, CrossPlatformMachineEpsilon * 10);
+        }
+    }
+
+    // ---- MaxMagnitude / MinMagnitude ----
+
+    [Theory]
+    [InlineData(-5.0, 3.0, -5.0)]
+    [InlineData(2.0, -7.0, -7.0)]
+    [InlineData(3.0, 3.0, 3.0)]
+    [InlineData(-3.0, 3.0, 3.0)]
+    [InlineData(double.PositiveInfinity, 1.0, double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity, 1.0, double.NegativeInfinity)]
+    public void MaxMagnitude_EdgeCases_ReturnsExpected(double x, double y, double expected)
+    {
+        Math.MaxMagnitude(x, y).Should().Be(expected);
     }
 
     [Fact]
-    public void MaxMagnitude_PicksLargerAbs()
+    public void MaxMagnitude_NaNInput_ReturnsNaN()
     {
-        Math.MaxMagnitude(-5.0, 3.0).Should().Be(-5.0);
-        Math.MaxMagnitude(2.0, -7.0).Should().Be(-7.0);
+        double.IsNaN(Math.MaxMagnitude(double.NaN, 1.0)).Should().BeTrue();
+        double.IsNaN(Math.MaxMagnitude(1.0, double.NaN)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(-5.0, 3.0, 3.0)]
+    [InlineData(2.0, -7.0, 2.0)]
+    [InlineData(3.0, 3.0, 3.0)]
+    [InlineData(-3.0, 3.0, -3.0)]
+    public void MinMagnitude_EdgeCases_ReturnsExpected(double x, double y, double expected)
+    {
+        Math.MinMagnitude(x, y).Should().Be(expected);
     }
 
     [Fact]
-    public void MinMagnitude_PicksSmallerAbs()
+    public void MinMagnitude_NaNInput_ReturnsNaN()
     {
-        Math.MinMagnitude(-5.0, 3.0).Should().Be(3.0);
-        Math.MinMagnitude(2.0, -7.0).Should().Be(2.0);
+        double.IsNaN(Math.MinMagnitude(double.NaN, 1.0)).Should().BeTrue();
+        double.IsNaN(Math.MinMagnitude(1.0, double.NaN)).Should().BeTrue();
     }
+
+    // ---- ScaleB ----
 
     [Theory]
     [InlineData(1.0, 1, 2.0)]
     [InlineData(1.0, 10, 1024.0)]
     [InlineData(1.0, -1, 0.5)]
     [InlineData(3.0, 0, 3.0)]
-    public void ScaleB_Basic_Computes(double x, int n, double expected)
+    [InlineData(0.0, 100, 0.0)]
+    [InlineData(double.PositiveInfinity, 0, double.PositiveInfinity)]
+    [InlineData(double.NegativeInfinity, 0, double.NegativeInfinity)]
+    [InlineData(double.NaN, 0, double.NaN)]
+    [InlineData(1.0, int.MaxValue, double.PositiveInfinity)]
+    [InlineData(double.MaxValue, 1, double.PositiveInfinity)]
+    public void ScaleB_EdgeCases_ReturnsExpected(double x, int n, double expected)
     {
-        Math.ScaleB(x, n).Should().Be(expected);
+        double actual = Math.ScaleB(x, n);
+        if (double.IsNaN(expected))
+        {
+            double.IsNaN(actual).Should().BeTrue();
+        }
+        else
+        {
+            actual.Should().Be(expected);
+        }
     }
+
+    [Fact]
+    public void ScaleB_LargeNegativeN_ReachesSubnormal()
+    {
+        // 1.0 * 2^-1074 == double.Epsilon (smallest subnormal).
+        Math.ScaleB(1.0, -1074).Should().Be(double.Epsilon);
+    }
+
+    // ---- ReciprocalEstimate / ReciprocalSqrtEstimate / SinCos ----
 
     [Fact]
     public void ReciprocalEstimate_OfTwo_IsHalf()
@@ -246,32 +557,68 @@ public class MathExtensionsTests
         cos.Should().Be(1.0);
     }
 
-    [Fact]
-    public void BigMul_Int_ReturnsLong()
+    [Theory]
+    [InlineData(1.0)]
+    [InlineData(1.5707963267948966)] // pi/2
+    [InlineData(3.1415926535897932)] // pi
+    public void SinCos_MatchesIndividualSinAndCos(double value)
     {
-        Math.BigMul(int.MaxValue, 2).Should().Be((long)int.MaxValue * 2);
+        (double sin, double cos) = Math.SinCos(value);
+        sin.Should().BeApproximately(Math.Sin(value), 1e-15);
+        cos.Should().BeApproximately(Math.Cos(value), 1e-15);
+    }
+
+    // ---- BigMul ----
+
+    [Theory]
+    [InlineData(0, 0, 0L)]
+    [InlineData(2, 3, 6L)]
+    [InlineData(3, -2, -6L)]
+    [InlineData(-1, -1, 1L)]
+    [InlineData(int.MaxValue, 2, (long)int.MaxValue * 2)]
+    [InlineData(int.MinValue, 2, (long)int.MinValue * 2)]
+    public void BigMul_Int_ReturnsLong(int a, int b, long expected)
+    {
+        Math.BigMul(a, b).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0L, 0L, 0L, 0L)]
+    [InlineData(2L, 3L, 0L, 6L)]
+    [InlineData(3L, -2L, -1L, -6L)]
+    [InlineData(-1L, -1L, 0L, 1L)]
+    [InlineData(-1L, long.MinValue, 0L, long.MinValue)]
+    [InlineData(1L, long.MinValue, -1L, long.MinValue)]
+    [InlineData(long.MaxValue, 2L, 0L, -2L)]
+    public void BigMul_Long_ReturnsHighAndLow(long a, long b, long expectedHigh, long expectedLow)
+    {
+        long high = Math.BigMul(a, b, out long low);
+        high.Should().Be(expectedHigh);
+        low.Should().Be(expectedLow);
+    }
+
+    [Theory]
+    [InlineData(0UL, 0UL, 0UL, 0UL)]
+    [InlineData(2UL, 3UL, 0UL, 6UL)]
+    [InlineData(ulong.MaxValue, 1UL, 0UL, ulong.MaxValue)]
+    public void BigMul_Ulong_ReturnsHighAndLow(ulong a, ulong b, ulong expectedHigh, ulong expectedLow)
+    {
+        ulong high = Math.BigMul(a, b, out ulong low);
+        high.Should().Be(expectedHigh);
+        low.Should().Be(expectedLow);
     }
 
     [Fact]
-    public void BigMul_Long_ReturnsHighAndLow()
+    public void BigMul_Ulong_MaxTimesMax_HighIsMaxMinusOne()
     {
-        long high = Math.BigMul(long.MaxValue, 2L, out long low);
-        // long.MaxValue * 2 = 0xFFFFFFFFFFFFFFFE (as 128-bit unsigned), which as 128-bit signed is high=0, low=-2.
-        high.Should().Be(0);
-        low.Should().Be(-2L);
+        // ulong.MaxValue * ulong.MaxValue = 0xFFFFFFFFFFFFFFFE_0000000000000001 (128-bit)
+        ulong high = Math.BigMul(ulong.MaxValue, ulong.MaxValue, out ulong low);
+        high.Should().Be(ulong.MaxValue - 1);
+        low.Should().Be(1UL);
     }
 
     [Fact]
-    public void BigMul_Long_NegativeOperands_ReturnsHighAndLow()
-    {
-        // (-1) * (-1) == 1 → high = 0, low = 1
-        long high = Math.BigMul(-1L, -1L, out long low);
-        high.Should().Be(0);
-        low.Should().Be(1L);
-    }
-
-    [Fact]
-    public void BigMul_Ulong_ReturnsHighAndLow()
+    public void BigMul_Ulong_MaxTimesTwo_OverflowsCleanly()
     {
         ulong high = Math.BigMul(ulong.MaxValue, 2UL, out ulong low);
         high.Should().Be(1UL);

--- a/touki.tests/System/MathExtensionsTests.cs
+++ b/touki.tests/System/MathExtensionsTests.cs
@@ -1,0 +1,252 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class MathExtensionsTests
+{
+    [Theory]
+    [InlineData(5, 0, 10, 5)]
+    [InlineData(-5, 0, 10, 0)]
+    [InlineData(15, 0, 10, 10)]
+    [InlineData(0, 0, 10, 0)]
+    [InlineData(10, 0, 10, 10)]
+    public void Clamp_Int_ReturnsExpected(int value, int min, int max, int expected)
+    {
+        Math.Clamp(value, min, max).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Clamp_MinGreaterThanMax_Throws()
+    {
+        Action action = () => Math.Clamp(0, 10, 5);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(0.5, 0.0, 1.0, 0.5)]
+    [InlineData(-0.5, 0.0, 1.0, 0.0)]
+    [InlineData(1.5, 0.0, 1.0, 1.0)]
+    public void Clamp_Double_ReturnsExpected(double value, double min, double max, double expected)
+    {
+        Math.Clamp(value, min, max).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Clamp_AllSignedAndUnsigned_RoundTrips()
+    {
+        Math.Clamp((byte)5, (byte)0, (byte)10).Should().Be((byte)5);
+        Math.Clamp((sbyte)-5, (sbyte)-10, (sbyte)0).Should().Be((sbyte)-5);
+        Math.Clamp((short)5, (short)0, (short)10).Should().Be((short)5);
+        Math.Clamp((ushort)5, (ushort)0, (ushort)10).Should().Be((ushort)5);
+        Math.Clamp(5u, 0u, 10u).Should().Be(5u);
+        Math.Clamp(5L, 0L, 10L).Should().Be(5L);
+        Math.Clamp(5UL, 0UL, 10UL).Should().Be(5UL);
+        Math.Clamp(0.5f, 0f, 1f).Should().Be(0.5f);
+        Math.Clamp(0.5m, 0m, 1m).Should().Be(0.5m);
+    }
+
+    [Fact]
+    public void DivRem_Long_ReturnsTuple()
+    {
+        (long q, long r) = Math.DivRem(17L, 5L);
+        q.Should().Be(3L);
+        r.Should().Be(2L);
+    }
+
+    [Fact]
+    public void DivRem_Byte_ReturnsTuple()
+    {
+        (byte q, byte r) = Math.DivRem((byte)17, (byte)5);
+        q.Should().Be((byte)3);
+        r.Should().Be((byte)2);
+    }
+
+    [Fact]
+    public void DivRem_Sbyte_ReturnsTuple()
+    {
+        (sbyte q, sbyte r) = Math.DivRem((sbyte)-17, (sbyte)5);
+        q.Should().Be((sbyte)-3);
+        r.Should().Be((sbyte)-2);
+    }
+
+    [Fact]
+    public void DivRem_Short_ReturnsTuple()
+    {
+        (short q, short r) = Math.DivRem((short)17, (short)5);
+        q.Should().Be((short)3);
+        r.Should().Be((short)2);
+    }
+
+    [Fact]
+    public void DivRem_Ushort_ReturnsTuple()
+    {
+        (ushort q, ushort r) = Math.DivRem((ushort)17, (ushort)5);
+        q.Should().Be((ushort)3);
+        r.Should().Be((ushort)2);
+    }
+
+    [Fact]
+    public void Acosh_OfOne_IsZero()
+    {
+        Math.Acosh(1.0).Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Asinh_OfZero_IsZero()
+    {
+        Math.Asinh(0.0).Should().Be(0.0);
+    }
+
+    [Fact]
+    public void Atanh_OfZero_IsZero()
+    {
+        Math.Atanh(0.0).Should().Be(0.0);
+    }
+
+    [Theory]
+    [InlineData(8.0, 2.0)]
+    [InlineData(27.0, 3.0)]
+    [InlineData(0.0, 0.0)]
+    public void Cbrt_Positive_ReturnsExpected(double value, double expected)
+    {
+        Math.Cbrt(value).Should().BeApproximately(expected, 1e-12);
+    }
+
+    [Fact]
+    public void Cbrt_Negative_ReturnsNegative()
+    {
+        Math.Cbrt(-8.0).Should().BeApproximately(-2.0, 1e-12);
+    }
+
+    [Fact]
+    public void BitDecrement_PositiveZero_ReturnsNegativeEpsilon()
+    {
+        Math.BitDecrement(0.0).Should().Be(-double.Epsilon);
+    }
+
+    [Fact]
+    public void BitIncrement_NegativeZero_ReturnsEpsilon()
+    {
+        Math.BitIncrement(-0.0).Should().Be(double.Epsilon);
+    }
+
+    [Fact]
+    public void BitIncrement_PositiveInfinity_ReturnsPositiveInfinity()
+    {
+        Math.BitIncrement(double.PositiveInfinity).Should().Be(double.PositiveInfinity);
+    }
+
+    [Fact]
+    public void CopySign_PositiveAndNegative_TakesSignOfSecond()
+    {
+        Math.CopySign(5.0, -1.0).Should().Be(-5.0);
+        Math.CopySign(-5.0, 1.0).Should().Be(5.0);
+    }
+
+    [Fact]
+    public void FusedMultiplyAdd_Basic_Computes()
+    {
+        Math.FusedMultiplyAdd(2.0, 3.0, 4.0).Should().Be(10.0);
+    }
+
+    [Fact]
+    public void ILogB_PowersOfTwo_ReturnExponent()
+    {
+        Math.ILogB(1.0).Should().Be(0);
+        Math.ILogB(2.0).Should().Be(1);
+        Math.ILogB(0.5).Should().Be(-1);
+    }
+
+    [Fact]
+    public void ILogB_Zero_ReturnsIntMinValue()
+    {
+        Math.ILogB(0.0).Should().Be(int.MinValue);
+    }
+
+    [Theory]
+    [InlineData(1.0, 0.0)]
+    [InlineData(2.0, 1.0)]
+    [InlineData(8.0, 3.0)]
+    public void Log2_PowersOfTwo_ReturnExponent(double value, double expected)
+    {
+        Math.Log2(value).Should().BeApproximately(expected, 1e-12);
+    }
+
+    [Fact]
+    public void MaxMagnitude_PicksLargerAbs()
+    {
+        Math.MaxMagnitude(-5.0, 3.0).Should().Be(-5.0);
+        Math.MaxMagnitude(2.0, -7.0).Should().Be(-7.0);
+    }
+
+    [Fact]
+    public void MinMagnitude_PicksSmallerAbs()
+    {
+        Math.MinMagnitude(-5.0, 3.0).Should().Be(3.0);
+        Math.MinMagnitude(2.0, -7.0).Should().Be(2.0);
+    }
+
+    [Theory]
+    [InlineData(1.0, 1, 2.0)]
+    [InlineData(1.0, 10, 1024.0)]
+    [InlineData(1.0, -1, 0.5)]
+    [InlineData(3.0, 0, 3.0)]
+    public void ScaleB_Basic_Computes(double x, int n, double expected)
+    {
+        Math.ScaleB(x, n).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReciprocalEstimate_OfTwo_IsHalf()
+    {
+        Math.ReciprocalEstimate(2.0).Should().BeApproximately(0.5, 1e-12);
+    }
+
+    [Fact]
+    public void ReciprocalSqrtEstimate_OfFour_IsHalf()
+    {
+        Math.ReciprocalSqrtEstimate(4.0).Should().BeApproximately(0.5, 1e-12);
+    }
+
+    [Fact]
+    public void SinCos_ReturnsSinAndCos()
+    {
+        (double sin, double cos) = Math.SinCos(0.0);
+        sin.Should().Be(0.0);
+        cos.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void BigMul_Int_ReturnsLong()
+    {
+        Math.BigMul(int.MaxValue, 2).Should().Be((long)int.MaxValue * 2);
+    }
+
+    [Fact]
+    public void BigMul_Long_ReturnsHighAndLow()
+    {
+        long high = Math.BigMul(long.MaxValue, 2L, out long low);
+        // long.MaxValue * 2 = 0xFFFFFFFFFFFFFFFE (as 128-bit unsigned), which as 128-bit signed is high=0, low=-2.
+        high.Should().Be(0);
+        low.Should().Be(-2L);
+    }
+
+    [Fact]
+    public void BigMul_Long_NegativeOperands_ReturnsHighAndLow()
+    {
+        // (-1) * (-1) == 1 → high = 0, low = 1
+        long high = Math.BigMul(-1L, -1L, out long low);
+        high.Should().Be(0);
+        low.Should().Be(1L);
+    }
+
+    [Fact]
+    public void BigMul_Ulong_ReturnsHighAndLow()
+    {
+        ulong high = Math.BigMul(ulong.MaxValue, 2UL, out ulong low);
+        high.Should().Be(1UL);
+        low.Should().Be(unchecked((ulong)-2L));
+    }
+}

--- a/touki.tests/System/SingleExtensionsTests.cs
+++ b/touki.tests/System/SingleExtensionsTests.cs
@@ -2,105 +2,270 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+#pragma warning disable xUnit1025 // duplicate InlineData (xUnit doesn't distinguish 0.0 from -0.0)
+
 namespace Touki;
 
 public class SingleExtensionsTests
 {
+    private const float MinNormal = 1.17549435E-38f;
+    private const float MaxSubnormal = 1.17549421E-38f;
+    private const float NegativeZero = -0.0f;
+    private const float NegativeMinNormal = -1.17549435E-38f;
+    private const float NegativeMaxSubnormal = -1.17549421E-38f;
+    private const float NegativeEpsilon = -float.Epsilon;
+
+    // ---- IsFinite ----
+
     [Theory]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, true)]
+    [InlineData(-1f, true)]
+    [InlineData(NegativeMinNormal, true)]
+    [InlineData(NegativeMaxSubnormal, true)]
+    [InlineData(NegativeEpsilon, true)]
+    [InlineData(float.NaN, false)]
     [InlineData(0f, true)]
+    [InlineData(float.Epsilon, true)]
+    [InlineData(MaxSubnormal, true)]
+    [InlineData(MinNormal, true)]
     [InlineData(1f, true)]
     [InlineData(float.MaxValue, true)]
-    [InlineData(float.Epsilon, true)]
     [InlineData(float.PositiveInfinity, false)]
-    [InlineData(float.NegativeInfinity, false)]
-    [InlineData(float.NaN, false)]
     public void IsFinite_ReturnsExpected(float value, bool expected)
     {
         float.IsFinite(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsFinite_NegativeZero_ReturnsTrue()
+    {
+        float.IsFinite(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsNegative ----
+
     [Theory]
-    [InlineData(0f, false)]
-    [InlineData(-1f, true)]
-    [InlineData(float.NaN, true)]
-    [InlineData(float.PositiveInfinity, false)]
     [InlineData(float.NegativeInfinity, true)]
+    [InlineData(float.MinValue, true)]
+    [InlineData(-1f, true)]
+    [InlineData(NegativeMinNormal, true)]
+    [InlineData(NegativeMaxSubnormal, true)]
+    [InlineData(NegativeEpsilon, true)]
+    [InlineData(float.NaN, true)]
+    [InlineData(0f, false)]
+    [InlineData(float.Epsilon, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, false)]
+    [InlineData(1f, false)]
+    [InlineData(float.MaxValue, false)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsNegative_ReturnsExpected(float value, bool expected)
     {
         float.IsNegative(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsNegative_NegativeZero_ReturnsTrue()
+    {
+        float.IsNegative(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsNormal ----
+
     [Theory]
-    [InlineData(1f, true)]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, true)]
+    [InlineData(-1f, true)]
+    [InlineData(NegativeMinNormal, true)]
+    [InlineData(NegativeMaxSubnormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(float.NaN, false)]
     [InlineData(0f, false)]
     [InlineData(float.Epsilon, false)]
-    [InlineData(float.NaN, false)]
+    [InlineData(MaxSubnormal, false)]
+    [InlineData(MinNormal, true)]
+    [InlineData(1f, true)]
+    [InlineData(float.MaxValue, true)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsNormal_ReturnsExpected(float value, bool expected)
     {
         float.IsNormal(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsNormal_NegativeZero_ReturnsFalse()
+    {
+        float.IsNormal(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsSubnormal ----
+
     [Theory]
-    [InlineData(1f, false)]
-    [InlineData(float.Epsilon, true)]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, false)]
+    [InlineData(-1f, false)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeMaxSubnormal, true)]
+    [InlineData(NegativeEpsilon, true)]
+    [InlineData(float.NaN, false)]
     [InlineData(0f, false)]
+    [InlineData(float.Epsilon, true)]
+    [InlineData(MaxSubnormal, true)]
+    [InlineData(MinNormal, false)]
+    [InlineData(1f, false)]
+    [InlineData(float.MaxValue, false)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsSubnormal_ReturnsExpected(float value, bool expected)
     {
         float.IsSubnormal(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsSubnormal_NegativeZero_ReturnsFalse()
+    {
+        float.IsSubnormal(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsPositive ----
+
     [Theory]
-    [InlineData(1f, true)]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, false)]
     [InlineData(-1f, false)]
     [InlineData(float.NaN, false)]
+    [InlineData(0f, true)]
+    [InlineData(1f, true)]
+    [InlineData(float.MaxValue, true)]
+    [InlineData(float.PositiveInfinity, true)]
     public void IsPositive_ReturnsExpected(float value, bool expected)
     {
         float.IsPositive(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsPositive_NegativeZero_ReturnsFalse()
+    {
+        float.IsPositive(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsRealNumber ----
+
     [Theory]
-    [InlineData(1f, true)]
+    [InlineData(float.NegativeInfinity, true)]
+    [InlineData(-1f, true)]
     [InlineData(float.NaN, false)]
+    [InlineData(0f, true)]
+    [InlineData(1f, true)]
     [InlineData(float.PositiveInfinity, true)]
     public void IsRealNumber_ReturnsExpected(float value, bool expected)
     {
         float.IsRealNumber(value).Should().Be(expected);
     }
 
+    // ---- IsInteger ----
+
     [Theory]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, true)]
+    [InlineData(-1f, true)]
+    [InlineData(NegativeMinNormal, false)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(float.NaN, false)]
+    [InlineData(0f, true)]
+    [InlineData(float.Epsilon, false)]
+    [InlineData(MinNormal, false)]
     [InlineData(1f, true)]
     [InlineData(1.5f, false)]
-    [InlineData(float.NaN, false)]
+    [InlineData(float.MaxValue, true)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsInteger_ReturnsExpected(float value, bool expected)
     {
         float.IsInteger(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsInteger_NegativeZero_ReturnsTrue()
+    {
+        float.IsInteger(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsEvenInteger ----
+
     [Theory]
-    [InlineData(2f, true)]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, true)]
+    [InlineData(-1f, false)]
+    [InlineData(-2f, true)]
+    [InlineData(NegativeEpsilon, false)]
+    [InlineData(float.NaN, false)]
+    [InlineData(0f, true)]
+    [InlineData(float.Epsilon, false)]
     [InlineData(1f, false)]
+    [InlineData(2f, true)]
+    [InlineData(float.MaxValue, true)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsEvenInteger_ReturnsExpected(float value, bool expected)
     {
         float.IsEvenInteger(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsEvenInteger_NegativeZero_ReturnsTrue()
+    {
+        float.IsEvenInteger(NegativeZero).Should().BeTrue();
+    }
+
+    // ---- IsOddInteger ----
+
     [Theory]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.MinValue, false)]
+    [InlineData(-1f, true)]
+    [InlineData(-2f, false)]
+    [InlineData(float.NaN, false)]
+    [InlineData(0f, false)]
     [InlineData(1f, true)]
     [InlineData(2f, false)]
+    [InlineData(float.MaxValue, false)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsOddInteger_ReturnsExpected(float value, bool expected)
     {
         float.IsOddInteger(value).Should().Be(expected);
     }
 
+    [Fact]
+    public void IsOddInteger_NegativeZero_ReturnsFalse()
+    {
+        float.IsOddInteger(NegativeZero).Should().BeFalse();
+    }
+
+    // ---- IsPow2 ----
+
     [Theory]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(-1f, false)]
+    [InlineData(-2f, false)]
+    [InlineData(float.NaN, false)]
+    [InlineData(0f, false)]
+    [InlineData(float.Epsilon, true)]   // smallest subnormal is 2^-149
+    [InlineData(MinNormal, true)]       // 2^-126
+    [InlineData(0.5f, true)]
     [InlineData(1f, true)]
     [InlineData(2f, true)]
-    [InlineData(0.5f, true)]
+    [InlineData(4f, true)]
     [InlineData(3f, false)]
-    [InlineData(0f, false)]
-    [InlineData(-2f, false)]
+    [InlineData(1.5f, false)]
+    [InlineData(float.MaxValue, false)]
+    [InlineData(float.PositiveInfinity, false)]
     public void IsPow2_ReturnsExpected(float value, bool expected)
     {
         float.IsPow2(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsPow2_NegativeZero_ReturnsFalse()
+    {
+        float.IsPow2(NegativeZero).Should().BeFalse();
     }
 }

--- a/touki.tests/System/SingleExtensionsTests.cs
+++ b/touki.tests/System/SingleExtensionsTests.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class SingleExtensionsTests
+{
+    [Theory]
+    [InlineData(0f, true)]
+    [InlineData(1f, true)]
+    [InlineData(float.MaxValue, true)]
+    [InlineData(float.Epsilon, true)]
+    [InlineData(float.PositiveInfinity, false)]
+    [InlineData(float.NegativeInfinity, false)]
+    [InlineData(float.NaN, false)]
+    public void IsFinite_ReturnsExpected(float value, bool expected)
+    {
+        float.IsFinite(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(0f, false)]
+    [InlineData(-1f, true)]
+    [InlineData(float.NaN, true)]
+    [InlineData(float.PositiveInfinity, false)]
+    [InlineData(float.NegativeInfinity, true)]
+    public void IsNegative_ReturnsExpected(float value, bool expected)
+    {
+        float.IsNegative(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, true)]
+    [InlineData(0f, false)]
+    [InlineData(float.Epsilon, false)]
+    [InlineData(float.NaN, false)]
+    public void IsNormal_ReturnsExpected(float value, bool expected)
+    {
+        float.IsNormal(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, false)]
+    [InlineData(float.Epsilon, true)]
+    [InlineData(0f, false)]
+    public void IsSubnormal_ReturnsExpected(float value, bool expected)
+    {
+        float.IsSubnormal(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, true)]
+    [InlineData(-1f, false)]
+    [InlineData(float.NaN, false)]
+    public void IsPositive_ReturnsExpected(float value, bool expected)
+    {
+        float.IsPositive(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, true)]
+    [InlineData(float.NaN, false)]
+    [InlineData(float.PositiveInfinity, true)]
+    public void IsRealNumber_ReturnsExpected(float value, bool expected)
+    {
+        float.IsRealNumber(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, true)]
+    [InlineData(1.5f, false)]
+    [InlineData(float.NaN, false)]
+    public void IsInteger_ReturnsExpected(float value, bool expected)
+    {
+        float.IsInteger(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(2f, true)]
+    [InlineData(1f, false)]
+    public void IsEvenInteger_ReturnsExpected(float value, bool expected)
+    {
+        float.IsEvenInteger(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, true)]
+    [InlineData(2f, false)]
+    public void IsOddInteger_ReturnsExpected(float value, bool expected)
+    {
+        float.IsOddInteger(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(1f, true)]
+    [InlineData(2f, true)]
+    [InlineData(0.5f, true)]
+    [InlineData(3f, false)]
+    [InlineData(0f, false)]
+    [InlineData(-2f, false)]
+    public void IsPow2_ReturnsExpected(float value, bool expected)
+    {
+        float.IsPow2(value).Should().Be(expected);
+    }
+}

--- a/touki/Framework/Polyfills/System/DoubleExtensions.cs
+++ b/touki/Framework/Polyfills/System/DoubleExtensions.cs
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System;
+
+/// <summary>
+///  <see cref="double"/> static methods that don't have a direct equivalent in the .NET Framework build.
+/// </summary>
+public static class DoubleExtensions
+{
+    extension(double)
+    {
+        /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
+        public static bool IsFinite(double d)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(d);
+            return (bits & 0x7FFFFFFFFFFFFFFFL) < 0x7FF0000000000000L;
+        }
+
+        /// <summary>Determines whether the specified value is negative.</summary>
+        public static bool IsNegative(double d) => BitConverter.DoubleToInt64Bits(d) < 0;
+
+        /// <summary>Determines whether the specified value is normal.</summary>
+        public static bool IsNormal(double d)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(d) & 0x7FFFFFFFFFFFFFFFL;
+            return (bits < 0x7FF0000000000000L) && (bits != 0) && ((bits & 0x7FF0000000000000L) != 0);
+        }
+
+        /// <summary>Determines whether the specified value is subnormal.</summary>
+        public static bool IsSubnormal(double d)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(d) & 0x7FFFFFFFFFFFFFFFL;
+            return (bits < 0x7FF0000000000000L) && (bits != 0) && ((bits & 0x7FF0000000000000L) == 0);
+        }
+
+        /// <summary>Determines whether the specified value is positive.</summary>
+        public static bool IsPositive(double d) => BitConverter.DoubleToInt64Bits(d) >= 0;
+
+        /// <summary>Determines whether the specified value represents a real number (i.e. not NaN).</summary>
+        public static bool IsRealNumber(double d) => !double.IsNaN(d);
+
+        /// <summary>Determines whether the specified value is integral (finite and equal to its truncation).</summary>
+        public static bool IsInteger(double d) => double.IsFinite(d) && (d == Math.Truncate(d));
+
+        /// <summary>Determines whether the specified value is integral and even.</summary>
+        public static bool IsEvenInteger(double d) => double.IsInteger(d) && (Math.Abs(d % 2.0) == 0.0);
+
+        /// <summary>Determines whether the specified value is integral and odd.</summary>
+        public static bool IsOddInteger(double d) => double.IsInteger(d) && (Math.Abs(d % 2.0) == 1.0);
+
+        /// <summary>Determines whether the specified value is a power of two.</summary>
+        public static bool IsPow2(double d)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(d);
+            // Positive, finite, normal or subnormal, mantissa is zero (i.e. value is 2^n).
+            if (bits <= 0)
+            {
+                return false;
+            }
+
+            int exponent = (int)((bits >> 52) & 0x7FF);
+            long mantissa = bits & 0x000FFFFFFFFFFFFFL;
+
+            if (exponent == 0)
+            {
+                // Subnormal: must be a single-bit mantissa.
+                return mantissa != 0 && (mantissa & (mantissa - 1)) == 0;
+            }
+
+            if (exponent == 0x7FF)
+            {
+                // Infinity / NaN.
+                return false;
+            }
+
+            return mantissa == 0;
+        }
+    }
+}

--- a/touki/Framework/Polyfills/System/MathExtensions.cs
+++ b/touki/Framework/Polyfills/System/MathExtensions.cs
@@ -215,18 +215,44 @@ public static class MathExtensions
         }
 
         /// <summary>Returns the angle whose hyperbolic cosine is the specified number.</summary>
-        public static double Acosh(double d) => Math.Log(d + Math.Sqrt((d * d) - 1.0));
+        public static double Acosh(double d)
+        {
+            // Stable form: for very large d, d*d overflows. Switch to Log(2d) = Log(d) + Log(2)
+            // when d is large enough that 1 is negligible compared to d*d.
+            const double LargeThreshold = 268435456.0; // 2^28
+            if (d >= LargeThreshold)
+            {
+                return Math.Log(d) + Math.Log(2.0);
+            }
+
+            // Sqrt((d-1)*(d+1)) is preferred over Sqrt(d*d - 1) near d == 1 to avoid loss of precision.
+            return Math.Log(d + Math.Sqrt((d - 1.0) * (d + 1.0)));
+        }
 
         /// <summary>Returns the angle whose hyperbolic sine is the specified number.</summary>
         public static double Asinh(double d)
         {
-            // Equivalent to Log(d + Sqrt(d * d + 1)) but more accurate for large |d|.
-            if (double.IsNegativeInfinity(d))
+            if (double.IsNaN(d) || double.IsInfinity(d) || d == 0.0)
             {
-                return double.NegativeInfinity;
+                return d;
             }
 
-            return Math.Log(d + Math.Sqrt((d * d) + 1.0));
+            // Operate on the magnitude and apply the sign at the end so we avoid
+            // catastrophic cancellation for large negative values.
+            double abs = Math.Abs(d);
+            double result;
+            const double LargeThreshold = 268435456.0; // 2^28
+            if (abs >= LargeThreshold)
+            {
+                // For large |d|, abs*abs overflows; use Asinh(x) ~= Log(2*|x|).
+                result = Math.Log(abs) + Math.Log(2.0);
+            }
+            else
+            {
+                result = Math.Log(abs + Math.Sqrt((abs * abs) + 1.0));
+            }
+
+            return d < 0 ? -result : result;
         }
 
         /// <summary>Returns the angle whose hyperbolic tangent is the specified number.</summary>
@@ -235,6 +261,12 @@ public static class MathExtensions
         /// <summary>Returns the cube root of a specified number.</summary>
         public static double Cbrt(double d)
         {
+            // Preserve the sign of zero (Math.Cbrt(-0.0) must return -0.0).
+            if (d == 0.0)
+            {
+                return d;
+            }
+
             if (d < 0)
             {
                 return -Math.Pow(-d, 1.0 / 3.0);
@@ -449,7 +481,10 @@ public static class MathExtensions
         /// <summary>Produces the full product of two 32-bit signed numbers.</summary>
         public static long BigMul(int a, int b) => (long)a * b;
 
-        /// <summary>Produces the full product of two 64-bit signed numbers, returning the lower 64 bits and the upper 64 bits via <paramref name="low"/>.</summary>
+        /// <summary>
+        ///  Produces the full product of two 64-bit signed numbers. Returns the upper 64 bits of the
+        ///  product; the lower 64 bits are written to <paramref name="low"/>.
+        /// </summary>
         public static long BigMul(long a, long b, out long low)
         {
             // Split each operand into 32-bit halves and recombine the 128-bit product.
@@ -482,7 +517,10 @@ public static class MathExtensions
             return high;
         }
 
-        /// <summary>Produces the full product of two 64-bit unsigned numbers, returning the lower 64 bits and the upper 64 bits via <paramref name="low"/>.</summary>
+        /// <summary>
+        ///  Produces the full product of two 64-bit unsigned numbers. Returns the upper 64 bits of the
+        ///  product; the lower 64 bits are written to <paramref name="low"/>.
+        /// </summary>
         public static ulong BigMul(ulong a, ulong b, out ulong low)
         {
             ulong al = a & 0xFFFFFFFF;
@@ -501,5 +539,5 @@ public static class MathExtensions
 
     [DoesNotReturn]
     private static void ThrowMinMaxException<T>(T min, T max) =>
-        throw new ArgumentException($"'{min}' cannot be greater than {max}.");
+        throw new ArgumentException($"'{min}' cannot be greater than {max}.", nameof(min));
 }

--- a/touki/Framework/Polyfills/System/MathExtensions.cs
+++ b/touki/Framework/Polyfills/System/MathExtensions.cs
@@ -48,5 +48,458 @@ public static class MathExtensions
             ulong quotient = left / right;
             return (quotient, left - (quotient * right));
         }
+
+        /// <inheritdoc cref="DivRem(int, int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (long Quotient, long Remainder) DivRem(long left, long right)
+        {
+            long quotient = left / right;
+            return (quotient, left - (quotient * right));
+        }
+
+        /// <inheritdoc cref="DivRem(int, int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (sbyte Quotient, sbyte Remainder) DivRem(sbyte left, sbyte right)
+        {
+            sbyte quotient = (sbyte)(left / right);
+            return (quotient, (sbyte)(left - (quotient * right)));
+        }
+
+        /// <inheritdoc cref="DivRem(int, int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (byte Quotient, byte Remainder) DivRem(byte left, byte right)
+        {
+            byte quotient = (byte)(left / right);
+            return (quotient, (byte)(left - (quotient * right)));
+        }
+
+        /// <inheritdoc cref="DivRem(int, int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (short Quotient, short Remainder) DivRem(short left, short right)
+        {
+            short quotient = (short)(left / right);
+            return (quotient, (short)(left - (quotient * right)));
+        }
+
+        /// <inheritdoc cref="DivRem(int, int)"/>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static (ushort Quotient, ushort Remainder) DivRem(ushort left, ushort right)
+        {
+            ushort quotient = (ushort)(left / right);
+            return (quotient, (ushort)(left - (quotient * right)));
+        }
+
+        /// <summary>Returns <paramref name="value"/> clamped to the inclusive range of <paramref name="min"/> and <paramref name="max"/>.</summary>
+        /// <param name="value">The value to be clamped.</param>
+        /// <param name="min">The lower bound of the result.</param>
+        /// <param name="max">The upper bound of the result.</param>
+        public static byte Clamp(byte value, byte min, byte max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static sbyte Clamp(sbyte value, sbyte min, sbyte max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static short Clamp(short value, short min, short max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static ushort Clamp(ushort value, ushort min, ushort max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static int Clamp(int value, int min, int max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static uint Clamp(uint value, uint min, uint max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static long Clamp(long value, long min, long max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static ulong Clamp(ulong value, ulong min, ulong max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static float Clamp(float value, float min, float max)
+        {
+            // BCL semantics: NaN propagates; if min > max throws.
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static double Clamp(double value, double min, double max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <inheritdoc cref="Clamp(byte, byte, byte)"/>
+        public static decimal Clamp(decimal value, decimal min, decimal max)
+        {
+            if (min > max)
+            {
+                ThrowMinMaxException(min, max);
+            }
+
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <summary>Returns the angle whose hyperbolic cosine is the specified number.</summary>
+        public static double Acosh(double d) => Math.Log(d + Math.Sqrt((d * d) - 1.0));
+
+        /// <summary>Returns the angle whose hyperbolic sine is the specified number.</summary>
+        public static double Asinh(double d)
+        {
+            // Equivalent to Log(d + Sqrt(d * d + 1)) but more accurate for large |d|.
+            if (double.IsNegativeInfinity(d))
+            {
+                return double.NegativeInfinity;
+            }
+
+            return Math.Log(d + Math.Sqrt((d * d) + 1.0));
+        }
+
+        /// <summary>Returns the angle whose hyperbolic tangent is the specified number.</summary>
+        public static double Atanh(double d) => 0.5 * Math.Log((1.0 + d) / (1.0 - d));
+
+        /// <summary>Returns the cube root of a specified number.</summary>
+        public static double Cbrt(double d)
+        {
+            if (d < 0)
+            {
+                return -Math.Pow(-d, 1.0 / 3.0);
+            }
+
+            return Math.Pow(d, 1.0 / 3.0);
+        }
+
+        /// <summary>
+        ///  Returns the next smallest value that compares less than <paramref name="x"/>.
+        /// </summary>
+        public static double BitDecrement(double x)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(x);
+
+            if (((bits >> 32) & 0x7FF00000) >= 0x7FF00000)
+            {
+                // NaN returns NaN; -Infinity returns -Infinity; +Infinity returns double.MaxValue.
+                return bits == 0x7FF00000_00000000 ? double.MaxValue : x;
+            }
+
+            if (bits == 0x00000000_00000000)
+            {
+                // +0.0 returns -double.Epsilon
+                return -double.Epsilon;
+            }
+
+            // Negate the magnitude when the sign is set, otherwise step down toward zero.
+            bits += bits < 0 ? +1 : -1;
+            return BitConverter.Int64BitsToDouble(bits);
+        }
+
+        /// <summary>
+        ///  Returns the next largest value that compares greater than <paramref name="x"/>.
+        /// </summary>
+        public static double BitIncrement(double x)
+        {
+            long bits = BitConverter.DoubleToInt64Bits(x);
+
+            if (((bits >> 32) & 0x7FF00000) >= 0x7FF00000)
+            {
+                // NaN returns NaN; +Infinity returns +Infinity; -Infinity returns double.MinValue.
+                return bits == unchecked((long)0xFFF00000_00000000) ? double.MinValue : x;
+            }
+
+            if (bits == unchecked((long)0x80000000_00000000))
+            {
+                // -0.0 returns double.Epsilon
+                return double.Epsilon;
+            }
+
+            bits += bits < 0 ? -1 : +1;
+            return BitConverter.Int64BitsToDouble(bits);
+        }
+
+        /// <summary>
+        ///  Returns a value with the magnitude of <paramref name="x"/> and the sign of <paramref name="y"/>.
+        /// </summary>
+        public static double CopySign(double x, double y)
+        {
+            const long signMask = unchecked((long)0x8000000000000000);
+            long xbits = BitConverter.DoubleToInt64Bits(x);
+            long ybits = BitConverter.DoubleToInt64Bits(y);
+            return BitConverter.Int64BitsToDouble((xbits & ~signMask) | (ybits & signMask));
+        }
+
+        /// <summary>
+        ///  Returns <c>(<paramref name="x"/> * <paramref name="y"/>) + <paramref name="z"/></c> rounded as one ternary operation.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   On .NET Framework this polyfill performs the multiplication and addition as
+        ///   separate operations and is not a true fused multiply-add.
+        ///  </para>
+        /// </remarks>
+        public static double FusedMultiplyAdd(double x, double y, double z) => (x * y) + z;
+
+        /// <summary>
+        ///  Returns the integer (base-2) logarithm of a specified number.
+        /// </summary>
+        public static int ILogB(double x)
+        {
+            if (double.IsNaN(x))
+            {
+                return int.MaxValue;
+            }
+
+            long bits = BitConverter.DoubleToInt64Bits(x);
+            int exponent = (int)((bits >> 52) & 0x7FF);
+
+            if (exponent == 0)
+            {
+                if ((bits & 0x000FFFFFFFFFFFFFL) == 0)
+                {
+                    // Zero
+                    return int.MinValue;
+                }
+
+                // Subnormal: normalize.
+                ulong significand = (ulong)(bits & 0x000FFFFFFFFFFFFFL);
+                exponent = -1022;
+                while ((significand & 0x0010000000000000UL) == 0)
+                {
+                    significand <<= 1;
+                    exponent--;
+                }
+
+                return exponent;
+            }
+
+            if (exponent == 0x7FF)
+            {
+                // Infinity
+                return int.MaxValue;
+            }
+
+            return exponent - 1023;
+        }
+
+        /// <summary>Returns the base-2 logarithm of a specified number.</summary>
+        public static double Log2(double x) => Math.Log(x) / 0.6931471805599453; // ln(2)
+
+        /// <summary>Returns the larger magnitude of two double-precision floating-point numbers.</summary>
+        public static double MaxMagnitude(double x, double y)
+        {
+            double ax = Math.Abs(x);
+            double ay = Math.Abs(y);
+
+            if ((ax > ay) || double.IsNaN(ax))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return double.IsNegative(x) ? y : x;
+            }
+
+            return y;
+        }
+
+        /// <summary>Returns the smaller magnitude of two double-precision floating-point numbers.</summary>
+        public static double MinMagnitude(double x, double y)
+        {
+            double ax = Math.Abs(x);
+            double ay = Math.Abs(y);
+
+            if ((ax < ay) || double.IsNaN(ax))
+            {
+                return x;
+            }
+
+            if (ax == ay)
+            {
+                return double.IsNegative(x) ? x : y;
+            }
+
+            return y;
+        }
+
+        /// <summary>Returns x * 2^n efficiently.</summary>
+        public static double ScaleB(double x, int n)
+        {
+            // Cap the multiplier to two safe steps to avoid intermediate over/underflow.
+            const double Two1023 = 8.98846567431158e+307;
+            const double TwoM1022 = 2.2250738585072014e-308;
+            const double Two53 = 9007199254740992.0;
+
+            double y = x;
+            if (n > 1023)
+            {
+                y *= Two1023;
+                n -= 1023;
+                if (n > 1023)
+                {
+                    y *= Two1023;
+                    n -= 1023;
+                    if (n > 1023)
+                    {
+                        n = 1023;
+                    }
+                }
+            }
+            else if (n < -1022)
+            {
+                y *= TwoM1022 * Two53;
+                n += 1022 - 53;
+                if (n < -1022)
+                {
+                    y *= TwoM1022 * Two53;
+                    n += 1022 - 53;
+                    if (n < -1022)
+                    {
+                        n = -1022;
+                    }
+                }
+            }
+
+            double u = BitConverter.Int64BitsToDouble(((long)(0x3FF + n) << 52));
+            return y * u;
+        }
+
+        /// <summary>Returns an estimate of the reciprocal of a specified number.</summary>
+        public static double ReciprocalEstimate(double d) => 1.0 / d;
+
+        /// <summary>Returns an estimate of the reciprocal square root of a specified number.</summary>
+        public static double ReciprocalSqrtEstimate(double d) => 1.0 / Math.Sqrt(d);
+
+        /// <summary>Returns the sine and cosine of the specified angle.</summary>
+        public static (double Sin, double Cos) SinCos(double x) => (Math.Sin(x), Math.Cos(x));
+
+        /// <summary>Produces the full product of two 32-bit signed numbers.</summary>
+        public static long BigMul(int a, int b) => (long)a * b;
+
+        /// <summary>Produces the full product of two 64-bit signed numbers, returning the lower 64 bits and the upper 64 bits via <paramref name="low"/>.</summary>
+        public static long BigMul(long a, long b, out long low)
+        {
+            // Split each operand into 32-bit halves and recombine the 128-bit product.
+            ulong ua = (ulong)a;
+            ulong ub = (ulong)b;
+
+            ulong al = ua & 0xFFFFFFFF;
+            ulong ah = ua >> 32;
+            ulong bl = ub & 0xFFFFFFFF;
+            ulong bh = ub >> 32;
+
+            ulong mull = al * bl;
+            ulong t = (ah * bl) + (mull >> 32);
+            ulong tl = (al * bh) + (t & 0xFFFFFFFF);
+
+            low = unchecked((long)((tl << 32) | (mull & 0xFFFFFFFF)));
+            long high = (long)((ah * bh) + (t >> 32) + (tl >> 32));
+
+            // Sign-correct: if a or b were negative, subtract the other operand from the high.
+            if (a < 0)
+            {
+                high -= b;
+            }
+
+            if (b < 0)
+            {
+                high -= a;
+            }
+
+            return high;
+        }
+
+        /// <summary>Produces the full product of two 64-bit unsigned numbers, returning the lower 64 bits and the upper 64 bits via <paramref name="low"/>.</summary>
+        public static ulong BigMul(ulong a, ulong b, out ulong low)
+        {
+            ulong al = a & 0xFFFFFFFF;
+            ulong ah = a >> 32;
+            ulong bl = b & 0xFFFFFFFF;
+            ulong bh = b >> 32;
+
+            ulong mull = al * bl;
+            ulong t = (ah * bl) + (mull >> 32);
+            ulong tl = (al * bh) + (t & 0xFFFFFFFF);
+
+            low = (tl << 32) | (mull & 0xFFFFFFFF);
+            return (ah * bh) + (t >> 32) + (tl >> 32);
+        }
     }
+
+    [DoesNotReturn]
+    private static void ThrowMinMaxException<T>(T min, T max) =>
+        throw new ArgumentException($"'{min}' cannot be greater than {max}.");
 }

--- a/touki/Framework/Polyfills/System/SingleExtensions.cs
+++ b/touki/Framework/Polyfills/System/SingleExtensions.cs
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System;
+
+/// <summary>
+///  <see cref="float"/> static methods that don't have a direct equivalent in the .NET Framework build.
+/// </summary>
+public static class SingleExtensions
+{
+    extension(float)
+    {
+        /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
+        public static bool IsFinite(float f)
+        {
+            int bits = BitConverter.SingleToInt32Bits(f);
+            return (bits & 0x7FFFFFFF) < 0x7F800000;
+        }
+
+        /// <summary>Determines whether the specified value is negative.</summary>
+        public static bool IsNegative(float f) => BitConverter.SingleToInt32Bits(f) < 0;
+
+        /// <summary>Determines whether the specified value is normal.</summary>
+        public static bool IsNormal(float f)
+        {
+            int bits = BitConverter.SingleToInt32Bits(f) & 0x7FFFFFFF;
+            return (bits < 0x7F800000) && (bits != 0) && ((bits & 0x7F800000) != 0);
+        }
+
+        /// <summary>Determines whether the specified value is subnormal.</summary>
+        public static bool IsSubnormal(float f)
+        {
+            int bits = BitConverter.SingleToInt32Bits(f) & 0x7FFFFFFF;
+            return (bits < 0x7F800000) && (bits != 0) && ((bits & 0x7F800000) == 0);
+        }
+
+        /// <summary>Determines whether the specified value is positive.</summary>
+        public static bool IsPositive(float f) => BitConverter.SingleToInt32Bits(f) >= 0;
+
+        /// <summary>Determines whether the specified value represents a real number (i.e. not NaN).</summary>
+        public static bool IsRealNumber(float f) => !float.IsNaN(f);
+
+        /// <summary>Determines whether the specified value is integral (finite and equal to its truncation).</summary>
+        public static bool IsInteger(float f) => float.IsFinite(f) && (f == (float)Math.Truncate((double)f));
+
+        /// <summary>Determines whether the specified value is integral and even.</summary>
+        public static bool IsEvenInteger(float f) => float.IsInteger(f) && (Math.Abs(f % 2f) == 0f);
+
+        /// <summary>Determines whether the specified value is integral and odd.</summary>
+        public static bool IsOddInteger(float f) => float.IsInteger(f) && (Math.Abs(f % 2f) == 1f);
+
+        /// <summary>Determines whether the specified value is a power of two.</summary>
+        public static bool IsPow2(float f)
+        {
+            int bits = BitConverter.SingleToInt32Bits(f);
+            if (bits <= 0)
+            {
+                return false;
+            }
+
+            int exponent = (bits >> 23) & 0xFF;
+            int mantissa = bits & 0x007FFFFF;
+
+            if (exponent == 0)
+            {
+                return mantissa != 0 && (mantissa & (mantissa - 1)) == 0;
+            }
+
+            if (exponent == 0xFF)
+            {
+                return false;
+            }
+
+            return mantissa == 0;
+        }
+    }
+}


### PR DESCRIPTION
Polyfills .NET Core / .NET 5+ APIs on `Math`, `double`, and `float` for the net472 target.

## `Math` ([MathExtensions.cs](touki/Framework/Polyfills/System/MathExtensions.cs))

- **`Clamp`** for byte, sbyte, short, ushort, int, uint, long, ulong, float, double, decimal (netcoreapp2.0)
- **`DivRem`** tuple-returning overloads for byte, sbyte, short, ushort, long (net6.0). Existing int/uint/ulong overloads preserved.
- **Hyperbolic / cube root**: `Acosh`, `Asinh`, `Atanh`, `Cbrt` (netcoreapp2.1)
- **IEEE 754 helpers**: `BitDecrement`, `BitIncrement`, `CopySign`, `FusedMultiplyAdd`, `ILogB`, `Log2`, `MaxMagnitude`, `MinMagnitude`, `ScaleB` (netcoreapp3.0)
- **Estimates**: `ReciprocalEstimate`, `ReciprocalSqrtEstimate`, `SinCos` (net6.0)
- **`BigMul`**: `BigMul(int, int) → long` (netcoreapp2.0), `BigMul(long, long, out long)` and `BigMul(ulong, ulong, out ulong)` (net5.0)

`FusedMultiplyAdd` is implemented as `(x * y) + z` on net472 (no hardware FMA path), documented in remarks.

## `double` ([DoubleExtensions.cs](touki/Framework/Polyfills/System/DoubleExtensions.cs)) and `float` ([SingleExtensions.cs](touki/Framework/Polyfills/System/SingleExtensions.cs))

- **netcoreapp2.1**: `IsFinite`, `IsNegative`, `IsNormal`, `IsSubnormal`
- **net7.0**: `IsPositive`, `IsRealNumber`, `IsInteger`, `IsEvenInteger`, `IsOddInteger`, `IsPow2`

All implemented via bit-level inspection matching the BCL reference, and exposed through `extension(double)` / `extension(float)`.

## Tests

Three new test files under `touki.tests/System/` covering all added APIs. Tests run on both target frameworks: `net10.0` (BCL) and `net481` (polyfill). `dotnet test -c Release` passes 3290 net10.0 / 3478 net481 tests, 0 failures.

Out of scope (deferred to follow-up PRs per the polyfill plan): `Random`, `Enum`, `String`, `Convert`, `Array` extensions.