### PR TITLE
Polyfill Enum.Get*/Parse/TryParse generic and ROS<char> APIs for net472

### DIFF
--- a/.agents/skills/polyfill-dotnet-api/SKILL.md
+++ b/.agents/skills/polyfill-dotnet-api/SKILL.md
@@ -236,7 +236,9 @@ enforces these; this section explains *why*.
 3. Add tests under [`touki.tests/`](../../../touki.tests/) running on
    both TFMs. Identical observable behavior to modern BCL for matching
    inputs.
-4. Run [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) before
+4. Consult [`dotnet/runtime`](https://github.com/dotnet/runtime) tests
+   for additional edge cases. Location pattern is `src/libraries/<AreaName>/tests/...`.
+5. Run [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) and get user approval before
    invoking [`create-pr`](../create-pr/SKILL.md).
 
 ## Examples in this repo

--- a/touki.tests/Framework/Touki/EnumTests.cs
+++ b/touki.tests/Framework/Touki/EnumTests.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using Touki;
-
 namespace Framework.Touki;
 
 public class EnumTests
@@ -14,7 +12,7 @@ public class EnumTests
         var expectedValues = new ulong[] { 0, 1, 2, 3, 4, 5, 6 };
         var expectedNames = new string[] { "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday" };
 
-        var (values, names) = EnumExtensions.GetValuesAndNames<DayOfWeek>();
+        var (values, names) = typeof(DayOfWeek).GetEnumValuesAndNames();
 
         values.Should().BeEquivalentTo(expectedValues);
         names.Should().BeEquivalentTo(expectedNames);

--- a/touki.tests/System/EnumExtensionsTests.cs
+++ b/touki.tests/System/EnumExtensionsTests.cs
@@ -290,6 +290,35 @@ public class EnumExtensionsTests
         value.Should().Be(Color.Green);
     }
 
+    [Fact]
+    public void TryParse_NonGeneric_NullEnumType_Throws()
+    {
+        // BCL contract: invalid enumType throws even from TryParse.
+        Action action = () => Enum.TryParse(null!, "Red".AsSpan(), out object? _);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryParse_NonGeneric_NonEnumType_Throws()
+    {
+        Action action = () => Enum.TryParse(typeof(int), "1".AsSpan(), out object? _);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void TryParse_NonGeneric_IgnoreCase_NullEnumType_Throws()
+    {
+        Action action = () => Enum.TryParse(null!, "Red".AsSpan(), ignoreCase: true, out object? _);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void TryParse_NonGeneric_IgnoreCase_NonEnumType_Throws()
+    {
+        Action action = () => Enum.TryParse(typeof(int), "1".AsSpan(), ignoreCase: true, out object? _);
+        action.Should().Throw<ArgumentException>();
+    }
+
     // ---- Whitespace handling (matches BCL: leading/trailing whitespace trimmed) ----
 
     [Theory]
@@ -326,9 +355,12 @@ public class EnumExtensionsTests
     [Fact]
     public void Parse_Generic_NegativeNumeric_Unsigned_Throws()
     {
-        // Unsigned enum can't take a negative literal.
+        // Unsigned enum can't take a negative literal. The exact exception type depends on TFM:
+        // older runtimes throw ArgumentException via the parser; modern runtimes throw OverflowException.
         Action action = () => Enum.Parse<UInt32Enum>("-1".AsSpan());
-        action.Should().Throw<Exception>(); // OverflowException or ArgumentException
+        Exception? exception = Record.Exception(action);
+        exception.Should().NotBeNull();
+        (exception is OverflowException or ArgumentException).Should().BeTrue();
     }
 
     // ---- Multiple underlying integral types ----

--- a/touki.tests/System/EnumExtensionsTests.cs
+++ b/touki.tests/System/EnumExtensionsTests.cs
@@ -1,0 +1,426 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System.Tests;
+
+public class EnumExtensionsTests
+{
+    public enum Color
+    {
+        Red = 1,
+        Green = 2,
+        Blue = 4,
+    }
+
+    [Flags]
+    public enum FileAccess
+    {
+        None = 0,
+        Read = 1,
+        Write = 2,
+        ReadWrite = Read | Write,
+    }
+
+    public enum SByteEnum : sbyte
+    {
+        Min = sbyte.MinValue,
+        One = 1,
+        Two = 2,
+        Max = sbyte.MaxValue,
+    }
+
+    public enum ByteEnum : byte
+    {
+        Min = byte.MinValue,
+        One = 1,
+        Two = 2,
+        Max = byte.MaxValue,
+    }
+
+    public enum Int16Enum : short
+    {
+        Min = short.MinValue,
+        One = 1,
+        Max = short.MaxValue,
+    }
+
+    public enum UInt16Enum : ushort
+    {
+        Min = ushort.MinValue,
+        One = 1,
+        Max = ushort.MaxValue,
+    }
+
+    public enum UInt32Enum : uint
+    {
+        Min = uint.MinValue,
+        One = 1u,
+        Max = uint.MaxValue,
+    }
+
+    public enum Int64Enum : long
+    {
+        Min = long.MinValue,
+        One = 1L,
+        Max = long.MaxValue,
+    }
+
+    public enum UInt64Enum : ulong
+    {
+        Min = ulong.MinValue,
+        One = 1UL,
+        Max = ulong.MaxValue,
+    }
+
+    // ---- GetValues<TEnum> ----
+
+    [Fact]
+    public void GetValues_ReturnsAllValuesInDeclarationOrder()
+    {
+        Color[] values = Enum.GetValues<Color>();
+        values.Should().Equal(Color.Red, Color.Green, Color.Blue);
+    }
+
+    [Fact]
+    public void GetValues_FlagsEnum_IncludesCombinedValues()
+    {
+        FileAccess[] values = Enum.GetValues<FileAccess>();
+        values.Should().Contain(FileAccess.None).And.Contain(FileAccess.ReadWrite);
+    }
+
+    // ---- GetNames<TEnum> ----
+
+    [Fact]
+    public void GetNames_ReturnsNamesInValueOrder()
+    {
+        string[] names = Enum.GetNames<Color>();
+        names.Should().Equal("Red", "Green", "Blue");
+    }
+
+    // ---- GetName<TEnum> ----
+
+    [Fact]
+    public void GetName_DefinedValue_ReturnsName()
+    {
+        Enum.GetName(Color.Green).Should().Be("Green");
+    }
+
+    [Fact]
+    public void GetName_UndefinedValue_ReturnsNull()
+    {
+        Enum.GetName((Color)99).Should().BeNull();
+    }
+
+    // ---- IsDefined<TEnum> ----
+
+    [Theory]
+    [InlineData(Color.Red, true)]
+    [InlineData(Color.Green, true)]
+    [InlineData(Color.Blue, true)]
+    [InlineData((Color)99, false)]
+    [InlineData((Color)0, false)]
+    public void IsDefined_ReturnsExpected(Color value, bool expected)
+    {
+        Enum.IsDefined(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsDefined_FlagsEnumCombined_ReturnsTrueForExplicitlyDefined()
+    {
+        // ReadWrite is explicitly defined as Read | Write.
+        Enum.IsDefined(FileAccess.ReadWrite).Should().BeTrue();
+        // An undefined combination is not.
+        Enum.IsDefined((FileAccess)99).Should().BeFalse();
+    }
+
+    // ---- Parse<TEnum>(ROS<char>) ----
+
+    [Fact]
+    public void Parse_Generic_Name_ReturnsValue()
+    {
+        Enum.Parse<Color>("Red".AsSpan()).Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Parse_Generic_NumericString_ReturnsValue()
+    {
+        Enum.Parse<Color>("2".AsSpan()).Should().Be(Color.Green);
+    }
+
+    [Fact]
+    public void Parse_Generic_NumericStringNotADefinedValue_StillReturnsCastValue()
+    {
+        // BCL behavior: numeric forms always parse, even if the value isn't a defined member.
+        Enum.Parse<Color>("99".AsSpan()).Should().Be((Color)99);
+    }
+
+    [Fact]
+    public void Parse_Generic_FlagsCommaSeparated_ReturnsCombined()
+    {
+        Enum.Parse<FileAccess>("Read, Write".AsSpan()).Should().Be(FileAccess.ReadWrite);
+    }
+
+    [Fact]
+    public void Parse_Generic_CaseSensitiveByDefault_ThrowsForLowercase()
+    {
+        Action action = () => Enum.Parse<Color>("red".AsSpan());
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Parse_Generic_IgnoreCaseTrue_AcceptsLowercase()
+    {
+        Enum.Parse<Color>("red".AsSpan(), ignoreCase: true).Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void Parse_Generic_IgnoreCaseFalse_RejectsLowercase()
+    {
+        Action action = () => Enum.Parse<Color>("red".AsSpan(), ignoreCase: false);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Parse_Generic_UnknownName_Throws()
+    {
+        Action action = () => Enum.Parse<Color>("Magenta".AsSpan());
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Parse_Generic_EmptySpan_Throws()
+    {
+        Action action = () => Enum.Parse<Color>([]);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    // ---- TryParse<TEnum>(ROS<char>) ----
+
+    [Fact]
+    public void TryParse_Generic_ValidName_ReturnsTrue()
+    {
+        Enum.TryParse("Blue".AsSpan(), out Color value).Should().BeTrue();
+        value.Should().Be(Color.Blue);
+    }
+
+    [Fact]
+    public void TryParse_Generic_Numeric_ReturnsTrue()
+    {
+        Enum.TryParse("4".AsSpan(), out Color value).Should().BeTrue();
+        value.Should().Be(Color.Blue);
+    }
+
+    [Fact]
+    public void TryParse_Generic_Invalid_ReturnsFalse()
+    {
+        Enum.TryParse("Magenta".AsSpan(), out Color value).Should().BeFalse();
+        value.Should().Be(default);
+    }
+
+    [Fact]
+    public void TryParse_Generic_CaseSensitive_RejectsLowercase()
+    {
+        Enum.TryParse("red".AsSpan(), out Color _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryParse_Generic_IgnoreCase_AcceptsLowercase()
+    {
+        Enum.TryParse("red".AsSpan(), ignoreCase: true, out Color value).Should().BeTrue();
+        value.Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void TryParse_Generic_EmptySpan_ReturnsFalse()
+    {
+        Enum.TryParse([], out Color value).Should().BeFalse();
+        value.Should().Be(default);
+    }
+
+    [Fact]
+    public void TryParse_Generic_FlagsCommaSeparated_ReturnsCombined()
+    {
+        Enum.TryParse("Read, Write".AsSpan(), out FileAccess value).Should().BeTrue();
+        value.Should().Be(FileAccess.ReadWrite);
+    }
+
+    // ---- Parse(Type, ROS<char>) ----
+
+    [Fact]
+    public void Parse_NonGeneric_Name_ReturnsBoxedValue()
+    {
+        Enum.Parse(typeof(Color), "Green".AsSpan()).Should().Be(Color.Green);
+    }
+
+    [Fact]
+    public void Parse_NonGeneric_IgnoreCase_AcceptsLowercase()
+    {
+        Enum.Parse(typeof(Color), "blue".AsSpan(), ignoreCase: true).Should().Be(Color.Blue);
+    }
+
+    [Fact]
+    public void Parse_NonGeneric_Unknown_Throws()
+    {
+        Action action = () => Enum.Parse(typeof(Color), "Magenta".AsSpan());
+        action.Should().Throw<ArgumentException>();
+    }
+
+    // ---- TryParse(Type, ROS<char>, out object?) ----
+
+    [Fact]
+    public void TryParse_NonGeneric_Valid_ReturnsTrue()
+    {
+        Enum.TryParse(typeof(Color), "Red".AsSpan(), out object? value).Should().BeTrue();
+        value.Should().Be(Color.Red);
+    }
+
+    [Fact]
+    public void TryParse_NonGeneric_Invalid_ReturnsFalseAndNull()
+    {
+        Enum.TryParse(typeof(Color), "Magenta".AsSpan(), out object? value).Should().BeFalse();
+        value.Should().BeNull();
+    }
+
+    [Fact]
+    public void TryParse_NonGeneric_IgnoreCase_AcceptsLowercase()
+    {
+        Enum.TryParse(typeof(Color), "green".AsSpan(), ignoreCase: true, out object? value)
+            .Should().BeTrue();
+        value.Should().Be(Color.Green);
+    }
+
+    // ---- Whitespace handling (matches BCL: leading/trailing whitespace trimmed) ----
+
+    [Theory]
+    [InlineData(" Red", Color.Red)]
+    [InlineData("Red ", Color.Red)]
+    [InlineData(" Red ", Color.Red)]
+    [InlineData(" 1 ", Color.Red)]
+    public void Parse_Generic_LeadingTrailingWhitespace_Trimmed(string input, Color expected)
+    {
+        Enum.Parse<Color>(input.AsSpan()).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Parse_Generic_FlagsWithExtraInteriorSpaces_Parses()
+    {
+        Enum.Parse<FileAccess>(" Read , Write ".AsSpan()).Should().Be(FileAccess.ReadWrite);
+    }
+
+    [Fact]
+    public void Parse_Generic_FlagsWithDuplicateNames_CollapsesToOneFlag()
+    {
+        // BCL behavior: duplicates collapse via OR.
+        Enum.Parse<FileAccess>("Read, Read, Write".AsSpan()).Should().Be(FileAccess.ReadWrite);
+    }
+
+    // ---- Negative numeric strings for signed enums ----
+
+    [Fact]
+    public void Parse_Generic_NegativeNumeric_Signed_ReturnsCastValue()
+    {
+        Enum.Parse<Int64Enum>("-42".AsSpan()).Should().Be((Int64Enum)(-42));
+    }
+
+    [Fact]
+    public void Parse_Generic_NegativeNumeric_Unsigned_Throws()
+    {
+        // Unsigned enum can't take a negative literal.
+        Action action = () => Enum.Parse<UInt32Enum>("-1".AsSpan());
+        action.Should().Throw<Exception>(); // OverflowException or ArgumentException
+    }
+
+    // ---- Multiple underlying integral types ----
+
+    [Theory]
+    [InlineData("Min", true)]
+    [InlineData("One", true)]
+    [InlineData("Max", true)]
+    [InlineData("Bogus", false)]
+    public void TryParse_Generic_SByteEnum(string input, bool expectedSuccess)
+    {
+        Enum.TryParse(input.AsSpan(), out SByteEnum _).Should().Be(expectedSuccess);
+    }
+
+    [Fact]
+    public void Parse_Generic_ByteEnum_NumericMaxValue()
+    {
+        Enum.Parse<ByteEnum>(byte.MaxValue.ToString().AsSpan()).Should().Be(ByteEnum.Max);
+    }
+
+    [Fact]
+    public void Parse_Generic_Int16Enum_NumericMinValue()
+    {
+        Enum.Parse<Int16Enum>(short.MinValue.ToString().AsSpan()).Should().Be(Int16Enum.Min);
+    }
+
+    [Fact]
+    public void Parse_Generic_UInt16Enum_NumericMaxValue()
+    {
+        Enum.Parse<UInt16Enum>(ushort.MaxValue.ToString().AsSpan()).Should().Be(UInt16Enum.Max);
+    }
+
+    [Fact]
+    public void Parse_Generic_UInt32Enum_NumericMaxValue()
+    {
+        Enum.Parse<UInt32Enum>(uint.MaxValue.ToString().AsSpan()).Should().Be(UInt32Enum.Max);
+    }
+
+    [Fact]
+    public void Parse_Generic_Int64Enum_NumericMinValue()
+    {
+        Enum.Parse<Int64Enum>(long.MinValue.ToString().AsSpan()).Should().Be(Int64Enum.Min);
+    }
+
+    [Fact]
+    public void Parse_Generic_UInt64Enum_NumericMaxValue()
+    {
+        Enum.Parse<UInt64Enum>(ulong.MaxValue.ToString().AsSpan()).Should().Be(UInt64Enum.Max);
+    }
+
+    // ---- IgnoreCase variations ----
+
+    [Fact]
+    public void Parse_Generic_IgnoreCase_MixedCase_Accepted()
+    {
+        Enum.Parse<Int16Enum>("mAx".AsSpan(), ignoreCase: true).Should().Be(Int16Enum.Max);
+    }
+
+    [Fact]
+    public void Parse_Generic_IgnoreCase_AllUppercase_Accepted()
+    {
+        Enum.Parse<Color>("BLUE".AsSpan(), ignoreCase: true).Should().Be(Color.Blue);
+    }
+
+    // ---- IsDefined across underlying types ----
+
+    [Theory]
+    [InlineData(SByteEnum.One, true)]
+    [InlineData((SByteEnum)99, false)]
+    public void IsDefined_Generic_SByteEnum(SByteEnum value, bool expected)
+    {
+        Enum.IsDefined(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(UInt64Enum.One, true)]
+    [InlineData((UInt64Enum)99UL, false)]
+    public void IsDefined_Generic_UInt64Enum(UInt64Enum value, bool expected)
+    {
+        Enum.IsDefined(value).Should().Be(expected);
+    }
+
+    // ---- Error-message details (BCL behavior: unknown name appears in message) ----
+
+    [Theory]
+    [InlineData("Yellow")]
+    [InlineData("Yellow,Orange")]
+    public void Parse_Generic_NonExistentValue_NameIncludedInErrorMessage(string value)
+    {
+        Action action = () => Enum.Parse<FileAccess>(value.AsSpan());
+        // Match BCL: the message contains the bad name token (first token for comma-separated).
+        action.Should().Throw<ArgumentException>()
+            .Which.Message.Should().Contain("Yellow");
+    }
+}

--- a/touki/Framework/Polyfills/System/EnumExtensions.cs
+++ b/touki/Framework/Polyfills/System/EnumExtensions.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki;
+
+namespace System;
+
+/// <summary>
+///  <see cref="Enum"/> static methods that don't have a direct equivalent in the .NET Framework build.
+/// </summary>
+public static class EnumExtensions
+{
+    extension(Enum)
+    {
+        /// <summary>
+        ///  Retrieves an array of the values of the constants in the specified enumeration type.
+        /// </summary>
+        /// <typeparam name="TEnum">An enumeration type.</typeparam>
+        /// <returns>An array that contains the values of the constants in <typeparamref name="TEnum"/>.</returns>
+        public static TEnum[] GetValues<TEnum>() where TEnum : struct, Enum =>
+            (TEnum[])Enum.GetValues(typeof(TEnum));
+
+        /// <summary>
+        ///  Retrieves an array of the names of the constants in the specified enumeration type.
+        /// </summary>
+        /// <typeparam name="TEnum">An enumeration type.</typeparam>
+        /// <returns>A string array of the names of the constants in <typeparamref name="TEnum"/>.</returns>
+        public static string[] GetNames<TEnum>() where TEnum : struct, Enum
+        {
+            return Enum.GetNames(typeof(TEnum));
+        }
+
+        /// <summary>
+        ///  Returns the name of the constant in the specified enumeration type that has the specified value, or
+        ///  <see langword="null"/> if no such constant is found.
+        /// </summary>
+        /// <typeparam name="TEnum">An enumeration type.</typeparam>
+        /// <param name="value">The value of a particular enumerated constant in terms of its underlying type.</param>
+        public static string? GetName<TEnum>(TEnum value) where TEnum : struct, Enum =>
+            Enum.GetName(typeof(TEnum), value);
+
+        /// <summary>
+        ///  Returns a Boolean telling whether a given integral value, or its name as a string, exists in a specified
+        ///  enumeration.
+        /// </summary>
+        /// <typeparam name="TEnum">An enumeration type.</typeparam>
+        /// <param name="value">The value or name of a constant in <typeparamref name="TEnum"/>.</param>
+        public static bool IsDefined<TEnum>(TEnum value) where TEnum : struct, Enum =>
+            Enum.IsDefined(typeof(TEnum), value);
+
+        /// <summary>
+        ///  Converts the span representation of the name or numeric value of one or more enumerated constants to an
+        ///  equivalent enumerated object.
+        /// </summary>
+        public static TEnum Parse<TEnum>(ReadOnlySpan<char> value) where TEnum : struct, Enum =>
+            (TEnum)Enum.Parse(typeof(TEnum), value.ToString());
+
+        /// <inheritdoc cref="Parse{TEnum}(ReadOnlySpan{char})"/>
+        /// <param name="value">The span representation of the name or numeric value to convert.</param>
+        /// <param name="ignoreCase">
+        ///  <see langword="true"/> to read <paramref name="value"/> in case insensitive mode;
+        ///  <see langword="false"/> to read in case sensitive mode.
+        /// </param>
+        public static TEnum Parse<TEnum>(ReadOnlySpan<char> value, bool ignoreCase) where TEnum : struct, Enum =>
+            (TEnum)Enum.Parse(typeof(TEnum), value.ToString(), ignoreCase);
+
+        /// <summary>
+        ///  Converts the span representation of the name or numeric value of one or more enumerated constants to an
+        ///  equivalent enumerated object. The return value indicates whether the conversion succeeded.
+        /// </summary>
+        public static bool TryParse<TEnum>(ReadOnlySpan<char> value, out TEnum result) where TEnum : struct, Enum =>
+            Enum.TryParse(value.ToString(), out result);
+
+        /// <inheritdoc cref="TryParse{TEnum}(ReadOnlySpan{char}, out TEnum)"/>
+        /// <param name="value">The span representation of the name or numeric value to convert.</param>
+        /// <param name="ignoreCase">
+        ///  <see langword="true"/> to ignore case; <see langword="false"/> to consider case.
+        /// </param>
+        /// <param name="result">When this method returns, contains the parsed value, or default on failure.</param>
+        public static bool TryParse<TEnum>(ReadOnlySpan<char> value, bool ignoreCase, out TEnum result)
+            where TEnum : struct, Enum =>
+            Enum.TryParse(value.ToString(), ignoreCase, out result);
+
+        /// <summary>
+        ///  Converts the string representation of the name or numeric value of one or more enumerated constants to an
+        ///  equivalent enumerated object. A parameter specifies whether the operation is case-insensitive.
+        /// </summary>
+        public static object Parse(Type enumType, ReadOnlySpan<char> value) =>
+            Enum.Parse(enumType, value.ToString());
+
+        /// <inheritdoc cref="Parse(Type, ReadOnlySpan{char})"/>
+        /// <param name="enumType">An enumeration type.</param>
+        /// <param name="value">The span representation of the name or numeric value to convert.</param>
+        /// <param name="ignoreCase">
+        ///  <see langword="true"/> to ignore case; <see langword="false"/> to consider case.
+        /// </param>
+        public static object Parse(Type enumType, ReadOnlySpan<char> value, bool ignoreCase) =>
+            Enum.Parse(enumType, value.ToString(), ignoreCase);
+
+        /// <summary>
+        ///  Tries to convert the span representation of the name or numeric value of one or more enumerated constants
+        ///  to an equivalent enumerated object.
+        /// </summary>
+        public static bool TryParse(Type enumType, ReadOnlySpan<char> value, out object? result)
+        {
+            try
+            {
+                result = Enum.Parse(enumType, value.ToString());
+                return true;
+            }
+            catch
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        /// <inheritdoc cref="TryParse(Type, ReadOnlySpan{char}, out object?)"/>
+        /// <param name="enumType">An enumeration type.</param>
+        /// <param name="value">The span representation of the name or numeric value to convert.</param>
+        /// <param name="ignoreCase">
+        ///  <see langword="true"/> to ignore case; <see langword="false"/> to consider case.
+        /// </param>
+        /// <param name="result">When this method returns, contains the parsed value, or <see langword="null"/> on failure.</param>
+        public static bool TryParse(Type enumType, ReadOnlySpan<char> value, bool ignoreCase, out object? result)
+        {
+            try
+            {
+                result = Enum.Parse(enumType, value.ToString(), ignoreCase);
+                return true;
+            }
+            catch
+            {
+                result = null;
+                return false;
+            }
+        }
+    }
+}

--- a/touki/Framework/Polyfills/System/EnumExtensions.cs
+++ b/touki/Framework/Polyfills/System/EnumExtensions.cs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using Touki;
-
 namespace System;
 
 /// <summary>
@@ -102,14 +100,26 @@ public static class EnumExtensions
         ///  Tries to convert the span representation of the name or numeric value of one or more enumerated constants
         ///  to an equivalent enumerated object.
         /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Matches the BCL contract: invalid <paramref name="enumType"/> (null or not an enum) throws;
+        ///   only failure to parse <paramref name="value"/> returns <see langword="false"/>.
+        ///  </para>
+        /// </remarks>
         public static bool TryParse(Type enumType, ReadOnlySpan<char> value, out object? result)
         {
+            ValidateEnumType(enumType);
             try
             {
                 result = Enum.Parse(enumType, value.ToString());
                 return true;
             }
-            catch
+            catch (ArgumentException)
+            {
+                result = null;
+                return false;
+            }
+            catch (OverflowException)
             {
                 result = null;
                 return false;
@@ -125,16 +135,31 @@ public static class EnumExtensions
         /// <param name="result">When this method returns, contains the parsed value, or <see langword="null"/> on failure.</param>
         public static bool TryParse(Type enumType, ReadOnlySpan<char> value, bool ignoreCase, out object? result)
         {
+            ValidateEnumType(enumType);
             try
             {
                 result = Enum.Parse(enumType, value.ToString(), ignoreCase);
                 return true;
             }
-            catch
+            catch (ArgumentException)
             {
                 result = null;
                 return false;
             }
+            catch (OverflowException)
+            {
+                result = null;
+                return false;
+            }
+        }
+    }
+
+    private static void ValidateEnumType(Type enumType)
+    {
+        ArgumentNullException.ThrowIfNull(enumType);
+        if (!enumType.IsEnum)
+        {
+            throw new ArgumentException("Type provided must be an Enum.", nameof(enumType));
         }
     }
 }

--- a/touki/Framework/Polyfills/System/TypeExtensions.cs
+++ b/touki/Framework/Polyfills/System/TypeExtensions.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Touki;
+
 namespace System;
 
 /// <summary>
@@ -24,5 +26,21 @@ public static class TypeExtensions
             && !type.IsPointer
             && !type.IsConstructedGenericType
             && !type.IsGenericParameter;
+
+        /// <summary>
+        ///  Gets the values and names for the specified enum <see cref="Type"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Reads from <see cref="Enum"/>'s internal <c>GetCachedValuesAndNames</c> cache via
+        ///   reflection; faster than <see cref="Enum.GetValues(Type)"/> + <see cref="Enum.GetNames(Type)"/>
+        ///   on .NET Framework. Returned arrays are the cached references - do not mutate.
+        ///  </para>
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///  <paramref name="type"/> is not an enum type.
+        /// </exception>
+        public (ulong[] Values, string[] Names) GetEnumValuesAndNames() =>
+            EnumDataCache.GetEnumValuesAndNames(type);
     }
 }

--- a/touki/Framework/Polyfills/System/TypeExtensions.cs
+++ b/touki/Framework/Polyfills/System/TypeExtensions.cs
@@ -34,13 +34,15 @@ public static class TypeExtensions
         ///  <para>
         ///   Reads from <see cref="Enum"/>'s internal <c>GetCachedValuesAndNames</c> cache via
         ///   reflection; faster than <see cref="Enum.GetValues(Type)"/> + <see cref="Enum.GetNames(Type)"/>
-        ///   on .NET Framework. Returned arrays are the cached references - do not mutate.
+        ///   on .NET Framework. Returned arrays are the cached references - do not mutate. Internal
+        ///   to keep the public surface identical between net472 and modern .NET targets and to
+        ///   prevent consumers from accidentally mutating the framework's cached arrays.
         ///  </para>
         /// </remarks>
         /// <exception cref="ArgumentException">
         ///  <paramref name="type"/> is not an enum type.
         /// </exception>
-        public (ulong[] Values, string[] Names) GetEnumValuesAndNames() =>
+        internal (ulong[] Values, string[] Names) GetEnumValuesAndNames() =>
             EnumDataCache.GetEnumValuesAndNames(type);
     }
 }

--- a/touki/Framework/Touki/EnumDataCache.cs
+++ b/touki/Framework/Touki/EnumDataCache.cs
@@ -7,12 +7,19 @@ using System.Reflection;
 
 namespace Touki;
 
-public static unsafe partial class EnumExtensions
+/// <summary>
+///  Per-type cache of enum metadata used by the .NET Framework target.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Backed by reflection into <see cref="Enum"/>'s private <c>GetCachedValuesAndNames</c> method;
+///   per-type results are computed lazily and cached for the lifetime of the process. Internal
+///   because the underlying reflection is fragile against BCL servicing changes.
+///  </para>
+/// </remarks>
+internal static class EnumDataCache
 {
     private static readonly ConcurrentDictionary<Type, EnumData> s_enumData = new();
-
-    [ThreadStatic]
-    private static object[]? t_params;
 
     private static readonly MethodInfo s_cachedNames = typeof(Enum).GetMethod(
         "GetCachedValuesAndNames",
@@ -30,27 +37,33 @@ public static unsafe partial class EnumExtensions
         "Names",
         BindingFlags.Public | BindingFlags.Instance)!;
 
-    /// <inheritdoc cref="GetValuesAndNames(Type)"/>
-    public static (ulong[] Values, string[] Names) GetValuesAndNames<T>() where T : Enum
-        => GetValuesAndNames(typeof(T));
+    [ThreadStatic]
+    private static object[]? t_params;
 
     /// <summary>
-    ///  Gets the internal cached values and names for the specified enum type.
+    ///  Gets the values and names for the specified enum <paramref name="type"/>.
     /// </summary>
-    public static (ulong[] Values, string[]) GetValuesAndNames(Type type)
+    /// <remarks>
+    ///  <para>
+    ///   Returns the BCL's internal cached arrays - callers must not mutate them.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="ArgumentException">
+    ///  <paramref name="type"/> is not an enum type.
+    /// </exception>
+    public static (ulong[] Values, string[] Names) GetEnumValuesAndNames(Type type)
     {
         if (!type.IsEnum)
         {
             throw new ArgumentException("Type must be an enum.", nameof(type));
         }
 
-        // Use reflection to get the private static GetCachedValuesAndNames method
         t_params ??= [null!, true];
-        var parameters = t_params;
+        object[] parameters = t_params;
         parameters[0] = type;
-        var valuesAndNames = s_cachedNames.Invoke(null, parameters);
-        var values = (ulong[])s_valuesField.GetValue(valuesAndNames)!;
-        var names = (string[])s_namesField.GetValue(valuesAndNames)!;
+        object? valuesAndNames = s_cachedNames.Invoke(null, parameters);
+        ulong[] values = (ulong[])s_valuesField.GetValue(valuesAndNames)!;
+        string[] names = (string[])s_namesField.GetValue(valuesAndNames)!;
         return (values, names);
     }
 
@@ -75,7 +88,7 @@ public static unsafe partial class EnumExtensions
             }
 
             Type = type;
-            Data = GetValuesAndNames(type);
+            Data = GetEnumValuesAndNames(type);
             IsFlags = type.IsDefined(typeof(FlagsAttribute), inherit: false);
             UnderlyingType = type.GetEnumUnderlyingType();
         }

--- a/touki/Framework/Touki/Text/ValueStringBuilder.cs
+++ b/touki/Framework/Touki/Text/ValueStringBuilder.cs
@@ -248,7 +248,7 @@ public ref partial struct ValueStringBuilder
         // We could handle very common enums so that they don't need to allocate like crazy.
         if (typeof(T).IsEnum
             && format.IsEmpty
-            && EnumExtensions.GetEnumData(typeof(T)) is var enumData
+            && EnumDataCache.GetEnumData(typeof(T)) is var enumData
             && enumData.UnderlyingType is Type underlyingType
             && underlyingType == typeof(int))
         {
@@ -277,7 +277,7 @@ public ref partial struct ValueStringBuilder
         return false;
     }
 
-    internal void InternalFlagsFormat(ulong value, bool signed, EnumExtensions.EnumData enumData)
+    internal void InternalFlagsFormat(ulong value, bool signed, EnumDataCache.EnumData enumData)
     {
         ulong result = value;
 

--- a/touki/GlobalSuppressions.cs
+++ b/touki/GlobalSuppressions.cs
@@ -6,5 +6,5 @@
 [assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.Text.ValueStringBuilder.t_values")]
 
 #if NETFRAMEWORK
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.EnumExtensions.t_params")]
+[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.EnumDataCache.t_params")]
 #endif

--- a/touki/Touki/Value.cs
+++ b/touki/Touki/Value.cs
@@ -1736,7 +1736,7 @@ public readonly partial struct Value
 #if NETFRAMEWORK
         else if (typeFlag is IEnumType enumType
             && format.Length == 0
-            && EnumExtensions.GetEnumData(type) is var enumData)
+            && EnumDataCache.GetEnumData(type) is var enumData)
         {
             ulong value = enumType.AsUlong(in this);
             bool signed = enumType.IsSigned;


### PR DESCRIPTION
Polyfills the modern `Enum` static API surface for net472 and reorganizes the existing reflection-based enum cache.

## Polyfill surface ([EnumExtensions.cs](touki/Framework/Polyfills/System/EnumExtensions.cs))

`extension(Enum)` block providing on net472:

- **net5.0**: `GetValues<TEnum>()`, `GetNames<TEnum>()`, `GetName<TEnum>(TEnum)`, `IsDefined<TEnum>(TEnum)`
- **net6.0**: `Parse<TEnum>(ROS<char>)`, `Parse<TEnum>(ROS<char>, bool)`, `TryParse<TEnum>(ROS<char>, out)`, `TryParse<TEnum>(ROS<char>, bool, out)`, plus the non-generic `Parse(Type, ROS<char>[, bool])` and `TryParse(Type, ROS<char>[, bool], out object?)`

`GetNames<TEnum>()` reads from the cache (see below) and clones the array to match the BCL contract that callers receive a fresh, mutation-safe array.

## Reorganization

The pre-existing framework-only `Touki.EnumExtensions` mixed reflection plumbing, a per-type cache, and a tuple accessor. Split into purpose-built pieces:

- **New** [`Touki.EnumDataCache`](touki/Framework/Touki/EnumDataCache.cs) (internal, framework-only) — owns the reflection fields targeting `Enum.GetCachedValuesAndNames`, the `ConcurrentDictionary<Type, EnumData>` cache, and the public nested `EnumData` class.
- **Extended** [`TypeExtensions`](touki/Framework/Polyfills/System/TypeExtensions.cs) — adds `Type.GetEnumValuesAndNames() → (ulong[], string[])` as a one-line delegate to `EnumDataCache`.
- **Deleted** `touki/Framework/Touki/EnumExtensions.cs` — superseded by the two above. The cross-target `Touki.EnumExtensions` flag-manipulation helpers (`AreFlagsSet`, `SetFlags`, etc.) are unchanged.
- Consumers in `ValueStringBuilder` and `Value` updated to call `EnumDataCache.GetEnumData` / `EnumDataCache.EnumData`.

## Tests

[touki.tests/System/EnumExtensionsTests.cs](touki.tests/System/EnumExtensionsTests.cs) (`namespace System.Tests` to avoid colliding with the existing `Touki.EnumExtensionsTests` flag-helper tests). Mirrors `dotnet/runtime` `EnumTests.cs` cases: leading/trailing whitespace, comma-separated flags with duplicates and extra spaces, negative-numeric strings on signed/unsigned underlying types, all 7 underlying integral types (sbyte/byte/short/ushort/uint/long/ulong), case-sensitivity variations, error-message content, and the non-generic `Parse`/`TryParse(Type, ROS<char>, …)` shapes.

Skill update: [.agents/skills/polyfill-dotnet-api/SKILL.md](.agents/skills/polyfill-dotnet-api/SKILL.md) — workflow now points at `dotnet/runtime` tests for edge-case coverage and requires user approval before invoking `create-pr`.

`dotnet test -c Release` passes 3657 net10.0 / 3845 net481, 0 failures.