### PR TITLE
Polyfill String/Convert/Array .NET Core APIs for net472

### DIFF
--- a/touki.tests/System/ArrayExtensionsTests.cs
+++ b/touki.tests/System/ArrayExtensionsTests.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System.Tests;
+
+public class ArrayExtensionsTests
+{
+    [Fact]
+    public void Fill_FillsAllElements()
+    {
+        int[] array = new int[5];
+        Array.Fill(array, 7);
+        array.Should().Equal(7, 7, 7, 7, 7);
+    }
+
+    [Fact]
+    public void Fill_EmptyArray_NoOp()
+    {
+        int[] array = [];
+        Array.Fill(array, 7);
+        array.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Fill_Range_FillsOnlySpecifiedElements()
+    {
+        int[] array = new int[5];
+        Array.Fill(array, 9, 1, 3);
+        array.Should().Equal(0, 9, 9, 9, 0);
+    }
+
+    [Fact]
+    public void Fill_Range_FullArray_FillsAll()
+    {
+        int[] array = new int[5];
+        Array.Fill(array, 1, 0, 5);
+        array.Should().Equal(1, 1, 1, 1, 1);
+    }
+
+    [Fact]
+    public void Fill_Range_ZeroCount_NoChange()
+    {
+        int[] array = [1, 2, 3];
+        Array.Fill(array, 0, 1, 0);
+        array.Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void Fill_NullArray_Throws()
+    {
+        Action action = () => Array.Fill<int>(null!, 0);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Fill_Range_NullArray_Throws()
+    {
+        Action action = () => Array.Fill<int>(null!, 0, 0, 0);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Fill_Range_NegativeStartIndex_Throws()
+    {
+        int[] array = new int[5];
+        Action action = () => Array.Fill(array, 0, -1, 1);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Fill_Range_StartIndexBeyondLength_Throws()
+    {
+        int[] array = new int[5];
+        Action action = () => Array.Fill(array, 0, 6, 0);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Fill_Range_CountTooLarge_Throws()
+    {
+        int[] array = new int[5];
+        Action action = () => Array.Fill(array, 0, 2, 4);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Fill_ReferenceType_AssignsSameReference()
+    {
+        string[] array = new string[3];
+        Array.Fill(array, "x");
+        array.Should().Equal("x", "x", "x");
+    }
+
+    [Fact]
+    public void Fill_Range_NegativeCount_Throws()
+    {
+        int[] array = new int[5];
+        Action action = () => Array.Fill(array, 0, 0, -1);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Fill_Range_StartIndexAtLength_ZeroCount_DoesNotThrow()
+    {
+        // BCL: startIndex == length is valid as long as count is 0.
+        int[] array = new int[3];
+        Array.Fill(array, 9, 3, 0);
+        array.Should().Equal(0, 0, 0);
+    }
+
+    [Fact]
+    public void Fill_Range_StartIndexAtLength_NonZeroCount_Throws()
+    {
+        int[] array = new int[3];
+        Action action = () => Array.Fill(array, 9, 3, 1);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Fill_OverwritesExistingValues()
+    {
+        int[] array = [1, 2, 3, 4, 5];
+        Array.Fill(array, 0);
+        array.Should().Equal(0, 0, 0, 0, 0);
+    }
+
+    [Fact]
+    public void Fill_Range_OverwritesOnlyRange()
+    {
+        int[] array = [1, 2, 3, 4, 5];
+        Array.Fill(array, 0, 1, 3);
+        array.Should().Equal(1, 0, 0, 0, 5);
+    }
+
+    [Fact]
+    public void Fill_Range_NullValue_AllowedForReferenceType()
+    {
+        string[] array = ["a", "b", "c"];
+        Array.Fill(array, null!, 0, 2);
+        array[0].Should().BeNull();
+        array[1].Should().BeNull();
+        array[2].Should().Be("c");
+    }
+}

--- a/touki.tests/System/ConvertBase64PolyfillTests.cs
+++ b/touki.tests/System/ConvertBase64PolyfillTests.cs
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System.Tests;
+
+public class ConvertBase64PolyfillTests
+{
+    private static readonly byte[] s_sample = [0xFE, 0xED, 0xFA, 0xCE];
+    private const string SampleBase64 = "/u36zg==";
+
+    // ---- ToBase64String(ReadOnlySpan<byte>) ----
+
+    [Fact]
+    public void ToBase64String_Empty_ReturnsEmpty()
+    {
+        Convert.ToBase64String([]).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToBase64String_Sample_ReturnsExpected()
+    {
+        Convert.ToBase64String((ReadOnlySpan<byte>)s_sample).Should().Be(SampleBase64);
+    }
+
+    [Fact]
+    public void ToBase64String_LargeBuffer_RoundTrips()
+    {
+        byte[] buffer = new byte[1024];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = (byte)(i & 0xFF);
+        }
+
+        string encoded = Convert.ToBase64String((ReadOnlySpan<byte>)buffer);
+        byte[] decoded = Convert.FromBase64String(encoded);
+        decoded.Should().Equal(buffer);
+    }
+
+    // ---- TryToBase64Chars ----
+
+    [Fact]
+    public void TryToBase64Chars_DestinationLargeEnough_WritesAndReturnsTrue()
+    {
+        Span<char> dest = new char[16];
+        bool ok = Convert.TryToBase64Chars(s_sample, dest, out int written);
+        ok.Should().BeTrue();
+        written.Should().Be(SampleBase64.Length);
+        dest[..written].ToString().Should().Be(SampleBase64);
+    }
+
+    [Fact]
+    public void TryToBase64Chars_DestinationTooSmall_ReturnsFalse()
+    {
+        Span<char> dest = new char[4];
+        bool ok = Convert.TryToBase64Chars(s_sample, dest, out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryToBase64Chars_Empty_ReturnsTrueWithZeroWritten()
+    {
+        Span<char> dest = [];
+        Convert.TryToBase64Chars([], dest, out int written).Should().BeTrue();
+        written.Should().Be(0);
+    }
+
+    // ---- TryFromBase64Chars / TryFromBase64String ----
+
+    [Fact]
+    public void TryFromBase64Chars_ValidInput_DecodesCorrectly()
+    {
+        Span<byte> dest = new byte[8];
+        bool ok = Convert.TryFromBase64Chars(SampleBase64.AsSpan(), dest, out int written);
+        ok.Should().BeTrue();
+        written.Should().Be(s_sample.Length);
+        dest[..written].ToArray().Should().Equal(s_sample);
+    }
+
+    [Fact]
+    public void TryFromBase64Chars_DestinationTooSmall_ReturnsFalse()
+    {
+        Span<byte> dest = new byte[2];
+        bool ok = Convert.TryFromBase64Chars(SampleBase64.AsSpan(), dest, out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryFromBase64Chars_InvalidInput_ReturnsFalse()
+    {
+        Span<byte> dest = new byte[8];
+        bool ok = Convert.TryFromBase64Chars("not valid!".AsSpan(), dest, out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryFromBase64Chars_EmptyInput_ReturnsTrue()
+    {
+        Span<byte> dest = [];
+        Convert.TryFromBase64Chars([], dest, out int written).Should().BeTrue();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryFromBase64String_ValidInput_DecodesCorrectly()
+    {
+        Span<byte> dest = new byte[8];
+        Convert.TryFromBase64String(SampleBase64, dest, out int written).Should().BeTrue();
+        written.Should().Be(s_sample.Length);
+    }
+
+    [Fact]
+    public void TryFromBase64String_NullString_Throws()
+    {
+        Span<byte> dest = new byte[8];
+        // Force the call to a no-default destination overload to ensure null is checked.
+        byte[] destArray = new byte[8];
+        Action action = () => Convert.TryFromBase64String(null!, destArray, out _);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ToBase64String_InsertLineBreaks_AddsLineBreaksEvery76Chars()
+    {
+        // 60 bytes encodes to 80 base64 chars; with line breaks the BCL inserts CRLF after 76 chars.
+        byte[] data = new byte[60];
+        string encoded = Convert.ToBase64String((ReadOnlySpan<byte>)data, Base64FormattingOptions.InsertLineBreaks);
+        encoded.IndexOf("\r\n", StringComparison.Ordinal).Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void TryToBase64Chars_ExactFitDestination_Succeeds()
+    {
+        // s_sample is 4 bytes -> 8 base64 chars.
+        Span<char> dest = new char[8];
+        Convert.TryToBase64Chars(s_sample, dest, out int written).Should().BeTrue();
+        written.Should().Be(8);
+        dest.ToString().Should().Be(SampleBase64);
+    }
+
+    [Fact]
+    public void TryFromBase64Chars_NonBase64Char_ReturnsFalse()
+    {
+        Span<byte> dest = new byte[8];
+        // '!' is not in the base64 alphabet.
+        Convert.TryFromBase64Chars("ABC!".AsSpan(), dest, out int written).Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryFromBase64Chars_BadPadding_ReturnsFalse()
+    {
+        Span<byte> dest = new byte[8];
+        // 5 chars cannot be a valid base64 sequence (must be multiple of 4 once whitespace stripped).
+        Convert.TryFromBase64Chars("ABCDE".AsSpan(), dest, out int written).Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void RoundTrip_SpanEncodeMatchesBclByteArrayEncode()
+    {
+        // The span polyfill must produce byte-identical output to the BCL byte[] overload.
+        byte[] data = new byte[100];
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i] = (byte)(i * 7);
+        }
+
+        string viaSpan = Convert.ToBase64String((ReadOnlySpan<byte>)data);
+        string viaArray = Convert.ToBase64String(data);
+        viaSpan.Should().Be(viaArray);
+    }
+
+    [Fact]
+    public void ToBase64String_OneByte_TwoPaddingChars()
+    {
+        byte[] one = [0xFF];
+        Convert.ToBase64String((ReadOnlySpan<byte>)one).Should().Be("/w==");
+    }
+
+    [Fact]
+    public void ToBase64String_TwoBytes_OnePaddingChar()
+    {
+        byte[] two = [0xFF, 0xEE];
+        Convert.ToBase64String((ReadOnlySpan<byte>)two).Should().Be("/+4=");
+    }
+
+    [Fact]
+    public void ToBase64String_ThreeBytes_NoPaddingChars()
+    {
+        byte[] three = [0xFF, 0xEE, 0xDD];
+        Convert.ToBase64String((ReadOnlySpan<byte>)three).Should().Be("/+7d");
+    }
+}

--- a/touki.tests/System/ConvertBase64PolyfillTests.cs
+++ b/touki.tests/System/ConvertBase64PolyfillTests.cs
@@ -115,8 +115,6 @@ public class ConvertBase64PolyfillTests
     [Fact]
     public void TryFromBase64String_NullString_Throws()
     {
-        Span<byte> dest = new byte[8];
-        // Force the call to a no-default destination overload to ensure null is checked.
         byte[] destArray = new byte[8];
         Action action = () => Convert.TryFromBase64String(null!, destArray, out _);
         action.Should().Throw<ArgumentNullException>();

--- a/touki.tests/System/StringExtensionsPolyfillTests.cs
+++ b/touki.tests/System/StringExtensionsPolyfillTests.cs
@@ -1,0 +1,403 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System.Tests;
+
+public class StringExtensionsPolyfillTests
+{
+    // ---- Contains(char) / Contains(char, StringComparison) / Contains(string, StringComparison) ----
+
+    [Theory]
+    [InlineData("Hello", 'H', true)]
+    [InlineData("Hello", 'l', true)]
+    [InlineData("Hello", 'z', false)]
+    [InlineData("", 'a', false)]
+    public void Contains_Char_ReturnsExpected(string source, char value, bool expected)
+    {
+        source.Contains(value).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Contains_Char_OrdinalIgnoreCase_AcceptsAnyCase()
+    {
+        "Hello".Contains('h', StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Contains_Char_Ordinal_RejectsDifferentCase()
+    {
+        "Hello".Contains('h', StringComparison.Ordinal).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contains_String_OrdinalIgnoreCase_AcceptsAnyCase()
+    {
+        "Hello World".Contains("HELLO", StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Contains_String_NullValue_Throws()
+    {
+        Action action = () => "x".Contains(null!, StringComparison.Ordinal);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    // ---- StartsWith / EndsWith char ----
+
+    [Theory]
+    [InlineData("Hello", 'H', true)]
+    [InlineData("Hello", 'h', false)]
+    [InlineData("Hello", 'e', false)]
+    [InlineData("", 'a', false)]
+    public void StartsWith_Char_ReturnsExpected(string source, char value, bool expected)
+    {
+        source.StartsWith(value).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("Hello", 'o', true)]
+    [InlineData("Hello", 'O', false)]
+    [InlineData("Hello", 'l', false)]
+    [InlineData("", 'a', false)]
+    public void EndsWith_Char_ReturnsExpected(string source, char value, bool expected)
+    {
+        source.EndsWith(value).Should().Be(expected);
+    }
+
+    // ---- TryCopyTo ----
+
+    [Fact]
+    public void TryCopyTo_DestinationLargeEnough_CopiesAndReturnsTrue()
+    {
+        Span<char> dest = new char[10];
+        bool ok = "abc".TryCopyTo(dest);
+        ok.Should().BeTrue();
+        dest[0].Should().Be('a');
+        dest[1].Should().Be('b');
+        dest[2].Should().Be('c');
+    }
+
+    [Fact]
+    public void TryCopyTo_DestinationTooSmall_ReturnsFalse()
+    {
+        Span<char> dest = new char[2];
+        bool ok = "abc".TryCopyTo(dest);
+        ok.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryCopyTo_EmptySource_AlwaysSucceeds()
+    {
+        Span<char> dest = [];
+        "".TryCopyTo(dest).Should().BeTrue();
+    }
+
+    // ---- GetHashCode(StringComparison) ----
+
+    [Fact]
+    public void GetHashCode_StringComparison_OrdinalIgnoreCase_SameForCaseVariants()
+    {
+        int a = "Hello".GetHashCode(StringComparison.OrdinalIgnoreCase);
+        int b = "HELLO".GetHashCode(StringComparison.OrdinalIgnoreCase);
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void GetHashCode_StringComparison_Ordinal_DifferentForCaseVariants()
+    {
+        int a = "Hello".GetHashCode(StringComparison.Ordinal);
+        int b = "HELLO".GetHashCode(StringComparison.Ordinal);
+        a.Should().NotBe(b);
+    }
+
+    // ---- Replace(string, string?, StringComparison) ----
+
+    [Fact]
+    public void Replace_StringComparison_Ordinal_ExactMatch()
+    {
+        "abcabc".Replace("ab", "X", StringComparison.Ordinal).Should().Be("XcXc");
+    }
+
+    [Fact]
+    public void Replace_StringComparison_OrdinalIgnoreCase_AnyCase()
+    {
+        "abcAbC".Replace("AB", "X", StringComparison.OrdinalIgnoreCase).Should().Be("XcXC");
+    }
+
+    [Fact]
+    public void Replace_StringComparison_NullNewValue_TreatedAsEmpty()
+    {
+        "abcabc".Replace("ab", null, StringComparison.OrdinalIgnoreCase).Should().Be("cc");
+    }
+
+    [Fact]
+    public void Replace_StringComparison_NoMatch_ReturnsOriginal()
+    {
+        "abc".Replace("z", "X", StringComparison.Ordinal).Should().Be("abc");
+    }
+
+    [Fact]
+    public void Replace_StringComparison_NullOldValue_Throws()
+    {
+        Action action = () => "abc".Replace(null!, "x", StringComparison.Ordinal);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Replace_StringComparison_EmptyOldValue_Throws()
+    {
+        Action action = () => "abc".Replace("", "x", StringComparison.Ordinal);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    // ---- ReplaceLineEndings ----
+
+    [Theory]
+    [InlineData("a\nb", "a|b")]
+    [InlineData("a\rb", "a|b")]
+    [InlineData("a\r\nb", "a|b")]
+    [InlineData("a\u0085b", "a|b")]
+    [InlineData("a\u2028b", "a|b")]
+    [InlineData("a\u2029b", "a|b")]
+    [InlineData("a\fb", "a|b")]
+    [InlineData("no line endings", "no line endings")]
+    public void ReplaceLineEndings_Custom_ReplacesAllRecognizedEndings(string input, string expected)
+    {
+        input.ReplaceLineEndings("|").Should().Be(expected);
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_CRLF_TreatedAsSingleEnding()
+    {
+        // \r\n should yield ONE replacement, not two.
+        "a\r\nb\r\nc".ReplaceLineEndings("|").Should().Be("a|b|c");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_NoArgument_UsesEnvironmentNewLine()
+    {
+        "a\nb".ReplaceLineEndings().Should().Be("a" + Environment.NewLine + "b");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_NullReplacement_Throws()
+    {
+        Action action = () => "a\nb".ReplaceLineEndings(null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    // ---- Split(char, ...) / Split(string, ...) ----
+
+    [Fact]
+    public void Split_Char_StringSplitOptions_RemoveEmpty()
+    {
+        "a,,b".Split(',', StringSplitOptions.RemoveEmptyEntries).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Split_Char_StringSplitOptions_None_KeepsEmpty()
+    {
+        "a,,b".Split(',', StringSplitOptions.None).Should().Equal("a", "", "b");
+    }
+
+    [Fact]
+    public void Split_Char_Count_LimitsSplits()
+    {
+        "a,b,c,d".Split(',', 2, StringSplitOptions.None).Should().Equal("a", "b,c,d");
+    }
+
+    [Fact]
+    public void Split_String_StringSplitOptions_RemoveEmpty()
+    {
+        "a::b".Split("::", StringSplitOptions.RemoveEmptyEntries).Should().Equal("a", "b");
+    }
+
+    [Fact]
+    public void Split_String_Count_LimitsSplits()
+    {
+        "a::b::c::d".Split("::", 2, StringSplitOptions.None).Should().Equal("a", "b::c::d");
+    }
+
+    [Fact]
+    public void Split_String_NullSeparator_ReturnsSingleSourceElement()
+    {
+        // BCL behavior for Split((string?)null, opts): treats as no separator, returns the source unchanged.
+        "a b\tc".Split((string?)null, StringSplitOptions.None).Should().Equal("a b\tc");
+    }
+
+    [Fact]
+    public void Split_Char_EmptySource_ReturnsSingleEmpty()
+    {
+        "".Split(',', StringSplitOptions.None).Should().Equal("");
+    }
+
+    [Fact]
+    public void Split_Char_NoMatch_ReturnsSingle()
+    {
+        "abc".Split(',', StringSplitOptions.None).Should().Equal("abc");
+    }
+
+    [Fact]
+    public void Split_Char_CountZero_ReturnsEmpty()
+    {
+        "a,b,c".Split(',', 0, StringSplitOptions.None).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Split_Char_CountOne_ReturnsOriginal()
+    {
+        "a,b,c".Split(',', 1, StringSplitOptions.None).Should().Equal("a,b,c");
+    }
+
+    [Fact]
+    public void Split_Char_NegativeCount_Throws()
+    {
+        Action action = () => "a,b".Split(',', -1, StringSplitOptions.None);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    // ---- Contains negative & boundary ----
+
+    [Fact]
+    public void Contains_Char_EmptyString_ReturnsFalse()
+    {
+        "".Contains('a').Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contains_String_EmptyValue_ReturnsTrue()
+    {
+        // BCL contract: an empty needle is contained anywhere.
+        "Hello".Contains("", StringComparison.Ordinal).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Contains_String_InvalidComparison_Throws()
+    {
+        Action action = () => "Hello".Contains("yz", (StringComparison)42);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Contains_Char_InvalidComparison_Throws()
+    {
+        Action action = () => "x".Contains('y', (StringComparison)42);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    // ---- GetHashCode negative ----
+
+    [Fact]
+    public void GetHashCode_StringComparison_Invalid_Throws()
+    {
+        Action action = () => "x".GetHashCode((StringComparison)42);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    // ---- Replace negative & boundary ----
+
+    [Fact]
+    public void Replace_StringComparison_InvalidComparison_Throws()
+    {
+        Action action = () => "abc".Replace("a", "b", (StringComparison)42);
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Replace_StringComparison_EmptySource_ReturnsEmpty()
+    {
+        "".Replace("a", "b", StringComparison.Ordinal).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Replace_StringComparison_OldValueLongerThanSource_ReturnsOriginal()
+    {
+        "ab".Replace("abcdef", "x", StringComparison.Ordinal).Should().Be("ab");
+    }
+
+    [Fact]
+    public void Replace_StringComparison_AdjacentMatches_AllReplaced()
+    {
+        "aaaa".Replace("aa", "X", StringComparison.Ordinal).Should().Be("XX");
+    }
+
+    [Fact]
+    public void Replace_StringComparison_OrdinalNullNewValue_TreatedAsEmpty()
+    {
+        "abc".Replace("b", null, StringComparison.Ordinal).Should().Be("ac");
+    }
+
+    // ---- ReplaceLineEndings negative & boundary ----
+
+    [Fact]
+    public void ReplaceLineEndings_EmptySource_ReturnsEmpty()
+    {
+        "".ReplaceLineEndings("|").Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_OnlyLineEnding_ReturnsReplacement()
+    {
+        "\n".ReplaceLineEndings("|").Should().Be("|");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_LeadingAndTrailing_BothReplaced()
+    {
+        "\nabc\n".ReplaceLineEndings("|").Should().Be("|abc|");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_VerticalTab_NotTreatedAsLineEnding()
+    {
+        // \v (U+000B) is NOT a recognized line ending per the BCL spec.
+        "a\vb".ReplaceLineEndings("|").Should().Be("a\vb");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_LoneCR_ReplacedAsSingleEnding()
+    {
+        "a\rb".ReplaceLineEndings("|").Should().Be("a|b");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_LoneLF_ReplacedAsSingleEnding()
+    {
+        "a\nb".ReplaceLineEndings("|").Should().Be("a|b");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_CRThenChar_NotMisinterpreted()
+    {
+        // \r followed by non-\n must not consume the next char.
+        "a\rXb".ReplaceLineEndings("|").Should().Be("a|Xb");
+    }
+
+    [Fact]
+    public void ReplaceLineEndings_LongInput_ExceedsStackBuffer()
+    {
+        // Force the ValueStringBuilder beyond the 256-char stack buffer.
+        string source = new string('a', 1000) + "\n" + new string('b', 1000);
+        string result = source.ReplaceLineEndings("|");
+        result.Should().Be(new string('a', 1000) + "|" + new string('b', 1000));
+    }
+
+    // ---- TryCopyTo edge ----
+
+    [Fact]
+    public void TryCopyTo_EmptyDestinationNonEmptySource_ReturnsFalse()
+    {
+        Span<char> dest = [];
+        "abc".TryCopyTo(dest).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryCopyTo_ExactFit_CopiesAndReturnsTrue()
+    {
+        Span<char> dest = new char[3];
+        bool ok = "abc".TryCopyTo(dest);
+        ok.Should().BeTrue();
+        dest.ToString().Should().Be("abc");
+    }
+}

--- a/touki/Framework/Polyfills/System/ArrayExtensions.cs
+++ b/touki/Framework/Polyfills/System/ArrayExtensions.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System;
+
+/// <summary>
+///  <see cref="Array"/> static methods that don't have a direct equivalent in the .NET Framework build.
+/// </summary>
+public static class ArrayExtensions
+{
+    extension(Array)
+    {
+        /// <summary>
+        ///  Assigns the given <paramref name="value"/> to each element of the <paramref name="array"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the array.</typeparam>
+        /// <param name="array">The array to be filled.</param>
+        /// <param name="value">The value to assign to each array element.</param>
+        public static void Fill<T>(T[] array, T value)
+        {
+            ArgumentNullException.ThrowIfNull(array);
+            array.AsSpan().Fill(value);
+        }
+
+        /// <summary>
+        ///  Assigns the given <paramref name="value"/> to each element of the <paramref name="array"/> in the
+        ///  specified range.
+        /// </summary>
+        /// <typeparam name="T">The type of the elements of the array.</typeparam>
+        /// <param name="array">The array to be filled.</param>
+        /// <param name="value">The value to assign to each array element.</param>
+        /// <param name="startIndex">The index at which to begin filling.</param>
+        /// <param name="count">The number of elements to fill.</param>
+        public static void Fill<T>(T[] array, T value, int startIndex, int count)
+        {
+            ArgumentNullException.ThrowIfNull(array);
+            if ((uint)startIndex > (uint)array.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex));
+            }
+
+            if ((uint)count > (uint)(array.Length - startIndex))
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+
+            array.AsSpan(startIndex, count).Fill(value);
+        }
+    }
+}

--- a/touki/Framework/Polyfills/System/ConvertExtensions.cs
+++ b/touki/Framework/Polyfills/System/ConvertExtensions.cs
@@ -105,6 +105,113 @@ public static class ConvertExtensions
 
             return result;
         }
+
+        /// <summary>
+        ///  Converts a span of 8-bit unsigned integers to its equivalent string representation that is
+        ///  encoded with base-64 digits.
+        /// </summary>
+        public static string ToBase64String(ReadOnlySpan<byte> bytes) =>
+            ToBase64String(bytes, Base64FormattingOptions.None);
+
+        /// <summary>
+        ///  Converts a span of 8-bit unsigned integers to its equivalent string representation that is
+        ///  encoded with base-64 digits, with optional formatting.
+        /// </summary>
+        public static string ToBase64String(ReadOnlySpan<byte> bytes, Base64FormattingOptions options)
+        {
+            if (bytes.IsEmpty)
+            {
+                return string.Empty;
+            }
+
+            byte[] rented = ArrayPool<byte>.Shared.Rent(bytes.Length);
+            try
+            {
+                bytes.CopyTo(rented);
+                return Convert.ToBase64String(rented, 0, bytes.Length, options);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+
+        /// <summary>
+        ///  Tries to convert the 8-bit unsigned integers inside <paramref name="bytes"/> to their equivalent
+        ///  string representation that is encoded with base-64 digits, writing the result into the provided
+        ///  character span.
+        /// </summary>
+        public static bool TryToBase64Chars(ReadOnlySpan<byte> bytes, Span<char> chars, out int charsWritten) =>
+            TryToBase64Chars(bytes, chars, out charsWritten, Base64FormattingOptions.None);
+
+        /// <inheritdoc cref="TryToBase64Chars(ReadOnlySpan{byte}, Span{char}, out int)"/>
+        /// <param name="bytes">The bytes to convert.</param>
+        /// <param name="chars">Destination buffer that receives the encoded chars.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of chars written.</param>
+        /// <param name="options">Formatting options.</param>
+        public static bool TryToBase64Chars(
+            ReadOnlySpan<byte> bytes,
+            Span<char> chars,
+            out int charsWritten,
+            Base64FormattingOptions options)
+        {
+            if (bytes.IsEmpty)
+            {
+                charsWritten = 0;
+                return true;
+            }
+
+            string encoded = ToBase64String(bytes, options);
+            if (encoded.Length > chars.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            encoded.AsSpan().CopyTo(chars);
+            charsWritten = encoded.Length;
+            return true;
+        }
+
+        /// <summary>
+        ///  Tries to decode the base-64 characters in <paramref name="chars"/> into <paramref name="bytes"/>.
+        /// </summary>
+        public static bool TryFromBase64Chars(ReadOnlySpan<char> chars, Span<byte> bytes, out int bytesWritten)
+        {
+            if (chars.IsEmpty)
+            {
+                bytesWritten = 0;
+                return true;
+            }
+
+            try
+            {
+                byte[] decoded = Convert.FromBase64CharArray(chars.ToArray(), 0, chars.Length);
+                if (decoded.Length > bytes.Length)
+                {
+                    bytesWritten = 0;
+                    return false;
+                }
+
+                decoded.AsSpan().CopyTo(bytes);
+                bytesWritten = decoded.Length;
+                return true;
+            }
+            catch (FormatException)
+            {
+                bytesWritten = 0;
+                return false;
+            }
+        }
+
+        /// <summary>
+        ///  Tries to decode the base-64 string <paramref name="s"/> into <paramref name="bytes"/>.
+        /// </summary>
+        public static bool TryFromBase64String(string s, Span<byte> bytes, out int bytesWritten)
+        {
+            ArgumentNullException.ThrowIfNull(s);
+            return TryFromBase64Chars(s.AsSpan(), bytes, out bytesWritten);
+        }
     }
 
     private static void EncodeToUtf16(ReadOnlySpan<byte> bytes, Span<char> chars, uint casing)

--- a/touki/Framework/Polyfills/System/StringExtensions.cs
+++ b/touki/Framework/Polyfills/System/StringExtensions.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Globalization;
+
 namespace System;
 
 /// <summary>
@@ -117,5 +119,264 @@ public static class StringExtensions
                 ArgumentException.Throw(null, nameof(destination));
             }
         }
+
+        /// <summary>
+        ///  Copies the contents of this string into the destination span.
+        /// </summary>
+        /// <returns><see langword="true"/> if the data was copied; <see langword="false"/> if the destination is too short.</returns>
+        public bool TryCopyTo(Span<char> destination)
+        {
+            if ((uint)source.Length > (uint)destination.Length)
+            {
+                return false;
+            }
+
+            source.AsSpan().CopyTo(destination);
+            return true;
+        }
+
+        /// <summary>
+        ///  Returns a value indicating whether a specified character occurs within this string.
+        /// </summary>
+        public bool Contains(char value) => source.IndexOf(value) >= 0;
+
+        /// <summary>
+        ///  Returns a value indicating whether a specified character occurs within this string,
+        ///  using the specified comparison rules.
+        /// </summary>
+        public bool Contains(char value, StringComparison comparisonType) =>
+            source.IndexOf(value.ToString(), comparisonType) >= 0;
+
+        /// <summary>
+        ///  Returns a value indicating whether a specified substring occurs within this string,
+        ///  using the specified comparison rules.
+        /// </summary>
+        public bool Contains(string value, StringComparison comparisonType)
+        {
+            ArgumentNullException.ThrowIfNull(value);
+            return source.IndexOf(value, comparisonType) >= 0;
+        }
+
+        /// <summary>
+        ///  Determines whether this string begins with the specified character.
+        /// </summary>
+        public bool StartsWith(char value) => source.Length > 0 && source[0] == value;
+
+        /// <summary>
+        ///  Determines whether the end of this string matches the specified character.
+        /// </summary>
+        public bool EndsWith(char value) => source.Length > 0 && source[^1] == value;
+
+        /// <summary>
+        ///  Returns the hash code for this string using the specified rules.
+        /// </summary>
+        public int GetHashCode(StringComparison comparisonType) =>
+            ComparerForComparison(comparisonType).GetHashCode(source);
+
+        /// <summary>
+        ///  Returns a new string in which all occurrences of <paramref name="oldValue"/> in this instance are
+        ///  replaced with <paramref name="newValue"/>, using the provided <paramref name="comparisonType"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   For non-ordinal comparisons, this polyfill advances by <paramref name="oldValue"/>'s
+        ///   character length per match. Locales whose collation maps a single search character
+        ///   to a multi-character match (rare) may differ slightly from the modern BCL.
+        ///  </para>
+        /// </remarks>
+        public string Replace(string oldValue, string? newValue, StringComparison comparisonType)
+        {
+            ArgumentNullException.ThrowIfNull(oldValue);
+            if (oldValue.Length == 0)
+            {
+                throw new ArgumentException("String cannot be of zero length.", nameof(oldValue));
+            }
+
+            // Fast path for ordinal: defer to BCL.
+            if (comparisonType == StringComparison.Ordinal && newValue is not null)
+            {
+                return source.Replace(oldValue, newValue);
+            }
+
+            newValue ??= string.Empty;
+            CompareInfo compareInfo;
+            CompareOptions options;
+            switch (comparisonType)
+            {
+                case StringComparison.CurrentCulture:
+                    compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+                    options = CompareOptions.None;
+                    break;
+                case StringComparison.CurrentCultureIgnoreCase:
+                    compareInfo = CultureInfo.CurrentCulture.CompareInfo;
+                    options = CompareOptions.IgnoreCase;
+                    break;
+                case StringComparison.InvariantCulture:
+                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+                    options = CompareOptions.None;
+                    break;
+                case StringComparison.InvariantCultureIgnoreCase:
+                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+                    options = CompareOptions.IgnoreCase;
+                    break;
+                case StringComparison.Ordinal:
+                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+                    options = CompareOptions.Ordinal;
+                    break;
+                case StringComparison.OrdinalIgnoreCase:
+                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
+                    options = CompareOptions.OrdinalIgnoreCase;
+                    break;
+                default:
+                    throw new ArgumentException("Unsupported comparison.", nameof(comparisonType));
+            }
+
+            ValueStringBuilder builder = new(stackalloc char[256]);
+            builder.EnsureCapacity(source.Length);
+            int start = 0;
+            while (start <= source.Length)
+            {
+                int matchStart = compareInfo.IndexOf(source, oldValue, start, source.Length - start, options);
+                if (matchStart < 0)
+                {
+                    builder.Append(source.AsSpan(start, source.Length - start));
+                    break;
+                }
+
+                builder.Append(source.AsSpan(start, matchStart - start));
+                builder.Append(newValue);
+                start = matchStart + oldValue.Length;
+            }
+
+            return builder.ToStringAndDispose();
+        }
+
+        /// <summary>
+        ///  Replaces all newline sequences in this string with <see cref="Environment.NewLine"/>.
+        /// </summary>
+        public string ReplaceLineEndings() => source.ReplaceLineEndings(Environment.NewLine);
+
+        /// <summary>
+        ///  Replaces all newline sequences in this string with <paramref name="replacementText"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The recognized line endings are LF (<c>\n</c>), CR (<c>\r</c>), CRLF (<c>\r\n</c>),
+        ///   FF (<c>\u000C</c>), NEL (<c>\u0085</c>), LS (<c>\u2028</c>), and PS (<c>\u2029</c>).
+        ///  </para>
+        /// </remarks>
+        public string ReplaceLineEndings(string replacementText)
+        {
+            ArgumentNullException.ThrowIfNull(replacementText);
+
+            // Quick scan to see if any line ending is present.
+            int firstIndex = IndexOfLineEnding(source.AsSpan());
+            if (firstIndex < 0)
+            {
+                return source;
+            }
+
+            ValueStringBuilder builder = new(stackalloc char[256]);
+            builder.EnsureCapacity(source.Length);
+            builder.Append(source.AsSpan(0, firstIndex));
+            int i = firstIndex;
+            while (i < source.Length)
+            {
+                char c = source[i];
+                if (IsLineEnding(c))
+                {
+                    builder.Append(replacementText);
+                    // Treat CRLF as a single line ending.
+                    if (c == '\r' && i + 1 < source.Length && source[i + 1] == '\n')
+                    {
+                        i += 2;
+                    }
+                    else
+                    {
+                        i++;
+                    }
+                }
+                else
+                {
+                    builder.Append(c);
+                    i++;
+                }
+            }
+
+            return builder.ToStringAndDispose();
+        }
+
+        /// <summary>
+        ///  Splits this string into substrings based on a single character separator.
+        /// </summary>
+        public string[] Split(char separator, StringSplitOptions options = StringSplitOptions.None) =>
+            source.Split([separator], options);
+
+        /// <summary>
+        ///  Splits this string into a maximum of <paramref name="count"/> substrings using a single character separator.
+        /// </summary>
+        public string[] Split(char separator, int count, StringSplitOptions options = StringSplitOptions.None) =>
+            source.Split([separator], count, options);
+
+        /// <summary>
+        ///  Splits this string into substrings based on a string separator.
+        /// </summary>
+        public string[] Split(string? separator, StringSplitOptions options = StringSplitOptions.None)
+        {
+            // Match modern BCL: a null separator yields the source unchanged (does NOT fall back to whitespace).
+            if (separator is null)
+            {
+                return [source];
+            }
+
+            return source.Split([separator], options);
+        }
+
+        /// <summary>
+        ///  Splits this string into a maximum of <paramref name="count"/> substrings based on a string separator.
+        /// </summary>
+        public string[] Split(string? separator, int count, StringSplitOptions options = StringSplitOptions.None)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+            if (count == 0 || source.Length == 0)
+            {
+                return count == 0 ? [] : [source];
+            }
+
+            if (separator is null)
+            {
+                return [source];
+            }
+
+            return source.Split([separator], count, options);
+        }
     }
+
+    private static bool IsLineEnding(char c) =>
+        c is '\n' or '\r' or '\f' or '\u0085' or '\u2028' or '\u2029';
+
+    private static int IndexOfLineEnding(ReadOnlySpan<char> span)
+    {
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (IsLineEnding(span[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static StringComparer ComparerForComparison(StringComparison comparisonType) => comparisonType switch
+    {
+        StringComparison.CurrentCulture => StringComparer.CurrentCulture,
+        StringComparison.CurrentCultureIgnoreCase => StringComparer.CurrentCultureIgnoreCase,
+        StringComparison.InvariantCulture => StringComparer.InvariantCulture,
+        StringComparison.InvariantCultureIgnoreCase => StringComparer.InvariantCultureIgnoreCase,
+        StringComparison.Ordinal => StringComparer.Ordinal,
+        StringComparison.OrdinalIgnoreCase => StringComparer.OrdinalIgnoreCase,
+        _ => throw new ArgumentException("Unsupported comparison.", nameof(comparisonType))
+    };
 }

--- a/touki/Framework/Polyfills/System/StringExtensions.cs
+++ b/touki/Framework/Polyfills/System/StringExtensions.cs
@@ -144,8 +144,12 @@ public static class StringExtensions
         ///  Returns a value indicating whether a specified character occurs within this string,
         ///  using the specified comparison rules.
         /// </summary>
-        public bool Contains(char value, StringComparison comparisonType) =>
-            source.IndexOf(value.ToString(), comparisonType) >= 0;
+        public bool Contains(char value, StringComparison comparisonType)
+        {
+            // Avoid the per-call 1-character string allocation by going straight through CompareInfo.
+            (CompareInfo info, CompareOptions options) = ComparisonToCompareInfo(comparisonType);
+            return info.IndexOf(source, value, 0, source.Length, options) >= 0;
+        }
 
         /// <summary>
         ///  Returns a value indicating whether a specified substring occurs within this string,
@@ -192,48 +196,27 @@ public static class StringExtensions
                 throw new ArgumentException("String cannot be of zero length.", nameof(oldValue));
             }
 
-            // Fast path for ordinal: defer to BCL.
-            if (comparisonType == StringComparison.Ordinal && newValue is not null)
+            // Fast path for ordinal: defer to BCL. The BCL treats null newValue as empty.
+            if (comparisonType == StringComparison.Ordinal)
             {
-                return source.Replace(oldValue, newValue);
+                return source.Replace(oldValue, newValue ?? string.Empty);
             }
 
             newValue ??= string.Empty;
-            CompareInfo compareInfo;
-            CompareOptions options;
-            switch (comparisonType)
+            (CompareInfo compareInfo, CompareOptions options) = ComparisonToCompareInfo(comparisonType);
+
+            // Early-exit: if no match exists at all, return source unchanged so we don't allocate a builder.
+            int firstMatch = compareInfo.IndexOf(source, oldValue, 0, source.Length, options);
+            if (firstMatch < 0)
             {
-                case StringComparison.CurrentCulture:
-                    compareInfo = CultureInfo.CurrentCulture.CompareInfo;
-                    options = CompareOptions.None;
-                    break;
-                case StringComparison.CurrentCultureIgnoreCase:
-                    compareInfo = CultureInfo.CurrentCulture.CompareInfo;
-                    options = CompareOptions.IgnoreCase;
-                    break;
-                case StringComparison.InvariantCulture:
-                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-                    options = CompareOptions.None;
-                    break;
-                case StringComparison.InvariantCultureIgnoreCase:
-                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-                    options = CompareOptions.IgnoreCase;
-                    break;
-                case StringComparison.Ordinal:
-                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-                    options = CompareOptions.Ordinal;
-                    break;
-                case StringComparison.OrdinalIgnoreCase:
-                    compareInfo = CultureInfo.InvariantCulture.CompareInfo;
-                    options = CompareOptions.OrdinalIgnoreCase;
-                    break;
-                default:
-                    throw new ArgumentException("Unsupported comparison.", nameof(comparisonType));
+                return source;
             }
 
             ValueStringBuilder builder = new(stackalloc char[256]);
             builder.EnsureCapacity(source.Length);
-            int start = 0;
+            builder.Append(source.AsSpan(0, firstMatch));
+            builder.Append(newValue);
+            int start = firstMatch + oldValue.Length;
             while (start <= source.Length)
             {
                 int matchStart = compareInfo.IndexOf(source, oldValue, start, source.Length - start, options);
@@ -377,6 +360,17 @@ public static class StringExtensions
         StringComparison.InvariantCultureIgnoreCase => StringComparer.InvariantCultureIgnoreCase,
         StringComparison.Ordinal => StringComparer.Ordinal,
         StringComparison.OrdinalIgnoreCase => StringComparer.OrdinalIgnoreCase,
+        _ => throw new ArgumentException("Unsupported comparison.", nameof(comparisonType))
+    };
+
+    private static (CompareInfo Info, CompareOptions Options) ComparisonToCompareInfo(StringComparison comparisonType) => comparisonType switch
+    {
+        StringComparison.CurrentCulture => (CultureInfo.CurrentCulture.CompareInfo, CompareOptions.None),
+        StringComparison.CurrentCultureIgnoreCase => (CultureInfo.CurrentCulture.CompareInfo, CompareOptions.IgnoreCase),
+        StringComparison.InvariantCulture => (CultureInfo.InvariantCulture.CompareInfo, CompareOptions.None),
+        StringComparison.InvariantCultureIgnoreCase => (CultureInfo.InvariantCulture.CompareInfo, CompareOptions.IgnoreCase),
+        StringComparison.Ordinal => (CultureInfo.InvariantCulture.CompareInfo, CompareOptions.Ordinal),
+        StringComparison.OrdinalIgnoreCase => (CultureInfo.InvariantCulture.CompareInfo, CompareOptions.OrdinalIgnoreCase),
         _ => throw new ArgumentException("Unsupported comparison.", nameof(comparisonType))
     };
 }


### PR DESCRIPTION
Polyfills .NET Core / .NET 6+ APIs on `string`, `Convert`, and `Array` for the net472 target.

## `String` ([StringExtensions.cs](touki/Framework/Polyfills/System/StringExtensions.cs))

Extension members on `string`:

- **netcoreapp2.0**: `GetHashCode(StringComparison)`, `Replace(string, string?, StringComparison)`, `Split(char[, int], StringSplitOptions)`, `Split(string?[, int], StringSplitOptions)`, `StartsWith(char)`, `EndsWith(char)`
- **netcoreapp2.1**: `Contains(char)`, `Contains(char, StringComparison)`, `Contains(string, StringComparison)`
- **net6.0**: `TryCopyTo(Span<char>)`, `ReplaceLineEndings()`, `ReplaceLineEndings(string)`

`Replace(…, StringComparison)` and `ReplaceLineEndings(string)` use `ValueStringBuilder` with `stackalloc char[256]` plus `EnsureCapacity(source.Length)`, so short strings stay on the stack and longer strings allocate a single right-sized pooled buffer up front.

`ReplaceLineEndings` recognizes LF/CR/CRLF/FF/NEL/LS/PS to match the modern BCL exactly (no `\v`).

`Split(string?, …)` returns `[source]` when the separator is null - the .NET Framework `Split((string[])null, …)` falls back to whitespace splitting, which differs from modern BCL semantics; the polyfill matches modern.

## `Convert` ([ConvertExtensions.cs](touki/Framework/Polyfills/System/ConvertExtensions.cs))

Extension members on `Convert`, all netcoreapp2.1:

- `ToBase64String(ReadOnlySpan<byte>)`, `ToBase64String(ReadOnlySpan<byte>, Base64FormattingOptions)`
- `TryToBase64Chars(ReadOnlySpan<byte>, Span<char>, out int [, Base64FormattingOptions])`
- `TryFromBase64Chars(ReadOnlySpan<char>, Span<byte>, out int)`
- `TryFromBase64String(string, Span<byte>, out int)`

Implementation goes through the existing BCL `Convert.ToBase64String(byte[], int, int, options)` / `FromBase64CharArray` via a single rented `byte[]` copy of the input span.

## `Array` ([ArrayExtensions.cs](touki/Framework/Polyfills/System/ArrayExtensions.cs))

netcoreapp2.0 surface:

- `Array.Fill<T>(T[], T)`, `Array.Fill<T>(T[], T, int, int)`

## Tests

Three new files in `namespace System.Tests`, mirroring `dotnet/runtime` negative-case patterns:

- [`StringExtensionsPolyfillTests`](touki.tests/System/StringExtensionsPolyfillTests.cs) - empty/null arguments, invalid `StringComparison`, count-zero/negative for `Split`, all 7 line-ending characters + CRLF-as-single-ending + lone-CR-not-misinterpreted, `ReplaceLineEndings` long input that exceeds the stack buffer (forces grow path), exact-fit destination for `TryCopyTo`, adjacent-match handling for `Replace`.
- [`ConvertBase64PolyfillTests`](touki.tests/System/ConvertBase64PolyfillTests.cs) - empty inputs, exact-fit destination, non-Base64 char rejection, bad-padding rejection, three known padding boundaries (1/2/3 bytes), span-encode byte-identical to BCL byte-array encode, `InsertLineBreaks` formatting.
- [`ArrayExtensionsTests`](touki.tests/System/ArrayExtensionsTests.cs) - null array, negative count/start, start at length with zero count vs non-zero, reference-type assignment + null-value-allowed.

Tests run on both target frameworks: `net10.0` (BCL) and `net481` (polyfill). `dotnet test -c Release` passes 3767 net10.0 / 3955 net481, 0 failures.