### PR TITLE
Switch test coverage tool to Microsoft.Testing.Extensions.CodeCoverage

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="coverlet.collector" Version="8.0.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <!-- Referencing our own package for the sample project to document consumption. -->
     <PackageVersion Include="KlutzyNinja.Touki" Version="0.1.0-alpha.8.11" />
@@ -14,6 +13,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.248" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />

--- a/touki.tests/touki.tests.csproj
+++ b/touki.tests/touki.tests.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="Microsoft.Build" />
-    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
 

--- a/touki.tests/touki.tests.csproj
+++ b/touki.tests/touki.tests.csproj
@@ -43,11 +43,8 @@
 
   <ItemGroup>
     <PackageReference Include="AwesomeAssertions" />
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Build" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
 


### PR DESCRIPTION
First step in the code-coverage rollout (see plan in chat).

## What

Replace `coverlet.collector` with `Microsoft.Testing.Extensions.CodeCoverage` (17.14.2) in `touki.tests`.

## Why

`touki.tests` runs under the Microsoft Testing Platform (`UseMicrosoftTestingPlatformRunner=true`). `coverlet.collector` is a **VSTest data collector** and is silently inert under MTP &mdash; it's been referenced but doing nothing. `Microsoft.Testing.Extensions.CodeCoverage` is the first-party MTP equivalent and registers automatically via the platform's builder-hook mechanism.

## How to use it

```pwsh
dotnet test touki.tests/touki.tests.csproj -c Release --no-build `
  -- --coverage --coverage-output-format cobertura
```

Cobertura reports land at `artifacts/x64/Release/touki.tests/<tfm>/TestResults/<guid>.cobertura.xml` per TFM.

## Baseline numbers (from local run, both TFMs)

| TFM | Lines | Branches |
|---|---|---|
| `net10.0` | 89.33% (2729 / 3055) | 85.50% (1462 / 1710) |
| `net481` | 76.10% (7232 / 9503) | 69.86% (3621 / 5183) |

The `net481` total has ~3&times; more lines than `net10.0` because `touki/Framework/**` (polyfills + Framework-only code) is only compiled into the net481 build &mdash; a single merged number would mask the gap.

## Follow-ups (separate PRs)

1. CI integration: wire `--coverage` into [.github/workflows/dotnet.yml](https://github.com/JeremyKuhne/touki/blob/main/.github/workflows/dotnet.yml), add ReportGenerator + Codecov upload, settle on per-TFM Codecov flags.
2. Authoring guidance: section in [AGENTS.md](https://github.com/JeremyKuhne/touki/blob/main/AGENTS.md) + a `tests.instructions.md` path-specific instruction, plus a coverage checkbox in the [pre-pr-self-review](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/pre-pr-self-review/SKILL.md) skill.
3. Triage `[ExcludeFromCodeCoverage]` for diagnostic-only types (`Touki.Debugging`, `Touki.DisposalTracking`, `Debug.Assert` interpolated handlers) and target tests at the entirely-uncovered public surface (`HebrewNumber`, `WaitHandleExtensions`, `CustomAttributeExtensions`, `ArrayList<T>`, `UnsafeExtensions`).