### PR TITLE
Collect and publish code coverage in CI

### DIFF
--- a/.config/coverage.settings.xml
+++ b/.config/coverage.settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*touki\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <ModulePath>.*touki\.tests\.dll$</ModulePath>
+        <ModulePath>.*touki\.testsupport\.dll$</ModulePath>
+        <ModulePath>.*touki\.perf\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+  </CodeCoverage>
+</Configuration>

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,10 +55,23 @@ jobs:
     - name: Generate coverage report
       if: always()
       run: |
-        dotnet tool install -g dotnet-reportgenerator-globaltool
-        $reports = Get-ChildItem -Path artifacts -Recurse -Filter '*.cobertura.xml' |
-          ForEach-Object { $_.FullName }
-        if (-not $reports) {
+        $reportGeneratorVersion = '5.5.9'
+        if (dotnet tool list -g | Select-String -SimpleMatch 'dotnet-reportgenerator-globaltool') {
+          dotnet tool update -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        }
+        else {
+          dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        }
+
+        if (-not (Test-Path artifacts)) {
+          Write-Warning 'No artifacts directory found; skipping report generation.'
+          exit 0
+        }
+        $reports = @(
+          Get-ChildItem -Path artifacts -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName }
+        )
+        if ($reports.Count -eq 0) {
           Write-Warning 'No cobertura reports found; skipping report generation.'
           exit 0
         }

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -48,7 +48,47 @@ jobs:
           -- `
           --results-directory "$resultsDir" `
           --report-xunit-trx `
-          --show-live-output on
+          --show-live-output on `
+          --coverage `
+          --coverage-output-format cobertura `
+          --coverage-settings "$PWD/.config/coverage.settings.xml"
+    - name: Generate coverage report
+      if: always()
+      run: |
+        dotnet tool install -g dotnet-reportgenerator-globaltool
+        $reports = Get-ChildItem -Path artifacts -Recurse -Filter '*.cobertura.xml' |
+          ForEach-Object { $_.FullName }
+        if (-not $reports) {
+          Write-Warning 'No cobertura reports found; skipping report generation.'
+          exit 0
+        }
+        $reportsArg = ($reports -join ';')
+        New-Item -ItemType Directory -Force -Path artifacts/coverage | Out-Null
+        reportgenerator `
+          "-reports:$reportsArg" `
+          -targetdir:artifacts/coverage `
+          -reporttypes:'Cobertura;HtmlInline;MarkdownSummaryGithub' `
+          -title:'touki'
+        if (Test-Path artifacts/coverage/SummaryGithub.md) {
+          Get-Content artifacts/coverage/SummaryGithub.md |
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY
+        }
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: artifacts/coverage
+        if-no-files-found: warn
+        retention-days: 14
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@v5
+      with:
+        files: artifacts/coverage/Cobertura.xml
+        fail_ci_if_error: false
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload raw logs
       if: always()
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,8 @@ _TeamCity*
 coverage*.json
 coverage*.xml
 coverage*.info
+# But keep the dotnet-coverage settings file checked in
+!.config/coverage.settings.xml
 
 # Visual Studio code coverage results
 *.coverage

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,34 @@
+# Codecov configuration. Lenient initial settings while we establish a
+# baseline; tighten once a few PRs have run through CI and we know the
+# uploaded number is stable.
+#
+# Reference: https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...90"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Treat the merged report from CI as the single source of truth. Per-TFM
+# uploads can be re-enabled later with separate flags once the workflow is
+# proven stable.
+ignore:
+  - "touki.tests/**"
+  - "touki.testsupport/**"
+  - "touki.perf/**"
+  - "sample/**"
+  - "**/*.g.cs"


### PR DESCRIPTION
Second step in the code-coverage rollout (follows #118).

## What

Wire `Microsoft.Testing.Extensions.CodeCoverage` into the `.NET` CI workflow and publish results.

## Changes

- [.github/workflows/dotnet.yml](https://github.com/JeremyKuhne/touki/blob/main/.github/workflows/dotnet.yml) &mdash; the existing **Test release** step now passes `--coverage --coverage-output-format cobertura --coverage-settings .config/coverage.settings.xml`, producing one cobertura report per TFM. New steps follow:
  - **Generate coverage report**: installs `dotnet-reportgenerator-globaltool`, merges all cobertura outputs into `artifacts/coverage/`, and appends the markdown summary to the GitHub Actions **step summary** (visible directly on the run page).
  - **Upload coverage report**: stores the merged HTML/Cobertura/Markdown as a `coverage-report` build artifact (14-day retention).
  - **Upload coverage to Codecov**: uploads the merged `Cobertura.xml` via `codecov/codecov-action@v5` with `fail_ci_if_error: false` and an optional `CODECOV_TOKEN` secret.
- `.config/coverage.settings.xml` &mdash; `dotnet-coverage` settings (now checked in; previously matched by the `coverage*.xml` ignore rule). Includes `touki.dll`, excludes test/perf/support assemblies, excludes `[ExcludeFromCodeCoverage]` and `[GeneratedCode]`.
- `.gitignore` &mdash; un-ignore that one file.
- `codecov.yml` &mdash; **deliberately lenient** initial settings:
  - Project status: `target: auto`, `threshold: 5%`, `informational: true`
  - Patch status: `informational: true`
  - Ignores `touki.tests/**`, `touki.testsupport/**`, `touki.perf/**`, `sample/**`, `**/*.g.cs`

  Both statuses are informational, so a coverage drop will be reported but **will not block PRs**. The plan is to tighten these once a few PRs have run through CI and we know the uploaded number is stable.

## Notes

- All new steps use `if: always()` so a coverage step glitch can't mask a real test failure.
- The Codecov action is tokenless-friendly for public repos, but a `CODECOV_TOKEN` repository secret should be added to make uploads reliable. Without it the upload step will warn and continue (still won't fail CI).
- The "Test" (Debug) step is intentionally left alone &mdash; coverage runs Release-only to match the project's own guidance about Release-mode inlining surfacing real bugs.

## Smoke test (local)

Reproduces the CI command exactly:

```pwsh
dotnet test -c Release --no-build -p:TestingPlatformCaptureOutput=false `
  -- --results-directory artifacts/test-results/release `
     --report-xunit-trx --show-live-output on `
     --coverage --coverage-output-format cobertura `
     --coverage-settings $PWD/.config/coverage.settings.xml
```

Both TFMs pass; cobertura reports emit; ReportGenerator produces the merged `Cobertura.xml`, `index.html`, and `SummaryGithub.md`.

## Follow-ups (separate PRs)

1. Authoring guidance: section in [AGENTS.md](https://github.com/JeremyKuhne/touki/blob/main/AGENTS.md) + a `tests.instructions.md` path-specific instruction, plus a coverage checkbox in the [pre-pr-self-review](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/pre-pr-self-review/SKILL.md) skill.
2. Triage `[ExcludeFromCodeCoverage]` for diagnostic-only types and target tests at the entirely-uncovered public surface (see PR #118 for the list).
3. Tighten the Codecov gates once we have a stable baseline.