### PR TITLE
Add Codecov badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ﻿# Touki (登器): Code for .NET and .NET Framework
 
 [![Build](https://github.com/JeremyKuhne/touki/actions/workflows/dotnet.yml/badge.svg)](https://github.com/JeremyKuhne/touki/actions/workflows/dotnet.yml)
+[![codecov](https://codecov.io/gh/JeremyKuhne/touki/branch/main/graph/badge.svg)](https://codecov.io/gh/JeremyKuhne/touki)
 [![NuGet](https://img.shields.io/nuget/v/KlutzyNinja.Touki.svg)](https://www.nuget.org/packages/KlutzyNinja.Touki/)
 
 Provides useful functionality both for .NET and .NET Framework applications.


### PR DESCRIPTION
Adds a Codecov badge next to the existing Build and NuGet badges in [README.md](https://github.com/JeremyKuhne/touki/blob/main/README.md).

## Why this PR exists

The badge is genuinely useful, but the primary purpose is to **validate the Codecov integration end-to-end** on a PR.

After merge of #119, the merge-to-`main` upload succeeded (commit `95b4e89`, dashboard registered 72.57% across both TFMs). What's still untested is the **per-PR experience** that Phase B will eventually gate on:

- The Codecov bot's PR comment.
- The `codecov/project` status check (currently `informational: true`).
- The `codecov/patch` status check (currently `informational: true`).
- The merged Cobertura comparison against `main`.

This README-only PR has no code under coverage, so:

- `codecov/patch` should report "no relevant changes" or pass with no patch.
- `codecov/project` should be near-zero delta vs. `main`.
- The bot comment should appear on the PR.

If those three things show up, Phase A is fully validated and we're ready for Phase B (tightening the gates) whenever the user wants.