### PR TITLE
Tighten Codecov gates (project/patch, fail_ci_if_error)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -99,7 +99,7 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         files: artifacts/coverage/Cobertura.xml
-        fail_ci_if_error: false
+        fail_ci_if_error: true
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload raw logs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,9 @@
-# Codecov configuration. Lenient initial settings while we establish a
-# baseline; tighten once a few PRs have run through CI and we know the
-# uploaded number is stable.
+# Codecov configuration. Initial gates after a stable baseline was confirmed:
+#   - project: auto target with a 1%% threshold (tolerate small drops on noisy PRs)
+#   - patch:   80%% of changed lines must be covered
+#
+# Both statuses are now blocking (informational removed). Adjust here when the
+# floor needs to be ratcheted up or down.
 #
 # Reference: https://docs.codecov.com/docs/codecovyml-reference
 
@@ -12,11 +15,11 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 5%
-        informational: true
+        threshold: 1%
     patch:
       default:
-        informational: true
+        target: 80%
+        threshold: 0%
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
-# Codecov configuration. Initial gates after a stable baseline was confirmed:
-#   - project: auto target with a 1%% threshold (tolerate small drops on noisy PRs)
-#   - patch:   80%% of changed lines must be covered
+# Codecov configuration. Initial gates after a stable baseline has been confirmed:
+#   - project: auto target with a 1% threshold (tolerate small drops on noisy PRs)
+#   - patch:   80% of changed lines must be covered
 #
 # Both statuses are now blocking (informational removed). Adjust here when the
 # floor needs to be ratcheted up or down.


### PR DESCRIPTION
Phase B of the code-coverage rollout (follows #118, #119, #120).

## What

Turn the Codecov gates from informational to blocking, now that the integration is fully validated.

| | Before | After |
|---|---|---|
| `codecov/project` | `informational: true`, threshold 5% | `target: auto`, threshold **1%** |
| `codecov/patch` | `informational: true` | `target: 80%`, threshold 0% |
| Codecov upload | `fail_ci_if_error: false` | `fail_ci_if_error: true` |

## Why now

Phase A is fully validated:

- `main` upload at `95b4e89` succeeded (dashboard shows 72.57% merged across both TFMs).
- PR #120 exercised the per-PR path end-to-end: Codecov bot comment + both status checks reported as expected.
- The `CODECOV_TOKEN` secret is set, so uploads are reliable.

This means we can safely flip `fail_ci_if_error: true` (a broken upload now fails CI instead of going unnoticed), and we can remove `informational: true` so the existing checks finally express a real opinion.

## Target rationale

- **`project: auto`, threshold `1%`** &mdash; the merged number can drop by up to 1 percentage point on any PR before complaining. Big enough to absorb refactors and noise; small enough to catch real regressions.
- **`patch: 80%`** &mdash; new/changed lines must be 80% covered. Standard floor; it forces new public APIs to ship with tests without retroactively penalizing existing low-coverage code (which is what the project status is for).

If 80% on patch turns out to be annoying for the codebase's mix of polyfills + format code, dialing it back to 70% is a one-line follow-up.

## What this PR does *not* do

It does **not** add the checks to branch protection. They have to report on at least one PR before GitHub's branch-protection picker will list them by name. Sequence:

1. This PR runs through CI &mdash; `codecov/project` and `codecov/patch` will report against the new (real) targets.
2. After merge, in **Settings &rarr; Branches &rarr; `main` &rarr; Require status checks to pass before merging**, add:
   - `.NET / build`
   - `codecov/project`
   - `codecov/patch`
3. Smoke test by opening a deliberately under-covered PR and confirming the merge button is blocked.

## Self-validation on this PR

This PR itself touches only YAML config &mdash; no `.cs` lines change. So:

- `codecov/patch` should report **no relevant changes / pass** (no patch surface).
- `codecov/project` should be near-zero delta vs. `main`.

If either reports red on this PR, that's a config bug to fix here before merging.