### PR TITLE
Tighten the publish-approval rule across agent files

### DIFF
--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -6,12 +6,15 @@ description: Address feedback on an existing pull request &mdash; review comment
 # Address PR feedback
 
 This skill is the post-PR counterpart to [`create-pr`](../create-pr/SKILL.md).
-The crucial difference between the two:
+Both skills share the **same** publish gate: neither `git commit` nor
+`git push` runs without an explicit publishing verb from the user. The
+difference is what each skill authorizes you to *edit*:
 
-- In `create-pr` the user asked you to publish work, so the request itself
-  authorizes the push at the end of the workflow.
-- In this skill the user asked you to *respond to feedback*. That
-  authorizes editing files and **nothing more**.
+- `create-pr` authorizes preparing a new PR from in-progress work —
+  branching, staging, proposing a commit message. The commit and push
+  still wait on approval.
+- This skill authorizes editing files in response to review feedback or
+  CI failures on an existing PR. Same approval gate before commit/push.
 
 The
 ["Working with the user on changes"](../../../AGENTS.md#working-with-the-user-on-changes)

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -25,23 +25,26 @@ Skim the most recent user message for an explicit publishing verb before
 you stage, commit, or push. Pattern-match the words, do not infer intent.
 
 **Approval** &mdash; verbs that authorize publishing the current change:
-`commit`, `push`, `update the PR`, `ship it`, `go ahead`, `send it`, or
-direct synonyms in context.
+`commit`, `push`, `update the PR`, `ship it`, `send it`, `yes push`, or
+direct synonyms when paired with a publishing intent.
 
 **Not approval** &mdash; everything else, including these phrasings that
 have caused violations on this repo:
 
 - "Address the review comments."
+- "Reply to the comments on the PR."
 - "Fix the comments / fix the CI failure."
 - "Look at Copilot's feedback / see what they said."
 - "See what you can do about this."
 - "Try a different approach."
 - "What about &lt;suggestion&gt;?"
+- "Do the next step" / "finish the rollout" / "go ahead to the next
+  thing" / a bare "go ahead" attached to a task description.
 - A reviewer (human or Copilot) leaving a new comment.
 - A failing check on the PR.
 
 If you are uncertain whether a phrase is approval, **it is not approval**.
-Stop and ask.
+Stop and ask one short yes/no question.
 
 ## Workflow
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -11,11 +11,11 @@ confirmation.
 
 **Approval scope.** A request to "open / make / create a PR" authorizes the
 *work* of preparing one. It does **not** authorize the commit or the push.
-Stop after step 3 (with changes staged but not committed) and wait for an
-explicit publishing verb &mdash; `commit`, `push`, `ship it`, or equivalent
-&mdash; before performing steps 4 and onward. See AGENTS.md § "Working with
-the user on changes" for the canonical rule and the recurring
-not-approval phrasings.
+The **Approval checkpoint** inside step 3 (Commit changes) is the gate:
+staging happens before it, `git commit` and everything after happen only
+once the user supplies an explicit publishing verb &mdash; `commit`, `push`,
+`ship it`, or equivalent. See AGENTS.md § "Working with the user on
+changes" for the canonical rule and the recurring not-approval phrasings.
 
 Before running this workflow, walk through the
 [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist &mdash; it

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -9,6 +9,14 @@ Follow these steps in order. Stop and ask the user if any check is ambiguous;
 do not force-push, rewrite history, or delete branches without explicit
 confirmation.
 
+**Approval scope.** A request to "open / make / create a PR" authorizes the
+*work* of preparing one. It does **not** authorize the commit or the push.
+Stop after step 3 (with changes staged but not committed) and wait for an
+explicit publishing verb &mdash; `commit`, `push`, `ship it`, or equivalent
+&mdash; before performing steps 4 and onward. See AGENTS.md § "Working with
+the user on changes" for the canonical rule and the recurring
+not-approval phrasings.
+
 Before running this workflow, walk through the
 [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist &mdash; it
 catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
@@ -62,6 +70,15 @@ Decide the PR base:
   commits (`git log --oneline -20`).
 - Do not amend or rebase published commits without explicit user approval.
 - Do not pass `--no-verify`; let hooks run.
+
+### Approval checkpoint
+
+**Stop here.** Show the user the staged diff (or summarize it) and the
+proposed commit message. Wait for an explicit publishing verb before
+running `git commit`. If the user already said "commit" / "push" /
+"ship it" in the message that triggered this skill, that is sufficient;
+otherwise ask. Do not infer approval from the original "open a PR"
+request.
 
 ## 4. Push the branch
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -133,14 +133,26 @@ Top-level layout:
 These rules exist because they have been violated and cost a review round-trip.
 Treat them as hard requirements.
 
-- **Never `git commit` or `git push` without explicit user approval, period.**
-  This applies to: fixing a failing build/test/CI run, addressing PR review
-  comments, follow-up cleanup, "obvious" small changes, and anything else.
-  After making changes, describe what you did and stop. Wait for the user
-  to say "commit", "push", "ship it", or equivalent. "Address the review
-  comments" is **not** approval to commit or push &mdash; it is approval to
-  edit files. Do not stack follow-up commits trying to "make CI green" or
-  "finish the review pass".
+- **Never `git commit` or `git push` without explicit user approval, every
+  time.** No exceptions. This applies to: opening the initial PR, fixing a
+  failing build/test/CI run, addressing PR review comments, follow-up
+  cleanup, "obvious" small changes, and anything else. After making
+  changes, describe what you did and stop. Wait for the user to say
+  "commit", "push", "ship it", or an equivalent **publishing verb**.
+
+  Phrasings that are **not** approval (recurring violations on this repo):
+  - "open a PR" / "make a PR" / "create the PR" &mdash; these authorize the
+    work, not the publish. Stage and propose a commit message, then stop.
+  - "address the review comments" / "fix the comments" / "reply to the
+    comments" &mdash; edit-only.
+  - "do the next step" / "finish the rollout" / "go ahead to the next
+    thing" / a bare "go ahead" attached to a task description &mdash;
+    selects which task to work on, not whether to publish it.
+  - "fix the CI failure" &mdash; edit-only.
+
+  When in doubt, it is **not** approval. Ask one short yes/no question.
+  Do not stack follow-up commits trying to "make CI green" or "finish
+  the review pass".
 - **Stage by path, never `git add -A`/`git add .`** when the working tree spans
   more than one logical change set. Run `git status --short` first; if topics
   are intermingled, ask how to split before staging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,14 +132,26 @@ Top-level layout:
 These rules exist because they have been violated and cost a review round-trip.
 Treat them as hard requirements.
 
-- **Never `git commit` or `git push` without explicit user approval, period.**
-  This applies to: fixing a failing build/test/CI run, addressing PR review
-  comments, follow-up cleanup, "obvious" small changes, and anything else.
-  After making changes, describe what you did and stop. Wait for the user
-  to say "commit", "push", "ship it", or equivalent. "Address the review
-  comments" is **not** approval to commit or push &mdash; it is approval to
-  edit files. Do not stack follow-up commits trying to "make CI green" or
-  "finish the review pass".
+- **Never `git commit` or `git push` without explicit user approval, every
+  time.** No exceptions. This applies to: opening the initial PR, fixing a
+  failing build/test/CI run, addressing PR review comments, follow-up
+  cleanup, "obvious" small changes, and anything else. After making
+  changes, describe what you did and stop. Wait for the user to say
+  "commit", "push", "ship it", or an equivalent **publishing verb**.
+
+  Phrasings that are **not** approval (recurring violations on this repo):
+  - "open a PR" / "make a PR" / "create the PR" &mdash; these authorize the
+    work, not the publish. Stage and propose a commit message, then stop.
+  - "address the review comments" / "fix the comments" / "reply to the
+    comments" &mdash; edit-only.
+  - "do the next step" / "finish the rollout" / "go ahead to the next
+    thing" / a bare "go ahead" attached to a task description &mdash;
+    selects which task to work on, not whether to publish it.
+  - "fix the CI failure" &mdash; edit-only.
+
+  When in doubt, it is **not** approval. Ask one short yes/no question.
+  Do not stack follow-up commits trying to "make CI green" or "finish
+  the review pass".
 - **Stage by path, never `git add -A`/`git add .`** when the working tree spans
   more than one logical change set. Run `git status --short` first; if topics
   are intermingled, ask how to split before staging.


### PR DESCRIPTION
## What

Codify the strict version of the publish-approval rule that has been violated repeatedly. A request to "open a PR", "make a PR", "do the next step", or "go ahead to the next thing" authorizes the *work*, not the publish. The agent must stage changes and propose a commit message, then **stop** and wait for an explicit publishing verb (`commit` / `push` / `ship it` / `send it`) before running `git commit` or `git push`.

## Why

This rollout shipped four PRs (#118, #119, #120, #121). On each of them the agent committed and pushed without explicit approval, treating "let's finish integrating code coverage", "reply to the comments on the PR", and "go ahead to the next step" as authorization. The previous wording in [AGENTS.md](https://github.com/JeremyKuhne/touki/blob/main/AGENTS.md) said "address the review comments is not approval" but didn't enumerate the broader pattern of task-sequencing phrasings that were also being mis-read.

## Changes

- **[AGENTS.md](https://github.com/JeremyKuhne/touki/blob/main/AGENTS.md)** &mdash; replaced the single-paragraph rule with an explicit table of recurring **not-approval** phrasings observed on this repo:
  - "open a PR" / "make a PR" / "create the PR"
  - "address the review comments" / "fix the comments" / "reply to the comments"
  - "do the next step" / "finish the rollout" / "go ahead to the next thing" / a bare "go ahead" attached to a task description
  - "fix the CI failure"

  Plus the rule "When in doubt, it is **not** approval. Ask one short yes/no question."

- **[.agents/skills/create-pr/SKILL.md](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/create-pr/SKILL.md)** &mdash; added a top-of-file approval-scope note and an explicit **Approval checkpoint** between step&nbsp;3 (stage) and the actual `git commit`. The skill no longer races from "ok, you said create a PR" straight through to push.

- **[.agents/skills/address-pr-feedback/SKILL.md](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/address-pr-feedback/SKILL.md)** &mdash; removed bare "go ahead" from the approval list (it was the exact phrasing that caused the latest violation), added "reply to the comments" and the task-sequencing phrasings to the not-approval list, and softened the approval list to require a *publishing intent* alongside the verb.

- **[.github/copilot-instructions.md](https://github.com/JeremyKuhne/touki/blob/main/.github/copilot-instructions.md)** &mdash; regenerated from AGENTS.md by `tools/Validate-AgentFiles.ps1 -Fix`. No hand edits.

## Behavioral change agents will see

Even when the user says "make a PR for X", the agent now:

1. Branches, edits, runs validation.
2. Stages changes, proposes a commit message.
3. **Stops.** Asks the user to confirm `commit` / `push` / `ship it`.
4. Only then runs `git commit` and `git push`.

This is the strictest interpretation of the rule. It costs one extra round-trip per PR; it removes the ambiguity that has caused four violations in this rollout alone.

## Validation

`pwsh tools/Validate-AgentFiles.ps1` &rarr; `Agent-file validation passed.`