### PR TITLE
Clarity and factual-drift pass on agent customization files

### DIFF
--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -24,8 +24,9 @@ decision-point reminder, not a replacement.
 
 ## Recognizing approval
 
-Skim the most recent user message for an explicit publishing verb before
-you stage, commit, or push. Pattern-match the words, do not infer intent.
+Carefully read the most recent user message and identify whether it
+contains an explicit publishing verb before you stage, commit, or push.
+Pattern-match the words, do not infer intent.
 
 **Approval** &mdash; verbs that authorize publishing the current change:
 `commit`, `push`, `update the PR`, `ship it`, `send it`, `yes push`, or
@@ -34,17 +35,14 @@ direct synonyms when paired with a publishing intent.
 **Not approval** &mdash; everything else, including these phrasings that
 have caused violations on this repo:
 
-- "Address the review comments."
-- "Reply to the comments on the PR."
-- "Fix the comments / fix the CI failure."
+- "Address the review comments." / "Reply to the comments on the PR." /
+  "Fix the comments / fix the CI failure."
 - "Look at Copilot's feedback / see what they said."
-- "See what you can do about this."
-- "Try a different approach."
-- "What about &lt;suggestion&gt;?"
+- "See what you can do about this." / "Try a different approach."
 - "Do the next step" / "finish the rollout" / "go ahead to the next
   thing" / a bare "go ahead" attached to a task description.
-- A reviewer (human or Copilot) leaving a new comment.
-- A failing check on the PR.
+- A reviewer (human or Copilot) leaving a new comment, or a failing
+  check on the PR.
 
 If you are uncertain whether a phrase is approval, **it is not approval**.
 Stop and ask one short yes/no question.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -47,15 +47,10 @@ Decide the PR base:
   branch from the current `HEAD` with a short, descriptive, kebab-case name
   derived from the change (e.g. `fix-span-enumerate-lines`,
   `add-create-pr-skill`).
-- When asking the user to confirm the branch name, use `vscode_askQuestions`
-  with the suggested name as a selectable option **and** allow free-form
-  input so the user can either accept the suggestion with one click or type
-  a different name. Example: a single question whose `options` contains the
-  suggested kebab-case name and whose `allowFreeformInput` is left at the
-  default (`true`). Note that `vscode_askQuestions` requires at least two
-  options or none — when offering a suggestion, pair it with a second
-  option such as `Use a different name` (which the user can ignore in favor
-  of free-form text), or omit `options` entirely and rely on free text.
+- Confirm the branch name with `vscode_askQuestions` before creating it,
+  using the suggested name as one option and free-form text for an override.
+  (`vscode_askQuestions` requires either zero options or two-plus, so pair
+  the suggestion with `Use a different name` or omit `options` entirely.)
 - Use `git switch -c <branch>` to move uncommitted changes onto the new
   branch.
 - If already on a non-`main` branch, keep using it.
@@ -74,11 +69,12 @@ Decide the PR base:
 ### Approval checkpoint
 
 **Stop here.** Show the user the staged diff (or summarize it) and the
-proposed commit message. Wait for an explicit publishing verb before
-running `git commit`. If the user already said "commit" / "push" /
-"ship it" in the message that triggered this skill, that is sufficient;
-otherwise ask. Do not infer approval from the original "open a PR"
-request.
+proposed commit message. Wait for the user to explicitly say `commit`,
+`push`, or `ship it` (or one of the other verbs listed in AGENTS.md
+§ "Working with the user on changes") before running `git commit`. If
+the user already used one of those verbs in the message that triggered
+this skill, proceed without asking again. Do not infer approval from the
+original "open a PR" request.
 
 ## 4. Push the branch
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -47,10 +47,11 @@ Decide the PR base:
   branch from the current `HEAD` with a short, descriptive, kebab-case name
   derived from the change (e.g. `fix-span-enumerate-lines`,
   `add-create-pr-skill`).
-- Confirm the branch name with `vscode_askQuestions` before creating it,
-  using the suggested name as one option and free-form text for an override.
-  (`vscode_askQuestions` requires either zero options or two-plus, so pair
-  the suggestion with `Use a different name` or omit `options` entirely.)
+- Confirm the branch name with `vscode_askQuestions` before creating it.
+  Pass two `options`: the suggested kebab-case name and `Use a different
+  name`. Free-form text is allowed by default, so the user can either
+  click the suggestion or type an override.
+  (`vscode_askQuestions` requires either zero options or two-plus.)
 - Use `git switch -c <branch>` to move uncommitted changes onto the new
   branch.
 - If already on a non-`main` branch, keep using it.

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -55,9 +55,10 @@ Do not re-import these.
 
 ### Required attributes for memory evaluation
 
-Always annotate the class with `[MemoryDiagnoser]` so allocations are reported. This
-adds three columns to the results table: **Gen0 / Gen1 / Gen2** (collections per 1000
-ops) and **Allocated** (bytes per op). Without it you only get timings.
+Always annotate every benchmark class with `[MemoryDiagnoser]`, regardless of
+its purpose. This adds three columns to the results table:
+**Gen0 / Gen1 / Gen2** (collections per 1000 ops) and **Allocated** (bytes
+per op). Without it you only get timings.
 
 ```c#
 [MemoryDiagnoser]
@@ -87,33 +88,26 @@ alternative implementations &mdash; the report adds a **Ratio** and
 
 ### What a benchmark method must do
 
-- **Return a value. ALWAYS. Even when measuring `void`-returning APIs that mutate a
-  buffer.** This is the single most common mistake: writing a `[Benchmark]` method
-  that returns `void` (or returns the same constant every iteration) lets the JIT
-  dead-code-eliminate the entire body, producing meaningless near-zero or wildly
-  inconsistent timings. Per the
-  [BenchmarkDotNet good practices](https://benchmarkdotnet.org/articles/guides/good-practices.html),
-  every benchmark method must produce a value derived from the work performed so the
-  result escapes the method &mdash; BenchmarkDotNet consumes the return value to
-  prevent elimination.
-- For methods that mutate a buffer in place (e.g. `Span<T>.Replace`, `Random.NextBytes`,
-  `Encoding.GetBytes`), return `buffer[0]`, `buffer[buffer.Length - 1]`, or an XOR /
-  sum digest of the buffer &mdash; some value that depends on the work the method
-  actually performed. Do **not** return `void`, do **not** return a constant, and
-  do **not** return `buffer.Length` or any other value the JIT can prove is
-  invariant of the body's execution.
-- Symptoms of forgetting this: the "optimized" variant looks slower than the
-  baseline because the baseline got eliminated entirely; ratios that vary wildly
-  (>50% StdDev) between runs; near-zero timings for non-trivial work.
-- Be cheap to call repeatedly &mdash; BenchmarkDotNet will invoke it millions of times.
+- **Return a value derived from the measured work, even when measuring
+  `void`-returning APIs.** Returning `void` (or a constant the JIT can
+  prove invariant) lets dead-code elimination wipe the body, producing
+  meaningless near-zero or wildly inconsistent timings. BenchmarkDotNet
+  consumes the return value to prevent that. For buffer-mutating APIs
+  (`Span<T>.Replace`, `Random.NextBytes`, `Encoding.GetBytes`) return
+  `buffer[0]`, the last element, or an XOR/sum digest of the buffer
+  &mdash; not `buffer.Length` or any other value invariant of execution.
+  Symptoms of forgetting: "optimized" variants slower than the baseline
+  (because the baseline got eliminated), >50% StdDev between runs,
+  near-zero timings for non-trivial work. See
+  [BenchmarkDotNet good practices](https://benchmarkdotnet.org/articles/guides/good-practices.html).
+- Be cheap to call repeatedly &mdash; BenchmarkDotNet invokes it millions of times.
 - Avoid per-call setup; move setup into `[GlobalSetup]` or readonly fields.
-- Avoid wrapping the system-under-test in a helper method just to satisfy the type
-  system &mdash; the helper's overhead (extra call frame, type check, generic
-  instantiation) shows up in the measurement. If you cannot call the target API
-  directly because of overload resolution, either rename one overload temporarily
-  while measuring, or factor the test into two separate benchmark classes.
-- Ref structs cannot be returned from `[Benchmark]` methods; consume them inside the
-  method and return a representative scalar (e.g. a length or hash).
+- Avoid wrapping the system-under-test in a helper method just to satisfy
+  overload resolution &mdash; the helper's call frame, type check, and
+  generic instantiation show up in the measurement. Either rename one
+  overload temporarily while measuring, or split into two benchmark classes.
+- Ref structs cannot be returned from `[Benchmark]` methods; consume them
+  inside the method and return a representative scalar (length or hash).
 
 ## 2. Running benchmarks
 

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -146,8 +146,9 @@ For code changes in `touki/Framework/` driven by a perf claim:
 
 - Add a benchmark in `touki.perf/` per the
   [`performance-testing`](../performance-testing/SKILL.md) skill, *or*
-- State explicitly in the commit / PR / `<remarks>` that you have not
-  measured.
+- Include a statement in the commit message, the PR description, or the
+  method's `<remarks>` explicitly indicating that no performance
+  measurements were conducted.
 
 If a polyfill is slower than the array-taking BCL it shadows, quantify
 the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,8 +16,8 @@ customizations (skills, prompts, custom agents, path-specific instructions), see
 
 ## Project overview
 
-`touki` is a C# library that targets both **.NET 9** and **.NET Framework 4.7.2**. All
-code must compile and behave correctly on both targets.
+`touki` is a C# library that targets both **.NET 10** and **.NET Framework 4.7.2**.
+All code must compile and behave correctly on both targets.
 
 Top-level layout:
 
@@ -30,14 +30,14 @@ Top-level layout:
 
 ## Environment setup
 
-- On Unix, run `./setup.sh` once after cloning to install the .NET 9 SDK and update PATH.
+- On Unix, run `./setup.sh` once after cloning to install the .NET 10 SDK and update PATH.
 - On Windows, install the .NET SDK from <https://dotnet.microsoft.com/download> and use
   `dotnet` directly. PowerShell is the preferred terminal.
 - Use the `dotnet` CLI for building and testing. CI runs `dotnet build` and `dotnet test`.
 
 ## Coding style
 
-- Use the latest C# features (C# 13) where applicable.
+- Use the latest C# features (C# 14) where applicable.
 - Always use C# keywords for types (`int`, `string`, `bool`) instead of their aliases
   (`Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
@@ -168,11 +168,8 @@ Treat them as hard requirements.
 
 ## General guidance
 
-- Ensure code is cross-compatible with both .NET 9 and .NET Framework 4.7.2.
-- Adhere to the repository's MIT license and copyright.
-- PowerShell is the terminal environment for building and testing.
+- Ensure code is cross-compatible with both .NET 10 and .NET Framework 4.7.2.
 - Check `GlobalUsings.cs` for global usings and don't add unnecessary usings.
-- Write XML documentation for public APIs.
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
   prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,8 @@ customizations (skills, prompts, custom agents, path-specific instructions), see
 
 ## Project overview
 
-`touki` is a C# library that targets both **.NET 9** and **.NET Framework 4.7.2**. All
-code must compile and behave correctly on both targets.
+`touki` is a C# library that targets both **.NET 10** and **.NET Framework 4.7.2**.
+All code must compile and behave correctly on both targets.
 
 Top-level layout:
 
@@ -29,14 +29,14 @@ Top-level layout:
 
 ## Environment setup
 
-- On Unix, run `./setup.sh` once after cloning to install the .NET 9 SDK and update PATH.
+- On Unix, run `./setup.sh` once after cloning to install the .NET 10 SDK and update PATH.
 - On Windows, install the .NET SDK from <https://dotnet.microsoft.com/download> and use
   `dotnet` directly. PowerShell is the preferred terminal.
 - Use the `dotnet` CLI for building and testing. CI runs `dotnet build` and `dotnet test`.
 
 ## Coding style
 
-- Use the latest C# features (C# 13) where applicable.
+- Use the latest C# features (C# 14) where applicable.
 - Always use C# keywords for types (`int`, `string`, `bool`) instead of their aliases
   (`Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
@@ -167,11 +167,8 @@ Treat them as hard requirements.
 
 ## General guidance
 
-- Ensure code is cross-compatible with both .NET 9 and .NET Framework 4.7.2.
-- Adhere to the repository's MIT license and copyright.
-- PowerShell is the terminal environment for building and testing.
+- Ensure code is cross-compatible with both .NET 10 and .NET Framework 4.7.2.
 - Check `GlobalUsings.cs` for global usings and don't add unnecessary usings.
-- Write XML documentation for public APIs.
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
   prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,


### PR DESCRIPTION
Combines two passes over the agent customization files:

1. Trivial wording clarifications surfaced by the Chat Customizations Evaluations analyzer.
2. A sweep for factual drift, redundancy, and over-long paragraphs that weren't carrying their own weight.

Net: **&minus;17 lines of prose** across 6 files, **no rule removed**, validator clean.

## Factual drift &mdash; [AGENTS.md](https://github.com/JeremyKuhne/touki/blob/main/AGENTS.md) and the regenerated [.github/copilot-instructions.md](https://github.com/JeremyKuhne/touki/blob/main/.github/copilot-instructions.md) mirror

| Was | Is | Source |
|---|---|---|
| ".NET 9" (3 places) | ".NET 10" | `Directory.Build.props` &rarr; `DotNetCoreVersion=net10.0` |
| "C# 13" | "C# 14" | `Directory.Build.props` &rarr; `LangVersion=14` |

Trimmed three duplicates from the General guidance bullet list (each is already stated elsewhere in AGENTS.md):

- MIT license / copyright &mdash; covered by the file-header rule in Coding style.
- "PowerShell is the terminal environment" &mdash; Environment setup.
- "Write XML documentation for public APIs" &mdash; Comments and XML documentation.

## Skill-file clarifications

### [`create-pr`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/create-pr/SKILL.md)

- **Step 2** &mdash; collapsed the nine-line `vscode_askQuestions` paragraph into four lines covering the same three points (suggested name, free-form override, the two-options-or-none gotcha).
- **Approval checkpoint** &mdash; replaced "wait for an explicit publishing verb / that is sufficient; otherwise ask" with concrete verb names (`commit` / `push` / `ship it`) and "proceed without asking again" (Copilot review feedback on #122).

### [`address-pr-feedback`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/address-pr-feedback/SKILL.md)

- **"Skim the most recent user message"** &rarr; "Carefully read... and identify whether it contains an explicit publishing verb" (analyzer flagged "skim" as ambiguous).
- **Not-approval bullet list merged**: combined the three review-comment phrasings, the three "different approach" phrasings, and "reviewer left comment" + "failing check" into single bullets. Dropped `"What about <suggestion>?"` (already covered by "everything else").

### [`performance-testing`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/performance-testing/SKILL.md)

- **`[MemoryDiagnoser]` wording**: "Always annotate the class" &rarr; "Always annotate every benchmark class, regardless of its purpose" (analyzer flagged ambiguity about scope).
- **"What a benchmark method must do"**: folded the three bullets that all said the same thing (return non-void, return non-constant, symptoms of forgetting) into one bullet that still covers all three angles and links to the BenchmarkDotNet good-practices doc.

### [`pre-pr-self-review`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/pre-pr-self-review/SKILL.md)

- **"State explicitly in the commit / PR / `<remarks>`"** &rarr; "Include a statement... explicitly indicating that no performance measurements were conducted" (analyzer flagged "explicitly" as subjective).

## Validation

`pwsh tools/Validate-AgentFiles.ps1 -Fix` &rarr; `Wrote .github/copilot-instructions.md` then `Agent-file validation passed.`

## What I deliberately did *not* touch

- [`polyfill-dotnet-api`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/polyfill-dotnet-api/SKILL.md) and the [`framework-jit-optimization`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/framework-jit-optimization/) files &mdash; every paragraph carries technical detail (allocation strategies, gotchas, the JIT data table). Tightening risks losing facts.
- [`agent-files-review`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/agent-files-review/SKILL.md) &mdash; already lean.
- The [`pre-pr-self-review`](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/pre-pr-self-review/SKILL.md) checklist body &mdash; checklist genre, volume is the value.