### PR TITLE
Mark diagnostic-only types with [ExcludeFromCodeCoverage]

### DIFF
--- a/touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs
+++ b/touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs
@@ -7,7 +7,9 @@ namespace System.Diagnostics;
 /// <summary>
 ///  Provides an interpolated string handler for <see cref="Debug.Assert(bool)"/> that only formats when the assert fails.
 /// </summary>
+// Only invoked from Debug.Assert overloads, which are [Conditional("DEBUG")] and unreachable in Release coverage runs.
 [InterpolatedStringHandler]
+[ExcludeFromCodeCoverage]
 public ref struct AssertInterpolatedStringHandler
 {
     private Touki.Text.ValueStringBuilder _builder;

--- a/touki/Framework/Polyfills/System.Text/ChunkEnumerator.cs
+++ b/touki/Framework/Polyfills/System.Text/ChunkEnumerator.cs
@@ -25,6 +25,8 @@ public struct ChunkEnumerator
     // Accessor type to get at the private fields of StringBuilder. We could use reflection, but
     // there would be significant overhead to call through the FieldInfo APIs. Using Unsafe.As
     // as on .NET Framework we don't expect the initial fields to change.
+    // Layout-only Unsafe.As shim; members are reinterpreted, never directly executed.
+    [ExcludeFromCodeCoverage]
     private class StringBuilderAccessor
     {
 #pragma warning disable IDE1006 // Naming Styles

--- a/touki/Framework/Polyfills/System/ThrowHelper.cs
+++ b/touki/Framework/Polyfills/System/ThrowHelper.cs
@@ -47,7 +47,10 @@ using Touki.Framework.Resources;
 
 namespace System;
 
+// Throw-only helpers; every method ends with throw new ... and is [DoesNotReturn]. Coverage is exercised transitively
+// via the throwing call sites.
 [StackTraceHidden]
+[ExcludeFromCodeCoverage]
 internal static class ThrowHelper
 {
     [DoesNotReturn]

--- a/touki/Touki/Debugging.cs
+++ b/touki/Touki/Debugging.cs
@@ -7,6 +7,8 @@ namespace Touki;
 /// <summary>
 ///  Helper methods that mirror <see cref="Debug"/>.
 /// </summary>
+// All members are [Conditional("DEBUG")] and unreachable in Release coverage runs.
+[ExcludeFromCodeCoverage]
 public static class Debugging
 {
     /// <inheritdoc cref="Debug.Assert(bool)"/>

--- a/touki/Touki/Debugging/DebugOnly.cs
+++ b/touki/Touki/Debugging/DebugOnly.cs
@@ -4,6 +4,8 @@
 
 namespace Touki;
 
+// Internal helper; throws in Release and is unreachable in Release coverage runs.
+[ExcludeFromCodeCoverage]
 internal static class DebugOnly
 {
     internal static bool CallerIsInToukiAssembly()

--- a/touki/Touki/DisposalTracking.cs
+++ b/touki/Touki/DisposalTracking.cs
@@ -14,6 +14,9 @@ namespace Touki;
 /// <summary>
 ///  Helper for tracking disposal of objects in debug builds.
 /// </summary>
+// Debug-only diagnostics: SuppressFinalize is [Conditional("DEBUG")] and the Tracker finalizer fires only when an
+// object leaks.
+[ExcludeFromCodeCoverage]
 public static class DisposalTracking
 {
     /// <summary>


### PR DESCRIPTION
First step in the coverage-improvement rollout (follows #118 - #123).

## What

Apply `[ExcludeFromCodeCoverage]` to six types that contain code which is unreachable from a Release coverage run by design. These were dragging the merged number down without representing real coverage gaps.

| Type | Why it's diagnostic-only |
|---|---|
| `Touki.Debugging` | All members are `[Conditional("DEBUG")]`. |
| `Touki.DebugOnly` | Internal helper; `throw new InvalidOperationException()` in Release. |
| `Touki.DisposalTracking` | `SuppressFinalize` is `[Conditional("DEBUG")]`; the `Tracker` finalizer fires only when an object leaks. |
| `System.Diagnostics.AssertInterpolatedStringHandler` | Only invoked from `Debug.Assert` overloads, all `[Conditional("DEBUG")]`. |
| `System.Text.ChunkEnumerator.StringBuilderAccessor` | Layout-only `Unsafe.As` shim; members are reinterpreted, never directly executed. |
| `System.ThrowHelper` | Throw-only helpers, all `[DoesNotReturn]`. Coverage is exercised transitively via the throwing call sites. Matches dotnet/runtime convention. |

## Coverage delta

| Metric | Before | After | Delta |
|---|---|---|---|
| Merged line coverage | 76.50% (8608 / 11249) | **77.83%** (8588 / 11035) | **+1.33 pts** |
| Merged branch coverage | 68.90% (3965 / 5754) | **69.70%** (3959 / 5680) | +0.80 pts |
| Coverable lines (denominator) | 11249 | 11035 | &minus;214 |

Tests unchanged: 3767 net10.0 + 3955 net481 still pass.

## Implementation note

`ExcludeFromCodeCoverageAttribute.Justification` is .NET 5+ only &mdash; **not** available on net472 / net481 and **not** generated by PolySharp. So the attribute is applied bare and the rationale lives in a `//` comment immediately above each one. Worth knowing for future polyfill / cross-TFM work.

## What this is *not*

This PR does **not** add tests. It just stops counting code that was never going to be covered against the project total. The next PRs in the sequence add tests for entirely-uncovered public surface (`ArrayList<T>`, `UnsafeExtensions.BitCast`, `HandleRef<T>`, `HResultException`) and then expand toward `HebrewNumber`, `WaitHandleExtensions`, `CustomAttributeExtensions`, and the long-tail branch coverage on `Number` / `SpanExtensions`.

## Validation

- `dotnet build -c Release` &mdash; clean on both TFMs (zero warnings).
- `dotnet test -c Release` &mdash; both TFMs pass.
- Local cobertura merge confirms the delta above.