### PR TITLE
Add tests for ArrayList&lt;T&gt;, Unsafe.BitCast, and HResultException

### DIFF
--- a/touki.tests/Framework/System/UnsafeExtensionsTests.cs
+++ b/touki.tests/Framework/System/UnsafeExtensionsTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System.Runtime.CompilerServices;
+
+public class UnsafeExtensionsTests
+{
+    [Fact]
+    public void BitCast_FloatToUInt32_RoundTrips()
+    {
+        const float Value = 3.14159f;
+        uint bits = Unsafe.BitCast<float, uint>(Value);
+        float roundTripped = Unsafe.BitCast<uint, float>(bits);
+        roundTripped.Should().Be(Value);
+    }
+
+    [Fact]
+    public void BitCast_DoubleToUInt64_MatchesBitConverter()
+    {
+        const double Value = -123.456;
+        ulong bits = Unsafe.BitCast<double, ulong>(Value);
+        bits.Should().Be((ulong)BitConverter.DoubleToInt64Bits(Value));
+    }
+
+    [Fact]
+    public void BitCast_Int32ToFloat_PreservesBitPattern()
+    {
+        int bits = unchecked((int)0xC0490FDB);
+        float result = Unsafe.BitCast<int, float>(bits);
+        result.Should().Be(BitConverter.Int32BitsToSingle(bits));
+    }
+
+    [Fact]
+    public void BitCast_DifferentSizes_ThrowsNotSupportedException()
+    {
+        Action act = () => _ = Unsafe.BitCast<int, long>(1);
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void BitCast_FromShortToUShort_RoundTrips()
+    {
+        const short Value = -1234;
+        ushort bits = Unsafe.BitCast<short, ushort>(Value);
+        bits.Should().Be(unchecked((ushort)Value));
+        short roundTripped = Unsafe.BitCast<ushort, short>(bits);
+        roundTripped.Should().Be(Value);
+    }
+}

--- a/touki.tests/Framework/Touki/HResultExceptionTests.cs
+++ b/touki.tests/Framework/Touki/HResultExceptionTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Windows.Win32.Foundation;
+
+namespace Touki.Exceptions;
+
+public class HResultExceptionTests
+{
+    [Fact]
+    public void HResultException_HResultCtor_FormatsHexMessage()
+    {
+        HRESULT hresult = (HRESULT)unchecked((int)0x80004005);
+        HResultException exception = new(hresult);
+        exception.HResult.Should().Be(unchecked((int)0x80004005));
+        exception.Message.Should().Be("HRESULT: 0x80004005");
+    }
+
+    [Fact]
+    public void HResultException_IntMessageCtor_PreservesBoth()
+    {
+        HResultException exception = new(unchecked((int)0x80070005), "Access denied");
+        exception.HResult.Should().Be(unchecked((int)0x80070005));
+        exception.Message.Should().Be("Access denied");
+    }
+
+    [Fact]
+    public void HResultException_PositiveSuccessHResult_PreservesValue()
+    {
+        HRESULT hresult = (HRESULT)0;
+        HResultException exception = new(hresult);
+        exception.HResult.Should().Be(0);
+        exception.Message.Should().Be("HRESULT: 0x00000000");
+    }
+
+    [Fact]
+    public void InvalidOperationHResultException_HResultCtor_FormatsHexMessage()
+    {
+        HRESULT hresult = (HRESULT)unchecked((int)0x80004001);
+        InvalidOperationHResultException exception = new(hresult);
+        exception.HResult.Should().Be(unchecked((int)0x80004001));
+        exception.Message.Should().Be("Invalid operation HRESULT: 0x80004001");
+    }
+
+    [Fact]
+    public void InvalidOperationHResultException_IntMessageCtor_PreservesBoth()
+    {
+        InvalidOperationHResultException exception = new(unchecked((int)0x8000FFFF), "Catastrophic failure");
+        exception.HResult.Should().Be(unchecked((int)0x8000FFFF));
+        exception.Message.Should().Be("Catastrophic failure");
+    }
+}

--- a/touki.tests/Framework/Touki/HResultExceptionTests.cs
+++ b/touki.tests/Framework/Touki/HResultExceptionTests.cs
@@ -26,7 +26,7 @@ public class HResultExceptionTests
     }
 
     [Fact]
-    public void HResultException_PositiveSuccessHResult_PreservesValue()
+    public void HResultException_ZeroSuccessHResult_PreservesValue()
     {
         HRESULT hresult = (HRESULT)0;
         HResultException exception = new(hresult);

--- a/touki.tests/Touki/Collections/ArrayListTests.cs
+++ b/touki.tests/Touki/Collections/ArrayListTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Collections;
+
+public class ArrayListTests
+{
+    [Fact]
+    public void Ctor_Default_HasZeroCount()
+    {
+        using ArrayList<int> list = new();
+        list.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Ctor_Default_AcceptsAdds()
+    {
+        using ArrayList<string> list = new();
+        for (int i = 0; i < 32; i++)
+        {
+            list.Add(i.ToString());
+        }
+
+        list.Count.Should().Be(32);
+        list[0].Should().Be("0");
+        list[31].Should().Be("31");
+    }
+
+    [Fact]
+    public void Ctor_PositiveCapacity_HasZeroCount()
+    {
+        using ArrayList<int> list = new(16);
+        list.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Ctor_ZeroCapacity_StillUsable()
+    {
+        using ArrayList<int> list = new(0);
+        list.Count.Should().Be(0);
+        list.Add(1);
+        list.Add(2);
+        list.Count.Should().Be(2);
+        list[0].Should().Be(1);
+        list[1].Should().Be(2);
+    }
+
+    [Fact]
+    public void Ctor_NegativeCapacity_ThrowsArgumentOutOfRangeException()
+    {
+        Action act = () => _ = new ArrayList<int>(-1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Add_NullItem_ThrowsArgumentNullException()
+    {
+        using ArrayList<string> list = new();
+        Action act = () => list.Add(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/touki.tests/Touki/Value/MemoryWatch.cs
+++ b/touki.tests/Touki/Value/MemoryWatch.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Touki.Text;
+
 namespace Touki.ValueTests;
 
 public ref struct MemoryWatch
@@ -33,6 +35,7 @@ public ref struct MemoryWatch
         Value.Create((double)default).As<double>();
         Value.Create((DateTime)default).As<DateTime>();
         Value.Create((DateTimeOffset)default).As<DateTimeOffset>();
+        Value.Create(default(StringSegment)).As<StringSegment>();
 
         Value.Create((bool?)default).As<bool?>();
         Value.Create((byte?)default).As<byte?>();
@@ -66,6 +69,7 @@ public ref struct MemoryWatch
         value.TryGetValue(out double _);
         value.TryGetValue(out DateTime _);
         value.TryGetValue(out DateTimeOffset _);
+        value.TryGetValue(out StringSegment _);
 
         s_jit = true;
     }


### PR DESCRIPTION
Second step in the coverage-improvement rollout (follows #124).

## What

Adds tests for three types that were sitting at 0% line coverage in the merged report. All public-looking surface, none of it intentionally diagnostic-only, just unreached.

| Target | File | TFMs | Tests |
|---|---|---|---|
| `Touki.Collections.ArrayList<T>` | [touki.tests/Touki/Collections/ArrayListTests.cs](https://github.com/JeremyKuhne/touki/blob/coverage/zero-coverage-public-surface/touki.tests/Touki/Collections/ArrayListTests.cs) | both | 6 |
| `Unsafe.BitCast<TFrom,TTo>` (extension polyfill) | [touki.tests/Framework/System/UnsafeExtensionsTests.cs](https://github.com/JeremyKuhne/touki/blob/coverage/zero-coverage-public-surface/touki.tests/Framework/System/UnsafeExtensionsTests.cs) | net481 | 5 |
| `Touki.Exceptions.HResultException` + `InvalidOperationHResultException` | [touki.tests/Framework/Touki/HResultExceptionTests.cs](https://github.com/JeremyKuhne/touki/blob/coverage/zero-coverage-public-surface/touki.tests/Framework/Touki/HResultExceptionTests.cs) | net481 | 5 |

### Coverage details

- **`ArrayList<T>`** &mdash; default ctor, positive / zero / negative initial-capacity ctors, basic `Add` behavior, and the null-item rejection inherited from `ArrayBackedList<T>`.
- **`Unsafe.BitCast`** &mdash; `float`&harr;`uint`, `double`&harr;`ulong` (cross-checked against `BitConverter.DoubleToInt64Bits`), `int`&rarr;`float`, `short`&harr;`ushort`, plus the size-mismatch `NotSupportedException` path.
- **`HResultException` / `InvalidOperationHResultException`** &mdash; both ctors of each, including verifying the `"HRESULT: 0xXXXXXXXX"` and `"Invalid operation HRESULT: 0xXXXXXXXX"` formatted messages and that `Exception.HResult` is preserved.

## Coverage delta

| Metric | After PR A (#124) | After this PR | Delta |
|---|---|---|---|
| Merged line coverage | 77.83% (8588/11035) | **78.08%** (8616/11035) | **+0.25 pts** |
| Merged branch coverage | 69.70% (3959/5680) | **69.84%** (3967/5680) | +0.14 pts |
| Lines covered | 8588 | 8616 | +28 |

Combined with PR A, total coverage lift since the rollout began:
- **Merged line: 76.50% &rarr; 78.08% (+1.58 pts)**
- **Merged branch: 68.90% &rarr; 69.84% (+0.94 pts)**

Test counts: 3767+3955 &rarr; 3773+3971, all passing on both TFMs.

## Bug found while researching, deferred to a separate PR

In [touki/Touki/Interop/HandleRef.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Interop/HandleRef.cs):

```csharp
public override bool Equals([NotNullWhen(true)] object? obj)
    => obj is THandle other && Equals(other);
```

That checks whether `obj` is the unmanaged `THandle`, not a `HandleRef<THandle>`. The `Equals(other)` path is the strongly-typed overload, and `obj` is never `THandle` at the boxed-equality call site, so this always returns `false` for a real `HandleRef` argument. Should be `obj is HandleRef<THandle> other`.

Keeping this out of the test PR so the test additions don't get tangled with a behavior change. Will land as its own one-line fix + test.

## Validation

- `dotnet build -c Release` &mdash; clean on both TFMs.
- `dotnet test -c Release` &mdash; both TFMs pass; new test methods all green.
- Local cobertura merge confirms the delta above.