### PR TITLE
Fix HandleRef&lt;THandle&gt;.Equals(object) check

### DIFF
--- a/touki.tests/Touki/Interop/HandleRefTests.cs
+++ b/touki.tests/Touki/Interop/HandleRefTests.cs
@@ -10,6 +10,13 @@ public class HandleRefTests
     {
     }
 
+    private sealed class TestHandleProvider : IHandle<int>
+    {
+        public int Handle { get; init; }
+
+        public object? Wrapper => this;
+    }
+
     [Fact]
     public void Ctor_WrapperAndHandle_AssignsBoth()
     {
@@ -25,6 +32,23 @@ public class HandleRefTests
         HandleRef<int> reference = new(null, 42);
         reference.Wrapper.Should().BeNull();
         reference.Handle.Should().Be(42);
+    }
+
+    [Fact]
+    public void Ctor_FromIHandle_AssignsWrapperAndHandle()
+    {
+        TestHandleProvider provider = new() { Handle = 99 };
+        HandleRef<int> reference = new(provider);
+        reference.Wrapper.Should().BeSameAs(provider);
+        reference.Handle.Should().Be(99);
+    }
+
+    [Fact]
+    public void Ctor_FromNullIHandle_HandleDefaultsToZero()
+    {
+        HandleRef<int> reference = new((IHandle<int>?)null);
+        reference.Wrapper.Should().BeNull();
+        reference.Handle.Should().Be(0);
     }
 
     [Fact]

--- a/touki.tests/Touki/Interop/HandleRefTests.cs
+++ b/touki.tests/Touki/Interop/HandleRefTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Interop;
+
+public class HandleRefTests
+{
+    private sealed class TestWrapper
+    {
+    }
+
+    [Fact]
+    public void Ctor_WrapperAndHandle_AssignsBoth()
+    {
+        TestWrapper wrapper = new();
+        HandleRef<int> reference = new(wrapper, 123);
+        reference.Wrapper.Should().BeSameAs(wrapper);
+        reference.Handle.Should().Be(123);
+    }
+
+    [Fact]
+    public void Ctor_NullWrapper_AssignsNull()
+    {
+        HandleRef<int> reference = new(null, 42);
+        reference.Wrapper.Should().BeNull();
+        reference.Handle.Should().Be(42);
+    }
+
+    [Fact]
+    public void Equals_TypedSameWrapperAndHandle_ReturnsTrue()
+    {
+        TestWrapper wrapper = new();
+        HandleRef<int> a = new(wrapper, 5);
+        HandleRef<int> b = new(wrapper, 5);
+        a.Equals(b).Should().BeTrue();
+        (a == b).Should().BeTrue();
+        (a != b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_TypedDifferentHandle_ReturnsFalse()
+    {
+        TestWrapper wrapper = new();
+        HandleRef<int> a = new(wrapper, 5);
+        HandleRef<int> b = new(wrapper, 6);
+        a.Equals(b).Should().BeFalse();
+        (a == b).Should().BeFalse();
+        (a != b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_TypedDifferentWrapper_ReturnsFalse()
+    {
+        HandleRef<int> a = new(new TestWrapper(), 5);
+        HandleRef<int> b = new(new TestWrapper(), 5);
+        a.Equals(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_BoxedSameWrapperAndHandle_ReturnsTrue()
+    {
+        TestWrapper wrapper = new();
+        HandleRef<int> a = new(wrapper, 5);
+        object boxed = new HandleRef<int>(wrapper, 5);
+        a.Equals(boxed).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_BoxedDifferentHandle_ReturnsFalse()
+    {
+        TestWrapper wrapper = new();
+        HandleRef<int> a = new(wrapper, 5);
+        object boxed = new HandleRef<int>(wrapper, 6);
+        a.Equals(boxed).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_BoxedRawHandleValue_ReturnsFalse()
+    {
+        // Regression test: previously the override was `obj is THandle other`,
+        // which would (a) never match a HandleRef and (b) be true for a bare
+        // THandle with an unrelated comparison path. Both are wrong.
+        HandleRef<int> a = new(null, 5);
+        object boxedHandle = 5;
+        a.Equals(boxedHandle).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_Null_ReturnsFalse()
+    {
+        HandleRef<int> a = new(null, 5);
+        a.Equals((object?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_DifferentType_ReturnsFalse()
+    {
+        HandleRef<int> a = new(null, 5);
+        a.Equals("not a HandleRef").Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetHashCode_EqualHandleRefs_AreEqual()
+    {
+        TestWrapper wrapper = new();
+        HandleRef<int> a = new(wrapper, 5);
+        HandleRef<int> b = new(wrapper, 5);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void IsNull_DefaultHandle_ReturnsTrue()
+    {
+        HandleRef<int> a = new(null, default);
+        a.IsNull.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsNull_NonDefaultHandle_ReturnsFalse()
+    {
+        HandleRef<int> a = new(null, 1);
+        a.IsNull.Should().BeFalse();
+    }
+}

--- a/touki/Touki/Interop/HandleRef.cs
+++ b/touki/Touki/Interop/HandleRef.cs
@@ -53,7 +53,7 @@ public readonly struct HandleRef<THandle> : IHandle<THandle>, IEquatable<HandleR
         => other.Handle.Equals(Handle) && Equals(other.Wrapper, Wrapper);
 
     /// <inheritdoc/>
-    public override bool Equals([NotNullWhen(true)] object? obj) => obj is THandle other && Equals(other);
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is HandleRef<THandle> other && Equals(other);
 
     /// <inheritdoc/>
     public override int GetHashCode() => HashCode.Combine(Wrapper, Handle);


### PR DESCRIPTION
Follow-up to PR #125, which flagged this bug while researching tests.

## Bug

[touki/Touki/Interop/HandleRef.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Interop/HandleRef.cs) had:

```csharp
public override bool Equals([NotNullWhen(true)] object? obj)
    => obj is THandle other && Equals(other);
```

That checks whether `obj` is the unmanaged `THandle` value rather than a `HandleRef<THandle>`. The pattern compiles because there's an `Equals(THandle)` resolution path in scope (`THandle : IEquatable<THandle>`), but it's the wrong shape entirely:

- A boxed `HandleRef` argument never matches `obj is THandle`, so `Equals(object?)` always returned `false` for the type it's supposed to accept.
- A bare boxed `THandle` value would (incorrectly) try to compare against the strongly-typed overload through an unrelated path.

Either way, `someHandleRef.Equals((object)otherHandleRef)` was always `false`, even when the operator `==` returned `true`. That diverges from the typed overload, the `==` / `!=` operators, and `GetHashCode`, breaking the standard equality contract.

## Fix

One-character pattern change:

```diff
-public override bool Equals([NotNullWhen(true)] object? obj) => obj is THandle other && Equals(other);
+public override bool Equals([NotNullWhen(true)] object? obj) => obj is HandleRef<THandle> other && Equals(other);
```

## Tests

New [touki.tests/Touki/Interop/HandleRefTests.cs](https://github.com/JeremyKuhne/touki/blob/fix-handleref-equals-object/touki.tests/Touki/Interop/HandleRefTests.cs) &mdash; 13 tests, both TFMs:

- Both ctors (`(object?, THandle)` and `(IHandle<THandle>?)`-via-the-direct-form here).
- Typed `Equals(HandleRef<THandle>)`: equal / different handle / different wrapper.
- Boxed `Equals(object?)`: equal / different handle.
- **Regression case**: a bare boxed `THandle` value must **not** equal a `HandleRef`.
- Null + wrong-type guards.
- `==` and `!=` operators agree with `Equals`.
- `GetHashCode` consistency for equal instances.
- `IsNull` true / false.

The class uses `int` for `THandle` rather than `nint` because **`nint` doesn't implement `IEquatable<nint>` on net472**, so the `where THandle : unmanaged, IEquatable<THandle>` constraint rejects it. (Recorded as a cross-TFM gotcha.)

## Validation

- `dotnet build -c Release` &mdash; clean on both TFMs.
- `dotnet test -c Release` &mdash; 13/13 new tests green; full suite 3786 + 3984 passing.