### PR TITLE
Test DateTimeFormat and SpanExtensions search overloads

### DIFF
--- a/touki.tests/Framework/System/DateTimeFormatTests.cs
+++ b/touki.tests/Framework/System/DateTimeFormatTests.cs
@@ -74,12 +74,12 @@ public class DateTimeFormatTests
             new object[] { "FF" },
             new object[] { "FFF" },
             new object[] { "FFFF" },
-            new object[] { "g" },           // era
-            new object[] { "gg" },          // era
+            new object[] { "g yyyy" },      // era token in a custom format
+            new object[] { "gg yyyy" },     // era token, double-letter form
             new object[] { @"yyyy\-MM\-dd" },
             new object[] { "'literal' yyyy" },
             new object[] { "\"quoted\" yyyy" },
-            new object[] { "% h" },         // single-char custom format
+            new object[] { "%h" },          // single-char custom format
             new object[] { "%H" },
             new object[] { "%t" },
             new object[] { "%y" },

--- a/touki.tests/Framework/System/DateTimeFormatTests.cs
+++ b/touki.tests/Framework/System/DateTimeFormatTests.cs
@@ -1,0 +1,376 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Text;
+
+namespace System.Globalization;
+
+/// <summary>
+///  Tests for the <see cref="DateTimeFormat"/> polyfill on .NET Framework. Many
+///  cases drive the polyfill side-by-side with the BCL's
+///  <see cref="DateTime.ToString(string, IFormatProvider)"/> as an oracle and
+///  assert byte-identical output. Where the polyfill is intentionally narrower
+///  (e.g. it does not currently handle every full standard expansion the BCL
+///  does), tests assert the documented behavior directly.
+/// </summary>
+public class DateTimeFormatTests
+{
+    private static readonly DateTime s_sample = new(2026, 5, 6, 14, 23, 45, 678, DateTimeKind.Utc);
+    private static readonly DateTime s_morning = new(2026, 1, 7, 3, 4, 5, DateTimeKind.Local);
+    private static readonly DateTime s_unspec = new(2026, 12, 31, 23, 59, 59, 999, DateTimeKind.Unspecified);
+
+    private static string Format(DateTime dateTime, string format, IFormatProvider? provider)
+    {
+        ValueStringBuilder builder = new(stackalloc char[128]);
+        try
+        {
+            DateTimeFormat.Format(dateTime, format.AsSpan(), provider, ref builder);
+            return builder.ToString();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private static string Format(DateTime dateTime, string format, TimeSpan offset, IFormatProvider? provider)
+    {
+        ValueStringBuilder builder = new(stackalloc char[128]);
+        try
+        {
+            DateTimeFormat.Format(dateTime, format.AsSpan(), provider, offset, ref builder);
+            return builder.ToString();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    public static IEnumerable<object[]> CustomFormat_TestData() =>
+        new List<object[]>
+        {
+            new object[] { "yyyy-MM-dd" },
+            new object[] { "yyyy/MM/dd HH:mm:ss" },
+            new object[] { "yy-M-d" },
+            new object[] { "MMM dd, yyyy" },
+            new object[] { "MMMM dd, yyyy" },
+            new object[] { "ddd, dd MMM yyyy HH:mm:ss" },
+            new object[] { "dddd" },
+            new object[] { "h:mm tt" },
+            new object[] { "hh:mm:ss.fff" },
+            new object[] { "HH:mm:ss.fffffff" },
+            new object[] { "yyyyMMddHHmmss" },
+            new object[] { "yyyy" },
+            new object[] { "MM" },
+            new object[] { "dd" },
+            new object[] { "ff" },
+            new object[] { "fff" },
+            new object[] { "ffff" },
+            new object[] { "fffff" },
+            new object[] { "ffffff" },
+            new object[] { "fffffff" },
+            new object[] { "FF" },
+            new object[] { "FFF" },
+            new object[] { "FFFF" },
+            new object[] { "g" },           // era
+            new object[] { "gg" },          // era
+            new object[] { @"yyyy\-MM\-dd" },
+            new object[] { "'literal' yyyy" },
+            new object[] { "\"quoted\" yyyy" },
+            new object[] { "% h" },         // single-char custom format
+            new object[] { "%H" },
+            new object[] { "%t" },
+            new object[] { "%y" },
+        };
+
+    [Theory]
+    [MemberData(nameof(CustomFormat_TestData))]
+    public void Format_Custom_MatchesBcl_InvariantCulture(string format)
+    {
+        // Polyfill output must equal BCL output for invariant culture across the common token set.
+        Format(s_sample, format, CultureInfo.InvariantCulture)
+            .Should().Be(s_sample.ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [MemberData(nameof(CustomFormat_TestData))]
+    public void Format_Custom_MatchesBcl_EnUs(string format)
+    {
+        CultureInfo culture = CultureInfo.GetCultureInfo("en-US");
+        Format(s_sample, format, culture).Should().Be(s_sample.ToString(format, culture));
+    }
+
+    [Theory]
+    [InlineData("uk-UA")]   // genitive month names
+    [InlineData("ru-RU")]   // genitive month names
+    [InlineData("fr-FR")]   // accented month names
+    [InlineData("de-DE")]
+    [InlineData("ja-JP")]
+    public void Format_Custom_MatchesBcl_AcrossCultures(string cultureName)
+    {
+        CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
+        // Use a date that exercises a genitive form (day before month).
+        const string FormatString = "d MMMM yyyy";
+        Format(s_sample, FormatString, culture).Should().Be(s_sample.ToString(FormatString, culture));
+    }
+
+    public static IEnumerable<object[]> StandardFormat_TestData() =>
+        new List<object[]>
+        {
+            new object[] { "d" },
+            new object[] { "D" },
+            new object[] { "f" },
+            new object[] { "F" },
+            new object[] { "g" },
+            new object[] { "G" },
+            new object[] { "m" },
+            new object[] { "M" },
+            new object[] { "o" },
+            new object[] { "O" },
+            new object[] { "r" },
+            new object[] { "R" },
+            new object[] { "s" },
+            new object[] { "t" },
+            new object[] { "T" },
+            new object[] { "u" },
+            // "U" not included: invariant culture's UniversalSortableDateTimePattern adjusts the
+            // displayed time to UTC, which the polyfill handles only when the input is UTC.
+            new object[] { "y" },
+            new object[] { "Y" },
+        };
+
+    [Theory]
+    [MemberData(nameof(StandardFormat_TestData))]
+    public void Format_Standard_MatchesBcl_InvariantCulture(string format)
+    {
+        Format(s_sample, format, CultureInfo.InvariantCulture)
+            .Should().Be(s_sample.ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    // Spot checks ported from dotnet/runtime DateTimeTests.ToString_MatchesExpected_MemberData.
+    // These are explicit (DateTime, format, expected) tuples so the polyfill is validated against
+    // values the runtime team chose to lock in, not just whatever the BCL happens to produce on
+    // this machine.
+    [Theory]
+    [InlineData(2714985378271158548L, DateTimeKind.Utc, "D", "Wednesday, 13 June 8604")]
+    [InlineData(388901633623941264L, DateTimeKind.Unspecified, "O", "1233-05-19T15:09:22.3941264")]
+    [InlineData(319688581620784322L, DateTimeKind.Utc, "d", "01/20/1014")]
+    [InlineData(1633263998564961778L, DateTimeKind.Unspecified, "G", "08/10/5176 20:24:16")]
+    [InlineData(1850421988142570769L, DateTimeKind.Utc, "U", "Monday, 03 October 5864 02:46:54")]
+    [InlineData(2161519739750829933L, DateTimeKind.Utc, "g", "08/01/6850 22:59")]
+    [InlineData(94926719545582445L, DateTimeKind.Unspecified, "g", "10/24/0301 21:19")]
+    [InlineData(1345442651123205077L, DateTimeKind.Utc, "U", "Saturday, 16 July 4264 06:58:32")]
+    [InlineData(1683269053145633504L, DateTimeKind.Unspecified, "f", "Wednesday, 26 January 5335 01:41")]
+    [InlineData(261818716531476839L, DateTimeKind.Utc, "G", "09/02/0830 22:07:33")]
+    [InlineData(149735664893692740L, DateTimeKind.Unspecified, "m", "June 30")]
+    [InlineData(2552572811382202194L, DateTimeKind.Unspecified, "D", "Wednesday, 12 October 8089")]
+    [InlineData(794982031942527306L, DateTimeKind.Utc, "o", "2520-03-14T02:13:14.2527306Z")]
+    [InlineData(2146466025818766443L, DateTimeKind.Utc, "o", "6802-11-18T16:16:21.8766443Z")]
+    [InlineData(806709007011133014L, DateTimeKind.Unspecified, "t", "23:31")]
+    [InlineData(2916204299343097820L, DateTimeKind.Unspecified, "F", "Friday, 31 January 9242 10:58:54")]
+    [InlineData(2540972632026940446L, DateTimeKind.Utc, "U", "Wednesday, 08 January 8053 13:06:42")]
+    [InlineData(316446896574206081L, DateTimeKind.Unspecified, "R", "Thu, 13 Oct 1003 23:34:17 GMT")]
+    [InlineData(1352087970149786791L, DateTimeKind.Unspecified, "s", "4285-08-06T15:10:14")]
+    [InlineData(975348914587607928L, DateTimeKind.Unspecified, "R", "Mon, 05 Oct 3091 01:24:18 GMT")]
+    [InlineData(806691560290860158L, DateTimeKind.Utc, "T", "18:53:49")]
+    [InlineData(2329057094873169055L, DateTimeKind.Unspecified, "t", "22:24")]
+    [InlineData(40244582424527696L, DateTimeKind.Utc, "m", "July 13")]
+    [InlineData(1502152713607918360L, DateTimeKind.Utc, "d", "02/18/4761")]
+    [InlineData(230701341483195296L, DateTimeKind.Unspecified, "T", "10:35:48")]
+    [InlineData(2946266365850485700L, DateTimeKind.Utc, "D", "Tuesday, 07 May 9337")]
+    [InlineData(322635236878311096L, DateTimeKind.Utc, "u", "1023-05-24 09:54:47Z")]
+    [InlineData(381748720453740183L, DateTimeKind.Unspecified, "D", "Saturday, 18 September 1210")]
+    [InlineData(42694710897975892L, DateTimeKind.Unspecified, "g", "04/18/0136 04:11")]
+    [InlineData(2889335867722033047L, DateTimeKind.Unspecified, "t", "17:39")]
+    [InlineData(1108255955917223459L, DateTimeKind.Unspecified, "u", "3512-12-04 15:39:51Z")]
+    [InlineData(102597329933554815L, DateTimeKind.Utc, "s", "0326-02-13T21:49:53")]
+    [InlineData(1316597307220179904L, DateTimeKind.Utc, "y", "4173 February")]
+    [InlineData(79516486664227528L, DateTimeKind.Unspecified, "y", "0252 December")]
+    public void Format_KnownExpected_MatchesRuntime(long ticks, DateTimeKind kind, string format, string expected)
+    {
+        DateTime dateTime = new(ticks, kind);
+        Format(dateTime, format, CultureInfo.InvariantCulture).Should().Be(expected);
+    }
+
+    [Fact]
+    public void Format_NonAsciiInFormatString_PreservedLiteral()
+    {
+        // From runtime test data: U+202D (LEFT-TO-RIGHT OVERRIDE) between HH and mm must be
+        // emitted as a literal, not interpreted.
+        DateTime dt = new(2023, 04, 17, 10, 46, 12, DateTimeKind.Utc);
+        Format(dt, "HH\u202dmm", CultureInfo.InvariantCulture).Should().Be("10\u202d46");
+    }
+
+    [Fact]
+    public void Format_MinValueAndMaxValue_RoundTripPattern_MatchesBcl()
+    {
+        DateTime min = DateTime.MinValue;
+        DateTime max = DateTime.MaxValue;
+        Format(min, "o", CultureInfo.InvariantCulture).Should().Be(min.ToString("o", CultureInfo.InvariantCulture));
+        Format(max, "o", CultureInfo.InvariantCulture).Should().Be(max.ToString("o", CultureInfo.InvariantCulture));
+    }
+
+    [Theory]
+    [InlineData("yyy")]
+    [InlineData("yyyyy")]
+    [InlineData("yyyyyy")]
+    [InlineData("yyyyyyy")]
+    public void Format_YearPaddingWidths_MatchBcl(string format)
+    {
+        // Custom yN format pads/truncates the era year to N digits. Touki's polyfill must match.
+        DateTime dt = new(1234, 5, 6);
+        Format(dt, format, CultureInfo.InvariantCulture)
+            .Should().Be(dt.ToString(format, CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Format_TimeZoneTokenZ_ContainsOffsetSign()
+    {
+        // Custom format with z/zz/zzz produces a signed offset.
+        DateTime utc = new(2026, 6, 15, 12, 0, 0, DateTimeKind.Utc);
+        string formatted = Format(utc, "HH:mm zzz", CultureInfo.InvariantCulture);
+        formatted.Should().Match(s => s.Contains('+') || s.Contains('-'));
+    }
+
+    [Fact]
+    public void Format_RoundtripK_OnUtcDateTime_AppendsZ()
+    {
+        DateTime utc = new(2026, 5, 6, 14, 0, 0, DateTimeKind.Utc);
+        Format(utc, "yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture)
+            .Should().Be(utc.ToString("yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Format_RoundtripK_OnUnspecifiedDateTime_OmitsZone()
+    {
+        Format(s_unspec, "yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture)
+            .Should().Be(s_unspec.ToString("yyyy-MM-ddTHH:mm:ssK", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Format_RoundtripK_WithExplicitOffset_AppendsOffset()
+    {
+        DateTime local = new(2026, 5, 6, 14, 0, 0, DateTimeKind.Unspecified);
+        TimeSpan offset = TimeSpan.FromHours(5.5);
+        string formatted = Format(local, "yyyy-MM-ddTHH:mm:ssK", offset, CultureInfo.InvariantCulture);
+        formatted.Should().EndWith("+05:30");
+    }
+
+    [Fact]
+    public void Format_TimeFractionWithFCapital_TrimsTrailingZeros()
+    {
+        // The capital 'F' specifier omits trailing zero fractional digits.
+        DateTime dt = new(2026, 1, 1, 0, 0, 0, 100, DateTimeKind.Unspecified); // .100 ms
+        Format(dt, "ss.FFF", CultureInfo.InvariantCulture)
+            .Should().Be(dt.ToString("ss.FFF", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Format_HourSpecifierH_TwentyFourHourClockNoLeadingZero()
+    {
+        // s_morning has hour=3; %H must produce "3" not "03".
+        Format(s_morning, "%H", CultureInfo.InvariantCulture).Should().Be("3");
+    }
+
+    [Fact]
+    public void Format_HourSpecifierLowerH_TwelveHourClock()
+    {
+        // 14:23 in 12-hour form is 2.
+        Format(s_sample, "%h", CultureInfo.InvariantCulture).Should().Be("2");
+    }
+
+    [Fact]
+    public void Format_Tt_Designator_PmAm()
+    {
+        DateTime pm = new(2026, 1, 1, 14, 0, 0);
+        DateTime am = new(2026, 1, 1, 9, 0, 0);
+        Format(pm, "tt", CultureInfo.InvariantCulture).Should().Be("PM");
+        Format(am, "tt", CultureInfo.InvariantCulture).Should().Be("AM");
+    }
+
+    [Fact]
+    public void Format_DayName_FullAndAbbreviated()
+    {
+        Format(s_sample, "ddd", CultureInfo.InvariantCulture)
+            .Should().Be(s_sample.ToString("ddd", CultureInfo.InvariantCulture));
+        Format(s_sample, "dddd", CultureInfo.InvariantCulture)
+            .Should().Be(s_sample.ToString("dddd", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void Format_QuotedLiteral_PreservedInOutput()
+    {
+        Format(s_sample, "'today is' yyyy-MM-dd", CultureInfo.InvariantCulture)
+            .Should().Be("today is 2026-05-06");
+    }
+
+    [Fact]
+    public void Format_DoubleQuotedLiteral_PreservedInOutput()
+    {
+        Format(s_sample, "\"yr\" yyyy", CultureInfo.InvariantCulture).Should().Be("yr 2026");
+    }
+
+    [Fact]
+    public void Format_BackslashEscape_PreservesNextChar()
+    {
+        Format(s_sample, @"yyyy\Tdd", CultureInfo.InvariantCulture).Should().Be("2026T06");
+    }
+
+    [Fact]
+    public void Format_HebrewCalendar_MonthName_EmitsHebrewLetters()
+    {
+        // Drives FormatHebrewMonthName, which is currently 0% covered.
+        CultureInfo culture = new("he-IL");
+        culture.DateTimeFormat.Calendar = new HebrewCalendar();
+        DateTime date = new(2026, 5, 1);
+        string formatted = Format(date, "MMMM", culture);
+        formatted.Should().NotBeEmpty();
+        formatted.Any(c => c is >= '\x05d0' and <= '\x05ea').Should().BeTrue(
+            "Hebrew calendar month name must contain Hebrew letters");
+    }
+
+    [Fact]
+    public void Format_HebrewCalendar_FullDate_EmitsGematria()
+    {
+        CultureInfo culture = new("he-IL");
+        culture.DateTimeFormat.Calendar = new HebrewCalendar();
+        DateTime date = new(2026, 5, 1);
+        string formatted = Format(date, "dd MM yyyy", culture);
+        formatted.Should().NotBeEmpty();
+        formatted.Any(c => c is >= '\x05d0' and <= '\x05ea').Should().BeTrue();
+    }
+
+    [Fact]
+    public void Format_UnterminatedSingleQuote_ThrowsFormatException()
+    {
+        // ParseQuoteString reaches end-of-format without finding the matching quote.
+        Action act = () => Format(s_sample, "'unterminated", CultureInfo.InvariantCulture);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Format_UnterminatedDoubleQuote_ThrowsFormatException()
+    {
+        Action act = () => Format(s_sample, "\"unterminated", CultureInfo.InvariantCulture);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Format_BackslashAtEndOfQuotedString_ThrowsFormatException()
+    {
+        // The format ends with the escape character inside a quoted literal:
+        // ParseQuoteString consumes the escape, then has no following character.
+        Action act = () => Format(s_sample, "'abc\\", CultureInfo.InvariantCulture);
+        act.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void Format_EscapedQuoteInsideQuote_PreservesQuoteCharacter()
+    {
+        // The runtime comment block on ParseQuoteString documents this exact case:
+        //   "'minute:' mm\""  =>  minute: 45"
+        Format(s_sample, "'minute:' mm\\\"", CultureInfo.InvariantCulture).Should().Be("minute: 23\"");
+    }
+}

--- a/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs
+++ b/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs
@@ -1,0 +1,397 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace System;
+
+/// <summary>
+///  Tests for the <c>LastIndexOfAnyExcept</c> / <c>IndexOfAnyExcept</c> /
+///  <c>ContainsAny*</c> / <c>Count</c> overloads on <c>SpanExtensions</c>. The
+///  existing <c>SpanExtensionsSearchTests</c> covers <c>int</c>; this file adds
+///  the type-specialized branches the polyfill picks for <c>byte</c>, <c>char</c>,
+///  <c>short</c>, <c>long</c>, plus the <c>Span&lt;T&gt;</c> wrappers and the
+///  multi-value overloads. Patterns are adapted from
+///  <c>dotnet/runtime/src/libraries/System.Memory/tests/Span/LastIndexOfAny*.cs</c>
+///  and <c>IndexOfAnyExcept.T.cs</c>.
+/// </summary>
+public class SpanExtensionsSearchExtraTests
+{
+    // ----- LastIndexOfAnyExcept (single value) -----
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [7, 7, 7, 7];
+        span.LastIndexOfAnyExcept(7).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_LastDifferent_ReturnsLastIndex()
+    {
+        ReadOnlySpan<int> span = [7, 7, 7, 5];
+        span.LastIndexOfAnyExcept(7).Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_FirstDifferent_ReturnsFirstIndex()
+    {
+        ReadOnlySpan<int> span = [5, 7, 7, 7];
+        span.LastIndexOfAnyExcept(7).Should().Be(0);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_Empty_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [];
+        span.LastIndexOfAnyExcept(0).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_Byte_FindsLastNonMatch()
+    {
+        ReadOnlySpan<byte> span = [(byte)1, (byte)1, (byte)2, (byte)1];
+        span.LastIndexOfAnyExcept((byte)1).Should().Be(2);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_Char_FindsLastNonMatch()
+    {
+        ReadOnlySpan<char> span = "aaab".AsSpan();
+        span.LastIndexOfAnyExcept('a').Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_Short_FindsLastNonMatch()
+    {
+        ReadOnlySpan<short> span = [(short)0, (short)0, (short)1];
+        span.LastIndexOfAnyExcept((short)0).Should().Be(2);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_Long_FindsLastNonMatch()
+    {
+        ReadOnlySpan<long> span = [0L, 0L, 1L];
+        span.LastIndexOfAnyExcept(0L).Should().Be(2);
+    }
+
+    // ----- LastIndexOfAnyExcept (two values) -----
+
+    [Fact]
+    public void LastIndexOfAnyExcept_TwoValues_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [1, 2, 1, 2];
+        span.LastIndexOfAnyExcept(1, 2).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_TwoValues_OneOutlier_ReturnsItsIndex()
+    {
+        ReadOnlySpan<int> span = [1, 2, 9, 1, 2];
+        span.LastIndexOfAnyExcept(1, 2).Should().Be(2);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_TwoValues_Byte_FindsLastNonMatch()
+    {
+        ReadOnlySpan<byte> span = [(byte)1, (byte)2, (byte)9];
+        span.LastIndexOfAnyExcept((byte)1, (byte)2).Should().Be(2);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_TwoValues_Char_FindsLastNonMatch()
+    {
+        ReadOnlySpan<char> span = "abXab".AsSpan();
+        span.LastIndexOfAnyExcept('a', 'b').Should().Be(2);
+    }
+
+    // ----- LastIndexOfAnyExcept (three values) -----
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ThreeValues_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 1];
+        span.LastIndexOfAnyExcept(1, 2, 3).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ThreeValues_OneOutlier_ReturnsItsIndex()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 9, 1, 2];
+        span.LastIndexOfAnyExcept(1, 2, 3).Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ThreeValues_Byte_FindsLastNonMatch()
+    {
+        ReadOnlySpan<byte> span = [(byte)1, (byte)2, (byte)3, (byte)9];
+        span.LastIndexOfAnyExcept((byte)1, (byte)2, (byte)3).Should().Be(3);
+    }
+
+    // ----- LastIndexOfAnyExcept (values span) -----
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ValuesSpan_Empty_ReturnsLastIndex()
+    {
+        // Documented contract: empty values matches no element, so the last element is "not in the empty set".
+        ReadOnlySpan<int> span = [1, 2, 3];
+        span.LastIndexOfAnyExcept((ReadOnlySpan<int>)[]).Should().Be(2);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ValuesSpan_BothEmpty_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int>.Empty.LastIndexOfAnyExcept((ReadOnlySpan<int>)[]).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ValuesSpan_FourValues_FindsLastOther()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 4, 9, 1, 2];
+        ReadOnlySpan<int> values = [1, 2, 3, 4];
+        span.LastIndexOfAnyExcept(values).Should().Be(4);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ValuesSpan_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 4];
+        ReadOnlySpan<int> values = [1, 2, 3, 4];
+        span.LastIndexOfAnyExcept(values).Should().Be(-1);
+    }
+
+    // ----- ContainsAny (multi-value) -----
+
+    [Fact]
+    public void ContainsAny_TwoValues_True()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3];
+        span.ContainsAny(2, 99).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAny_TwoValues_False()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3];
+        span.ContainsAny(98, 99).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAny_ThreeValues_True()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3];
+        span.ContainsAny(98, 99, 3).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAny_ThreeValues_False()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3];
+        span.ContainsAny(7, 8, 9).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAny_ValuesSpan_True()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 4];
+        ReadOnlySpan<int> values = [10, 4];
+        span.ContainsAny(values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAny_ValuesSpan_False()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 4];
+        ReadOnlySpan<int> values = [10, 11];
+        span.ContainsAny(values).Should().BeFalse();
+    }
+
+    // ----- ContainsAnyExcept -----
+
+    [Fact]
+    public void ContainsAnyExcept_SingleValue_True_WhenAnyDiffers()
+    {
+        ReadOnlySpan<int> span = [1, 1, 9, 1];
+        span.ContainsAnyExcept(1).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_SingleValue_False_WhenAllMatch()
+    {
+        ReadOnlySpan<int> span = [1, 1, 1, 1];
+        span.ContainsAnyExcept(1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_TwoValues_TrueAndFalse()
+    {
+        ReadOnlySpan<int> matching = [1, 2, 1, 2];
+        matching.ContainsAnyExcept(1, 2).Should().BeFalse();
+
+        ReadOnlySpan<int> withOther = [1, 2, 9];
+        withOther.ContainsAnyExcept(1, 2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_ThreeValues_TrueAndFalse()
+    {
+        ReadOnlySpan<int> matching = [1, 2, 3, 1];
+        matching.ContainsAnyExcept(1, 2, 3).Should().BeFalse();
+
+        ReadOnlySpan<int> withOther = [1, 2, 3, 9];
+        withOther.ContainsAnyExcept(1, 2, 3).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_ValuesSpan_TrueAndFalse()
+    {
+        ReadOnlySpan<int> matching = [1, 2, 3, 4];
+        matching.ContainsAnyExcept((ReadOnlySpan<int>)[1, 2, 3, 4]).Should().BeFalse();
+
+        ReadOnlySpan<int> withOther = [1, 2, 3, 9];
+        withOther.ContainsAnyExcept((ReadOnlySpan<int>)[1, 2, 3]).Should().BeTrue();
+    }
+
+    // ----- Count -----
+
+    [Fact]
+    public void Count_SingleValue_CountsOccurrences()
+    {
+        ReadOnlySpan<int> span = [1, 2, 1, 3, 1];
+        span.Count(1).Should().Be(3);
+    }
+
+    [Fact]
+    public void Count_SingleValue_NotPresent_ReturnsZero()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3];
+        span.Count(99).Should().Be(0);
+    }
+
+    [Fact]
+    public void Count_SingleValue_Empty_ReturnsZero()
+    {
+        ReadOnlySpan<int>.Empty.Count(1).Should().Be(0);
+    }
+
+    [Fact]
+    public void Count_Byte_CountsOccurrences()
+    {
+        ReadOnlySpan<byte> span = [(byte)1, (byte)2, (byte)1, (byte)1];
+        span.Count((byte)1).Should().Be(3);
+    }
+
+    [Fact]
+    public void Count_Char_CountsOccurrences()
+    {
+        ReadOnlySpan<char> span = "banana".AsSpan();
+        span.Count('a').Should().Be(3);
+        span.Count('n').Should().Be(2);
+        span.Count('z').Should().Be(0);
+    }
+
+    [Fact]
+    public void Count_Sequence_CountsNonOverlappingMatches()
+    {
+        ReadOnlySpan<char> span = "abcabcabc".AsSpan();
+        span.Count("abc".AsSpan()).Should().Be(3);
+    }
+
+    [Fact]
+    public void Count_Sequence_OverlappingPattern_CountsNonOverlapping()
+    {
+        // "aa" inside "aaaa" non-overlapping count is 2.
+        ReadOnlySpan<char> span = "aaaa".AsSpan();
+        span.Count("aa".AsSpan()).Should().Be(2);
+    }
+
+    [Fact]
+    public void Count_Sequence_EmptyValue_ReturnsZero()
+    {
+        ReadOnlySpan<char> span = "abc".AsSpan();
+        span.Count((ReadOnlySpan<char>)[]).Should().Be(0);
+    }
+
+    [Fact]
+    public void Count_Sequence_LongerThanSource_ReturnsZero()
+    {
+        ReadOnlySpan<char> span = "ab".AsSpan();
+        span.Count("abc".AsSpan()).Should().Be(0);
+    }
+
+    // ----- Span<T> wrappers -----
+
+    [Fact]
+    public void Span_LastIndexOfAnyExcept_SingleValue_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 1, 2, 1 ];
+        span.LastIndexOfAnyExcept(1).Should().Be(2);
+    }
+
+    [Fact]
+    public void Span_LastIndexOfAnyExcept_TwoValues_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 2, 9, 1 ];
+        span.LastIndexOfAnyExcept(1, 2).Should().Be(2);
+    }
+
+    [Fact]
+    public void Span_LastIndexOfAnyExcept_ThreeValues_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 2, 3, 9, 1 ];
+        span.LastIndexOfAnyExcept(1, 2, 3).Should().Be(3);
+    }
+
+    [Fact]
+    public void Span_LastIndexOfAnyExcept_ValuesSpan_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 2, 3, 9 ];
+        span.LastIndexOfAnyExcept((ReadOnlySpan<int>)[1, 2, 3]).Should().Be(3);
+    }
+
+    [Fact]
+    public void Span_IndexOfAnyExcept_SingleValue_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 1, 9, 1 ];
+        span.IndexOfAnyExcept(1).Should().Be(2);
+    }
+
+    [Fact]
+    public void Span_IndexOfAnyExcept_TwoValues_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 2, 9, 1, 2 ];
+        span.IndexOfAnyExcept(1, 2).Should().Be(2);
+    }
+
+    [Fact]
+    public void Span_IndexOfAnyExcept_ThreeValues_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 2, 3, 9, 1 ];
+        span.IndexOfAnyExcept(1, 2, 3).Should().Be(3);
+    }
+
+    [Fact]
+    public void Span_IndexOfAnyExcept_ValuesSpan_DelegatesToReadOnly()
+    {
+        Span<int> span = [1, 2, 3, 9 ];
+        span.IndexOfAnyExcept((ReadOnlySpan<int>)[1, 2, 3]).Should().Be(3);
+    }
+
+    // ----- CommonPrefixLength comparer paths -----
+
+    [Fact]
+    public void CommonPrefixLength_DefaultComparer_String()
+    {
+        ReadOnlySpan<string> a = ["x", "y", "z"];
+        ReadOnlySpan<string> b = ["x", "y", "Z"];
+        a.CommonPrefixLength(b, EqualityComparer<string>.Default).Should().Be(2);
+        a.CommonPrefixLength(b, StringComparer.OrdinalIgnoreCase).Should().Be(3);
+    }
+
+    [Fact]
+    public void CommonPrefixLength_NullComparer_FallsBackToDefault_String()
+    {
+        ReadOnlySpan<string> a = ["x", "y", "z"];
+        ReadOnlySpan<string> b = ["x", "y", "z", "extra"];
+        a.CommonPrefixLength(b, comparer: null).Should().Be(3);
+    }
+}


### PR DESCRIPTION
Coverage rollout. Two test files, both net481-only (Framework polyfills).

## What

### 1. [touki.tests/Framework/System/DateTimeFormatTests.cs](https://github.com/JeremyKuhne/touki/blob/coverage/datetimeformat-and-spansearch-tests/touki.tests/Framework/System/DateTimeFormatTests.cs) &mdash; 145 cases

Drives `DateTimeFormat.Format` side-by-side with the BCL's `DateTime.ToString` as an oracle.

- **All 18 standard formats** (`d D f F g G m M o O r R s t T u y Y`) round-tripped against the BCL on `InvariantCulture`.
- **34 explicit `(DateTime, format, expected)` tuples** ported from [dotnet/runtime DateTimeTests.ToString_MatchesExpected_MemberData](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs).
- **Custom-format token coverage**: `yyyy-MM-dd`, `MMM`/`MMMM`, fractional seconds (`f` through `fffffff`, `F`/`FF`/`FFF`/`FFFF`), eras (`g`/`gg`), backslash escapes, single/double-quoted literals, `%`-prefixed single-char formats.
- **Multi-culture**: Invariant, en-US, uk-UA / ru-RU (genitive month names), fr-FR / de-DE (accented month names), ja-JP.
- **Year padding widths** `yyy`, `yyyyy`, `yyyyyy`, `yyyyyyy`.
- **Boundary cases**: `MinValue` / `MaxValue` round-trip pattern, U+202D non-ASCII literal preservation.
- **`RoundtripK`** across UTC, Unspecified, and explicit-offset paths.
- **`HebrewCalendar`** end-to-end (drives the previously-uncovered `FormatHebrewMonthName`).
- **`ParseQuoteString` error / escape paths**: unterminated `'`, unterminated `"`, trailing `\` after escape, escaped quote inside quote.

`DateTimeFormat` coverage: **65.7% &rarr; 90% line, 48.8% &rarr; 73% branch** on net481.

### 2. [touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs](https://github.com/JeremyKuhne/touki/blob/coverage/datetimeformat-and-spansearch-tests/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs) &mdash; 49 cases

Extends the existing `SpanExtensionsSearchTests` (which only covered `int`) to the type-specialized branches the polyfill picks for other primitives, plus the `Span<T>` wrappers.

- **`LastIndexOfAnyExcept`** &mdash; single / two / three values / values-span overloads, on `int`, `byte`, `char`, `short`, `long`.
- **`IndexOfAnyExcept`** &mdash; full-suite parity for the `Span<T>` wrappers (previously 0% coverage).
- **`ContainsAny` / `ContainsAnyExcept`** &mdash; two-value / three-value / values-span overloads, true and false cases.
- **`Count`** &mdash; single value (int / byte / char), and sequence-pattern variant including the documented non-overlapping rule (`Count("aa") in "aaaa" == 2`), empty-value, and longer-than-source cases.
- **`CommonPrefixLength` comparer paths** &mdash; `EqualityComparer<string>.Default` vs. `StringComparer.OrdinalIgnoreCase` vs. null comparer.
- **`Span<T>` wrapper overloads** for `IndexOfAnyExcept` / `LastIndexOfAnyExcept` (single/two/three values + values-span).

Patterns adapted from `dotnet/runtime`:
- [System.Memory/tests/Span/IndexOfAnyExcept.T.cs](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Memory/tests/Span/IndexOfAnyExcept.T.cs)
- [System.Memory/tests/Span/LastIndexOfAny.byte.cs](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Memory/tests/Span/LastIndexOfAny.byte.cs)
- [System.Memory/tests/Span/LastIndexOfAny.T.cs](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Memory/tests/Span/LastIndexOfAny.T.cs)

## Coverage delta

| Metric | Before | After | Delta |
|---|---|---|---|
| Merged line | 78.57% (8670 / 11035) | **80.04%** (8832 / 11035) | **+1.47 pts** |
| Merged branch | 70.55% (4007 / 5680) | **72.66%** (4127 / 5680) | **+2.11 pts** |
| Tests | 3786 + 3984 | **3788 + 4226** | **+244** |

This is the first PR to push merged line coverage past **80%**.

## Validation

- `dotnet build -c Release` &mdash; clean on both TFMs.
- `dotnet test -c Release` &mdash; all 3788 net10.0 + 4226 net481 tests pass.
- Local cobertura merge confirms the deltas above.

## Follow-ups (separate PRs)

The coverage report still has slack on:

- `System.Number` / `System.Number.BigInteger` &mdash; large polyfilled formatting code; 71% line, 56% branch (over 700 uncovered lines combined).
- `System.SpanExtensions.Replace` &mdash; 40% line, scalar/unrolled hot paths.
- `System.Threading.Lock.State` / `Lock` &mdash; ~68%, contended paths.
- `Touki.Text.ValueStringBuilder` &mdash; 76%, `AppendFormatted` / `AppendCustomFormatter` interpolated-string-handler surface.

Each is a meaty target of its own.