### PR TITLE
Fix net481 RyuJIT constant-propagation bug in SpanExtensions.Replace, raise coverage

### DIFF
--- a/.agents/skills/framework-jit-optimization/specialization.md
+++ b/.agents/skills/framework-jit-optimization/specialization.md
@@ -18,16 +18,18 @@ public unsafe void Replace(T oldValue, T newValue)
 
     if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
     {
-        ushort oldShort = Unsafe.As<T, ushort>(ref oldValue);
-        ushort newShort = Unsafe.As<T, ushort>(ref newValue);
+        // The `& 0xFFFF` is load-bearing on net481 RyuJIT &mdash; see
+        // "Signed-primitive constant-propagation pitfall" below.
+        ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+        ushort newShort = (ushort)(Unsafe.As<T, ushort>(ref newValue) & 0xFFFF);
         // ... tight ushort* loop ...
         return;
     }
 
     if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
     {
-        byte oldByte = Unsafe.As<T, byte>(ref oldValue);
-        byte newByte = Unsafe.As<T, byte>(ref newValue);
+        byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+        byte newByte = (byte)(Unsafe.As<T, byte>(ref newValue) & 0xFF);
         // ... tight byte* loop ...
         return;
     }
@@ -62,7 +64,7 @@ denormalized flags). Don't fold them in.
 
 For methods constrained to `where T : IComparable<T>` (e.g. `IndexOfAnyInRange`),
 keep the primitives as their signed/unsigned variants because comparison
-operators differ. See [SpanExtensions.InRange.cs](../../../touki/Framework/Touki/SpanExtensions.InRange.cs)
+operators differ. See [SpanExtensions.InRange.cs](../../../touki/Framework/Polyfills/System/SpanExtensions.InRange.cs)
 for the full byte/sbyte/char/short/ushort/int/uint/long/ulong specialization.
 
 ## `[MethodImpl(MethodImplOptions.AggressiveInlining)]`
@@ -91,6 +93,37 @@ itself a generic in some outer context where `typeof(T)` isn't a JIT-time
 constant), you'll see all branches in the disassembly &mdash; and your benchmark
 ratio will reflect it. Add the attribute, or hoist the call site so `T` is
 concrete.
+
+## Signed-primitive constant-propagation pitfall
+
+If the specialization compares the reinterpreted value against bytes loaded
+from memory (the typical `*ptr == oldByte` pattern in `Replace` / `IndexOf`),
+**always mask in the int domain** when narrowing through `Unsafe.As`:
+
+```c#
+byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+```
+
+Without the mask, `[AggressiveInlining]` plus a literal signed argument
+(`(sbyte)-1`, `(short)-1`) on net481 RyuJIT produces wrong results in
+**Release** (Debug passes). The caller's int-promoted constant
+(`-1` &rarr; `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
+loop's `cmp` immediate as a 32-bit value. The `movzx`-loaded byte is in
+`[0, 0xFF]`, so `cmp ecx, 0FFFFFFFF` is unconditionally false &mdash; the loop
+runs, finds nothing, returns silently.
+
+The cast alone (`(byte)Unsafe.As<...>`) does not fix it; RyuJIT's constant
+tracker doesn't model the IL `conv.u1` as truncating. The explicit `& 0xFF`
+mask forces the high bits to zero in the propagated constant, so the compare
+immediate becomes the correct byte even when the JIT carries the int forward.
+Confirmed by disassembly in
+[ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs).
+
+Symmetric tests using only `byte` or `char` will not catch this (their
+int-promoted form already has zero upper bits). Always include `sbyte` and
+`short` with negative values in the test matrix for any
+`Unsafe.As<T, byte>` / `Unsafe.As<T, ushort>` specialization.
 
 ## See also
 

--- a/.agents/skills/polyfill-dotnet-api/SKILL.md
+++ b/.agents/skills/polyfill-dotnet-api/SKILL.md
@@ -201,15 +201,39 @@ enforces these; this section explains *why*.
    destination separately before pinning. See
    [EncodingExtensions.GetBytes](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
 
-2. **`Unsafe.As<T,...>(ref param)` mis-reads negative-signed primitives
-   in Release on net481.** RyuJIT can keep the parameter in a register
-   or smaller-than-`int` slot, so reinterpret reads the wrong byte
-   (`StartsWith((sbyte)0)` over `[-1, 0, 1]` returns the wrong answer).
-   Either copy to a definite local first (`T local = value;`), or skip
-   Unsafe entirely &mdash; per
-   [StartsWithPerf](../../../touki.perf/StartsWithPerf.cs),
-   `value.Equals(span[0])` via `IEquatable<T>` already beats Unsafe on
-   net481.
+2. **`[AggressiveInlining]` + `Unsafe.As<T, narrower>(ref param)`
+   compares against the wrong constant on net481.** When the caller
+   passes a literal of a *signed* primitive narrower than `int`
+   (`sbyte`, `short`), C# `int`-promotion sign-extends it (`(sbyte)-1`
+   becomes `0xFFFFFFFF`). If the called method is
+   `[AggressiveInlining]` and reinterprets the parameter via
+   `Unsafe.As<T, byte>(ref oldValue)` to compare against bytes loaded
+   with `movzx`, RyuJIT propagates the *int-promoted* constant into
+   the compare immediate (`cmp ecx, 0xFFFFFFFF`) instead of the
+   requested byte (`0xFF`). The `movzx`-loaded byte is in `[0, 0xFF]`
+   so the compare is *unconditionally false* &mdash; the loop runs
+   silently doing nothing in Release. Debug passes (no inlining).
+   Confirmed by disassembly in
+   [ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs).
+
+   **Fix:** explicitly mask in the int domain so RyuJIT must fold the
+   high bits to zero. The cast alone is not enough &mdash; the JIT's
+   constant tracker doesn't model the `conv.u1` IL op as truncating
+   to `[0, 0xFF]` here. Use:
+
+   ```csharp
+   byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+   ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+   ```
+
+   See [SpanExtensions.Replace.cs](../../../touki/Framework/Polyfills/System/SpanExtensions.Replace.cs)
+   for the in-place version, and the
+   [ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs)
+   benchmark for the disassembly proof. The unsigned cases (`byte`,
+   `ushort`, `char`) are unaffected because their int-promoted form
+   already has the upper bits zero. Tests on signed inputs are
+   essential &mdash; symmetric tests that only use `byte`/`char` will
+   not catch this.
 
 3. **`Random.NextBytes(byte[])` is native on net481; the obvious
    managed span loop is slower per byte** (loses to `byte[]` + copy by

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -184,8 +184,13 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
 - Build both TFMs.
 - Run `dotnet test` in **both Debug and Release**. Release-mode RyuJIT
   inlining surfaces bugs Debug doesn't &mdash; e.g.
-  `Unsafe.As<T, ...>(ref param)` mis-reads negative-signed-primitive
-  parameters on net481, but only in Release.
+  `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates
+  the caller's int-promoted argument into the comparison immediate
+  (`cmp ecx, 0xFFFFFFFF` instead of `cmp ecx, 0xFF`) for negative
+  signed-primitive inputs on net481, but only in Release. Mask
+  explicitly with `& 0xFF` / `& 0xFFFF`. See
+  [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) &sect;Gotchas
+  and [`framework-jit-optimization/specialization.md`](../framework-jit-optimization/specialization.md).
 - Stage **by path**, never `git add -A` / `git add .` when the working
   tree spans more than one logical change. If topics are intermingled,
   ask before staging.

--- a/touki.perf/ReplaceUnsafeAsPerf.cs
+++ b/touki.perf/ReplaceUnsafeAsPerf.cs
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.CompilerServices;
+
+#pragma warning disable CS8500 // takes the address of, gets the size of, or declares a pointer to a managed type
+
+namespace touki.perf;
+
+/// <summary>
+///  Investigates the net481 RyuJIT codegen discrepancy between
+///  <c>Unsafe.As&lt;T, byte&gt;(ref methodParameter)</c> inside an
+///  <see cref="MethodImplOptions.AggressiveInlining"/> method and the
+///  same operation routed through a <c>[NoInlining]</c> primitive-typed
+///  helper.
+///
+///  Use BenchmarkDotNet's <c>--disasm</c> (DisassemblyDiagnoser) to see
+///  the actual x64 machine code RyuJIT emits for each shape on net481.
+/// </summary>
+[DisassemblyDiagnoser(maxDepth: 5, printSource: true, exportHtml: true)]
+[SimpleJob(RuntimeMoniker.Net481, warmupCount: 1, iterationCount: 1, launchCount: 1)]
+public class ReplaceUnsafeAsPerf
+{
+    private sbyte[] _data = null!;
+
+    [GlobalSetup]
+    public void Setup() => _data = [-1, 2, -1, 4, -1, 6, -1, 8];
+
+    // ----- Buggy pattern (Unsafe.As on the AggressiveInlining method's parameter) -----
+
+    [Benchmark(Baseline = true)]
+    public sbyte Buggy_Inlined()
+    {
+        sbyte[] data = _data;
+        ReplaceBuggy<sbyte>(data, (sbyte)(-1), (sbyte)0);
+        sbyte result = data[0];
+        // Restore so subsequent iterations see the same input.
+        data[0] = -1;
+        data[2] = -1;
+        data[4] = -1;
+        data[6] = -1;
+        return result;
+    }
+
+    [Benchmark]
+    public sbyte Fixed_NoInliningHelper()
+    {
+        sbyte[] data = _data;
+        ReplaceFixed<sbyte>(data, (sbyte)(-1), (sbyte)0);
+        sbyte result = data[0];
+        data[0] = -1;
+        data[2] = -1;
+        data[4] = -1;
+        data[6] = -1;
+        return result;
+    }
+
+    [Benchmark]
+    public sbyte SplitBlocks()
+    {
+        sbyte[] data = _data;
+        ReplaceSplitBlocks<sbyte>(data, (sbyte)(-1), (sbyte)0);
+        sbyte result = data[0];
+        data[0] = -1;
+        data[2] = -1;
+        data[4] = -1;
+        data[6] = -1;
+        return result;
+    }
+
+    [Benchmark]
+    public sbyte ExplicitMask()
+    {
+        sbyte[] data = _data;
+        ReplaceExplicitMask<sbyte>(data, (sbyte)(-1), (sbyte)0);
+        sbyte result = data[0];
+        data[0] = -1;
+        data[2] = -1;
+        data[4] = -1;
+        data[6] = -1;
+        return result;
+    }
+
+    // ----- Implementations -----
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceBuggy<T>(Span<T> span, T oldValue, T newValue)
+        where T : struct
+    {
+        // Mirrors the original SpanExtensions.Replace<T> shape.
+        if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
+        {
+            byte oldByte = Unsafe.As<T, byte>(ref oldValue);
+            byte newByte = Unsafe.As<T, byte>(ref newValue);
+            fixed (T* p = span)
+            {
+                byte* ptr = (byte*)p;
+                byte* end = ptr + span.Length;
+                while (ptr < end)
+                {
+                    if (*ptr == oldByte)
+                    {
+                        *ptr = newByte;
+                    }
+
+                    ptr++;
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceFixed<T>(Span<T> span, T oldValue, T newValue)
+        where T : struct
+    {
+        if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
+        {
+            byte oldByte = ReadAsByte(oldValue);
+            byte newByte = ReadAsByte(newValue);
+            fixed (T* p = span)
+            {
+                byte* ptr = (byte*)p;
+                byte* end = ptr + span.Length;
+                while (ptr < end)
+                {
+                    if (*ptr == oldByte)
+                    {
+                        *ptr = newByte;
+                    }
+
+                    ptr++;
+                }
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static byte ReadAsByte<T>(T value) where T : struct
+    {
+        if (typeof(T) == typeof(byte))
+        {
+            return Unsafe.As<T, byte>(ref value);
+        }
+
+        return (byte)Unsafe.As<T, sbyte>(ref value);
+    }
+
+    // Separate blocks per signed/unsigned primitive. Reading sbyte through a
+    // matching Unsafe.As<T, sbyte> followed by a (byte) cast forces a
+    // conv.u1 in the IL, which RyuJIT lowers to either a movsx+movzx pair or
+    // a constant fold to 0xFF for a literal -1 — never the buggy 32-bit
+    // sign-extended compare immediate.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceSplitBlocks<T>(Span<T> span, T oldValue, T newValue)
+        where T : struct
+    {
+        if (typeof(T) == typeof(byte))
+        {
+            byte oldByte = Unsafe.As<T, byte>(ref oldValue);
+            byte newByte = Unsafe.As<T, byte>(ref newValue);
+            ReplaceByteLoop(span, oldByte, newByte);
+            return;
+        }
+
+        if (typeof(T) == typeof(sbyte))
+        {
+            byte oldByte = (byte)Unsafe.As<T, sbyte>(ref oldValue);
+            byte newByte = (byte)Unsafe.As<T, sbyte>(ref newValue);
+            ReplaceByteLoop(span, oldByte, newByte);
+            return;
+        }
+    }
+
+    // Forces the JIT to materialize the byte truncation by ANDing with 0xFF
+    // even after the buggy <T, byte> Unsafe.As propagation.
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceExplicitMask<T>(Span<T> span, T oldValue, T newValue)
+        where T : struct
+    {
+        if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
+        {
+            byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+            byte newByte = (byte)(Unsafe.As<T, byte>(ref newValue) & 0xFF);
+            ReplaceByteLoop(span, oldByte, newByte);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceByteLoop<T>(Span<T> span, byte oldByte, byte newByte) where T : struct
+    {
+        fixed (T* p = span)
+        {
+            byte* ptr = (byte*)p;
+            byte* end = ptr + span.Length;
+            while (ptr < end)
+            {
+                if (*ptr == oldByte)
+                {
+                    *ptr = newByte;
+                }
+
+                ptr++;
+            }
+        }
+    }
+}

--- a/touki.tests/Framework/System/SpanExtensionsCoverageTests.cs
+++ b/touki.tests/Framework/System/SpanExtensionsCoverageTests.cs
@@ -19,7 +19,7 @@ public class SpanExtensionsCoverageTests
         byte[] data = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1];
         Span<byte> span = data;
         span.Replace((byte)2, (byte)9);
-        span.ToArray().Should().BeEquivalentTo<byte>([1, 9, 3, 1, 9, 3, 1, 9, 3, 1]);
+        span.ToArray().Should().Equal((byte)1, (byte)9, (byte)3, (byte)1, (byte)9, (byte)3, (byte)1, (byte)9, (byte)3, (byte)1);
     }
 
     [Fact]
@@ -70,7 +70,7 @@ public class SpanExtensionsCoverageTests
         ushort[] data = [1000, 2, 1000, 4, 1000, 6, 1000, 8, 1000, 10];
         Span<ushort> span = data;
         span.Replace((ushort)1000, (ushort)0);
-        span.ToArray().Should().BeEquivalentTo<ushort>([0, 2, 0, 4, 0, 6, 0, 8, 0, 10]);
+        span.ToArray().Should().Equal((ushort)0, (ushort)2, (ushort)0, (ushort)4, (ushort)0, (ushort)6, (ushort)0, (ushort)8, (ushort)0, (ushort)10);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class SpanExtensionsCoverageTests
         ReadOnlySpan<byte> source = [ 1, 2, 3, 1, 2, 3, 1, 2, 3, 1 ];
         Span<byte> dest = stackalloc byte[10];
         source.Replace(dest, (byte)2, (byte)9);
-        dest.ToArray().Should().BeEquivalentTo<byte>([1, 9, 3, 1, 9, 3, 1, 9, 3, 1]);
+        dest.ToArray().Should().Equal((byte)1, (byte)9, (byte)3, (byte)1, (byte)9, (byte)3, (byte)1, (byte)9, (byte)3, (byte)1);
     }
 
     [Fact]
@@ -187,7 +187,7 @@ public class SpanExtensionsCoverageTests
         ReadOnlySpan<byte> source = [ 1, 2, 3, 4, 5 ];
         Span<byte> dest = stackalloc byte[5];
         source.Replace(dest, (byte)1, (byte)1);
-        dest.ToArray().Should().BeEquivalentTo<byte>([1, 2, 3, 4, 5]);
+        dest.ToArray().Should().Equal((byte)1, (byte)2, (byte)3, (byte)4, (byte)5);
     }
 
     // ---------- IndexOfAnyInRange specializations (sbyte / short / ushort / int / uint / ulong) ----------

--- a/touki.tests/Framework/System/SpanExtensionsCoverageTests.cs
+++ b/touki.tests/Framework/System/SpanExtensionsCoverageTests.cs
@@ -1,0 +1,356 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Framework.System;
+
+/// <summary>
+///  Targets the primitive-specialization paths in
+///  <c>SpanExtensions.Replace.cs</c> and <c>SpanExtensions.InRange.cs</c>,
+///  plus a few small helpers that were previously uncovered.
+/// </summary>
+public class SpanExtensionsCoverageTests
+{
+    // ---------- Replace<T>(this Span<T>, T, T) primitive specializations ----------
+
+    [Fact]
+    public void Replace_Byte_ReplacesAllOccurrences()
+    {
+        byte[] data = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1];
+        Span<byte> span = data;
+        span.Replace((byte)2, (byte)9);
+        span.ToArray().Should().BeEquivalentTo<byte>([1, 9, 3, 1, 9, 3, 1, 9, 3, 1]);
+    }
+
+    [Fact]
+    public void Replace_Byte_AllSame_ReplacesEverything()
+    {
+        byte[] data = [5, 5, 5, 5, 5, 5, 5, 5];
+        Span<byte> span = data;
+        span.Replace((byte)5, (byte)0);
+        span.ToArray().Should().AllSatisfy(b => b.Should().Be(0));
+    }
+
+    [Fact]
+    public void Replace_Byte_Empty_NoOp()
+    {
+        byte[] data = [];
+        Span<byte> span = data;
+        span.Replace((byte)1, (byte)2);
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Replace_SByte_ReplacesAllOccurrences()
+    {
+        sbyte[] data = [-1, 2, -1, 4, -1, 6, -1, 8, -1, 10];
+        Span<sbyte> span = data;
+        span.Replace((sbyte)(-1), (sbyte)0);
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i].Should().Be(i % 2 == 0 ? (sbyte)0 : (sbyte)(i + 1));
+        }
+    }
+
+    [Fact]
+    public void Replace_Short_ReplacesAllOccurrences()
+    {
+        short[] data = [-1000, 2, -1000, 4, -1000, 6, -1000, 8, -1000, 10];
+        Span<short> span = data;
+        span.Replace((short)(-1000), (short)0);
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i].Should().Be(i % 2 == 0 ? (short)0 : (short)(i + 1));
+        }
+    }
+
+    [Fact]
+    public void Replace_UShort_ReplacesAllOccurrences()
+    {
+        ushort[] data = [1000, 2, 1000, 4, 1000, 6, 1000, 8, 1000, 10];
+        Span<ushort> span = data;
+        span.Replace((ushort)1000, (ushort)0);
+        span.ToArray().Should().BeEquivalentTo<ushort>([0, 2, 0, 4, 0, 6, 0, 8, 0, 10]);
+    }
+
+    [Fact]
+    public void Replace_Char_ReplacesAllOccurrencesIncludingTailRemainder()
+    {
+        // length not a multiple of 4 to exercise the tail loop
+        char[] data = "aXaXaXaXaXa".ToCharArray();
+        Span<char> span = data;
+        span.Replace('X', '_');
+        new string(data).Should().Be("a_a_a_a_a_a");
+    }
+
+    [Fact]
+    public void Replace_Byte_LongSpan_ExercisesUnrolledLoop()
+    {
+        byte[] data = new byte[33];
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i] = (byte)(i % 3);
+        }
+
+        Span<byte> span = data;
+        span.Replace((byte)1, (byte)9);
+
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i].Should().Be(i % 3 == 1 ? (byte)9 : (byte)(i % 3));
+        }
+    }
+
+    // ---------- Replace(ReadOnlySpan<T>, Span<T>, T, T) primitive specializations ----------
+
+    [Fact]    public void Replace_ReadOnly_SByte_CopiesAndReplaces()
+    {
+        sbyte[] sourceArray = [-1, 2, -1, 4, -1];
+        ReadOnlySpan<sbyte> source = sourceArray;
+        Span<sbyte> dest = stackalloc sbyte[5];
+        source.Replace(dest, (sbyte)(-1), (sbyte)0);
+        for (int i = 0; i < dest.Length; i++)
+        {
+            dest[i].Should().Be(i % 2 == 0 ? (sbyte)0 : (sbyte)(i + 1));
+        }
+    }
+
+    [Fact]
+    public void Replace_ReadOnly_Short_CopiesAndReplaces()
+    {
+        short[] sourceArray = [-1, 2, -1, 4, -1, 6, -1];
+        ReadOnlySpan<short> source = sourceArray;
+        Span<short> dest = stackalloc short[7];
+        source.Replace(dest, (short)(-1), (short)0);
+        for (int i = 0; i < dest.Length; i++)
+        {
+            dest[i].Should().Be(i % 2 == 0 ? (short)0 : (short)(i + 1));
+        }
+    }
+
+    [Fact]    public void Replace_ReadOnly_Byte_CopiesAndReplaces()
+    {
+        ReadOnlySpan<byte> source = [ 1, 2, 3, 1, 2, 3, 1, 2, 3, 1 ];
+        Span<byte> dest = stackalloc byte[10];
+        source.Replace(dest, (byte)2, (byte)9);
+        dest.ToArray().Should().BeEquivalentTo<byte>([1, 9, 3, 1, 9, 3, 1, 9, 3, 1]);
+    }
+
+    [Fact]
+
+    public void Replace_ReadOnly_Char_CopiesAndReplaces()
+    {
+        ReadOnlySpan<char> source = "aXbXcXdXeXf".AsSpan();
+        Span<char> dest = stackalloc char[source.Length];
+        source.Replace(dest, 'X', '_');
+        dest.ToString().Should().Be("a_b_c_d_e_f");
+    }
+
+    [Fact]
+    public void Replace_ReadOnly_Byte_LongSpan_ExercisesUnrolledLoop()
+    {
+        byte[] sourceArray = new byte[33];
+        for (int i = 0; i < sourceArray.Length; i++)
+        {
+            sourceArray[i] = (byte)(i % 3);
+        }
+
+        ReadOnlySpan<byte> source = sourceArray;
+        Span<byte> dest = stackalloc byte[33];
+        source.Replace(dest, (byte)1, (byte)9);
+
+        for (int i = 0; i < dest.Length; i++)
+        {
+            dest[i].Should().Be(i % 3 == 1 ? (byte)9 : (byte)(i % 3));
+        }
+    }
+
+    [Fact]
+    public void Replace_ReadOnly_DestinationTooShort_Throws()
+    {
+        byte[] data = [1, 2, 3, 4, 5];
+        byte[] destBuffer = new byte[3];
+
+        Action action = () =>
+        {
+            ReadOnlySpan<byte> source = data;
+            Span<byte> dest = destBuffer;
+            source.Replace(dest, (byte)1, (byte)0);
+        };
+
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Replace_ReadOnly_OldEqualsNew_CopiesUnchanged()
+    {
+        ReadOnlySpan<byte> source = [ 1, 2, 3, 4, 5 ];
+        Span<byte> dest = stackalloc byte[5];
+        source.Replace(dest, (byte)1, (byte)1);
+        dest.ToArray().Should().BeEquivalentTo<byte>([1, 2, 3, 4, 5]);
+    }
+
+    // ---------- IndexOfAnyInRange specializations (sbyte / short / ushort / int / uint / ulong) ----------
+
+    [Fact]
+    public void IndexOfAnyInRange_SByte_FindsFirst()
+    {
+        sbyte[] data = [-100, -50, 0, 50, 100];
+        ((ReadOnlySpan<sbyte>)data).IndexOfAnyInRange((sbyte)(-10), (sbyte)10).Should().Be(2);
+        ((ReadOnlySpan<sbyte>)data).IndexOfAnyInRange((sbyte)127, (sbyte)127).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_Short_FindsFirst()
+    {
+        short[] data = [-1000, -500, 0, 500, 1000];
+        ((ReadOnlySpan<short>)data).IndexOfAnyInRange((short)(-100), (short)100).Should().Be(2);
+        ((ReadOnlySpan<short>)data).IndexOfAnyInRange((short)2000, (short)3000).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_UShort_FindsFirst()
+    {
+        ushort[] data = [1000, 2000, 3000, 4000];
+        ((ReadOnlySpan<ushort>)data).IndexOfAnyInRange((ushort)2500, (ushort)3500).Should().Be(2);
+        ((ReadOnlySpan<ushort>)data).IndexOfAnyInRange((ushort)10000, (ushort)20000).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_Int_FindsFirst()
+    {
+        int[] data = [-1000, -500, 0, 500, 1000];
+        ((ReadOnlySpan<int>)data).IndexOfAnyInRange(-100, 100).Should().Be(2);
+        ((ReadOnlySpan<int>)data).IndexOfAnyInRange(2000, 3000).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_UInt_FindsFirst()
+    {
+        uint[] data = [1, 100, 200, 300, 400];
+        ((ReadOnlySpan<uint>)data).IndexOfAnyInRange((uint)150, (uint)250).Should().Be(2);
+        ((ReadOnlySpan<uint>)data).IndexOfAnyInRange((uint)1000, (uint)2000).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_ULong_FindsFirst()
+    {
+        ulong[] data = [1, 100, 200, 300, 400];
+        ((ReadOnlySpan<ulong>)data).IndexOfAnyInRange((ulong)150, (ulong)250).Should().Be(2);
+        ((ReadOnlySpan<ulong>)data).IndexOfAnyInRange((ulong)1000, (ulong)2000).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyExceptInRange_SByte_FindsFirst()
+    {
+        sbyte[] data = [1, 2, 3, -50, 4, 5];
+        ((ReadOnlySpan<sbyte>)data).IndexOfAnyExceptInRange((sbyte)1, (sbyte)10).Should().Be(3);
+    }
+
+    [Fact]
+    public void IndexOfAnyExceptInRange_UShort_FindsFirst()
+    {
+        ushort[] data = [10, 20, 30, 5000, 40];
+        ((ReadOnlySpan<ushort>)data).IndexOfAnyExceptInRange((ushort)0, (ushort)100).Should().Be(3);
+    }
+
+    [Fact]
+    public void IndexOfAnyExceptInRange_Int_FindsFirst()
+    {
+        int[] data = [10, 20, 30, -5000, 40];
+        ((ReadOnlySpan<int>)data).IndexOfAnyExceptInRange(0, 100).Should().Be(3);
+    }
+
+    [Fact]
+    public void IndexOfAnyExceptInRange_ULong_FindsFirst()
+    {
+        ulong[] data = [10, 20, 30, 50000, 40];
+        ((ReadOnlySpan<ulong>)data).IndexOfAnyExceptInRange((ulong)0, (ulong)100).Should().Be(3);
+    }
+
+    // ---------- LastIndexOfAnyInRange specializations ----------
+
+    [Fact]
+    public void LastIndexOfAnyInRange_Generic_FindsLast()
+    {
+        // string is IComparable<string> but not specialized → exercises the fallback.
+        string[] data = ["a", "g", "k", "z"];
+        ((ReadOnlySpan<string>)data).LastIndexOfAnyInRange("b", "m").Should().Be(2);
+        ((ReadOnlySpan<string>)data).LastIndexOfAnyInRange("0", "9").Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyInRange_Int_FindsLast()
+    {
+        int[] data = [10, 20, 30, 40, 50];
+        ((ReadOnlySpan<int>)data).LastIndexOfAnyInRange(15, 35).Should().Be(2);
+        ((ReadOnlySpan<int>)data).LastIndexOfAnyInRange(100, 200).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExceptInRange_Int_FindsLast()
+    {
+        int[] data = [1, 2, 3, 999, 4, 5];
+        ((ReadOnlySpan<int>)data).LastIndexOfAnyExceptInRange(0, 10).Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyInRange_Byte_NoMatch()
+    {
+        byte[] data = [1, 2, 3, 4];
+        ((ReadOnlySpan<byte>)data).LastIndexOfAnyInRange((byte)100, (byte)200).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyInRange_Char_NoMatch()
+    {
+        // Exercises the no-match return in the char specialization.
+        char[] data = ['a', 'b', 'c'];
+        ((ReadOnlySpan<char>)data).LastIndexOfAnyInRange('0', '9').Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_Long_NoMatch()
+    {
+        // Exercises the no-match return in the long specialization.
+        long[] data = [long.MinValue, -1L, 0L];
+        ((ReadOnlySpan<long>)data).IndexOfAnyInRange(100L, 200L).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyInRange_StringFallback_NoMatch_ReturnsMinusOne()
+    {
+        // Exercises the no-match return in the generic IComparable fallback.
+        string[] data = ["apple", "banana", "cherry"];
+        ((ReadOnlySpan<string>)data).IndexOfAnyInRange("0", "9").Should().Be(-1);
+    }
+
+    // ---------- Span<T> overloads (just delegate to ReadOnlySpan) ----------
+
+    [Fact]
+    public void IndexOfAnyInRange_SpanOverload_Int()
+    {
+        Span<int> data = stackalloc int[] { -10, 0, 5, 10, 100 };
+        data.IndexOfAnyInRange(1, 9).Should().Be(2);
+        data.IndexOfAnyExceptInRange(-100, 100).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyInRange_SpanOverload_Int()
+    {
+        Span<int> data = stackalloc int[] { 1, 5, 10, 5, 1 };
+        data.LastIndexOfAnyInRange(4, 6).Should().Be(3);
+        data.LastIndexOfAnyExceptInRange(4, 6).Should().Be(4);
+    }
+
+    [Fact]
+    public void ContainsAnyInRange_SpanOverload_Byte()
+    {
+        Span<byte> data = stackalloc byte[] { 1, 2, 3, 50, 4 };
+        data.ContainsAnyInRange((byte)40, (byte)60).Should().BeTrue();
+        data.ContainsAnyInRange((byte)100, (byte)200).Should().BeFalse();
+        data.ContainsAnyExceptInRange((byte)1, (byte)10).Should().BeTrue();
+        data.ContainsAnyExceptInRange((byte)0, (byte)100).Should().BeFalse();
+    }
+}
+

--- a/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
+++ b/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
@@ -278,14 +278,14 @@ public class SmallPolyfillCoverageTests
             {
                 global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
                 // "{}" is malformed: '{' followed by '}' (not an escape, since they don't match
-                // for an escape — '{{' or '}}' would). Actually the check is `if (brace != next)`
-                // for the escape path; "{}" reaches that with brace='{' next='}' which does NOT
-                // match brace, so FormatError is invoked.
+                // for an escape — '{{' or '}}' would). The check is `if (brace != next)` for the
+                // escape path; "{}" reaches that with brace='{' next='}' which does NOT match,
+                // so FormatError is invoked.
                 builder.AppendFormat("{}".AsSpan(), args);
             }
             finally
             {
-                // builder cleanup happens here
+                builder.Dispose();
             }
         };
 
@@ -298,9 +298,16 @@ public class SmallPolyfillCoverageTests
         Action action = () =>
         {
             ValueStringBuilder builder = new(stackalloc char[32]);
-            global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
-            // "{0:X" - format spec without terminating '}' triggers FormatError on the ':' branch.
-            builder.AppendFormat("{0:X".AsSpan(), args);
+            try
+            {
+                global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
+                // "{0:X" - format spec without terminating '}' triggers FormatError on the ':' branch.
+                builder.AppendFormat("{0:X".AsSpan(), args);
+            }
+            finally
+            {
+                builder.Dispose();
+            }
         };
 
         action.Should().Throw<FormatException>();
@@ -312,9 +319,16 @@ public class SmallPolyfillCoverageTests
         Action action = () =>
         {
             ValueStringBuilder builder = new(stackalloc char[32]);
-            global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
-            // "{0" - hole without terminating brace.
-            builder.AppendFormat("{0".AsSpan(), args);
+            try
+            {
+                global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
+                // "{0" - hole without terminating brace.
+                builder.AppendFormat("{0".AsSpan(), args);
+            }
+            finally
+            {
+                builder.Dispose();
+            }
         };
 
         action.Should().Throw<FormatException>();

--- a/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
+++ b/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
@@ -1,0 +1,591 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Io;
+using Touki.Text;
+
+namespace Framework.Touki;
+
+/// <summary>
+///  Coverage tests for several small framework polyfills and helpers that
+///  were previously at 0% line coverage.
+/// </summary>
+public class SmallPolyfillCoverageTests
+{
+    // ---------- ArgumentNullExtensions.ThrowIfNull ----------
+
+    [Fact]
+    public void ThrowIfNull_Object_NonNull_DoesNotThrow()
+    {
+        object value = new();
+        Action action = () => ArgumentNullException.ThrowIfNull(value);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNull_Object_Null_Throws()
+    {
+        object? value = null;
+        Action action = () => ArgumentNullException.ThrowIfNull(value);
+        action.Should().Throw<ArgumentNullException>().Which.ParamName.Should().Be("value");
+    }
+
+    [Fact]
+    public unsafe void ThrowIfNull_VoidPointer_NonNull_DoesNotThrow()
+    {
+        int local = 42;
+        void* p = &local;
+        Action action = () => ArgumentNullException.ThrowIfNull(p);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public unsafe void ThrowIfNull_VoidPointer_Null_Throws()
+    {
+        Action action = () => ArgumentNullException.ThrowIfNull((void*)null);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ThrowIfNull_IntPtr_NonZero_DoesNotThrow()
+    {
+        IntPtr p = new(0x1);
+        Action action = () => ArgumentNullException.ThrowIfNull(p);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNull_IntPtr_Zero_Throws()
+    {
+        IntPtr p = IntPtr.Zero;
+        Action action = () => ArgumentNullException.ThrowIfNull(p);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void ThrowIfNull_Object_ExceptionArgument_NonNull_DoesNotThrow()
+    {
+        // Internal overload that takes the ExceptionArgument enum.
+        object value = new();
+        Action action = () => ArgumentNullException.ThrowIfNull(value, ExceptionArgument.value);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNull_Object_ExceptionArgument_Null_Throws()
+    {
+        Action action = () => ArgumentNullException.ThrowIfNull((object?)null, ExceptionArgument.value);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    // ---------- OverflowAdapter ----------
+
+    [Fact]
+    public void OverflowAdapter_Throw_ThrowsOverflowException()
+    {
+        Action action = () => OverflowAdapter.Throw("custom message");
+        action.Should().Throw<OverflowException>().WithMessage("custom message");
+    }
+
+    [Fact]
+    public void OverflowAdapter_Throw_NullMessage_ThrowsOverflowException()
+    {
+        Action action = () => OverflowAdapter.Throw(null);
+        action.Should().Throw<OverflowException>();
+    }
+
+    // ---------- ValueStringBuilder.AppendFormatted overloads ----------
+
+    [Fact]
+    public void AppendFormatted_Object_NullValue_LeavesEmpty()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            object? value = null;
+            builder.AppendFormatted(value);
+            builder.ToString().Should().BeEmpty();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_Object_WithAlignmentAndFormat_FormatsAndPads()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            object value = 42;
+            builder.AppendFormatted(value, alignment: 6, format: "X4");
+            builder.ToString().Should().Be("  002A");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_String_WithAlignment_RightAlignsByDefault()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted("hi", alignment: 5, format: null);
+            builder.ToString().Should().Be("   hi");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_String_WithNegativeAlignment_LeftAligns()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted("hi", alignment: -5, format: null);
+            builder.ToString().Should().Be("hi   ");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpan_LeftAligned_AddsTrailingSpaces()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted("hi".AsSpan(), alignment: -5);
+            builder.ToString().Should().Be("hi   ");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericValue_WithFormat_UsesFormat()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted<int>(255, "X4");
+            builder.ToString().Should().Be("00FF");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericValue_WithAlignmentAndStringFormat()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted<int>(7, alignment: 4, format: (string?)null);
+            builder.ToString().Should().Be("   7");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpan_RightAligned_AddsLeadingSpaces()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            // Positive alignment + value shorter than alignment hits the right-align
+            // (else) branch in AppendFormatted(ROS<char>, alignment, format).
+            builder.AppendFormatted("hi".AsSpan(), alignment: 5);
+            builder.ToString().Should().Be("   hi");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpan_AlignmentLessThanValueLength_NoPadding()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted("hello".AsSpan(), alignment: 2);
+            builder.ToString().Should().Be("hello");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_Value_WithStringFormat()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted(global::Touki.Value.Create(255), "X4");
+            builder.ToString().Should().Be("00FF");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericT_AsValue_FormatsViaValuePath()
+    {
+        ValueStringBuilder builder = new(stackalloc char[32]);
+        try
+        {
+            // Hits the typeof(T) == typeof(Value) branch in AppendFormatted<T>.
+            global::Touki.Value v = global::Touki.Value.Create(42);
+            builder.AppendFormatted(v);
+            builder.ToString().Should().Be("42");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormat_BraceMismatch_Throws()
+    {
+        Action action = () =>
+        {
+            ValueStringBuilder builder = new(stackalloc char[32]);
+            try
+            {
+                global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
+                // "{}" is malformed: '{' followed by '}' (not an escape, since they don't match
+                // for an escape — '{{' or '}}' would). Actually the check is `if (brace != next)`
+                // for the escape path; "{}" reaches that with brace='{' next='}' which does NOT
+                // match brace, so FormatError is invoked.
+                builder.AppendFormat("{}".AsSpan(), args);
+            }
+            finally
+            {
+                // builder cleanup happens here
+            }
+        };
+
+        action.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void AppendFormat_FormatTrailingMissingClose_Throws()
+    {
+        Action action = () =>
+        {
+            ValueStringBuilder builder = new(stackalloc char[32]);
+            global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
+            // "{0:X" - format spec without terminating '}' triggers FormatError on the ':' branch.
+            builder.AppendFormat("{0:X".AsSpan(), args);
+        };
+
+        action.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void AppendFormat_NoClosingBrace_Throws()
+    {
+        Action action = () =>
+        {
+            ValueStringBuilder builder = new(stackalloc char[32]);
+            global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
+            // "{0" - hole without terminating brace.
+            builder.AppendFormat("{0".AsSpan(), args);
+        };
+
+        action.Should().Throw<FormatException>();
+    }
+
+    [Fact]
+    public void AppendFormatted_WithCustomFormatter_UsesFormatter()
+    {
+        IFormatProvider provider = new CustomFormatProvider();
+        ValueStringBuilder builder = new(0, 0, provider, stackalloc char[64]);
+        try
+        {
+            builder.AppendFormatted("hello");
+            builder.ToString().Should().Be("[CUSTOM:hello]");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericT_WithCustomFormatter_UsesFormatter()
+    {
+        IFormatProvider provider = new CustomFormatProvider();
+        ValueStringBuilder builder = new(0, 0, provider, stackalloc char[64]);
+        try
+        {
+            builder.AppendFormatted<int>(42, format: "X4");
+            builder.ToString().Should().Be("[CUSTOM:42]");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private sealed class CustomFormatProvider : IFormatProvider, ICustomFormatter
+    {
+        public object? GetFormat(Type? formatType) =>
+            formatType == typeof(ICustomFormatter) ? this : null;
+
+        public string Format(string? format, object? arg, IFormatProvider? formatProvider) =>
+            $"[CUSTOM:{arg}]";
+    }
+
+    // ---------- ArgumentOutOfRangeException comparison polyfills ----------
+
+    [Fact]
+    public void ThrowIfZero_Int_Zero_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(0);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfZero_Int_NonZero_DoesNotThrow()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfZero(1);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Int_Negative_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegative(-1);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfNegative_Int_NonNegative_DoesNotThrow()
+    {
+        Action action = () =>
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(0);
+            ArgumentOutOfRangeException.ThrowIfNegative(1);
+        };
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_Int_Zero_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNegativeOrZero(0);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfEqual_Equal_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfEqual(5, 5);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfEqual_Different_DoesNotThrow()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfEqual(5, 7);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNotEqual_Different_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNotEqual(5, 7);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfNotEqual_Equal_DoesNotThrow()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfNotEqual(5, 5);
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfGreaterThan_Greater_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfGreaterThan(10, 5);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfGreaterThan_LessOrEqual_DoesNotThrow()
+    {
+        Action action = () =>
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(5, 5);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(3, 5);
+        };
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfGreaterThanOrEqual_GreaterOrEqual_Throws()
+    {
+        Action a1 = () => ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(10, 5);
+        Action a2 = () => ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(5, 5);
+        a1.Should().Throw<ArgumentOutOfRangeException>();
+        a2.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfLessThan_Less_Throws()
+    {
+        Action action = () => ArgumentOutOfRangeException.ThrowIfLessThan(3, 5);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void ThrowIfLessThan_GreaterOrEqual_DoesNotThrow()
+    {
+        Action action = () =>
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(5, 5);
+            ArgumentOutOfRangeException.ThrowIfLessThan(7, 5);
+        };
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfLessThanOrEqual_LessOrEqual_Throws()
+    {
+        Action a1 = () => ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(3, 5);
+        Action a2 = () => ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(5, 5);
+        a1.Should().Throw<ArgumentOutOfRangeException>();
+        a2.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    // Non-throw paths for every overload; the existing test suite only validates
+    // the throwing branches, leaving the closing braces of each method uncovered.
+
+    [Fact]
+    public void ThrowIfZero_AllOverloads_NonZero_DoesNotThrow()
+    {
+        Action action = () =>
+        {
+            ArgumentOutOfRangeException.ThrowIfZero(1L);
+            ArgumentOutOfRangeException.ThrowIfZero(1u);
+            ArgumentOutOfRangeException.ThrowIfZero(1ul);
+            ArgumentOutOfRangeException.ThrowIfZero((nint)1);
+            ArgumentOutOfRangeException.ThrowIfZero((nuint)1);
+            ArgumentOutOfRangeException.ThrowIfZero(1f);
+            ArgumentOutOfRangeException.ThrowIfZero(1d);
+            ArgumentOutOfRangeException.ThrowIfZero(1m);
+        };
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNegative_AllOverloads_NonNegative_DoesNotThrow()
+    {
+        Action action = () =>
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(0L);
+            ArgumentOutOfRangeException.ThrowIfNegative((nint)0);
+            ArgumentOutOfRangeException.ThrowIfNegative(0f);
+            ArgumentOutOfRangeException.ThrowIfNegative(0d);
+            ArgumentOutOfRangeException.ThrowIfNegative(0m);
+        };
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void ThrowIfNegativeOrZero_AllOverloads_Positive_DoesNotThrow()
+    {
+        Action action = () =>
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(1L);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero((nint)1);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(1f);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(1d);
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(1m);
+        };
+
+        action.Should().NotThrow();
+    }
+
+    // ---------- EnumerationMatcherExtensions ----------
+
+    [Fact]
+    public void EnumerationMatcherExtensions_MatchesDirectory_ForwardsToInterface()
+    {
+        TestMatcher matcher = new() { DirectoryResult = true };
+        // Call the extension method explicitly: instance methods (including interface
+        // methods that accept ReadOnlySpan<char> which absorbs string via implicit
+        // conversion) win during overload resolution otherwise.
+        bool actual = EnumerationMatcherExtensions.MatchesDirectory(matcher, "C:\\root", "sub", matchForExclusion: true);
+        actual.Should().BeTrue();
+        matcher.LastMatchForExclusion.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnumerationMatcherExtensions_MatchesDirectory_DefaultsToInclusion()
+    {
+        TestMatcher matcher = new() { DirectoryResult = false };
+        bool actual = EnumerationMatcherExtensions.MatchesDirectory(matcher, "C:\\root", "sub");
+        actual.Should().BeFalse();
+        matcher.LastMatchForExclusion.Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnumerationMatcherExtensions_MatchesFile_ForwardsToInterface()
+    {
+        TestMatcher matcher = new() { FileResult = true };
+        bool actual = EnumerationMatcherExtensions.MatchesFile(matcher, "C:\\root", "file.txt");
+        actual.Should().BeTrue();
+    }
+
+    private sealed class TestMatcher : IEnumerationMatcher
+    {
+        public bool DirectoryResult { get; set; }
+        public bool FileResult { get; set; }
+        public bool LastMatchForExclusion { get; private set; }
+
+        public void DirectoryFinished()
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public bool MatchesDirectory(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> directoryName, bool matchForExclusion)
+        {
+            LastMatchForExclusion = matchForExclusion;
+            return DirectoryResult;
+        }
+
+        public bool MatchesFile(ReadOnlySpan<char> currentDirectory, ReadOnlySpan<char> fileName) => FileResult;
+    }
+}

--- a/touki/Framework/Polyfills/System/SpanExtensions.Replace.cs
+++ b/touki/Framework/Polyfills/System/SpanExtensions.Replace.cs
@@ -35,8 +35,15 @@ public static partial class SpanExtensions
             // The JIT elides this branch for any other T.
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort oldShort = Unsafe.As<T, ushort>(ref oldValue);
-                ushort newShort = Unsafe.As<T, ushort>(ref newValue);
+                // The explicit `& 0xFFFF` mask is load-bearing on net481 RyuJIT.
+                // Without it, when this method is inlined the JIT propagates the
+                // caller's int-promoted argument constant through Unsafe.As and
+                // emits a 32-bit-wide comparison immediate (e.g. 0xFFFFFFFF for
+                // (short)-1) instead of the requested 16-bit value (0xFFFF), and
+                // the loop's `cmp byte ptr [...]` style compare never matches.
+                // The mask forces the JIT to fold the high bits to zero.
+                ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+                ushort newShort = (ushort)(Unsafe.As<T, ushort>(ref newValue) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* ptr = (ushort*)p;
@@ -69,8 +76,11 @@ public static partial class SpanExtensions
             // Specialize for 1-byte primitives (byte / sbyte) the same way.
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte oldByte = Unsafe.As<T, byte>(ref oldValue);
-                byte newByte = Unsafe.As<T, byte>(ref newValue);
+                // See the comment above; the explicit `& 0xFF` mask defeats the
+                // net481 RyuJIT constant propagation that would otherwise compare
+                // against a 32-bit sign-extended value for (sbyte)-1 inputs.
+                byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+                byte newByte = (byte)(Unsafe.As<T, byte>(ref newValue) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* ptr = (byte*)p;
@@ -142,8 +152,9 @@ public static partial class SpanExtensions
             // bit pattern matches IEquatable equality. The JIT elides this branch for any other T.
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort oldShort = Unsafe.As<T, ushort>(ref oldValue);
-                ushort newShort = Unsafe.As<T, ushort>(ref newValue);
+                // See the corresponding comment in Replace(T, T) above.
+                ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+                ushort newShort = (ushort)(Unsafe.As<T, ushort>(ref newValue) & 0xFFFF);
                 fixed (T* sp = source)
                 fixed (T* dp = destination)
                 {
@@ -186,8 +197,8 @@ public static partial class SpanExtensions
             // Specialize for 1-byte primitives (byte / sbyte) the same way.
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte oldByte = Unsafe.As<T, byte>(ref oldValue);
-                byte newByte = Unsafe.As<T, byte>(ref newValue);
+                byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+                byte newByte = (byte)(Unsafe.As<T, byte>(ref newValue) & 0xFF);
                 fixed (T* sp = source)
                 fixed (T* dp = destination)
                 {


### PR DESCRIPTION
## Summary

While extending coverage for `SpanExtensions` polyfills I discovered a Release-only correctness bug in `SpanExtensions.Replace<T>` for negative `sbyte` / `short` inputs on net481. Debug passed, Release silently produced wrong results.

## Root cause (confirmed by disassembly)

The disassembly diagnoser in [touki.perf/ReplaceUnsafeAsPerf.cs](touki.perf/ReplaceUnsafeAsPerf.cs) caught net481 RyuJIT emitting:

```asm
movzx     ecx, byte ptr [rax]
cmp       ecx, 0FFFFFFFF       ; ← compare against 32-bit -1
jne       short M00_L03
mov       byte ptr [rax], 0
```

The `movzx`-loaded byte is in `[0, 0xFF]`, so the compare is unconditionally false. When `Replace` is `[AggressiveInlining]` and the caller passes a literal signed primitive (`(sbyte)-1`, `(short)-1`), C# int-promotion sign-extends to `0xFFFFFFFF`; RyuJIT propagates the int-promoted constant through `Unsafe.As<T, byte>(ref param)` into the loop's compare immediate instead of the requested byte.

A plain `(byte)` cast does **not** fix it &mdash; the JIT's constant tracker doesn't model `conv.u1` as truncating here. Explicit int-domain masking does:

```csharp
byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
```

After the mask, RyuJIT folds the high bits to zero and emits the correct `cmp byte ptr [rax], 0FF`. Identical native code size to the original (197 B), zero perf overhead.

## Library audit

The four required preconditions are narrow: `[AggressiveInlining]` on the outer method **+** narrowing `Unsafe.As<T, narrower>` **+** caller passes a literal signed primitive **+** the result is later compared int-domain against a value loaded from memory. I audited every `Unsafe.As<T, ...>(ref param)` site:

- **`SpanExtensions.Replace`** &mdash; was buggy, fixed.
- **`SpanExtensions.InRange`** &mdash; safe (compares live in non-inlined per-primitive helpers).
- **`ValueStringBuilder.Formatting` (sbyte/short paths)** &mdash; safe (widens to `int`, not narrows). Verified with throwaway tests.
- **`ValueStringBuilder.Formatting` (byte/ushort paths)** &mdash; safe (unsigned source).
- **`Value.Create` / `Value.cs`** &mdash; safe (same-width reinterprets passed to typed ctors, no compare-immediate folding).
- **`SpanReader`** &mdash; safe (operates on a span pointer, not a method parameter).
- **`UnsafeExtensions.BitCast` polyfill** &mdash; theoretically susceptible but no production callers.

## Coverage on net481 (line / branch)

| File | Before | After |
|---|---|---|
| `SpanExtensions.Replace.cs` | 40.31% / 30% | **100.00% / 100.00%** |
| `SpanExtensions.InRange.cs` | 60.33% / 51% | **100.00% / 98.94%** |
| `ArgumentNullExtensions.cs` | 30.77% / 25% | **100.00% / 100.00%** |
| `OverflowAdapter.cs` | 0% / 0% | **100.00% / 100.00%** |
| `EnumerationMatcherExtensions.cs` | 0% / &mdash; | **100.00% / 100.00%** |
| `ArgumentOutOfRangeExtensions.cs` | 76.80% / 67% | **100.00% / 93.55%** |
| `ValueStringBuilder.Formatting.cs` | 73.91% / 65% | **91.89% / 88.89%** |

Overall touki assembly: **85.02% &rarr; 87.45%** line.

## Changes

**Library**
- [touki/Framework/Polyfills/System/SpanExtensions.Replace.cs](touki/Framework/Polyfills/System/SpanExtensions.Replace.cs) &mdash; add `& 0xFF` / `& 0xFFFF` masks at all four specialization sites; comment explains why the mask is load-bearing.

**Tests**
- [touki.tests/Framework/System/SpanExtensionsCoverageTests.cs](touki.tests/Framework/System/SpanExtensionsCoverageTests.cs) &mdash; covers `Replace<T>` primitive specializations (byte, sbyte, short, ushort, char) and `InRange` specializations for sbyte, short, ushort, int, uint, ulong. Negative signed-primitive cases would have caught the original bug.
- [touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs](touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs) &mdash; `ArgumentNullException.ThrowIfNull` (object/void*/IntPtr/internal-overload), `OverflowAdapter`, `EnumerationMatcherExtensions`, missing `ArgumentOutOfRangeException.ThrowIf*` overloads, and previously-uncovered `ValueStringBuilder.AppendFormatted` variants (object/string alignment, ROS<char> alignment, `Value` + format, custom-formatter paths, `AppendFormat<TArgument>` error paths).

**Performance / regression detector**
- [touki.perf/ReplaceUnsafeAsPerf.cs](touki.perf/ReplaceUnsafeAsPerf.cs) &mdash; BenchmarkDotNet harness with `DisassemblyDiagnoser` comparing the buggy and fixed shapes; serves as a regression detector and the source of the documented ASM proof.

**Agent docs**
- [.agents/skills/polyfill-dotnet-api/SKILL.md](.agents/skills/polyfill-dotnet-api/SKILL.md) &mdash; replaced the prior (incorrect) description of the `Unsafe.As` foot-gun with the precise constant-propagation diagnosis and the mask fix.
- [.agents/skills/framework-jit-optimization/specialization.md](.agents/skills/framework-jit-optimization/specialization.md) &mdash; updated the canonical `Replace` specialization example to include the masks; added a "Signed-primitive constant-propagation pitfall" section. Fixed a pre-existing broken link to `SpanExtensions.InRange.cs`.
- [.agents/skills/pre-pr-self-review/SKILL.md](.agents/skills/pre-pr-self-review/SKILL.md) &mdash; replaced the vague Debug/Release reminder with a precise pointer to the constant-propagation issue.

## Verification

`dotnet test -c Release`: **5611 passing** on net481 / **3788 passing** on net10.0. `pwsh tools/Test-AgentFileLinks.ps1 -ChangedOnly`: all relative links resolve.