### PR TITLE
Add tests to raise line coverage to 85%

### DIFF
--- a/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs
+++ b/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs
@@ -394,4 +394,215 @@ public class SpanExtensionsSearchExtraTests
         ReadOnlySpan<string> b = ["x", "y", "z", "extra"];
         a.CommonPrefixLength(b, comparer: null).Should().Be(3);
     }
+
+    // ----- Span<T> wrappers (delegate to ReadOnlySpan<T> overloads) -----
+
+    [Fact]
+    public void ContainsAny_Span_TwoValues_True()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        span.ContainsAny(2, 99).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAny_Span_TwoValues_False()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        span.ContainsAny(98, 99).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAny_Span_ThreeValues_True()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        span.ContainsAny(7, 8, 3).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAny_Span_ThreeValues_False()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        span.ContainsAny(7, 8, 9).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAny_Span_ValuesSpan_True()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        ReadOnlySpan<int> values = [9, 3];
+        span.ContainsAny(values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAny_Span_ValuesSpan_False()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        ReadOnlySpan<int> values = [7, 8];
+        span.ContainsAny(values).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_SingleValue_True()
+    {
+        int[] data = [1, 2, 1];
+        Span<int> span = data;
+        span.ContainsAnyExcept(1).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_SingleValue_False()
+    {
+        int[] data = [1, 1, 1];
+        Span<int> span = data;
+        span.ContainsAnyExcept(1).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_TwoValues_True()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        span.ContainsAnyExcept(1, 2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_TwoValues_False()
+    {
+        int[] data = [1, 2, 1, 2];
+        Span<int> span = data;
+        span.ContainsAnyExcept(1, 2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_ThreeValues_True()
+    {
+        int[] data = [1, 2, 3, 4];
+        Span<int> span = data;
+        span.ContainsAnyExcept(1, 2, 3).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_ThreeValues_False()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        span.ContainsAnyExcept(1, 2, 3).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_ValuesSpan_True()
+    {
+        int[] data = [1, 2, 3, 9];
+        Span<int> span = data;
+        ReadOnlySpan<int> values = [1, 2, 3];
+        span.ContainsAnyExcept(values).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ContainsAnyExcept_Span_ValuesSpan_False()
+    {
+        int[] data = [1, 2, 3];
+        Span<int> span = data;
+        ReadOnlySpan<int> values = [1, 2, 3];
+        span.ContainsAnyExcept(values).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Count_Span_SingleValue_CountsOccurrences()
+    {
+        int[] data = [1, 2, 1, 3, 1];
+        Span<int> span = data;
+        span.Count(1).Should().Be(3);
+    }
+
+    [Fact]
+    public void Count_Span_ValuesSpan_CountsNonOverlappingOccurrences()
+    {
+        int[] data = [1, 2, 1, 2, 1, 2];
+        Span<int> span = data;
+        ReadOnlySpan<int> values = [1, 2];
+        span.Count(values).Should().Be(3);
+    }
+
+    [Fact]
+    public void CommonPrefixLength_Span_DelegatesToReadOnly()
+    {
+        int[] dataA = [1, 2, 3, 4];
+        int[] dataB = [1, 2, 3, 5];
+        Span<int> a = dataA;
+        ReadOnlySpan<int> b = dataB;
+        a.CommonPrefixLength(b).Should().Be(3);
+    }
+
+    [Fact]
+    public void CommonPrefixLength_Span_WithComparer_DelegatesToReadOnly()
+    {
+        string[] dataA = ["x", "y", "z"];
+        string[] dataB = ["X", "Y", "Z"];
+        Span<string> a = dataA;
+        ReadOnlySpan<string> b = dataB;
+        a.CommonPrefixLength(b, StringComparer.OrdinalIgnoreCase).Should().Be(3);
+        a.CommonPrefixLength(b, EqualityComparer<string>.Default).Should().Be(0);
+    }
+
+    // ----- IndexOfAnyExcept extra coverage -----
+
+    [Fact]
+    public void IndexOfAnyExcept_SingleValue_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [7, 7, 7];
+        span.IndexOfAnyExcept(7).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_SingleValue_Empty_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int>.Empty.IndexOfAnyExcept(0).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_TwoValues_FindsFirstOther()
+    {
+        ReadOnlySpan<int> span = [1, 2, 9, 1, 2];
+        span.IndexOfAnyExcept(1, 2).Should().Be(2);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_TwoValues_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [1, 2, 1, 2];
+        span.IndexOfAnyExcept(1, 2).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_TwoValues_Empty_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int>.Empty.IndexOfAnyExcept(1, 2).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_ThreeValues_FindsFirstOther()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 9, 1];
+        span.IndexOfAnyExcept(1, 2, 3).Should().Be(3);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_ThreeValues_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int> span = [1, 2, 3, 1, 2];
+        span.IndexOfAnyExcept(1, 2, 3).Should().Be(-1);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_ThreeValues_Empty_ReturnsMinusOne()
+    {
+        ReadOnlySpan<int>.Empty.IndexOfAnyExcept(1, 2, 3).Should().Be(-1);
+    }
 }

--- a/touki.tests/Framework/Touki/Text/StringExtensionsTests.cs
+++ b/touki.tests/Framework/Touki/Text/StringExtensionsTests.cs
@@ -1,0 +1,128 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using global::Touki.Text;
+using TStringExtensions = global::Touki.Text.StringExtensions;
+
+namespace Framework.Touki.Text;
+
+public class StringExtensionsTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("a")]
+    [InlineData("ab")]
+    [InlineData("abc")]
+    [InlineData("abcd")]
+    [InlineData("abcde")]
+    [InlineData("abcdef")]
+    [InlineData("abcdefg")]
+    [InlineData("hello world")]
+    [InlineData("0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF")]
+    public void GetHashCode_Span_MatchesString(string value)
+    {
+        int spanHash = string.GetHashCode(value.AsSpan());
+        int stringHash = value.GetHashCode();
+        spanHash.Should().Be(stringHash);
+    }
+
+    [Fact]
+    public void GetHashCode_Span_EmptyMatchesEmptyString()
+    {
+        string.GetHashCode(ReadOnlySpan<char>.Empty).Should().Be(string.Empty.GetHashCode());
+    }
+
+    [Fact]
+    public void Create_WithState_PopulatesString()
+    {
+        string created = string.Create(5, 'X', static (span, state) =>
+        {
+            for (int i = 0; i < span.Length; i++)
+            {
+                span[i] = state;
+            }
+        });
+
+        created.Should().Be("XXXXX");
+    }
+
+    [Fact]
+    public void Create_WithState_ZeroLength_ReturnsEmpty()
+    {
+        string created = string.Create(0, 0, static (_, _) => { });
+        created.Should().BeSameAs(string.Empty);
+    }
+
+    [Fact]
+    public void Create_NullAction_Throws()
+    {
+        Action action = () => string.Create<int>(5, 0, null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Create_NegativeLength_Throws()
+    {
+        Action action = () => string.Create(-1, 0, static (_, _) => { });
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Create_InterpolatedHandler_FormatsString()
+    {
+        int value = 42;
+        string created = string.Create(global::System.Globalization.CultureInfo.InvariantCulture, $"value={value}");
+        created.Should().Be("value=42");
+    }
+
+    [Fact]
+    public void Create_InterpolatedHandlerWithBuffer_FormatsString()
+    {
+        char[] buffer = new char[64];
+        int value = 7;
+        string created = string.Create(global::System.Globalization.CultureInfo.InvariantCulture, buffer, $"v={value}");
+        created.Should().Be("v=7");
+    }
+
+    [Fact]
+    public void Concat_TwoSpans_Concatenates()
+    {
+        TStringExtensions.Concat("foo".AsSpan(), "bar".AsSpan()).Should().Be("foobar");
+    }
+
+    [Fact]
+    public void Concat_TwoSpans_BothEmpty_ReturnsEmpty()
+    {
+        TStringExtensions.Concat(ReadOnlySpan<char>.Empty, ReadOnlySpan<char>.Empty).Should().BeSameAs(string.Empty);
+    }
+
+    [Fact]
+    public void Concat_ThreeSpans_Concatenates()
+    {
+        TStringExtensions.Concat("a".AsSpan(), "b".AsSpan(), "c".AsSpan()).Should().Be("abc");
+    }
+
+    [Fact]
+    public void Concat_ThreeSpans_AllEmpty_ReturnsEmpty()
+    {
+        TStringExtensions.Concat(ReadOnlySpan<char>.Empty, ReadOnlySpan<char>.Empty, ReadOnlySpan<char>.Empty)
+            .Should().BeSameAs(string.Empty);
+    }
+
+    [Fact]
+    public void Concat_FourSpans_Concatenates()
+    {
+        TStringExtensions.Concat("a".AsSpan(), "b".AsSpan(), "c".AsSpan(), "d".AsSpan()).Should().Be("abcd");
+    }
+
+    [Fact]
+    public void Concat_FourSpans_AllEmpty_ReturnsEmpty()
+    {
+        TStringExtensions.Concat(
+            ReadOnlySpan<char>.Empty,
+            ReadOnlySpan<char>.Empty,
+            ReadOnlySpan<char>.Empty,
+            ReadOnlySpan<char>.Empty).Should().BeSameAs(string.Empty);
+    }
+}

--- a/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
+++ b/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
@@ -139,4 +139,113 @@ public class MemoryExtensionsTryWriteTests
         ok.Should().BeFalse();
         written.Should().Be(0);
     }
+
+    [Fact]
+    public void TryWrite_SpanValue_WithAlignment_RightPadded()
+    {
+        Span<char> dest = stackalloc char[16];
+        ReadOnlySpan<char> s = "abc".AsSpan();
+        bool ok = dest.TryWrite($">{s,5}<", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be(">  abc<");
+    }
+
+    [Fact]
+    public void TryWrite_SpanValue_WithAlignment_LeftPadded()
+    {
+        Span<char> dest = stackalloc char[16];
+        ReadOnlySpan<char> s = "abc".AsSpan();
+        bool ok = dest.TryWrite($">{s,-5}<", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be(">abc  <");
+    }
+
+    [Fact]
+    public void TryWrite_StringValue_WithAlignment_RightPadded()
+    {
+        Span<char> dest = stackalloc char[16];
+        string s = "ab";
+        bool ok = dest.TryWrite($"|{s,4}|", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("|  ab|");
+    }
+
+    [Fact]
+    public void TryWrite_StringValue_WithAlignment_LeftPadded()
+    {
+        Span<char> dest = stackalloc char[16];
+        string s = "ab";
+        bool ok = dest.TryWrite($"|{s,-4}|", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("|ab  |");
+    }
+
+    [Fact]
+    public void TryWrite_ObjectValue_WithAlignment_RightPadded()
+    {
+        Span<char> dest = stackalloc char[16];
+        object o = "ab";
+        bool ok = dest.TryWrite($"|{o,4}|", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("|  ab|");
+    }
+
+    [Fact]
+    public void TryWrite_ObjectValue_FormatString()
+    {
+        Span<char> dest = stackalloc char[16];
+        object o = 255;
+        bool ok = dest.TryWrite($"{o:X4}", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("00FF");
+    }
+
+    [Fact]
+    public void TryWrite_StringValue_AlignmentAndFormat()
+    {
+        Span<char> dest = stackalloc char[32];
+        string s = "ab";
+        // string ignores the format spec; verify alignment still applies.
+        bool ok = dest.TryWrite($"|{s,5:X}|", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("|   ab|");
+    }
+
+    [Fact]
+    public void TryWrite_ObjectValue_AlignmentAndFormat()
+    {
+        Span<char> dest = stackalloc char[32];
+        object o = 255;
+        bool ok = dest.TryWrite($"|{o,6:X4}|", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("|  00FF|");
+    }
+
+    [Fact]
+    public void TryWrite_CustomFormatter_Used()
+    {
+        Span<char> dest = stackalloc char[32];
+        ReverseCustomFormatProvider provider = new();
+        bool ok = dest.TryWrite(provider, $"{"abc"}", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("cba");
+    }
+
+    private sealed class ReverseCustomFormatProvider : IFormatProvider, ICustomFormatter
+    {
+        public object? GetFormat(Type? formatType) =>
+            formatType == typeof(ICustomFormatter) ? this : null;
+
+        public string Format(string? format, object? arg, IFormatProvider? formatProvider)
+        {
+            if (arg is string s)
+            {
+                char[] chars = s.ToCharArray();
+                Array.Reverse(chars);
+                return new string(chars);
+            }
+
+            return arg?.ToString() ?? string.Empty;
+        }
+    }
 }

--- a/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
+++ b/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
@@ -141,7 +141,7 @@ public class MemoryExtensionsTryWriteTests
     }
 
     [Fact]
-    public void TryWrite_SpanValue_WithAlignment_RightPadded()
+    public void TryWrite_SpanValue_WithAlignment_RightAligned()
     {
         Span<char> dest = stackalloc char[16];
         ReadOnlySpan<char> s = "abc".AsSpan();
@@ -151,7 +151,7 @@ public class MemoryExtensionsTryWriteTests
     }
 
     [Fact]
-    public void TryWrite_SpanValue_WithAlignment_LeftPadded()
+    public void TryWrite_SpanValue_WithAlignment_LeftAligned()
     {
         Span<char> dest = stackalloc char[16];
         ReadOnlySpan<char> s = "abc".AsSpan();
@@ -161,7 +161,7 @@ public class MemoryExtensionsTryWriteTests
     }
 
     [Fact]
-    public void TryWrite_StringValue_WithAlignment_RightPadded()
+    public void TryWrite_StringValue_WithAlignment_RightAligned()
     {
         Span<char> dest = stackalloc char[16];
         string s = "ab";
@@ -171,7 +171,7 @@ public class MemoryExtensionsTryWriteTests
     }
 
     [Fact]
-    public void TryWrite_StringValue_WithAlignment_LeftPadded()
+    public void TryWrite_StringValue_WithAlignment_LeftAligned()
     {
         Span<char> dest = stackalloc char[16];
         string s = "ab";
@@ -181,7 +181,7 @@ public class MemoryExtensionsTryWriteTests
     }
 
     [Fact]
-    public void TryWrite_ObjectValue_WithAlignment_RightPadded()
+    public void TryWrite_ObjectValue_WithAlignment_RightAligned()
     {
         Span<char> dest = stackalloc char[16];
         object o = "ab";


### PR DESCRIPTION
Adds tests targeting the largest coverage gaps surfaced by the latest Cobertura report:

- New `StringExtensionsTests` for the net481 `Touki.Text.StringExtensions` polyfill: `string.GetHashCode(ReadOnlySpan<char>)`, `string.Create<TState>`, `string.Create` with interpolated handlers, and the `Concat` span overloads (file went from 0% to ~93%).
- `Span<T>` wrapper coverage for `SpanExtensions` `ContainsAny` / `ContainsAnyExcept` / `Count` / `CommonPrefixLength`, plus more `IndexOfAnyExcept` cases in `SpanExtensionsSearchExtraTests`.
- `MemoryExtensions.TryWrite` tests covering the span / string / object alignment+format branches and the `AppendCustomFormatter<T>` path via an `ICustomFormatter` provider.

All tests pass on net10.0 and net481 in Release. Overall line coverage: 80.04% → 85.03% (10190/11984).