### PR TITLE
Add tests covering remaining plausible branches

### DIFF
--- a/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs
+++ b/touki.tests/Framework/System/SpanExtensionsSearchExtraTests.cs
@@ -821,6 +821,102 @@ public class SpanExtensionsSearchExtraTests
         span.LastIndexOfAnyExcept((short)0, (short)1).Should().Be(2);
     }
 
+    // ----- More LastIndexOfAnyExcept type-specialized branches -----
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_Char_LongSpan_HitsUnrolledLoop()
+    {
+        char[] data = new string('a', 33).ToCharArray();
+        data[15] = 'X';
+        ReadOnlySpan<char> span = data;
+        span.LastIndexOfAnyExcept('a').Should().Be(15);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_Char_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<char> span = "aaaa".AsSpan();
+        span.LastIndexOfAnyExcept('a').Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_Short_FindsLastNonMatch()
+    {
+        ReadOnlySpan<short> span = [(short)0, (short)1, (short)0];
+        span.LastIndexOfAnyExcept((short)0).Should().Be(1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_UShort_FindsLastNonMatch()
+    {
+        ReadOnlySpan<ushort> span = [(ushort)0, (ushort)1, (ushort)0];
+        span.LastIndexOfAnyExcept((ushort)0).Should().Be(1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_Byte_LongSpan_HitsUnrolledLoop()
+    {
+        byte[] data = new byte[33];
+        for (int i = 0; i < data.Length; i++)
+        {
+            data[i] = (byte)1;
+        }
+
+        data[20] = 9;
+        ReadOnlySpan<byte> span = data;
+        span.LastIndexOfAnyExcept((byte)1).Should().Be(20);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_Byte_AllMatch_ReturnsMinusOne()
+    {
+        byte[] data = [1, 1, 1, 1, 1];
+        ReadOnlySpan<byte> span = data;
+        span.LastIndexOfAnyExcept((byte)1).Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_SByte_FindsLastNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)9, (sbyte)(-1), (sbyte)(-1)];
+        span.LastIndexOfAnyExcept((sbyte)(-1)).Should().Be(0);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_String_NullValue_FindsLastNonNull()
+    {
+        ReadOnlySpan<string?> span = [null, "x", null];
+        span.LastIndexOfAnyExcept((string?)null).Should().Be(1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SingleValue_String_AllMatch_ReturnsMinusOne()
+    {
+        ReadOnlySpan<string> span = ["a", "a", "a"];
+        span.LastIndexOfAnyExcept("a").Should().Be(-1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_TwoValues_SByte_FindsLastNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)(-1), (sbyte)9, (sbyte)(-1), (sbyte)2];
+        span.LastIndexOfAnyExcept((sbyte)(-1), (sbyte)2).Should().Be(1);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ThreeValues_SByte_FindsLastNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)1, (sbyte)2, (sbyte)3, (sbyte)9, (sbyte)1];
+        span.LastIndexOfAnyExcept((sbyte)1, (sbyte)2, (sbyte)3).Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ThreeValues_UShort_FindsLastNonMatch()
+    {
+        ReadOnlySpan<ushort> span = [(ushort)0, (ushort)1, (ushort)2, (ushort)9];
+        span.LastIndexOfAnyExcept((ushort)0, (ushort)1, (ushort)2).Should().Be(3);
+    }
+
     [Fact]
     public void IndexOfAnyExcept_ValuesSpan_FourOrMoreValues_GenericPath()
     {

--- a/touki.tests/System/MathExtensionsTests.cs
+++ b/touki.tests/System/MathExtensionsTests.cs
@@ -47,6 +47,34 @@ public class MathExtensionsTests
         Math.Clamp(0.5m, 0m, 1m).Should().Be(0.5m);
     }
 
+    [Fact]
+    public void Clamp_AllTypes_BelowMin_ReturnsMin()
+    {
+        Math.Clamp((byte)0, (byte)5, (byte)10).Should().Be((byte)5);
+        Math.Clamp((sbyte)-20, (sbyte)-10, (sbyte)0).Should().Be((sbyte)-10);
+        Math.Clamp((short)-20, (short)0, (short)10).Should().Be((short)0);
+        Math.Clamp((ushort)0, (ushort)5, (ushort)10).Should().Be((ushort)5);
+        Math.Clamp(0u, 5u, 10u).Should().Be(5u);
+        Math.Clamp(-20L, 0L, 10L).Should().Be(0L);
+        Math.Clamp(0UL, 5UL, 10UL).Should().Be(5UL);
+        Math.Clamp(-1f, 0f, 1f).Should().Be(0f);
+        Math.Clamp(-1m, 0m, 1m).Should().Be(0m);
+    }
+
+    [Fact]
+    public void Clamp_AllTypes_AboveMax_ReturnsMax()
+    {
+        Math.Clamp((byte)20, (byte)0, (byte)10).Should().Be((byte)10);
+        Math.Clamp((sbyte)20, (sbyte)-10, (sbyte)0).Should().Be((sbyte)0);
+        Math.Clamp((short)20, (short)0, (short)10).Should().Be((short)10);
+        Math.Clamp((ushort)20, (ushort)0, (ushort)10).Should().Be((ushort)10);
+        Math.Clamp(20u, 0u, 10u).Should().Be(10u);
+        Math.Clamp(20L, 0L, 10L).Should().Be(10L);
+        Math.Clamp(20UL, 0UL, 10UL).Should().Be(10UL);
+        Math.Clamp(2f, 0f, 1f).Should().Be(1f);
+        Math.Clamp(2m, 0m, 1m).Should().Be(1m);
+    }
+
     // Mirror of BCL Clamp_MinGreaterThanMax_ThrowsArgumentException across all overloads.
     [Fact]
     public void Clamp_MinGreaterThanMax_AllTypes_Throw()

--- a/touki.tests/System/StringExtensionsPolyfillTests.cs
+++ b/touki.tests/System/StringExtensionsPolyfillTests.cs
@@ -111,6 +111,32 @@ public class StringExtensionsPolyfillTests
         a.Should().NotBe(b);
     }
 
+    [Theory]
+    [InlineData(StringComparison.CurrentCulture)]
+    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+    [InlineData(StringComparison.InvariantCulture)]
+    [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+    [InlineData(StringComparison.Ordinal)]
+    [InlineData(StringComparison.OrdinalIgnoreCase)]
+    public void GetHashCode_StringComparison_AllSupportedComparisons_Returns(StringComparison comparison)
+    {
+        // Just exercises every branch of ComparerForComparison.
+        "Hello".GetHashCode(comparison).Should().Be("Hello".GetHashCode(comparison));
+    }
+
+    [Theory]
+    [InlineData(StringComparison.CurrentCulture)]
+    [InlineData(StringComparison.CurrentCultureIgnoreCase)]
+    [InlineData(StringComparison.InvariantCulture)]
+    [InlineData(StringComparison.InvariantCultureIgnoreCase)]
+    [InlineData(StringComparison.Ordinal)]
+    [InlineData(StringComparison.OrdinalIgnoreCase)]
+    public void Contains_Char_AllSupportedComparisons_FindsMatch(StringComparison comparison)
+    {
+        // Exercises every branch of ComparisonToCompareInfo.
+        "Hello".Contains('e', comparison).Should().BeTrue();
+    }
+
     // ---- Replace(string, string?, StringComparison) ----
 
     [Fact]

--- a/touki.tests/Touki/Collections/SingleOptimizedListTests.cs
+++ b/touki.tests/Touki/Collections/SingleOptimizedListTests.cs
@@ -577,4 +577,82 @@ public class SingleOptimizedListTests
         values.Length.Should().Be(1);
         values[0].Should().Be(42);
     }
+
+    [Fact]
+    public void CopyTo_NonGenericArray_EmptyList_DoesNothing()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [];
+        Array array = new int[3];
+        list.CopyTo(array, 0);
+        ((int[])array).Should().Equal(0, 0, 0);
+    }
+
+    [Fact]
+    public void CopyTo_NonGenericArray_SingleItem_CopiesCorrectly()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [42];
+        Array array = new int[3];
+        list.CopyTo(array, 1);
+        ((int[])array).Should().Equal(0, 42, 0);
+    }
+
+    [Fact]
+    public void CopyTo_NonGenericArray_MultipleItems_CopiesCorrectly()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [1, 2, 3];
+        Array array = new int[5];
+        list.CopyTo(array, 1);
+        ((int[])array).Should().Equal(0, 1, 2, 3, 0);
+    }
+
+    [Fact]
+    public void CopyTo_NonGenericArray_NullArray_Throws()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [1];
+        Action act = () => list.CopyTo((Array)null!, 0);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void CopyTo_NonGenericArray_NegativeIndex_Throws()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [1];
+        Array array = new int[3];
+        Action act = () => list.CopyTo(array, -1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CopyTo_NonGenericArray_TooSmall_Throws()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [1, 2, 3];
+        Array array = new int[2];
+        Action act = () => list.CopyTo(array, 0);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void CopyTo_GenericArray_TooSmall_Throws()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [1, 2, 3];
+        int[] array = new int[2];
+        Action act = () => list.CopyTo(array, 0);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Clear_MultipleItems_ClearsBackingList()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [1, 2, 3];
+        list.Clear();
+        list.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Clear_EmptyList_NoOp()
+    {
+        using SingleOptimizedList<int, ArrayPoolList<int>> list = [];
+        list.Clear();
+        list.Count.Should().Be(0);
+    }
 }

--- a/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
@@ -823,4 +823,56 @@ public class MSBuildSpecificationTests
         string stringFromSpec = (string)new MSBuildSpecification("file.txt");
         stringFromSpec.Should().Be("file.txt");
     }
+
+    // ---- Equals branch coverage ----
+
+    [Fact]
+    public void Equals_Object_MSBuildSpecification_True()
+    {
+        object spec = new MSBuildSpecification("file.txt");
+        new MSBuildSpecification("FILE.txt").Equals(spec).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_Object_String_True()
+    {
+        object str = "FILE.txt";
+        new MSBuildSpecification("file.txt").Equals(str).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_Object_Null_False()
+    {
+        new MSBuildSpecification("file.txt").Equals((object?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_Object_OtherType_False()
+    {
+        new MSBuildSpecification("file.txt").Equals(42).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_String_NullString_False()
+    {
+        new MSBuildSpecification("file.txt").Equals((string?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_String_DifferentCase_True()
+    {
+        new MSBuildSpecification("file.txt").Equals("FILE.TXT").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_MSBuildSpecification_Null_False()
+    {
+        new MSBuildSpecification("file.txt").Equals((MSBuildSpecification?)null).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_MSBuildSpecification_DifferentCase_True()
+    {
+        new MSBuildSpecification("file.txt").Equals(new MSBuildSpecification("FILE.TXT")).Should().BeTrue();
+    }
 }

--- a/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
+++ b/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
@@ -370,7 +370,7 @@ public class MemoryExtensionsTryWriteTests
     }
 
     [Fact]
-    public void TryWrite_AppendFormatted_NullObject_NoAlignment_NoOp()
+    public void TryWrite_AppendFormatted_NullObject_NoAlignment_AppendsEmpty()
     {
         Span<char> dest = stackalloc char[16];
         object? value = null;

--- a/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
+++ b/touki.tests/Touki/MemoryExtensionsTryWriteTests.cs
@@ -319,4 +319,83 @@ public class MemoryExtensionsTryWriteTests
         public NonFormattable(string data) => _data = data;
         public override string ToString() => $"N:{_data}";
     }
+
+    [Fact]
+    public void TryWrite_AppendLiteralAfterFormatted_DestinationTooSmall_Fails()
+    {
+        Span<char> dest = stackalloc char[6];
+        bool ok = dest.TryWrite($"abcde{1}xyz", out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryWrite_AppendFormattedSpan_DestinationTooSmall_Fails()
+    {
+        Span<char> dest = stackalloc char[5];
+        ReadOnlySpan<char> tail = "longer".AsSpan();
+        bool ok = dest.TryWrite($"abc{tail}", out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryWrite_AppendFormattedSpan_AlignmentBufferTooSmall_Fails()
+    {
+        Span<char> dest = stackalloc char[6];
+        ReadOnlySpan<char> v = "ab".AsSpan();
+        bool ok = dest.TryWrite($"{v,10}", out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryWrite_AppendFormattedT_WithAlignment_PrimaryAppendFails()
+    {
+        Span<char> dest = stackalloc char[3];
+        bool ok = dest.TryWrite($"{12345,5}", out int written);
+        ok.Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [Fact]
+    public void TryWrite_CustomFormatter_NullValue_AppendsEmpty()
+    {
+        Span<char> dest = stackalloc char[16];
+        ReverseCustomFormatProvider provider = new();
+        string? value = null;
+        bool ok = dest.TryWrite(provider, $"[{value}]", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("[]");
+    }
+
+    [Fact]
+    public void TryWrite_AppendFormatted_NullObject_NoAlignment_NoOp()
+    {
+        Span<char> dest = stackalloc char[16];
+        object? value = null;
+        bool ok = dest.TryWrite($"[{value}]", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("[]");
+    }
+
+    [Fact]
+    public void TryWrite_LeftAlignment_LongPadding()
+    {
+        Span<char> dest = stackalloc char[32];
+        bool ok = dest.TryWrite($"|{42,-10}|", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be("|42        |");
+    }
+
+    [Fact]
+    public void TryWrite_RightAlignment_PaddingExactlyZero()
+    {
+        // alignment == value length: padding is 0, falls through to the no-padding branch.
+        Span<char> dest = stackalloc char[16];
+        ReadOnlySpan<char> v = "abc".AsSpan();
+        bool ok = dest.TryWrite($">{v,3}<", out int written);
+        ok.Should().BeTrue();
+        dest[..written].ToString().Should().Be(">abc<");
+    }
 }

--- a/touki.tests/Touki/SpanExtensionsSplitRangesTests.cs
+++ b/touki.tests/Touki/SpanExtensionsSplitRangesTests.cs
@@ -256,12 +256,27 @@ public class SpanExtensionsSplitRangesTests
     }
 
     [Fact]
-    public void Split_OnAnyWhiteSpace_TrimEntries_Works()
+    public void Split_OnAnyWhiteSpace_RemoveEmpty_DropsEmptySegments()
     {
         ReadOnlySpan<char> source = "  apple   banana   cherry  ";
         Span<Range> ranges = new Range[8];
         int count = source.SplitAny(ranges, ReadOnlySpan<char>.Empty, StringSplitOptions.RemoveEmptyEntries);
         count.Should().Be(3);
+    }
+
+    [Fact]
+    public void Split_OnAnyWhiteSpace_TrimEntries_TrimsAndKeeps()
+    {
+        ReadOnlySpan<char> source = "  apple   banana   cherry  ";
+        Span<Range> ranges = new Range[16];
+        int count = source.SplitAny(
+            ranges,
+            ReadOnlySpan<char>.Empty,
+            (StringSplitOptions)2 | StringSplitOptions.RemoveEmptyEntries);
+        count.Should().Be(3);
+        source[ranges[0]].ToString().Should().Be("apple");
+        source[ranges[1]].ToString().Should().Be("banana");
+        source[ranges[2]].ToString().Should().Be("cherry");
     }
 
     [Fact]

--- a/touki.tests/Touki/SpanExtensionsSplitRangesTests.cs
+++ b/touki.tests/Touki/SpanExtensionsSplitRangesTests.cs
@@ -216,4 +216,70 @@ public class SpanExtensionsSplitRangesTests
         };
         act.Should().Throw<ArgumentException>();
     }
+
+    // ---- Branch-coverage tests targeting TryWriteSegment / WriteWholeSource ----
+    // Some test cases use (StringSplitOptions)2 because StringSplitOptions.TrimEntries
+    // is .NET 5+ only and not present on net481's System.Memory polyfill. The
+    // implementation honors the integer flag at runtime regardless.
+
+    [Fact]
+    public void Split_Char_TrimEntries_TrimsLeadingAndTrailingWhitespace()
+    {
+        ReadOnlySpan<char> source = "  apple , banana ,  cherry  ";
+        Span<Range> ranges = new Range[8];
+        int count = source.Split(ranges, ',', (StringSplitOptions)2);
+        count.Should().Be(3);
+        source[ranges[0]].ToString().Should().Be("apple");
+        source[ranges[1]].ToString().Should().Be("banana");
+        source[ranges[2]].ToString().Should().Be("cherry");
+    }
+
+    [Fact]
+    public void Split_Char_TrimEntries_AllWhitespace_DropsWhenRemoveEmpty()
+    {
+        ReadOnlySpan<char> source = "   ,   ,   ";
+        Span<Range> ranges = new Range[8];
+        int count = source.Split(ranges, ',', (StringSplitOptions)2 | StringSplitOptions.RemoveEmptyEntries);
+        count.Should().Be(0);
+    }
+
+    [Fact]
+    public void Split_Char_TrimEntries_AllWhitespace_KeepsEmptyEntries()
+    {
+        ReadOnlySpan<char> source = "   ,   ,   ";
+        Span<Range> ranges = new Range[8];
+        int count = source.Split(ranges, ',', (StringSplitOptions)2);
+        count.Should().Be(3);
+        source[ranges[0]].Length.Should().Be(0);
+        source[ranges[1]].Length.Should().Be(0);
+        source[ranges[2]].Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void Split_OnAnyWhiteSpace_TrimEntries_Works()
+    {
+        ReadOnlySpan<char> source = "  apple   banana   cherry  ";
+        Span<Range> ranges = new Range[8];
+        int count = source.SplitAny(ranges, ReadOnlySpan<char>.Empty, StringSplitOptions.RemoveEmptyEntries);
+        count.Should().Be(3);
+    }
+
+    [Fact]
+    public void Split_WholeSource_TrimEntries_Trims()
+    {
+        ReadOnlySpan<char> source = "  hello  ";
+        Span<Range> ranges = new Range[4];
+        int count = source.Split(ranges, '!', (StringSplitOptions)2);
+        count.Should().Be(1);
+        source[ranges[0]].ToString().Should().Be("hello");
+    }
+
+    [Fact]
+    public void Split_WholeSource_TrimEntries_AllWhitespace_RemoveEmpty_Empty()
+    {
+        ReadOnlySpan<char> source = "    ";
+        Span<Range> ranges = new Range[4];
+        int count = source.Split(ranges, '!', (StringSplitOptions)2 | StringSplitOptions.RemoveEmptyEntries);
+        count.Should().Be(0);
+    }
 }

--- a/touki.tests/Touki/Text/StringSegmentTests.cs
+++ b/touki.tests/Touki/Text/StringSegmentTests.cs
@@ -2185,4 +2185,392 @@ public class StringSegmentTests
         memory.IsEmpty.Should().BeTrue();
         memory.Length.Should().Be(0);
     }
+
+    // ---- Branch-coverage tests for the lower-coverage methods ----
+
+#pragma warning disable IDE0057 // Use range operator — the whole point of these tests is to exercise the Slice methods directly.
+
+    [Fact]
+    public void Slice_DirectMethodCall_ReturnsCorrectSegment()
+    {
+        StringSegment segment = new("Hello World");
+        StringSegment sliced = segment.Slice(6);
+        sliced.ToString().Should().Be("World");
+    }
+
+    [Fact]
+    public void Slice_DirectMethodCall_StartZero_ReturnsSameContent()
+    {
+        StringSegment segment = new("Hello");
+        StringSegment sliced = segment.Slice(0);
+        sliced.ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Slice_DirectMethodCall_StartEqualsLength_ReturnsEmpty()
+    {
+        StringSegment segment = new("Hello");
+        StringSegment sliced = segment.Slice(5);
+        sliced.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Slice_DirectMethodCall_StartOutOfRange_Throws()
+    {
+        StringSegment segment = new("Hello");
+        Action action = () => segment.Slice(6);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Slice_DirectMethodCall_NegativeStart_Throws()
+    {
+        StringSegment segment = new("Hello");
+        Action action = () => segment.Slice(-1);
+        action.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Slice_DirectMethodCall_NullValue_ReturnsEmpty()
+    {
+        StringSegment segment = default;
+        StringSegment sliced = segment.Slice(0);
+        sliced.IsEmpty.Should().BeTrue();
+    }
+
+#pragma warning restore IDE0057
+
+    [Fact]
+    public void ToString_OutSegment_PopulatesSegment()
+    {
+        StringSegment original = new("Hello World", 6, 5);
+        string s = original.ToString(out StringSegment newSegment);
+        s.Should().Be("World");
+        newSegment.ToString().Should().Be("World");
+        // Resulting segment should reference the new string and start at 0.
+        newSegment.AsSpan().ToString().Should().Be("World");
+    }
+
+    [Fact]
+    public void WriteTo_NullWriter_Throws()
+    {
+        StringSegment segment = new("Hello");
+        Action action = () => segment.WriteTo(null!);
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void WriteTo_EmptySegment_WritesNothing()
+    {
+        System.IO.StringWriter writer = new();
+        StringSegment segment = default;
+        segment.WriteTo(writer);
+        writer.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void WriteTo_FullStringSegment_WritesString()
+    {
+        System.IO.StringWriter writer = new();
+        StringSegment segment = new("Hello");
+        segment.WriteTo(writer);
+        writer.ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void WriteTo_PartialSegment_WritesSpan()
+    {
+        System.IO.StringWriter writer = new();
+        StringSegment segment = new("Hello World", 6, 5);
+        segment.WriteTo(writer);
+        writer.ToString().Should().Be("World");
+    }
+
+    [Fact]
+    public void Equals_ReadOnlySpan_DifferentLength_ReturnsFalse()
+    {
+        StringSegment segment = new("Hello");
+        segment.Equals("Hi".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_ReadOnlySpan_SameContent_ReturnsTrue()
+    {
+        StringSegment segment = new("Hello");
+        segment.Equals("Hello".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AsSpan_StartLength_ZeroLength_ReturnsEmpty()
+    {
+        StringSegment segment = new("Hello");
+        ReadOnlySpan<char> span = segment.AsSpan(2, 0);
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AsSpan_StartLength_FullSegment_Works()
+    {
+        StringSegment segment = new("Hello");
+        segment.AsSpan(0, 5).ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void AsSpan_Start_FromMiddle_Works()
+    {
+        StringSegment segment = new("Hello");
+        segment.AsSpan(2).ToString().Should().Be("llo");
+    }
+
+    [Fact]
+    public void AsSpan_Start_End_ReturnsEmpty()
+    {
+        StringSegment segment = new("Hello");
+        segment.AsSpan(5).IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IndexOfAny_TwoChars_FirstMatch()
+    {
+        StringSegment segment = new("Hello");
+        segment.IndexOfAny('e', 'o').Should().Be(1);
+    }
+
+    [Fact]
+    public void IndexOfAny_TwoChars_NoMatch_ReturnsMinusOne()
+    {
+        StringSegment segment = new("Hello");
+        segment.IndexOfAny('x', 'y').Should().Be(-1);
+    }
+
+    [Fact]
+    public void TrimStart_NoLeadingWhitespace_ReturnsSelf()
+    {
+        StringSegment segment = new("Hello");
+        segment.TrimStart().ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void TrimStart_OnlyWhitespace_ReturnsEmpty()
+    {
+        StringSegment segment = new("   ");
+        segment.TrimStart().IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TrimStart_Char_Match_TrimsLeading()
+    {
+        StringSegment segment = new("xxxHello");
+        segment.TrimStart('x').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void TrimStart_Char_NoMatch_ReturnsSelf()
+    {
+        StringSegment segment = new("Hello");
+        segment.TrimStart('x').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void TrimEnd_Char_Match_TrimsTrailing()
+    {
+        StringSegment segment = new("Helloxxx");
+        segment.TrimEnd('x').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void TrimEnd_Char_NoMatch_ReturnsSelf()
+    {
+        StringSegment segment = new("Hello");
+        segment.TrimEnd('x').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Trim_Char_BothEnds_Trims()
+    {
+        StringSegment segment = new("xxxHelloxxx");
+        segment.Trim('x').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Trim_TwoChars_BothEnds_Trims()
+    {
+        StringSegment segment = new("xy Helloxx");
+        segment.Trim('x', 'y').ToString().Should().Be(" Hello");
+    }
+
+    [Fact]
+    public void TrimStart_TwoChars_TrimsLeading()
+    {
+        StringSegment segment = new("xyxHello");
+        segment.TrimStart('x', 'y').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void TrimEnd_TwoChars_TrimsTrailing()
+    {
+        StringSegment segment = new("Helloxyx");
+        segment.TrimEnd('x', 'y').ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void StartsWith_Span_OrdinalIgnoreCase_True()
+    {
+        StringSegment segment = new("Hello");
+        segment.StartsWith("HE".AsSpan(), StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void StartsWith_Span_Ordinal_DifferentCase_False()
+    {
+        StringSegment segment = new("Hello");
+        segment.StartsWith("HE".AsSpan(), StringComparison.Ordinal).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EndsWith_Span_OrdinalIgnoreCase_True()
+    {
+        StringSegment segment = new("Hello");
+        segment.EndsWith("LO".AsSpan(), StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EndsWith_Span_Ordinal_DifferentCase_False()
+    {
+        StringSegment segment = new("Hello");
+        segment.EndsWith("LO".AsSpan(), StringComparison.Ordinal).Should().BeFalse();
+    }
+
+    [Fact]
+    public void StartsWith_StringSegment_DifferentCase_OrdinalIgnoreCase_True()
+    {
+        StringSegment segment = new("Hello World");
+        segment.StartsWith(new StringSegment("HELLO"), StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EndsWith_StringSegment_OrdinalIgnoreCase_True()
+    {
+        StringSegment segment = new("Hello World");
+        segment.EndsWith(new StringSegment("WORLD"), StringComparison.OrdinalIgnoreCase).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_StartIndexLength_ZeroLength_OnEmptyString_Succeeds()
+    {
+        StringSegment segment = new(string.Empty, 0, 0);
+        segment.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_StartIndexLength_LengthExceedsBounds_Throws()
+    {
+        Action act = () => new StringSegment("Hello", 2, 10);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void CompareTo_StringSegment_Ordinal_LessThan()
+    {
+        StringSegment a = new("apple");
+        StringSegment b = new("banana");
+        a.CompareTo(b, StringComparison.Ordinal).Should().BeLessThan(0);
+    }
+
+    [Fact]
+    public void CompareTo_StringSegment_OrdinalIgnoreCase_Equal()
+    {
+        StringSegment a = new("Apple");
+        StringSegment b = new("APPLE");
+        a.CompareTo(b, StringComparison.OrdinalIgnoreCase).Should().Be(0);
+    }
+
+    [Fact]
+    public void CompareTo_StringSegment_InvalidComparison_Throws()
+    {
+        StringSegment a = new("a");
+        StringSegment b = new("b");
+        Action act = () => a.CompareTo(b, (StringComparison)42);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void AsSpan_Start_OutOfRange_Throws()
+    {
+        StringSegment segment = new("Hello");
+        Action act = () => _ = segment.AsSpan(6);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void AsSpan_StartLength_OutOfRange_Throws()
+    {
+        StringSegment segment = new("Hello");
+        Action act = () => _ = segment.AsSpan(0, 6);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void AsSpan_StartLength_NegativeStart_Throws()
+    {
+        StringSegment segment = new("Hello");
+        Action act = () => _ = segment.AsSpan(-1, 1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void IndexOfAny_TwoChars_NotFound_ReturnsMinusOne()
+    {
+        StringSegment segment = new("aaaa");
+        segment.IndexOfAny('x', 'y').Should().Be(-1);
+    }
+
+    [Fact]
+    public void EndsWith_Span_LongerThanSegment_False()
+    {
+        StringSegment segment = new("ab");
+        segment.EndsWith("hello".AsSpan(), StringComparison.Ordinal).Should().BeFalse();
+    }
+
+    [Fact]
+    public void StartsWith_Span_LongerThanSegment_False()
+    {
+        StringSegment segment = new("ab");
+        segment.StartsWith("hello".AsSpan(), StringComparison.Ordinal).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TrimStart_Default_OnlyWhitespace()
+    {
+        StringSegment segment = new("  \t\n  ");
+        segment.TrimStart().IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TrimEnd_Default_OnlyWhitespace()
+    {
+        StringSegment segment = new("  \t\n  ");
+        segment.TrimEnd().IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TrimEnd_Default_NoTrailingWhitespace_ReturnsSelf()
+    {
+        StringSegment segment = new("Hello");
+        segment.TrimEnd().ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Constructor_NegativeStartIndex_Throws()
+    {
+        Action act = () => _ = new StringSegment("Hello", -1, 2);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Constructor_NegativeLength_Throws()
+    {
+        Action act = () => _ = new StringSegment("Hello", 0, -1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
 }

--- a/touki.tests/Touki/Text/ValueStringBuilderTests.cs
+++ b/touki.tests/Touki/Text/ValueStringBuilderTests.cs
@@ -2217,4 +2217,227 @@ public unsafe class ValueStringBuilderTests
         builder.ToString().Should().StartWith("Large: AAAAA");
         builder.ToString().Should().EndWith("AAAAA");
     }
+
+    // ---- Branch-coverage tests ----
+
+    [Fact]
+    public void Insert_CharCount_TriggersGrow()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.Append("abc");
+        // Insert 20 X's at position 1, forcing a grow.
+        builder.Insert(1, 'X', 20);
+        builder.Length.Should().Be(23);
+        builder.ToString().Should().StartWith("aXXXXXXXXXX");
+        builder.ToString().Should().EndWith("XXXXbc");
+    }
+
+    [Fact]
+    public void Insert_NegativeIndex_Throws()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8]);
+        bool threw = false;
+        try
+        {
+            try
+            {
+                builder.Insert(-1, 'X', 1);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                threw = true;
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        threw.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Insert_IndexBeyondLength_Throws()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.Append("ab");
+        bool threw = false;
+        try
+        {
+            try
+            {
+                builder.Insert(5, 'X', 1);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                threw = true;
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        threw.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Insert_NegativeCount_Throws()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8]);
+        bool threw = false;
+        try
+        {
+            try
+            {
+                builder.Insert(0, 'X', -1);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                threw = true;
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        threw.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Insert_String_TriggersGrow()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.Append("ab");
+        builder.Insert(1, "abcdefghij");
+        builder.Length.Should().Be(12);
+        builder.ToString().Should().Be("aabcdefghijb");
+    }
+
+    [Fact]
+    public void Replace_OldEqualsNew_NoOp()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+        builder.Append("Hello");
+        builder.Replace('l', 'l');
+        builder.ToString().Should().Be("Hello");
+    }
+
+    [Fact]
+    public void Replace_EmptyBuilder_NoOp()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.Replace('a', 'b');
+        builder.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void Replace_ReplacesAllOccurrences()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+        builder.Append("Hello");
+        builder.Replace('l', 'X');
+        builder.ToString().Should().Be("HeXXo");
+    }
+
+    [Fact]
+    public void Append_Char_Count_TriggersGrow()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[4]);
+        builder.Append("ab");
+        builder.Append('X', 20);
+        builder.Length.Should().Be(22);
+        builder.ToString().Should().StartWith("abXXXXX");
+    }
+
+    [Fact]
+    public unsafe void Append_CharPointer_TriggersGrow()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[4]);
+        builder.Append("ab");
+        char[] chars = "0123456789ABCDEF".ToCharArray();
+        fixed (char* p = chars)
+        {
+            builder.Append(p, chars.Length);
+        }
+
+        builder.ToString().Should().Be("ab0123456789ABCDEF");
+    }
+
+    [Fact]
+    public void EnsureCapacity_NegativeCapacity_Throws()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8]);
+        bool threw = false;
+        try
+        {
+            try
+            {
+                builder.EnsureCapacity(-1);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                threw = true;
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        threw.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnsureCapacity_AlreadySufficient_NoGrow()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+        int originalCapacity = builder.Capacity;
+        builder.EnsureCapacity(8);
+        builder.Capacity.Should().Be(originalCapacity);
+    }
+
+    [Fact]
+    public void CopyTo_Stream_EmptyBuilder_NoOp()
+    {
+        using MemoryStream stream = new();
+        using ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.CopyTo(stream);
+        stream.Length.Should().Be(0);
+    }
+
+    [Fact]
+    public void CopyTo_TextWriter_EmptyBuilder_NoOp()
+    {
+        System.IO.StringWriter writer = new();
+        using ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.CopyTo(writer);
+        writer.ToString().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CopyTo_TextWriter_NullWriter_Throws()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8]);
+        builder.Append("x");
+        bool threw = false;
+        try
+        {
+            try
+            {
+                builder.CopyTo((System.IO.TextWriter)null!);
+            }
+            catch (ArgumentNullException)
+            {
+                threw = true;
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        threw.Should().BeTrue();
+    }
 }

--- a/touki.tests/Touki/Value/StoringArrays.cs
+++ b/touki.tests/Touki/Value/StoringArrays.cs
@@ -89,4 +89,18 @@ public class StoringArrays
         Assert.Equal(segment, (ArraySegment<char>)value.As<object>());
         Assert.Throws<InvalidCastException>(() => value.As<char[]>());
     }
+
+    [Fact]
+    public void ArraySegment_NullByteArray_Throws()
+    {
+        ArraySegment<byte> segment = default;
+        Assert.Throws<ArgumentNullException>(() => Value.Create(segment));
+    }
+
+    [Fact]
+    public void ArraySegment_NullCharArray_Throws()
+    {
+        ArraySegment<char> segment = default;
+        Assert.Throws<ArgumentNullException>(() => Value.Create(segment));
+    }
 }

--- a/touki.tests/Touki/Value/StoringObject.cs
+++ b/touki.tests/Touki/Value/StoringObject.cs
@@ -58,4 +58,19 @@ public class StoringObject
     {
         string? ToString();
     }
+
+    [Fact]
+    public void Box_StoresObject()
+    {
+        A a = new();
+        Value value = Value.Box(a);
+        value.As<A>().Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void Box_NullObject_StoresNull()
+    {
+        Value value = Value.Box(null);
+        value.Type.Should().BeNull();
+    }
 }

--- a/touki.tests/Touki/Value/StoringObject.cs
+++ b/touki.tests/Touki/Value/StoringObject.cs
@@ -68,9 +68,11 @@ public class StoringObject
     }
 
     [Fact]
-    public void Box_NullObject_StoresNull()
+    public void Box_NullObject_HasNoStoredValue()
     {
+        // Per Value docs, a Type of null means "no value is stored".
         Value value = Value.Box(null);
         value.Type.Should().BeNull();
+        Assert.Throws<InvalidCastException>(() => value.As<object>());
     }
 }


### PR DESCRIPTION
Targets the largest remaining branch-coverage gaps after #132. All additions are tests only; no production code changes.

- **`MathExtensions.Clamp`** — below-min and above-max branches across every numeric overload (`byte`, `sbyte`, `short`, `ushort`, `uint`, `long`, `ulong`, `float`, `decimal`).
- **`StringExtensions` polyfill** — `GetHashCode` and `Contains` across every supported `StringComparison`, exercising every branch of `ComparerForComparison` and `ComparisonToCompareInfo`.
- **`StringSegment`** — direct `Slice(int)` method calls, `ToString(out)`, `WriteTo` (null / empty / full / partial), `Equals(ReadOnlySpan<char>)`, `AsSpan(int)` / `AsSpan(int, int)` success + out-of-range, `IndexOfAny` two-char miss, `Trim` / `TrimStart` / `TrimEnd` char overloads, `StartsWith` / `EndsWith` span + `StringSegment` overloads with case-insensitive comparison, `CompareTo` invalid-comparison, constructor negative bounds.
- **`MSBuildSpecification`** — `Equals(object)`, `Equals(string)`, `Equals(MSBuildSpecification)` covering null / non-null / different-case / wrong-type branches.
- **`SingleOptimizedList`** — `CopyTo(Array, int)` for empty / single / multi list, null-array, negative-index, too-small array; `CopyTo(T[])` too-small; `Clear` empty + multi-item.
- **`ValueStringBuilder`** — `Insert(char, count)` Grow path + bounds checks, `Insert(string)` Grow, `Replace` empty / old-equals-new / normal, `Append(char, count)` Grow, `Append(char*, length)` Grow, `EnsureCapacity` bounds + already-sufficient, `CopyTo(Stream)` / `CopyTo(TextWriter)` empty + null-writer.
- **`MemoryExtensions.TryWrite`** — `AppendLiteral` failure after prior output, `AppendFormatted` span failure paths, `AppendFormatted<T>` with-alignment failure, custom-formatter null value, null-object no-alignment, left-aligned long padding, exact-zero padding.
- **`SpanExtensions.SplitRanges`** — `TrimEntries` with whitespace-only entries (RemoveEmpty + keep), trim + `RemoveEmpty` `WriteWholeSource`, `SplitOnAnyWhiteSpace` RemoveEmpty.
- **`SpanExtensions.Search`** — type-specialized `LastIndexOfAnyExcept` branches for `char`/`short`/`ushort`/`byte`/`sbyte`/`string` single-value, `sbyte` two-value, `sbyte`/`ushort` three-value.
- **`Value`** — `Box(object)`, `Box(null)`, and `ArraySegment<byte>` / `ArraySegment<char>` default-segment `ArgumentNullException` paths.

All 5879 tests pass on net10.0 and net481 in Release.

**Coverage:**
- Lines: 90.43% → **90.91%** (10236 / 11259)
- Branches: 84.95% → **86.60%** (4981 / 5752)

Remaining gaps are concentrated in code that's hard to drive deterministically — concurrency primitives (`Lock`, `WaitHandleExtensions`), the `HeapSort`/`DownHeap` IntroSort fallback (a comparer adversarial enough to drive `depthLimit` to 0 violates the `IComparer<T>` contract, per the prior PR review), and floating-point edge cases in `DateTimeFormat` / `Number.*Bits` / `BigInteger`.