### PR TITLE
docs: add overviews for collections, buffers, and IO helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,23 @@ Some of the design goals include:
 - `SpanReader` and `SpanWriter` for efficient reading and writing of data in spans
 - `BufferScope<T>` for easy management of temporary `ArrayPool` and stack based buffers
 - `Value` struct for creating strongly typed arbitrary collections of values without boxing most primitives
+- Pooled and single-item-optimized list types (`ArrayPoolList<T>`,
+  `SingleOptimizedList<TItem, TList>`) and ref-counted resource caches
+- `MSBuildEnumerator` for MSBuild-style glob enumeration with no
+  allocations until a match is produced
+- Polyfills for many modern .NET BCL APIs on .NET Framework 4.7.2 (see the
+  [polyfill layout doc](docs/polyfill-layout.md) for the full list)
+- A `DisposableBase` with double-disposal protection and disposal
+  tracking helpers for diagnosing leaks
 - Much more!
 
 ## Overviews
 
 - [Configuring Your Project for Touki](sample/README.md)
 - [Reducing String Allocations with Touki](docs/strings.md)
+- [Low-Allocation Collections](docs/collections.md)
+- [Buffers, Span Readers, and Span Writers](docs/buffers.md)
+- [IO Helpers (globs, paths, temp folders, stream formatting)](docs/io.md)
 - [.NET Framework Polyfill Layout & Disambiguation](docs/polyfill-layout.md)
 
 ## Package Installation

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -1,8 +1,9 @@
 # Buffers, Span Readers, and Span Writers
 
-Touki's [`Touki.Buffers`](../touki/Touki/Buffers/) namespace contains a
-small set of stack-friendly types for working with `Span<T>` and
-`ReadOnlySpan<T>`. They're available on .NET 10 and .NET Framework 4.7.2.
+Touki's buffer-related types in [`touki/Touki/Buffers/`](../touki/Touki/Buffers/)
+are declared in the `Touki` namespace and provide a small set of
+stack-friendly APIs for working with `Span<T>` and `ReadOnlySpan<T>`.
+They're available on .NET 10 and .NET Framework 4.7.2.
 
 ## `BufferScope<T>`
 
@@ -86,7 +87,9 @@ without exception overhead.
 ## `SpanExtensions`
 
 [`SpanExtensions`](../touki/Touki/Buffers/SpanExtensions.cs) adds
-allocation-free helpers on top of `Span<T>` and `ReadOnlySpan<T>`,
-including a `SpanSplitEnumerator<T>` polyfill for downlevel targets so
-the same `foreach (Range range in span.Split(...))` code compiles on
+allocation-free helpers on top of `Span<T>` and `ReadOnlySpan<T>`. For
+downlevel targets, the `Split(...)` / `SpanSplitEnumerator<T>` polyfill
+lives in
+[`System.SpanExtensions`](../touki/Framework/Polyfills/System/SpanExtensions.SpanSplitEnumerator.cs),
+so the same `foreach (Range range in span.Split(...))` code compiles on
 .NET 10 and .NET Framework 4.7.2.

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -1,0 +1,92 @@
+# Buffers, Span Readers, and Span Writers
+
+Touki's [`Touki.Buffers`](../touki/Touki/Buffers/) namespace contains a
+small set of stack-friendly types for working with `Span<T>` and
+`ReadOnlySpan<T>`. They're available on .NET 10 and .NET Framework 4.7.2.
+
+## `BufferScope<T>`
+
+[`BufferScope<T>`](../touki/Touki/Buffers/BufferScope.cs) is a
+`ref struct` that pairs a possibly-stack-allocated initial buffer with
+an `ArrayPool<T>.Shared` rental fallback. It's the buffer equivalent of
+`ValueStringBuilder`: small workloads stay on the stack, larger ones
+spill to the pool, and `Dispose` returns whatever was rented.
+
+```csharp
+using BufferScope<char> buffer = new(stackalloc char[64], minimumLength: 64);
+
+// Use as if it were a Span<char>.
+buffer[0] = 'H';
+buffer[1] = 'i';
+ReadOnlySpan<char> view = buffer[..2];
+```
+
+Constructors:
+
+| Constructor | Behavior |
+| --- | --- |
+| `new BufferScope<T>(int minimumLength)` | Always rents from `ArrayPool<T>.Shared`. |
+| `new BufferScope<T>(Span<T> initialBuffer)` | Wraps a caller-supplied (typically `stackalloc`) buffer. |
+| `new BufferScope<T>(Span<T> initialBuffer, int minimumLength)` | Uses the initial buffer if it's large enough, otherwise rents. |
+
+Call `EnsureCapacity(int, bool copy)` to grow the buffer; it switches to
+`ArrayPool<T>` automatically and (optionally) copies existing contents.
+
+## `SpanReader<T>`
+
+[`SpanReader<T>`](../touki/Touki/Buffers/SpanReader.cs) is a
+`ref struct` over a `ReadOnlySpan<T>` modeled on `SequenceReader<T>`. It
+constrains `T : unmanaged, IEquatable<T>`, which lets it read primitives,
+chars, bytes, and small structs:
+
+```csharp
+SpanReader<byte> reader = new(payload);
+
+if (reader.TryRead(out byte tag) && reader.TryRead<int>(out int length))
+{
+    if (reader.TryReadCount(length, out ReadOnlySpan<byte> body))
+    {
+        Process(tag, body);
+    }
+}
+```
+
+Highlights:
+
+* `TryRead`, `TryReadCount`, `TryReadTo`, `TryPeek`, `Advance`,
+  `AdvancePast` — the standard reader surface.
+* `Position`, `Length`, `Unread`, `End` for inspection.
+* `TryRead<TValue>(out TValue)` reads any other unmanaged value type
+  out of a `byte` reader via a checked reinterpret.
+* [`SpanReaderExtensions`](../touki/Touki/Buffers/SpanReaderExtensions.cs)
+  adds higher-level helpers (e.g. `TryReadPositiveInteger` on a
+  `SpanReader<char>`).
+
+## `SpanWriter<T>`
+
+[`SpanWriter<T>`](../touki/Touki/Buffers/SpanWriter.cs) is the symmetric
+type for writing into a `Span<T>` with `T : unmanaged`:
+
+```csharp
+Span<byte> destination = stackalloc byte[64];
+SpanWriter<byte> writer = new(destination);
+
+if (writer.TryWrite((byte)0x01)
+    && writer.TryWrite<int>(payload.Length)
+    && writer.TryWrite(payload))
+{
+    Send(destination[..writer.Position]);
+}
+```
+
+`TryWrite` returns `false` instead of throwing when there isn't room, so
+callers can fall back to a larger buffer (often a `BufferScope<T>`)
+without exception overhead.
+
+## `SpanExtensions`
+
+[`SpanExtensions`](../touki/Touki/Buffers/SpanExtensions.cs) adds
+allocation-free helpers on top of `Span<T>` and `ReadOnlySpan<T>`,
+including a `SpanSplitEnumerator<T>` polyfill for downlevel targets so
+the same `foreach (Range range in span.Split(...))` code compiles on
+.NET 10 and .NET Framework 4.7.2.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -22,7 +22,11 @@ more than necessary or don't fit the access pattern. They all live on
 | [`EmptyList<T>`](../touki/Touki/Collections/EmptyList.cs) | Singleton empty `IList<T>`/`IReadOnlyList<T>`. |
 
 `ListBase<T>` and friends require `T : notnull`; nulls are rejected at the
-boundary. All disposable lists return their buffer on `Dispose`.
+boundary. Pooled lists such as `ArrayPoolList<T>` (and
+`SingleOptimizedList<TItem, TList>` once it has promoted to a pooled
+`TList`) return rented buffers to `ArrayPool<T>.Shared` on `Dispose`;
+non-pooled lists such as `ArrayList<T>` simply drop their references and
+let the GC reclaim the backing array.
 
 ## `ArrayPoolList<T>`
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -1,0 +1,133 @@
+# Low-Allocation Collections in Touki
+
+Touki ships a small family of collection types under
+[Touki.Collections](../touki/Touki/Collections/) aimed at scenarios where
+the BCL `List<T>`, `LinkedList<T>` or `ConcurrentBag<T>` either allocate
+more than necessary or don't fit the access pattern. They all live on
+.NET 10 and .NET Framework 4.7.2.
+
+## Overview
+
+| Type | When to reach for it |
+| --- | --- |
+| [`ListBase<T>`](../touki/Touki/Collections/ListBase.cs) | Abstract base that implements `IList<T>`, `IReadOnlyList<T>`, and non-generic `IList` once so concrete lists only implement the interesting members. |
+| [`ContiguousList<T>`](../touki/Touki/Collections/ContiguousList.cs) | `ListBase<T>` for lists backed by contiguous storage (exposes `AsSpan`-style access for derived types). |
+| [`ArrayBackedList<T>`](../touki/Touki/Collections/ArrayBackedList.cs) | Concrete base for lists backed by a `T[]`; subclasses override how the array is rented and returned. |
+| [`ArrayList<T>`](../touki/Touki/Collections/ArrayList.cs) | Plain `T[]`-backed list (no pooling). |
+| [`ArrayPoolList<T>`](../touki/Touki/Collections/ArrayPoolList.cs) | `T[]`-backed list that rents from `ArrayPool<T>.Shared` and returns the buffer on `Dispose`. |
+| [`SingleOptimizedList<TItem, TList>`](../touki/Touki/Collections/SingleOptimizedList.cs) | Stores a single item inline; promotes to `TList` (e.g. `ArrayPoolList<T>`) only when a second item is added. |
+| [`SinglyLinkedList<T>`](../touki/Touki/Collections/SinglyLinkedList.cs) | Minimal singly-linked list used internally by `RefCountedCache<,,>`; useful when you need cheap front/back inserts without a doubly-linked layout. |
+| [`Cache<T>`](../touki/Touki/Collections/Cache.cs) | Fixed-size, thread-safe object pool with a per-thread fast slot. For pooling reusable workers, parsers, builders, etc. |
+| [`RefCountedCache<TValue, TCacheEntryData, TKey>`](../touki/Touki/Collections/RefCountedCache.cs) | Cache that hands out scoped, ref-counted handles to expensive resources (GDI objects, native handles, `Pen`/`Brush`/`Font`-style objects). |
+| [`EmptyList<T>`](../touki/Touki/Collections/EmptyList.cs) | Singleton empty `IList<T>`/`IReadOnlyList<T>`. |
+
+`ListBase<T>` and friends require `T : notnull`; nulls are rejected at the
+boundary. All disposable lists return their buffer on `Dispose`.
+
+## `ArrayPoolList<T>`
+
+A drop-in replacement for `List<T>` whose backing array is rented from
+`ArrayPool<T>.Shared`:
+
+```csharp
+using ArrayPoolList<int> values = new(minimumCapacity: 256);
+
+for (int i = 0; i < 1000; i++)
+{
+    values.Add(i);
+}
+
+int total = 0;
+foreach (int value in values)
+{
+    total += value;
+}
+```
+
+Disposing the list returns the buffer to the pool. Reference-typed
+elements are cleared on `Clear()` so the pool doesn't keep them alive.
+
+## `SingleOptimizedList<TItem, TList>`
+
+Many APIs accept a list but most callers only ever pass one item.
+`SingleOptimizedList` keeps that single item inline (no array, no pool
+rental) and promotes to a `TList` (typically `ArrayPoolList<T>`) only
+when a second item arrives:
+
+```csharp
+using SingleOptimizedList<string, ArrayPoolList<string>> matches = new();
+
+matches.Add("first");
+
+// Still inline — no array allocation yet.
+
+if (alsoMatchesSecond)
+{
+    matches.Add("second");
+    // Promoted to ArrayPoolList<string> here.
+}
+```
+
+## `Cache<T>`
+
+`Cache<T>` is a small, fixed-size pool with a `[ThreadStatic]` fast slot,
+suitable for reusable worker objects:
+
+```csharp
+public sealed class ParserCache : Cache<MyParser>
+{
+    public ParserCache() : base(cacheSpace: 0) { }
+}
+
+ParserCache cache = new();
+
+MyParser parser = cache.Acquire();
+try
+{
+    parser.Parse(input);
+}
+finally
+{
+    cache.Release(parser);
+}
+```
+
+`cacheSpace: 0` (or any value `< 1`) defaults to
+`Environment.ProcessorCount * 4`. `T` must have a public parameterless
+constructor; `Acquire` falls back to `new T()` when the cache is empty.
+
+## `RefCountedCache<TValue, TCacheEntryData, TKey>`
+
+For caching expensive or constrained resources (GDI handles, native
+objects, large buffers). Consumers get a `Scope` that ref-counts the
+underlying entry and releases it on `Dispose`:
+
+```csharp
+public sealed class PenCache : RefCountedCache<Pen, Color, Color>
+{
+    protected override CacheEntry CreateEntry(Color key, bool cached)
+        => new PenCacheEntry(key, cached);
+
+    protected override bool IsMatch(Color key, CacheEntry entry)
+        => key == entry.Data;
+
+    private sealed class PenCacheEntry : CacheEntry
+    {
+        private readonly Pen _pen;
+        public PenCacheEntry(Color color, bool cached) : base(color, cached)
+            => _pen = new Pen(color);
+        public override Pen Object => _pen;
+    }
+}
+
+PenCache pens = new();
+
+using (RefCountedCache<Pen, Color, Color>.Scope scope = pens.GetEntry(Color.Red))
+{
+    Pen pen = scope; // implicit conversion
+    DrawWith(pen);
+}
+```
+
+When the last `Scope` for an entry is disposed and the entry isn't
+cached, the underlying object is released.

--- a/docs/io.md
+++ b/docs/io.md
@@ -1,0 +1,84 @@
+# IO Helpers
+
+[`Touki.Io`](../touki/Touki/Io/) collects file-system, path, and stream
+helpers that are useful on both .NET 10 and .NET Framework 4.7.2.
+
+## `MSBuildEnumerator`: glob-style file matching
+
+[`MSBuildEnumerator`](../touki/Touki/Io/MSBuildEnumerator.cs) walks the
+file system using the same wildcard semantics MSBuild uses for items
+like `<Compile Include="src/**/*.cs" Exclude="**/obj/**"/>`. It builds
+on `Microsoft.IO.Enumeration` (or `System.IO.Enumeration` on .NET) and
+is allocation-free until it produces a match.
+
+Supported wildcards:
+
+| Pattern | Meaning |
+| --- | --- |
+| `*` | Zero or more characters within a single file or directory name. |
+| `**` | Zero or more directories (recursive). |
+| `?` | A single character. |
+
+```csharp
+using Touki.Io;
+
+string projectDirectory = @"C:\repos\my-project";
+
+foreach (string path in MSBuildEnumerator.Create(
+    fileSpec: @"src\**\*.cs",
+    excludeSpecs: @"**\obj\**;**\bin\**",
+    projectDirectory: projectDirectory))
+{
+    Console.WriteLine(path);
+}
+```
+
+By default, paths are returned relative to `projectDirectory` when the
+spec is not fully qualified, matching MSBuild's behavior. Casing follows
+the OS (case-insensitive on Windows / macOS / iOS, case-sensitive on
+Linux); pass an `EnumerationOptions` to override.
+
+## `Paths`
+
+[`Paths`](../touki/Touki/Io/Paths.cs) exposes:
+
+* `MaxShortPath` (260) for stack-allocation sizing.
+* `OSDefaultMatchCasing` and `GetFinalCasing(MatchCasing)` for
+  resolving `MatchCasing.PlatformDefault` consistently across .NET 10
+  and .NET Framework.
+* `Matches(expression, name, matchCasing)` for one-off glob matching
+  without spinning up an enumerator.
+
+## `TempFolder`
+
+[`TempFolder`](../touki/Touki/Io/TempFolder.cs) creates a uniquely-named
+folder under the OS temp directory and recursively deletes it on
+`Dispose`. Implicitly converts to `string`, so it slots into existing
+`Path.Combine` / `File.WriteAllText` calls:
+
+```csharp
+using TempFolder folder = new();
+
+string file = Path.Combine(folder, "input.txt");
+File.WriteAllText(file, "...");
+
+// Folder and all contents are deleted when 'folder' goes out of scope.
+```
+
+Failures during deletion (e.g. files held open by another process) are
+swallowed so `Dispose` is safe to call from `finally` blocks and test
+teardown.
+
+## `StreamExtensions` and `TextWriterExtensions`
+
+[`StreamExtensions`](../touki/Touki/Io/StreamExtensions.cs) and
+[`TextWriterExtensions`](../touki/Touki/Io/TextWriterExtensions.cs) add
+`WriteFormatted` overloads that accept a `ValueStringBuilder`-backed
+interpolated string handler, so formatted output flows directly into the
+target without an intermediate `string` allocation. See
+[strings.md](strings.md) for the full picture.
+
+```csharp
+using FileStream stream = File.Create("log.txt");
+stream.WriteFormatted($"Started at {DateTime.UtcNow:O} for user {userId}");
+```

--- a/docs/io.md
+++ b/docs/io.md
@@ -46,8 +46,8 @@ Linux); pass an `EnumerationOptions` to override.
 * `OSDefaultMatchCasing` and `GetFinalCasing(MatchCasing)` for
   resolving `MatchCasing.PlatformDefault` consistently across .NET 10
   and .NET Framework.
-* `Matches(expression, name, matchCasing)` for one-off glob matching
-  without spinning up an enumerator.
+* `MatchesExpression(name, expression, matchCasing, matchType)` for
+  one-off glob matching without spinning up an enumerator.
 
 ## `TempFolder`
 
@@ -69,10 +69,11 @@ Failures during deletion (e.g. files held open by another process) are
 swallowed so `Dispose` is safe to call from `finally` blocks and test
 teardown.
 
-## `StreamExtensions` and `TextWriterExtensions`
+## `WriteFormatted` on `Stream` and `TextWriter`
 
-[`StreamExtensions`](../touki/Touki/Io/StreamExtensions.cs) and
-[`TextWriterExtensions`](../touki/Touki/Io/TextWriterExtensions.cs) add
+[`TextWriterExtensions`](../touki/Touki/Io/TextWriterExtensions.cs) (and
+its `Stream`-targeted partial in
+[`StreamExtensions.cs`](../touki/Touki/Io/StreamExtensions.cs)) adds
 `WriteFormatted` overloads that accept a `ValueStringBuilder`-backed
 interpolated string handler, so formatted output flows directly into the
 target without an intermediate `string` allocation. See

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -6,7 +6,7 @@ On modern .NET platforms (from .NET 6 onward) the compiler rewrites interpolate
 
 For developers who need to target .NET Framework 4.8 or earlier, these improvements are not available because the framework lacks the built‑in interpolated‑string handler and many of the supporting APIs. The **Touki** library bridges that gap by providing a default interpolated string handler and polyfills for .NET Framework 4.7.2 and later.
 
-**Touki** also provides additional high‑performance text utilities on **both** .NET 9 **and** .NET Framework 4.7.2 and later so you can enjoy performant, lower allocation string handling while still supporting older frameworks.
+**Touki** also provides additional high‑performance text utilities on **both** .NET 10 **and** .NET Framework 4.7.2 and later so you can enjoy performant, lower allocation string handling while still supporting older frameworks.
 
 ## Why reducing allocations matters
 
@@ -18,7 +18,7 @@ Strings in .NET are immutable. Every time you use `string.Concat`, `StringBuilde
 
 ## Touki’s approach
 
-Touki (登器) provides low allocation interpolated‑string support for .NET Framework 4.7.2 and a number of additional helpers for *all* .NET versions. Touki ports portions of the .NET runtime under the MIT license and augments them with extra functionality. On .NET 9 it defers to the built‑in handler; on .NET Framework 4.7.2 it provides its own implementation.
+Touki (登器) provides low allocation interpolated‑string support for .NET Framework 4.7.2 and a number of additional helpers for *all* .NET versions. Touki ports portions of the .NET runtime under the MIT license and augments them with extra functionality. On .NET 10 it defers to the built‑in handler; on .NET Framework 4.7.2 it provides its own implementation.
 
 ### `ValueStringBuilder`: the core string builder
 
@@ -94,8 +94,14 @@ The builder writes directly to the stream buffer, so no extra string is created.
 C# 10 lets you define **custom interpolated‐string handlers**. Touki supplies `DefaultInterpolatedStringHandler` and `AssertInterpolatedStringHandler` ([AssertInterpolatedStringHandler.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs)). The former is the special class C# looks for to implement interpolated strings. The latter is used to provide a low allocation cross compiled assertions in the `Debugging` class:
 
 ```csharp
-// Works on *both* .NET 9 and .NET Framework 4.7.2
+// Works on *both* .NET 10 and .NET Framework 4.7.2
 Debugging.Assert(count == 0, $"The count should be 0, but is {count}.");
 ```
 
-Touki ports span number formatting from .NET 6 to the .NET Framework 4.7.2 build to allow zero allocation number formatting.
+Touki ports span number formatting from modern .NET to the .NET Framework 4.7.2 build to allow zero allocation number formatting.
+
+## See also
+
+- [Low-Allocation Collections](collections.md) for `ArrayPoolList<T>` and friends.
+- [Buffers, Span Readers, and Span Writers](buffers.md) for `BufferScope<T>`, `SpanReader<T>`, and `SpanWriter<T>`.
+- [IO Helpers](io.md) for `WriteFormatted` on `Stream` and `TextWriter`.

--- a/sample/README.md
+++ b/sample/README.md
@@ -1,16 +1,57 @@
 # Configuring Your Project for Touki
 
-The "sample" project is a sample "template" project to demonstrate how to configure
-your own projects to leverage the features provided by Touki.
+The `sample` project is a template-style project that shows how to wire
+up your own multi-targeted projects to take full advantage of Touki. The
+same source compiles on .NET 10 and .NET Framework 4.7.2 because the
+project file and `GlobalUsings.cs` together hide the differences.
 
-## Project File Setup
+## Project file setup
 
-To use Touki effectively when targeting .NET Framework, you need to ensure your project file is set up correctly.
+See [sample.csproj](sample.csproj) for a concrete example. The key
+points are:
 
-See [sample.csproj](sample.csproj) for a concrete example project for multi-targeting. The key points are:
+- Target both .NET Framework (4.7.2 or later) and .NET (10.0 or later)
+  via `<TargetFrameworks>`.
+- Set `<ImplicitUsings>disable</ImplicitUsings>` so you can redirect
+  `System.IO` to `Microsoft.IO` on .NET Framework without ambiguity.
+- Reference `KlutzyNinja.Touki`. On .NET Framework, also reference
+  `Microsoft.Bcl.Memory` (Touki's transitive dependency surfaces a
+  security advisory until the Touki package is updated).
+- On .NET (non-framework), opt into `<IsAotCompatible>true</IsAotCompatible>`
+  to get the AOT analyzer. Touki itself is written to be AOT-friendly.
 
-- Target both .NET Framework (4.7.2 or later) and .NET (10.0 or later) with `<TargetFrameworks>`.
-- Disable `<ImplicitUsings>` to allow redirecting `System.IO` to `Microsoft.IO`.
+## Global usings
 
-In addition to this, manually configure usings in [GlobalUsings.cs](GlobalUsings.cs) to seamlessly leverage "polyfill"
-extensions and manually add the "normal" implicit usings (outside of "System.IO").
+[GlobalUsings.cs](GlobalUsings.cs) is what makes Touki feel like a part
+of the BCL in your code:
+
+- Re-adds the usings you'd normally get from `<ImplicitUsings>` (`System`,
+  `System.Collections.Generic`, `System.Diagnostics`, `System.Numerics`,
+  `System.Threading`, ...).
+- Redirects `System.IO` to `Microsoft.IO` on .NET Framework, with
+  explicit aliases for the exception types that don't move.
+- Pulls in `Touki`, `Touki.Collections`, `Touki.Exceptions`,
+  `Touki.Interop`, `Touki.Io`, and `Touki.Text` so extension members
+  light up on the BCL types you already use (`Convert`, `Random`,
+  `string`, `Stream`, ...).
+- On .NET Framework, adds `Framework.Touki` for the small amount of
+  Touki-specific framework-only code.
+
+## What the example demonstrates
+
+[ExampleClass.cs](ExampleClass.cs) calls a handful of APIs that "just
+work" on both targets thanks to Touki:
+
+- `DefaultInterpolatedStringHandler` (interpolated strings without
+  allocations on .NET Framework).
+- `System.Numerics.BitOperations` (`LeadingZeroCount`, `TrailingZeroCount`,
+  `PopCount`, `IsPow2`).
+- `System.Threading.Lock` and `lock(Lock)` syntax.
+- `Math.DivRem` returning a tuple.
+- `Interlocked` overloads for `uint`.
+- `char.IsAsciiLetter`/`IsAsciiDigit`/`IsAsciiHexDigit`/`IsAsciiLetterOrDigit`.
+- `ArgumentNullException.ThrowIfNull`.
+- Collection expressions, switch expressions, and ranges/spans.
+
+For a wider tour of what Touki provides, see the docs linked from the
+[top-level README](../README.md).


### PR DESCRIPTION
Adds overview docs for parts of Touki that the README mentioned only in passing, and refreshes existing docs and the sample README.

## New docs

- **`docs/collections.md`** &mdash; tour of `Touki.Collections`:
  `ListBase<T>` / `ContiguousList<T>` / `ArrayBackedList<T>`,
  `ArrayList<T>`, `ArrayPoolList<T>`, `SingleOptimizedList<TItem, TList>`,
  `Cache<T>`, `RefCountedCache<TValue, TCacheEntryData, TKey>`,
  `SinglyLinkedList<T>`, `EmptyList<T>`. Includes usage examples for
  the pooled list, single-optimized list, simple cache, and the
  `PenCache` ref-counted cache pattern from the XML docs.
- **`docs/buffers.md`** &mdash; `BufferScope<T>`, `SpanReader<T>`,
  `SpanWriter<T>`, `SpanReaderExtensions`, and the
  `SpanSplitEnumerator<T>` polyfill exposed via `SpanExtensions`.
- **`docs/io.md`** &mdash; `MSBuildEnumerator` (with the supported
  wildcard table), `Paths`, `TempFolder`, and the `WriteFormatted`
  extensions on `Stream` / `TextWriter`.

## Updates

- **`README.md`** &mdash; expanded the feature list (pooled and
  single-optimized lists, ref-counted caches, `MSBuildEnumerator`,
  polyfills, `DisposableBase`) and added links to the new overviews.
- **`docs/strings.md`** &mdash; refreshed `.NET 9` references to .NET 10
  (three spots), dropped the stale ".NET 6" attribution for span number
  formatting, and added a See also section linking the new docs.
- **`sample/README.md`** &mdash; explains what `GlobalUsings.cs`
  actually does, why `Microsoft.Bcl.Memory` is referenced on net472,
  and summarizes what `ExampleClass` demonstrates.

No code changes; markdown only.