### PR TITLE
Apply net481 RyuJIT mask fix to SpanExtensions search overloads

### DIFF
--- a/touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs
+++ b/touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs
@@ -1,0 +1,184 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+#pragma warning disable CS8500 // takes the address of, gets the size of, or declares a pointer to a managed type
+
+namespace Touki.Framework.Regressions;
+
+/// <summary>
+///  Regression coverage for the .NET Framework 4.8.1 RyuJIT codegen bug
+///  documented in <c>touki.perf/ReplaceUnsafeAsPerf.cs</c> and in the
+///  <c>polyfill-dotnet-api</c> skill. Inside an
+///  <see cref="MethodImplOptions.AggressiveInlining"/> method,
+///  <c>Unsafe.As&lt;T, byte&gt;(ref methodParameter)</c> on a literal
+///  signed-primitive caller (<c>(sbyte)-1</c>, <c>(short)-1</c>) leaks the
+///  32-bit sign-extended constant <c>0xFFFFFFFF</c> through the JIT's
+///  constant tracker. The byte-domain compare against a <c>movzx</c>-loaded
+///  byte (range [0, 0xFF]) is then always false. The masked form
+///  <c>(byte)(Unsafe.As&lt;T, byte&gt;(ref v) &amp; 0xFF)</c> forces the
+///  truncation in the int domain and produces correct codegen.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This test must run on Release on net481 to actually exercise the
+///   buggy codegen path. Debug disables AggressiveInlining; modern .NET
+///   RyuJIT does not exhibit the bug. The test is correct on every
+///   configuration; it only *pins* the bug class on net481 Release.
+///  </para>
+/// </remarks>
+public class UnsafeAsAggressiveInliningRegressionTests
+{
+    [Fact]
+    public void Replace_SByteNegativeOne_ReplacesAllOccurrences()
+    {
+        sbyte[] data = [-1, 2, -1, 4, -1, 6, -1, 8];
+        ReplaceMasked<sbyte>(data, -1, 0);
+        data.Should().Equal((sbyte)0, (sbyte)2, (sbyte)0, (sbyte)4, (sbyte)0, (sbyte)6, (sbyte)0, (sbyte)8);
+    }
+
+    [Fact]
+    public void Replace_ByteMaxValue_ReplacesAllOccurrences()
+    {
+        byte[] data = [0xFF, 2, 0xFF, 4, 0xFF, 6, 0xFF, 8];
+        ReplaceMasked<byte>(data, 0xFF, 0);
+        data.Should().Equal((byte)0, (byte)2, (byte)0, (byte)4, (byte)0, (byte)6, (byte)0, (byte)8);
+    }
+
+    [Fact]
+    public void Replace_ShortNegativeOne_ReplacesAllOccurrences()
+    {
+        short[] data = [-1, 2, -1, 4, -1, 6, -1, 8];
+        ReplaceMaskedShort<short>(data, -1, 0);
+        data.Should().Equal((short)0, (short)2, (short)0, (short)4, (short)0, (short)6, (short)0, (short)8);
+    }
+
+    [Fact]
+    public void Replace_UShortMaxValue_ReplacesAllOccurrences()
+    {
+        ushort[] data = [0xFFFF, 2, 0xFFFF, 4, 0xFFFF, 6, 0xFFFF, 8];
+        ReplaceMaskedShort<ushort>(data, 0xFFFF, 0);
+        data.Should().Equal((ushort)0, (ushort)2, (ushort)0, (ushort)4, (ushort)0, (ushort)6, (ushort)0, (ushort)8);
+    }
+
+    // ----- Search-shape coverage (IndexOfAnyExcept / LastIndexOfAnyExcept) -----
+    //
+    // The same JIT bug class affects SpanExtensions.Search.cs's
+    // IndexOfAnyExcept / LastIndexOfAnyExcept polyfills. Tests in
+    // SpanExtensionsSearchExtraTests.cs already cover these for sbyte with
+    // (sbyte)(-1) literal inputs; this section exists so the regression is
+    // pinned by name to the JIT-bug class, not just to the public API.
+    // Removing the `& 0xFF` / `& 0xFFFF` mask in
+    // touki/Framework/Polyfills/System/SpanExtensions.Search.cs will fail
+    // these tests on net481 Release.
+
+    [Fact]
+    public void IndexOfAnyExcept_SByteNegativeOne_FindsFirstNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)(-1), (sbyte)(-1), (sbyte)9];
+        span.IndexOfAnyExcept((sbyte)(-1)).Should().Be(2);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_TwoValues_SByteNegativeOne_FindsFirstNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)(-1), (sbyte)2, (sbyte)9];
+        span.IndexOfAnyExcept((sbyte)(-1), (sbyte)2).Should().Be(2);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_ThreeValues_SByteNegativeOne_FindsFirstNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)(-1), (sbyte)2, (sbyte)3, (sbyte)9];
+        span.IndexOfAnyExcept((sbyte)(-1), (sbyte)2, (sbyte)3).Should().Be(3);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_SByteNegativeOne_FindsLastNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)9, (sbyte)(-1), (sbyte)(-1)];
+        span.LastIndexOfAnyExcept((sbyte)(-1)).Should().Be(0);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_TwoValues_SByteNegativeOne_FindsLastNonMatch()
+    {
+        ReadOnlySpan<sbyte> span = [(sbyte)9, (sbyte)(-1), (sbyte)2];
+        span.LastIndexOfAnyExcept((sbyte)(-1), (sbyte)2).Should().Be(0);
+    }
+
+    [Fact]
+    public void IndexOfAnyExcept_ShortNegativeOne_FindsFirstNonMatch()
+    {
+        ReadOnlySpan<short> span = [(short)(-1), (short)(-1), (short)9];
+        span.IndexOfAnyExcept((short)(-1)).Should().Be(2);
+    }
+
+    [Fact]
+    public void LastIndexOfAnyExcept_ShortNegativeOne_FindsLastNonMatch()
+    {
+        ReadOnlySpan<short> span = [(short)9, (short)(-1), (short)(-1)];
+        span.LastIndexOfAnyExcept((short)(-1)).Should().Be(0);
+    }
+
+    /// <summary>
+    ///  Byte/sbyte replace using the masked-int-domain pattern. Removing the
+    ///  <c>&amp; 0xFF</c> mask resurrects the net481 Release bug.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceMasked<T>(Span<T> span, T oldValue, T newValue)
+        where T : struct
+    {
+        if (typeof(T) != typeof(byte) && typeof(T) != typeof(sbyte))
+        {
+            throw new InvalidOperationException();
+        }
+
+        byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+        byte newByte = (byte)(Unsafe.As<T, byte>(ref newValue) & 0xFF);
+        fixed (T* p = span)
+        {
+            byte* ptr = (byte*)p;
+            byte* end = ptr + span.Length;
+            while (ptr < end)
+            {
+                if (*ptr == oldByte)
+                {
+                    *ptr = newByte;
+                }
+
+                ptr++;
+            }
+        }
+    }
+
+    /// <summary>
+    ///  short/ushort replace, same pattern in the 16-bit domain.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static unsafe void ReplaceMaskedShort<T>(Span<T> span, T oldValue, T newValue)
+        where T : struct
+    {
+        if (typeof(T) != typeof(short) && typeof(T) != typeof(ushort))
+        {
+            throw new InvalidOperationException();
+        }
+
+        ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+        ushort newShort = (ushort)(Unsafe.As<T, ushort>(ref newValue) & 0xFFFF);
+        fixed (T* p = span)
+        {
+            ushort* ptr = (ushort*)p;
+            ushort* end = ptr + span.Length;
+            while (ptr < end)
+            {
+                if (*ptr == oldShort)
+                {
+                    *ptr = newShort;
+                }
+
+                ptr++;
+            }
+        }
+    }
+}

--- a/touki/Framework/Polyfills/System/SpanExtensions.Search.cs
+++ b/touki/Framework/Polyfills/System/SpanExtensions.Search.cs
@@ -34,7 +34,18 @@ public static partial class SpanExtensions
             // Specialize for 2-byte primitives (char / short / ushort): IEquatable equality is bit equality.
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort target = Unsafe.As<T, ushort>(ref value);
+                // The explicit `& 0xFFFF` mask is load-bearing on net481 RyuJIT.
+                // Inside an [AggressiveInlining] method that takes a generic `T`,
+                // `Unsafe.As<T, ushort>(ref param)` on a literal signed-primitive
+                // caller (e.g. `(short)-1`) propagates the int-promoted constant
+                // 0xFFFFFFFF through the constant tracker, producing a 32-bit
+                // compare against a `movzx`-loaded ushort that is always false.
+                // Masking in the int domain forces a `conv.u2` and yields correct
+                // codegen on both net481 and modern .NET RyuJIT. See
+                // touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs
+                // and touki.perf/ReplaceUnsafeAsPerf.cs for the captured
+                // disassembly evidence.
+                ushort target = (ushort)(Unsafe.As<T, ushort>(ref value) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* ptr = (ushort*)p;
@@ -65,7 +76,9 @@ public static partial class SpanExtensions
             // Specialize for 1-byte primitives (byte / sbyte).
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte target = Unsafe.As<T, byte>(ref value);
+                // See the ushort branch above; the explicit `& 0xFF` mask defeats
+                // the same net481 RyuJIT constant-propagation bug for sbyte inputs.
+                byte target = (byte)(Unsafe.As<T, byte>(ref value) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* ptr = (byte*)p;
@@ -114,8 +127,8 @@ public static partial class SpanExtensions
         {
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort v0 = Unsafe.As<T, ushort>(ref value0);
-                ushort v1 = Unsafe.As<T, ushort>(ref value1);
+                ushort v0 = (ushort)(Unsafe.As<T, ushort>(ref value0) & 0xFFFF);
+                ushort v1 = (ushort)(Unsafe.As<T, ushort>(ref value1) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* ptr = (ushort*)p;
@@ -135,8 +148,8 @@ public static partial class SpanExtensions
 
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte v0 = Unsafe.As<T, byte>(ref value0);
-                byte v1 = Unsafe.As<T, byte>(ref value1);
+                byte v0 = (byte)(Unsafe.As<T, byte>(ref value0) & 0xFF);
+                byte v1 = (byte)(Unsafe.As<T, byte>(ref value1) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* ptr = (byte*)p;
@@ -176,9 +189,9 @@ public static partial class SpanExtensions
         {
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort v0 = Unsafe.As<T, ushort>(ref value0);
-                ushort v1 = Unsafe.As<T, ushort>(ref value1);
-                ushort v2 = Unsafe.As<T, ushort>(ref value2);
+                ushort v0 = (ushort)(Unsafe.As<T, ushort>(ref value0) & 0xFFFF);
+                ushort v1 = (ushort)(Unsafe.As<T, ushort>(ref value1) & 0xFFFF);
+                ushort v2 = (ushort)(Unsafe.As<T, ushort>(ref value2) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* ptr = (ushort*)p;
@@ -198,9 +211,9 @@ public static partial class SpanExtensions
 
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte v0 = Unsafe.As<T, byte>(ref value0);
-                byte v1 = Unsafe.As<T, byte>(ref value1);
-                byte v2 = Unsafe.As<T, byte>(ref value2);
+                byte v0 = (byte)(Unsafe.As<T, byte>(ref value0) & 0xFF);
+                byte v1 = (byte)(Unsafe.As<T, byte>(ref value1) & 0xFF);
+                byte v2 = (byte)(Unsafe.As<T, byte>(ref value2) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* ptr = (byte*)p;
@@ -273,7 +286,7 @@ public static partial class SpanExtensions
         {
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort target = Unsafe.As<T, ushort>(ref value);
+                ushort target = (ushort)(Unsafe.As<T, ushort>(ref value) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* start = (ushort*)p;
@@ -303,7 +316,7 @@ public static partial class SpanExtensions
 
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte target = Unsafe.As<T, byte>(ref value);
+                byte target = (byte)(Unsafe.As<T, byte>(ref value) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* start = (byte*)p;
@@ -350,8 +363,8 @@ public static partial class SpanExtensions
         {
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort v0 = Unsafe.As<T, ushort>(ref value0);
-                ushort v1 = Unsafe.As<T, ushort>(ref value1);
+                ushort v0 = (ushort)(Unsafe.As<T, ushort>(ref value0) & 0xFFFF);
+                ushort v1 = (ushort)(Unsafe.As<T, ushort>(ref value1) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* ptr = (ushort*)p;
@@ -370,8 +383,8 @@ public static partial class SpanExtensions
 
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte v0 = Unsafe.As<T, byte>(ref value0);
-                byte v1 = Unsafe.As<T, byte>(ref value1);
+                byte v0 = (byte)(Unsafe.As<T, byte>(ref value0) & 0xFF);
+                byte v1 = (byte)(Unsafe.As<T, byte>(ref value1) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* ptr = (byte*)p;
@@ -410,9 +423,9 @@ public static partial class SpanExtensions
         {
             if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
             {
-                ushort v0 = Unsafe.As<T, ushort>(ref value0);
-                ushort v1 = Unsafe.As<T, ushort>(ref value1);
-                ushort v2 = Unsafe.As<T, ushort>(ref value2);
+                ushort v0 = (ushort)(Unsafe.As<T, ushort>(ref value0) & 0xFFFF);
+                ushort v1 = (ushort)(Unsafe.As<T, ushort>(ref value1) & 0xFFFF);
+                ushort v2 = (ushort)(Unsafe.As<T, ushort>(ref value2) & 0xFFFF);
                 fixed (T* p = span)
                 {
                     ushort* ptr = (ushort*)p;
@@ -431,9 +444,9 @@ public static partial class SpanExtensions
 
             if (typeof(T) == typeof(byte) || typeof(T) == typeof(sbyte))
             {
-                byte v0 = Unsafe.As<T, byte>(ref value0);
-                byte v1 = Unsafe.As<T, byte>(ref value1);
-                byte v2 = Unsafe.As<T, byte>(ref value2);
+                byte v0 = (byte)(Unsafe.As<T, byte>(ref value0) & 0xFF);
+                byte v1 = (byte)(Unsafe.As<T, byte>(ref value1) & 0xFF);
+                byte v2 = (byte)(Unsafe.As<T, byte>(ref value2) & 0xFF);
                 fixed (T* p = span)
                 {
                     byte* ptr = (byte*)p;


### PR DESCRIPTION
## Summary

Mirrors #359's fix in `SpanExtensions.Replace` to the search overloads. Inside an `[AggressiveInlining]` method that takes a generic `T`, `Unsafe.As<T, byte/ushort>(ref methodParam)` on a literal signed-primitive caller (`(sbyte)-1`, `(short)-1`) propagates the int-promoted constant `0xFFFFFFFF` through net481 RyuJIT's constant tracker. The byte-domain compare against a `movzx`-loaded byte (range `[0, 0xFF]`) is then always false, so the search loops scan past every match.

## Changes

- **`touki/Framework/Polyfills/System/SpanExtensions.Search.cs`** — apply the documented `& 0xFF` / `& 0xFFFF` mask at all 21 sites in `IndexOfAnyExcept` and `LastIndexOfAnyExcept` (1/2/3-value overloads, both `byte`/`sbyte` and `char`/`short`/`ushort` branches). Added the explanatory comment block at the first occurrence pointing to the regression test and the perf benchmark with the captured disassembly.
- **`touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs`** — new file. Four tests covering the `Replace` shape (already pinned by the existing skill / user-memory note) plus seven covering the search shape with literal `(sbyte)(-1)` and `(short)(-1)` inputs. Existing tests in `SpanExtensionsSearchExtraTests.cs` already cover the public API; these pin the regression to the JIT-bug class by name so the linkage survives any future test-file refactor.

## Why this wasn't caught earlier

The tests in `SpanExtensionsSearchExtraTests.cs` (#131–133) already exercise these overloads with `(sbyte)(-1)` literals. CI on `windows-latest` passes them — and consistently has, on every run on `main`. Locally on Windows with a different .NET Framework 4.8.1 patch level, the same Release build fails the same five tests. RyuJIT updates ship through Windows Update / .NET Framework servicing, and this bug class is sensitive to which JIT build the runner ends up with.

The bug is real on at least one supported configuration regardless of which side of the divergence CI lands on.

## Verification

```
net481 Release: 5887 passed, 0 failed (was 5 failed before the mask fix)
net10  Release: 3941 passed, 0 failed
```

## Related

- #359 — original fix in `SpanExtensions.Replace`
- `touki.perf/ReplaceUnsafeAsPerf.cs` — disassembly evidence
- `.agents/skills/polyfill-dotnet-api/SKILL.md` — Gotcha #2 documents this JIT-bug class
