### PR TITLE
AI tooling: enforcement, MCP, skills catalog, path-specific instructions

### DIFF
--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -1,0 +1,41 @@
+# Agent Skills format reference
+
+Format details for files under `.agents/skills/`. For the catalog of skills
+currently present in this repo, see [README.md](./README.md).
+
+## Layout
+
+```text
+.agents/skills/
+  <skill-name>/
+    SKILL.md           # required
+    <other resources>  # scripts, templates, examples (optional)
+```
+
+The directory name **must** match the `name` field in `SKILL.md` exactly, or the
+skill silently fails to load.
+
+## `SKILL.md` format
+
+```markdown
+---
+name: skill-name                 # lowercase, digits, hyphens; max 64 chars; matches dir name
+description: One-sentence summary of what the skill does and when to use it.
+---
+
+# Body
+
+Detailed instructions, procedures, examples. Reference sibling files with
+relative Markdown links, e.g. `[template](./template.cs)`.
+```
+
+Optional frontmatter fields: `argument-hint`, `user-invocable`,
+`disable-model-invocation`, `context` (`inline` or `fork`).
+
+## Discovery
+
+Vendor-neutral location for [Agent Skills](https://agentskills.io/). Discovered
+by GitHub Copilot (VS Code, CLI, cloud agent) and Claude Code.
+
+See [docs/agent-customization.md](../../docs/agent-customization.md) for the
+full decision matrix and tooling support.

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -1,37 +1,86 @@
-# Skills (`.agents/skills/`)
+# Skills catalog (`.agents/skills/`)
 
-Vendor-neutral location for [Agent Skills](https://agentskills.io/) &mdash; portable
-folders of instructions, scripts, and resources that an agent can load on demand.
-Discovered by GitHub Copilot (VS Code, CLI, cloud agent) and Claude Code.
+Inventory of skills available in this repo, what triggers each, and how to
+disambiguate overlapping ones. For the file format and discovery rules, see
+[FORMAT.md](./FORMAT.md).
 
-## Layout
+Skill auto-invocation matches against the `description` field. When two skills
+have overlapping verbs in their descriptions, the wrong one can fire silently.
+The "Disambiguation" section below records every known overlap.
 
-```text
-.agents/skills/
-  <skill-name>/
-    SKILL.md           # required
-    <other resources>  # scripts, templates, examples (optional)
-```
+## Inventory
 
-The directory name **must** match the `name` field in `SKILL.md` exactly, or the skill
-silently fails to load.
+| Skill | Trigger phrasing | Cross-references |
+| ----- | ---------------- | ---------------- |
+| [polyfill-dotnet-api](./polyfill-dotnet-api/SKILL.md) | "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", missing-on-net472-present-on-net10 | `pre-pr-self-review`, `performance-testing`, `framework-jit-optimization`, `create-pr` |
+| [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | hot-path tuning for `net481` in `touki/Framework/`, generic specialization, scalar/unrolled vs BCL delegation, net481 RyuJIT regressions | `performance-testing` |
+| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations | `framework-jit-optimization` |
+| [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review checklist before opening or pushing a PR; missing tests, unchecked length sums, empty-span foot-guns, TFM phrasing | `create-pr`, `polyfill-dotnet-api` |
+| [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", "publish for review" &mdash; **initial** publish | `pre-pr-self-review` |
+| [address-pr-feedback](./address-pr-feedback/SKILL.md) | "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure" &mdash; **post-PR** review-cycle work | `pre-pr-self-review` |
+| [agent-files-review](./agent-files-review/SKILL.md) | reviewing/validating agent-customization files (`AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, validator, CI workflow); fixing `agent-files.yml` failures | &mdash; |
 
-## `SKILL.md` format
+## Disambiguation
 
-```markdown
----
-name: skill-name                 # lowercase, digits, hyphens; max 64 chars; matches dir name
-description: One-sentence summary of what the skill does and when to use it.
----
+These pairs are known to compete for auto-invocation. When both descriptions
+match the user's request, follow the rule below.
 
-# Body
+### `create-pr` vs `address-pr-feedback`
 
-Detailed instructions, procedures, examples. Reference sibling files with relative
-Markdown links, e.g. `[template](./template.cs)`.
-```
+Both touch PR mechanics. They are mutually exclusive by **lifecycle stage**:
 
-Optional frontmatter fields: `argument-hint`, `user-invocable`,
-`disable-model-invocation`, `context` (`inline` or `fork`).
+- **No PR exists yet** &rarr; `create-pr`. The skill ensures changes are on a
+  non-`main` branch, commits and pushes, and targets `upstream/main` when
+  available.
+- **PR exists, reviewer left comments / CI failed** &rarr; `address-pr-feedback`.
+  Edit-only by default. Does **not** push without explicit approval.
 
-See [docs/agent-customization.md](../../docs/agent-customization.md) for the full
-decision matrix and tooling support.
+If the user says "open a PR" while a PR already exists for this branch, ask
+which they mean before invoking either.
+
+### `polyfill-dotnet-api` vs `framework-jit-optimization`
+
+Both can land code under `touki/Framework/`. They are mutually exclusive by
+**intent**:
+
+- **Adding/back-porting an API surface** missing on net472 &rarr;
+  `polyfill-dotnet-api`. Picks the right source (Microsoft package vs PolySharp
+  vs hand-rolled) and enforces namespace/`#if` rules.
+- **Tuning an existing hot path** for net481 RyuJIT specifically &rarr;
+  `framework-jit-optimization`. No new public surface; the file already exists.
+
+If a polyfill needs hot-path tuning after the fact, run `polyfill-dotnet-api`
+first to land the surface, then `framework-jit-optimization` for the tuning
+pass.
+
+### `performance-testing` vs `framework-jit-optimization`
+
+Adjacent, not overlapping, but easy to confuse:
+
+- **Harness mechanics** (writing a benchmark class, parameters, diagnosers,
+  reading the output) &rarr; `performance-testing`.
+- **What the JIT will do with the code under benchmark** (inlining, intrinsics,
+  devirtualization, the `Unsafe.As` foot-gun) &rarr;
+  `framework-jit-optimization`.
+
+You will frequently use both in sequence.
+
+## Maintenance
+
+Freshness is tracked from git history, not from a manual column. CI warns
+(does not fail) when a skill directory has no commits in the last 90 days
+&mdash; see [.github/workflows/agent-files.yml](../../.github/workflows/agent-files.yml).
+
+A stale warning means "re-read this skill end-to-end against the current
+codebase." Confirm:
+
+1. Every cross-reference resolves.
+2. Every file path / type / API mentioned still exists.
+3. Every claim about the codebase is still true.
+
+The only way to clear the warning is to commit a change to the skill
+directory &mdash; ideally the result of a real review pass, but at minimum a
+whitespace touch with a commit message stating "verified still current."
+
+When adding a new skill, append a row to the inventory above in the same
+change set; the skill is not "shipped" until the catalog reflects it.

--- a/.github/agents/touki-reviewer.agent.md
+++ b/.github/agents/touki-reviewer.agent.md
@@ -1,0 +1,77 @@
+---
+description: Read-only reviewer for touki PRs. Checks cross-TFM correctness, the JIT-naming rule, polyfill conventions, and missing tests/docs. Findings only — never offers fixes.
+tools: ['search', 'usages', 'problems', 'changes', 'fetch']
+---
+
+# Touki-Reviewer
+
+You are reviewing changes to the `touki` library. You **do not edit code**.
+You produce findings only.
+
+Your output is a Markdown table grouped by severity (`blocker` / `major` /
+`minor` / `nit`), with one row per finding. Each row has: file:line, severity,
+category, finding, suggested fix (one sentence, not code).
+
+If you have no findings, say so explicitly with one sentence on what you
+checked. Do not pad.
+
+## What to check (in priority order)
+
+1. **Cross-TFM correctness.** All code must compile and behave on both .NET 10
+   and .NET Framework 4.7.2. Flag any modern C# / BCL usage not gated for the
+   older target. Flag missing `#if NET` where required (note: code under
+   `touki/Framework/` already targets only the framework, so `#if NETFRAMEWORK`
+   inside that tree is dead — see
+   [.github/instructions/polyfills.instructions.md](../instructions/polyfills.instructions.md)).
+
+2. **Polyfill conventions.** For files under `touki/Framework/Polyfills/`:
+   - Namespace must equal the BCL namespace being polyfilled (e.g.
+     `Polyfills/System/Foo.cs` &rarr; `namespace System;`).
+   - No `#if NETFRAMEWORK` directives.
+   - Hand-rolled is a last resort; flag any new file if a Microsoft package
+     or PolySharp source-gen would have worked. Reference the
+     [`polyfill-dotnet-api`](../../.agents/skills/polyfill-dotnet-api/SKILL.md)
+     skill in the finding.
+
+3. **JIT-naming rule.** Performance claims in code comments, PR descriptions,
+   or commit messages must say either ".NET Framework 4.8.1 RyuJIT" or
+   "modern .NET RyuJIT". Unqualified "RyuJIT" claims are a finding. Flag
+   `[MethodImpl(MethodImplOptions.AggressiveInlining)]` methods that take a
+   generic `T` and call `Unsafe.As<T, byte/sbyte/short/ushort>(ref param)`
+   without masking &mdash; this is the documented net481 codegen bug. See
+   [touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs](../../touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs).
+
+4. **Public API additions.**
+   - XML doc comments on every new public type, method, property.
+   - At least one test in `touki.tests/` covering the new surface.
+   - If the addition is a polyfill, the `Examples` table in the polyfill
+     skill is updated.
+
+5. **Test conventions.** See
+   [.github/instructions/tests.instructions.md](../instructions/tests.instructions.md).
+   Common findings:
+   - Test name not in `MethodName_StateUnderTest_ExpectedBehavior` form.
+   - "Arrange / Act / Assert" comments present.
+   - New `using` for `FluentAssertions` or `Xunit` (already global).
+   - Reflection used instead of `TestAccessor` for private members.
+   - Ref-struct under test exercised inside a lambda.
+
+6. **Whitespace and formatting.** Trailing whitespace; tabs in Markdown;
+   missing blank line between methods; lines exceeding 150 characters
+   without a break before 120.
+
+7. **Approval-verb hygiene** (for PR descriptions only). The PR description
+   should not assume publish authority from "open a PR" / "address the
+   review" / similar non-publishing verbs. See "Working with the user on
+   changes" in [AGENTS.md](../../AGENTS.md).
+
+## What you do not do
+
+- Do not propose fixes as code. One sentence per finding, no diffs.
+- Do not "just fix it real quick." You have no edit tools by design.
+- Do not rubber-stamp a small diff. If a one-line change still touches a
+  hot path, perf-sensitive type, or polyfill file, check it against the
+  rules above. State explicitly what you checked.
+- Do not recommend changes that contradict
+  [AGENTS.md](../../AGENTS.md) or any path-specific
+  [instructions](../instructions/) file.

--- a/.github/agents/touki-reviewer.agent.md
+++ b/.github/agents/touki-reviewer.agent.md
@@ -19,10 +19,10 @@ checked. Do not pad.
 
 1. **Cross-TFM correctness.** All code must compile and behave on both .NET 10
    and .NET Framework 4.7.2. Flag any modern C# / BCL usage not gated for the
-   older target. Flag missing `#if NET` where required (note: code under
+   older target. Flag missing `#if NET` where required. Note: code under
    `touki/Framework/` already targets only the framework, so `#if NETFRAMEWORK`
-   inside that tree is dead — see
-   [.github/instructions/polyfills.instructions.md](../instructions/polyfills.instructions.md)).
+   inside that tree is dead &mdash; see
+   [.github/instructions/polyfills.instructions.md](../instructions/polyfills.instructions.md).
 
 2. **Polyfill conventions.** For files under `touki/Framework/Polyfills/`:
    - Namespace must equal the BCL namespace being polyfilled (e.g.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -111,22 +111,16 @@ Top-level layout:
 
 ## Testing
 
-- Place tests in the `touki.tests` project.
-- Test classes should be in the same namespace as the class they are testing, with
-  `Tests` appended (e.g. `ListBaseTests` for `ListBase`).
-- Test methods should be named `MethodName_StateUnderTest_ExpectedBehavior`
-  (e.g. `MoveNext_AtStart_ReturnsTrue`).
-- Test methods should be ordered by the method they are testing.
-- Cover edge and negative cases.
-- Do **not** add "Arrange, Act, Assert" comments in tests.
-- Ref structs cannot be used in lambdas; use `try`/`finally` blocks to validate error
-  cases.
-- Use FluentAssertions for assertions in tests.
-- FluentAssertions and Xunit are already global usings &mdash; do not add new usings for
-  these to test files.
-- Tests have access to internals via `InternalsVisibleTo`, so you can test internal
-  members directly.
-- For private members, use the `TestAccessor` and `TestAccessors` extension methods.
+Detailed test conventions live in
+[.github/instructions/tests.instructions.md](instructions/tests.instructions.md)
+(applies to `touki.tests/**/*.cs`). Headline rules: place tests in `touki.tests`;
+name them `MethodName_StateUnderTest_ExpectedBehavior`; use FluentAssertions (global
+using); access internals directly via `InternalsVisibleTo` and private members via
+`TestAccessor`; ref structs can't be used in lambdas &mdash; use `try`/`finally`.
+
+Performance-test conventions for `touki.perf/` (BenchmarkDotNet, Release-only,
+JIT-naming rule, regression thresholds) live in
+[.github/instructions/perf.instructions.md](instructions/perf.instructions.md).
 
 ## Working with the user on changes
 
@@ -156,15 +150,36 @@ Treat them as hard requirements.
 - **Stage by path, never `git add -A`/`git add .`** when the working tree spans
   more than one logical change set. Run `git status --short` first; if topics
   are intermingled, ask how to split before staging.
-- **Name the JIT in performance claims.** ".NET Framework 4.8.1 RyuJIT" (older,
-  no `EqualityComparer<T>.Default` intrinsic, no tiered JIT, weaker inlining)
-  vs **modern .NET RyuJIT** (.NET 6+, devirtualization, tiered JIT, dynamic
-  PGO). Unqualified "RyuJIT" claims are wrong about half the time. Code
-  changes in `touki/Framework/` driven by such claims need a benchmark or an
-  explicit "not measured" note.
 - **Run `dotnet test -c Release` before declaring a fix done.** Release-mode
   inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As` on a method
   parameter is a known foot-gun on net481 RyuJIT.
+
+The JIT-naming rule for performance claims (".NET Framework 4.8.1 RyuJIT" vs
+"modern .NET RyuJIT") and BenchmarkDotNet conventions live in
+[.github/instructions/perf.instructions.md](instructions/perf.instructions.md).
+
+### Enforcement
+
+The publish-boundary rule above is also enforced mechanically so that model
+rationalization cannot bypass it:
+
+- **VS Code Copilot agent mode.** [.vscode/settings.json](../.vscode/settings.json)
+  configures `chat.tools.terminal.autoApprove` to deny `git commit`, `git push`,
+  `git reset --hard`, `git rebase`, `git merge`, `git cherry-pick`, `git tag`,
+  destructive `git branch -d/-D`, and `gh pr create|merge|close|edit`. Each
+  invocation requires an explicit in-chat **Allow** click; that click is the
+  approval. Routine read-only verbs (`git status`, `git diff`, `git log`,
+  `git show`, `git branch`, `git stash list`, `git rev-parse`, `git ls-files`)
+  are auto-approved so review work stays frictionless.
+- **Branch protection on `main`.** Configured in repo settings: PR required,
+  status checks required, force pushes and branch deletion blocked. This covers
+  surfaces the local denylist does not (Copilot cloud agent, other agents,
+  scripted runs).
+
+The prose rules above still apply: they explain *why*, and they apply on
+surfaces where the mechanical gate doesn't fire (e.g. cloud-agent runs that
+bypass the local terminal). Treat the mechanical gate as a backstop, not a
+license to skip the conversation.
 
 ## General guidance
 
@@ -193,3 +208,6 @@ automatically based on each file's `applyTo` glob.
 Currently:
 
 - [.github/instructions/msbuild.instructions.md](instructions/msbuild.instructions.md) &mdash; rules for `*.csproj`, `*.props`, `*.targets`.
+- [.github/instructions/tests.instructions.md](instructions/tests.instructions.md) &mdash; conventions for `touki.tests/**/*.cs`.
+- [.github/instructions/perf.instructions.md](instructions/perf.instructions.md) &mdash; BenchmarkDotNet conventions and the JIT-naming rule for `touki.perf/**/*.cs`.
+- [.github/instructions/polyfills.instructions.md](instructions/polyfills.instructions.md) &mdash; the two non-negotiable rules for `touki/Framework/Polyfills/**/*.cs`.

--- a/.github/instructions/perf.instructions.md
+++ b/.github/instructions/perf.instructions.md
@@ -1,0 +1,59 @@
+---
+applyTo: 'touki.perf/**/*.cs'
+---
+
+# Performance test conventions for `touki.perf`
+
+Rules for BenchmarkDotNet benchmarks under `touki.perf/`. See also the
+[`performance-testing`](../../.agents/skills/performance-testing/SKILL.md) and
+[`framework-jit-optimization`](../../.agents/skills/framework-jit-optimization/SKILL.md)
+skills for the workflow and net481-specific JIT details.
+
+## Run mode
+
+- Always run benchmarks in **Release** configuration. Debug numbers are
+  meaningless and will mislead any performance claim built on them.
+- Benchmarks must run cleanly on **both** target frameworks (.NET 10 and
+  .NET Framework 4.8.1). A regression on one TFM and not the other is a real
+  signal, not noise &mdash; see the JIT-naming rule below.
+
+## JIT-naming rule (non-negotiable)
+
+When making any performance claim in code comments, PR descriptions, or
+benchmark commentary, name the JIT explicitly:
+
+- **".NET Framework 4.8.1 RyuJIT"** &mdash; older, no
+  `EqualityComparer<T>.Default` intrinsic, no tiered JIT, weaker inlining,
+  no dynamic PGO.
+- **"modern .NET RyuJIT"** (.NET 6+) &mdash; devirtualization, tiered JIT,
+  dynamic PGO, much more aggressive inlining.
+
+Unqualified "RyuJIT" claims are wrong about half the time. Code changes in
+`touki/Framework/` driven by such claims need a benchmark or an explicit
+"not measured" note.
+
+## Reading BenchmarkDotNet output
+
+- **Mean** is what you compare; **Median** is a sanity check (large
+  Mean&ndash;Median spread = unstable benchmark, fix before drawing
+  conclusions).
+- **Allocated** is per-operation managed allocation. **Any new allocation
+  in a documented hot path is a regression**, regardless of throughput.
+- **Gen0/Gen1/Gen2** are GC events per 1000 ops. Watch for new Gen1/Gen2
+  promotion in steady-state benches.
+
+## Regression threshold
+
+- > 5 % throughput delta vs the prior baseline, **or** any new allocation in a
+  hot path = regression.
+- Below 5 % with no new allocation = noise. Say so explicitly when reporting.
+
+## Authoring conventions
+
+- One benchmark class per scenario; name it `<Subject>Perf` to match the
+  existing `touki.perf/*Perf.cs` files.
+- Use `[MemoryDiagnoser]` on every benchmark class.
+- Parameterize with `[Params]` only when the parameter changes the algorithmic
+  shape; otherwise hard-code and add a second class.
+- Do not check generated reports under `BenchmarkDotNet.Artifacts/` into git
+  unless the change is intentionally pinning a baseline.

--- a/.github/instructions/polyfills.instructions.md
+++ b/.github/instructions/polyfills.instructions.md
@@ -1,0 +1,45 @@
+---
+applyTo: 'touki/Framework/Polyfills/**/*.cs'
+---
+
+# Polyfill conventions for `touki/Framework/Polyfills/`
+
+These two rules are non-negotiable. The full workflow lives in the
+[`polyfill-dotnet-api`](../../.agents/skills/polyfill-dotnet-api/SKILL.md)
+skill; this file restates the rules at the file-pattern level so agents that
+don't auto-invoke the skill still pick them up.
+
+## Rule 1: namespace = BCL namespace being polyfilled
+
+Files under `touki/Framework/Polyfills/<BclNamespace>/` declare the BCL
+namespace they are polyfilling, **not** a `Touki.*` namespace:
+
+- `Polyfills/System/Foo.cs` &rarr; `namespace System;`
+- `Polyfills/System.Text/Foo.cs` &rarr; `namespace System.Text;`
+- `Polyfills/System.Buffers/Foo.cs` &rarr; `namespace System.Buffers;`
+
+Touki-specific code that is **not** a polyfill of a modern .NET API stays
+under `touki/Framework/Touki/...` with `Touki.*` namespaces.
+
+## Rule 2: no `#if NETFRAMEWORK` inside `touki/Framework/`
+
+Everything under `touki/Framework/` already compiles only for the framework
+target. `#if NETFRAMEWORK` inside this tree is dead-code-by-construction and
+adds noise. Don't add it. If a polyfill needs to vary by sub-target (rare),
+prefer separate files per target with appropriate `<Compile>` conditions in
+the project file.
+
+## Source-preference order (summary)
+
+The full preference order with examples is in the
+[`polyfill-dotnet-api`](../../.agents/skills/polyfill-dotnet-api/SKILL.md)
+skill. Headline:
+
+1. Microsoft-shipped package (`System.Memory`, `Microsoft.Bcl.*`,
+   `Microsoft.IO.Redist`).
+2. PolySharp source-gen for compiler attributes.
+3. Hand-rolled polyfill in this directory &mdash; **last resort**, only with
+   a real caller. Don't polyfill for completeness.
+
+See [docs/polyfill-layout.md](../../docs/polyfill-layout.md) for the
+user-facing description and the `extern alias` recipe for type-name conflicts.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,46 @@
+---
+applyTo: 'touki.tests/**/*.cs'
+---
+
+# Test conventions for `touki.tests`
+
+These rules duplicate the summary in [AGENTS.md](../../AGENTS.md) and add the
+detail that would bloat the canonical file. Both are authoritative; if they
+ever drift, AGENTS.md wins.
+
+## Placement and naming
+
+- Place tests in the `touki.tests` project.
+- Test classes live in the same namespace as the class under test, with `Tests`
+  appended (e.g. `ListBaseTests` for `ListBase`).
+- Test methods are named `MethodName_StateUnderTest_ExpectedBehavior`
+  (e.g. `MoveNext_AtStart_ReturnsTrue`).
+- Order test methods by the method they are testing.
+- Cover edge and negative cases.
+
+## Style
+
+- Do **not** add "Arrange, Act, Assert" comments in tests.
+- Use FluentAssertions for assertions. `FluentAssertions` and `Xunit` are
+  already global usings &mdash; do not add new usings for these to test files.
+- Prefer `[Theory]` with `[InlineData]` only when there are 3+ inputs;
+  otherwise `[Fact]`.
+
+## Internals and private access
+
+- Tests have access to internals via `InternalsVisibleTo`, so you can test
+  internal members directly.
+- For private members, use the `TestAccessor` and `TestAccessors` extension
+  methods from `touki.testsupport`. Do not use reflection by hand.
+
+## Ref structs
+
+- Ref structs cannot be used in lambdas. To validate error cases that would
+  otherwise want `Assert.Throws(() => ...)`, use a `try`/`finally` block and
+  assert on the caught exception explicitly.
+
+## Release-mode rule
+
+- Run `dotnet test -c Release` before declaring a fix done. Release-mode
+  inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As` on a method
+  parameter is a known foot-gun on net481 RyuJIT.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -4,9 +4,10 @@ applyTo: 'touki.tests/**/*.cs'
 
 # Test conventions for `touki.tests`
 
-These rules duplicate the summary in [AGENTS.md](../../AGENTS.md) and add the
-detail that would bloat the canonical file. Both are authoritative; if they
-ever drift, AGENTS.md wins.
+[AGENTS.md](../../AGENTS.md) is canonical. This file is a path-scoped
+elaboration of the same rules for `touki.tests/**/*.cs` &mdash; it adds detail
+that would bloat the canonical file but must not contradict it. If the two
+ever drift, AGENTS.md wins; update this file to match.
 
 ## Placement and naming
 

--- a/.github/workflows/agent-files.yml
+++ b/.github/workflows/agent-files.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Detect relevant changes
         id: changes
@@ -35,6 +37,29 @@ jobs:
         if: steps.changes.outputs.agent == 'true'
         shell: pwsh
         run: pwsh tools/Validate-AgentFiles.ps1
+
+      - name: Skill freshness warning (90 days)
+        shell: pwsh
+        run: |
+          # Fetch enough history for `git log` on each skill directory.
+          git fetch --deepen=200 origin 2>$null
+          $threshold = (Get-Date).AddDays(-90)
+          $skillDirs = Get-ChildItem -Directory -Path '.agents/skills' -ErrorAction SilentlyContinue
+          $stale = @()
+          foreach ($dir in $skillDirs) {
+              $rel = ".agents/skills/$($dir.Name)"
+              $lastCommit = git log -1 --format=%cI -- $rel 2>$null
+              if (-not $lastCommit) { continue }
+              $when = [DateTime]::Parse($lastCommit)
+              if ($when -lt $threshold) {
+                  $stale += "$($dir.Name) (last touched $($when.ToString('yyyy-MM-dd')))"
+              }
+          }
+          if ($stale.Count -gt 0) {
+              foreach ($s in $stale) { Write-Host "::warning::Skill stale: $s" }
+          } else {
+              Write-Host 'OK: all skills touched within the last 90 days.'
+          }
 
       - name: markdownlint
         if: steps.changes.outputs.agent == 'true'

--- a/.github/workflows/agent-files.yml
+++ b/.github/workflows/agent-files.yml
@@ -39,10 +39,9 @@ jobs:
         run: pwsh tools/Validate-AgentFiles.ps1
 
       - name: Skill freshness warning (90 days)
+        if: steps.changes.outputs.agent == 'true'
         shell: pwsh
         run: |
-          # Fetch enough history for `git log` on each skill directory.
-          git fetch --deepen=200 origin 2>$null
           $threshold = (Get-Date).AddDays(-90)
           $skillDirs = Get-ChildItem -Directory -Path '.agents/skills' -ErrorAction SilentlyContinue
           $stale = @()

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,10 @@
+{
+    // MCP servers wired up for this workspace.
+    // See docs/agent-customization.md "MCP servers" for rationale.
+    "servers": {
+        "microsoft-learn": {
+            "type": "http",
+            "url": "https://learn.microsoft.com/api/mcp"
+        }
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,22 @@
       "Pinnable",
       "slnx",
       "Touki"
-    ]
+    ],
+    // Publish-boundary enforcement for Copilot agent-mode terminal calls.
+    // See AGENTS.md "Working with the user on changes". Deny entries force an
+    // explicit in-chat Allow click before the command runs; allow entries keep
+    // routine read-only git verbs frictionless.
+    "chat.tools.terminal.autoApprove": {
+        "/^git\\s+(status|diff|log|show|branch|stash\\s+list|rev-parse|ls-files|config\\s+--get)\\b/": true,
+        "/^git\\s+commit\\b/": false,
+        "/^git\\s+push\\b/": false,
+        "/^git\\s+reset\\s+--hard\\b/": false,
+        "/^git\\s+rebase\\b/": false,
+        "/^git\\s+merge\\b/": false,
+        "/^git\\s+cherry-pick\\b/": false,
+        "/^git\\s+tag\\b/": false,
+        "/^git\\s+branch\\s+-[dD]\\b/": false,
+        "/^gh\\s+pr\\s+(create|merge|close|edit)\\b/": false,
+        "/^gh\\s+(repo|release)\\s+/": false
+    }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,22 +110,16 @@ Top-level layout:
 
 ## Testing
 
-- Place tests in the `touki.tests` project.
-- Test classes should be in the same namespace as the class they are testing, with
-  `Tests` appended (e.g. `ListBaseTests` for `ListBase`).
-- Test methods should be named `MethodName_StateUnderTest_ExpectedBehavior`
-  (e.g. `MoveNext_AtStart_ReturnsTrue`).
-- Test methods should be ordered by the method they are testing.
-- Cover edge and negative cases.
-- Do **not** add "Arrange, Act, Assert" comments in tests.
-- Ref structs cannot be used in lambdas; use `try`/`finally` blocks to validate error
-  cases.
-- Use FluentAssertions for assertions in tests.
-- FluentAssertions and Xunit are already global usings &mdash; do not add new usings for
-  these to test files.
-- Tests have access to internals via `InternalsVisibleTo`, so you can test internal
-  members directly.
-- For private members, use the `TestAccessor` and `TestAccessors` extension methods.
+Detailed test conventions live in
+[.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md)
+(applies to `touki.tests/**/*.cs`). Headline rules: place tests in `touki.tests`;
+name them `MethodName_StateUnderTest_ExpectedBehavior`; use FluentAssertions (global
+using); access internals directly via `InternalsVisibleTo` and private members via
+`TestAccessor`; ref structs can't be used in lambdas &mdash; use `try`/`finally`.
+
+Performance-test conventions for `touki.perf/` (BenchmarkDotNet, Release-only,
+JIT-naming rule, regression thresholds) live in
+[.github/instructions/perf.instructions.md](.github/instructions/perf.instructions.md).
 
 ## Working with the user on changes
 
@@ -155,15 +149,36 @@ Treat them as hard requirements.
 - **Stage by path, never `git add -A`/`git add .`** when the working tree spans
   more than one logical change set. Run `git status --short` first; if topics
   are intermingled, ask how to split before staging.
-- **Name the JIT in performance claims.** ".NET Framework 4.8.1 RyuJIT" (older,
-  no `EqualityComparer<T>.Default` intrinsic, no tiered JIT, weaker inlining)
-  vs **modern .NET RyuJIT** (.NET 6+, devirtualization, tiered JIT, dynamic
-  PGO). Unqualified "RyuJIT" claims are wrong about half the time. Code
-  changes in `touki/Framework/` driven by such claims need a benchmark or an
-  explicit "not measured" note.
 - **Run `dotnet test -c Release` before declaring a fix done.** Release-mode
   inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As` on a method
   parameter is a known foot-gun on net481 RyuJIT.
+
+The JIT-naming rule for performance claims (".NET Framework 4.8.1 RyuJIT" vs
+"modern .NET RyuJIT") and BenchmarkDotNet conventions live in
+[.github/instructions/perf.instructions.md](.github/instructions/perf.instructions.md).
+
+### Enforcement
+
+The publish-boundary rule above is also enforced mechanically so that model
+rationalization cannot bypass it:
+
+- **VS Code Copilot agent mode.** [.vscode/settings.json](.vscode/settings.json)
+  configures `chat.tools.terminal.autoApprove` to deny `git commit`, `git push`,
+  `git reset --hard`, `git rebase`, `git merge`, `git cherry-pick`, `git tag`,
+  destructive `git branch -d/-D`, and `gh pr create|merge|close|edit`. Each
+  invocation requires an explicit in-chat **Allow** click; that click is the
+  approval. Routine read-only verbs (`git status`, `git diff`, `git log`,
+  `git show`, `git branch`, `git stash list`, `git rev-parse`, `git ls-files`)
+  are auto-approved so review work stays frictionless.
+- **Branch protection on `main`.** Configured in repo settings: PR required,
+  status checks required, force pushes and branch deletion blocked. This covers
+  surfaces the local denylist does not (Copilot cloud agent, other agents,
+  scripted runs).
+
+The prose rules above still apply: they explain *why*, and they apply on
+surfaces where the mechanical gate doesn't fire (e.g. cloud-agent runs that
+bypass the local terminal). Treat the mechanical gate as a backstop, not a
+license to skip the conversation.
 
 ## General guidance
 
@@ -192,3 +207,6 @@ automatically based on each file's `applyTo` glob.
 Currently:
 
 - [.github/instructions/msbuild.instructions.md](.github/instructions/msbuild.instructions.md) &mdash; rules for `*.csproj`, `*.props`, `*.targets`.
+- [.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md) &mdash; conventions for `touki.tests/**/*.cs`.
+- [.github/instructions/perf.instructions.md](.github/instructions/perf.instructions.md) &mdash; BenchmarkDotNet conventions and the JIT-naming rule for `touki.perf/**/*.cs`.
+- [.github/instructions/polyfills.instructions.md](.github/instructions/polyfills.instructions.md) &mdash; the two non-negotiable rules for `touki/Framework/Polyfills/**/*.cs`.

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -28,6 +28,19 @@ right one for your needs, place it in the right folder, and CI will validate it.
 universally; reach for the more specialized formats only when you need their extra
 features (path scoping, tool restrictions, slash-command UX, packaged scripts).
 
+## MCP servers
+
+Workspace-scoped MCP server config lives in [.vscode/mcp.json](../.vscode/mcp.json).
+Add a server here only when the agent genuinely cannot reach the data otherwise &mdash;
+prefer instructions and skills first (see the practitioner guide rule "instructions
+&rarr; skills &rarr; MCP").
+
+Currently wired up:
+
+| Server | Purpose |
+| ------ | ------- |
+| `microsoft-learn` (`https://learn.microsoft.com/api/mcp`) | Current official .NET BCL docs and reference content. Used by the [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) workflow when verifying modern API shapes before deciding whether to polyfill. |
+
 ## Frontmatter requirements
 
 | Format               | Required                              | Notes                                                                  |
@@ -61,6 +74,67 @@ pwsh tools/Validate-AgentFiles.ps1 -Fix
 ```
 
 The same checks run in CI via [.github/workflows/agent-files.yml](../.github/workflows/agent-files.yml).
+
+## Improvement loop
+
+The customization layer is source code: it is iterated, not set once. Every
+correction you give an agent is a signal that something is missing.
+
+### Triage matrix
+
+When the agent does something wrong, classify the failure and place the fix
+at the right layer.
+
+| Failure class                                 | Right layer                                                    |
+| --------------------------------------------- | -------------------------------------------------------------- |
+| Factual: wrong about *what the code is*       | [AGENTS.md](../AGENTS.md) or path-specific `*.instructions.md` |
+| Procedural: wrong *workflow*, repeated        | New skill in [.agents/skills/](../.agents/skills/)             |
+| Capability: agent literally cannot reach data | MCP server (or a script the agent can run)                     |
+| Enforcement: agent rationalizes around a rule | Hook, CI check, or `chat.tools.terminal.autoApprove` denylist  |
+
+The order matters. Try instructions before skills, skills before MCP, and
+prefer deterministic enforcement (CI, denylist, branch protection) over more
+prose anywhere a rule has been violated before.
+
+### Size budget
+
+Attention to instructions degrades as files grow. Targets:
+
+- [AGENTS.md](../AGENTS.md): &le; 10 KB. If it grows past this, split rules into
+  a path-specific `*.instructions.md` and leave a one-line summary pointer.
+- Each `*.instructions.md`: &le; 8 KB. If a single area needs more, split it
+  further by glob.
+- Each `SKILL.md`: &le; 15 KB body. Move long examples or scripts into sibling
+  files within the skill directory.
+
+### Periodic maintenance
+
+Roughly monthly:
+
+1. Read [AGENTS.md](../AGENTS.md) end to end. Anything stale, contradictory,
+   or vague? Tighten.
+2. Skim each `*.instructions.md`. Same.
+3. Check [.agents/skills/README.md](../.agents/skills/README.md): every
+   cross-reference should resolve, every disambiguation should still match
+   the skills it names. The CI freshness warning (90 days, derived from git
+   history) flags individual skills that have not been touched.
+4. Scan the recent git log for repeated CI fixes to the same rule, repeated
+   "fix the comments" cycles on PRs, or repeated permission requests for
+   the same command. These are gap signals; address them at the right layer
+   from the matrix above.
+
+### Hygiene rules
+
+- The phrasing-bank lists in
+  [AGENTS.md](../AGENTS.md) "Working with the user on changes" (verbs that
+  are / are not approval) are **append-only**. Add new misreads when they
+  occur. Do not rewrite past entries except to deduplicate.
+- When changing a skill, also update any cross-reference in
+  [.agents/skills/README.md](../.agents/skills/README.md) within the same
+  change set.
+- When a rule moves from instructions to a CI check (or vice versa), keep
+  the prose in instructions explaining *why*. The mechanical gate is the
+  *what*; instructions explain the *why*.
 
 ## Verifying instructions are loaded
 


### PR DESCRIPTION
Three-phase improvement to the AI customization layer. No production code touched. Validator passes.

## Phase 1 — Publish-boundary enforcement

The "never `git commit` / `git push` / `gh pr create` without explicit user approval" rule has been violated multiple times on this repo (documented in `AGENTS.md` and in the user-memory note). Instructions alone are insufficient against model rationalization. This phase adds a mechanical backstop where the agent already operates.

- **`.vscode/settings.json`** — `chat.tools.terminal.autoApprove` denies `git commit`, `git push`, `git reset --hard`, `git rebase`, `git merge`, `git cherry-pick`, `git tag`, destructive `git branch -d/-D`, `gh pr create|merge|close|edit`, and `gh repo|release …`. Each invocation requires an explicit in-chat **Allow** click; that click _is_ the approval. Routine read-only verbs (`status`, `diff`, `log`, `show`, `branch`, `stash list`, `rev-parse`, `ls-files`, `config --get`) are auto-approved.
- **`AGENTS.md`** — new "Enforcement" subsection documenting the denylist and branch protection as the mechanical backstop, with the explicit note that prose rules still apply on surfaces where the gate doesn't fire (cloud agent, scripted runs).
- **`.github/copilot-instructions.md`** — auto-regenerated by the validator from `AGENTS.md`.

Branch protection on `main` (PR required, status checks required, force pushes / deletion blocked) covers cloud-agent and scripted surfaces; that's a repo-settings change, not in this diff.

## Phase 2 — Capability and structure

### Microsoft Learn Docs MCP

- **`.vscode/mcp.json`** — wires up the Microsoft Learn Docs HTTP MCP server. Used by the polyfill workflow when verifying modern API shapes before deciding whether to polyfill, replacing reliance on training-data recall.
- **`docs/agent-customization.md`** — new "MCP servers" section documenting the policy (instructions → skills → MCP) and what's wired up.

### Skills catalog

- **`.agents/skills/README.md`** — replaced the format reference with a real catalog of all 7 skills, with trigger phrasings, cross-references, and three explicit disambiguation pairs:
  - `create-pr` (initial publish) vs `address-pr-feedback` (post-PR cycle)
  - `polyfill-dotnet-api` (API surface) vs `framework-jit-optimization` (hot-path tuning)
  - `performance-testing` (harness) vs `framework-jit-optimization` (codegen)
- **`.agents/skills/FORMAT.md`** (new) — the format reference moved here as a sibling.
- **`.github/workflows/agent-files.yml`** — new soft-warning step that uses `git log -1 --format=%cI` per skill directory to detect any untouched in 90+ days. Checkout uses `fetch-depth: 0` so the freshness check has the history. Definition of "reviewed" is git-history-derived (commit to the directory) rather than a manually maintained column, so the warning can't drift from reality.

### Path-specific instructions (duplicate-and-trim)

Three new files under `.github/instructions/`. Each duplicates the rules into a path-scoped file and `AGENTS.md` keeps a one-line summary pointing at it:

- **`tests.instructions.md`** (`applyTo: touki.tests/**/*.cs`) — full test conventions including FluentAssertions/xUnit globals, `TestAccessor` for private members, ref-struct-in-lambda gotcha, Release-mode rule.
- **`perf.instructions.md`** (`applyTo: touki.perf/**/*.cs`) — BenchmarkDotNet conventions, the JIT-naming rule (`.NET Framework 4.8.1 RyuJIT` vs modern .NET RyuJIT), Mean/Median/Allocated column meanings, regression threshold (>5% throughput **or** any new allocation in a hot path).
- **`polyfills.instructions.md`** (`applyTo: touki/Framework/Polyfills/**/*.cs`) — the two non-negotiable rules (namespace = BCL namespace; no `#if NETFRAMEWORK` inside `touki/Framework/`).

`AGENTS.md` size went from ~9.5 KB to ~7 KB after the trim.

## Phase 3 — Sophistication

- **`.github/agents/touki-reviewer.agent.md`** (new) — Copilot custom agent. Read-only by design (`tools: ['search', 'usages', 'problems', 'changes', 'fetch']`, no edit tools). Checks cross-TFM correctness, polyfill conventions, the JIT-naming rule (including the `Unsafe.As`/`AggressiveInlining` foot-gun pinned by #135), public API tests/docs, test conventions, whitespace, and approval-verb hygiene. Outputs severity-grouped findings (`blocker`/`major`/`minor`/`nit`) — never offers fixes.
- **`docs/agent-customization.md`** — new "Improvement loop" section with:
  - **Triage matrix** (factual / procedural / capability / enforcement → instructions / skill / MCP / hook-or-CI)
  - **Size budgets** (`AGENTS.md` ≤ 10 KB, `*.instructions.md` ≤ 8 KB, `SKILL.md` ≤ 15 KB)
  - **Monthly maintenance checklist**
  - **Hygiene rules** (phrase-bank append-only; cross-reference updates in same change set; prose explains *why* even when CI enforces *what*)

## What was deferred

- Claude Code accommodations (`CLAUDE.md` stub, `.claude/agents/perf-investigator.md` with `memory: project`) — repo is Copilot-first today; deferred until Claude Code becomes a primary tool.
- Promoting `polyfill-dotnet-api` to a public skill marketplace.
- A `#if NETFRAMEWORK` CI guard under `touki/Framework/Polyfills/` — handled by instructions instead.

## Verification

- `pwsh tools/Validate-AgentFiles.ps1` passes.
- `dotnet test -c Release` on both TFMs: 9828 passed, 0 failed (matches `main` after #135).
