### PR TITLE
Pin SDK via global.json; pack on PR; validate publish tag format

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
+      with: { fetch-depth: 0 }
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '10.0.x'
-        dotnet-quality: 'preview'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
     - name: Build release
       run: dotnet build --configuration Release --no-restore
+    - name: Pack (release)
+      run: dotnet pack --configuration Release --no-build -o ./artifacts/packages
     - name: Test
       run: |
         $resultsDir = Join-Path $PWD.Path 'artifacts/test-results/debug'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,11 +18,17 @@ jobs:
     steps:
     - uses: actions/checkout@v5
       with: { fetch-depth: 0 }
+    - name: Validate tag format
+      shell: pwsh
+      run: |
+        $tag = '${{ github.ref_name }}'
+        if ($tag -notmatch '^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$') {
+          Write-Error "Tag '$tag' does not match expected SemVer pattern v<major>.<minor>.<patch>[-<prerelease>]."
+          exit 1
+        }
+        Write-Host "Tag '$tag' OK."
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '10.0.x'
-        dotnet-quality: 'ga'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/publishtestsupport.yml
+++ b/.github/workflows/publishtestsupport.yml
@@ -18,9 +18,6 @@ jobs:
       with: { fetch-depth: 0 }
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: '10.0.x'
-        dotnet-quality: 'ga'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ For an IDE experience, once you have the [.NET SDK](https://dotnet.microsoft.com
 
 #### Unix
 
-Run `setup.sh` once after cloning the repository to automatically install the .NET 9 SDK and configure your PATH. The script updates `~/.bashrc` so that the SDK is available in future sessions.
+Run `setup.sh` once after cloning the repository to automatically install the .NET 10 SDK and configure your PATH. The script updates `~/.bashrc` so that the SDK is available in future sessions.
 
 ```bash
 ./setup.sh

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.203",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/sample/sample.csproj
+++ b/sample/sample.csproj
@@ -33,6 +33,9 @@
 
     <!-- Want "Sample" rather than "sample". If this is explicitly set to blank it messes with resource generation. -->
     <RootNamespace>Sample</RootNamespace>
+
+    <!-- This is a sample / demo project; never publish a NuGet package for it. -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/setup.sh
+++ b/setup.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 # Directory of this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Install .NET 9 SDK if not already installed
-if ! command -v dotnet >/dev/null || ! dotnet --list-sdks | grep -q '^9\.'; then
-  echo "Installing .NET 9 SDK..."
+# Install .NET 10 SDK if not already installed
+if ! command -v dotnet >/dev/null || ! dotnet --list-sdks | grep -q '^10\.'; then
+  echo "Installing .NET 10 SDK..."
   curl -SL https://dot.net/v1/dotnet-install.sh -o "$SCRIPT_DIR/dotnet-install.sh"
   chmod +x "$SCRIPT_DIR/dotnet-install.sh"
-  "$SCRIPT_DIR/dotnet-install.sh" --channel 9.0 --install-dir "$HOME/.dotnet"
+  "$SCRIPT_DIR/dotnet-install.sh" --channel 10.0 --install-dir "$HOME/.dotnet"
 fi
 
 # Ensure PATH includes the installed SDK


### PR DESCRIPTION
Implements the first three items from the versioning audit.

## Changes

### 1. Pin the SDK with `global.json`
- New `global.json` at the repo root pinning .NET SDK `10.0.203` with `rollForward: latestFeature` and `allowPrerelease: false`.
- Removed `dotnet-version` / `dotnet-quality` from all three workflows so `actions/setup-dotnet@v5` reads `global.json` everywhere. Previously `dotnet.yml` ran `preview` and `publish.yml` ran `ga`, meaning PR validation and release builds could use different SDK feature bands.

### 2. Pack on PRs
- `dotnet.yml` now uses `fetch-depth: 0` (so MinVer can see the tag history) and adds a `dotnet pack --configuration Release --no-build -o ./artifacts/packages` step after the Release build. MinVer-driven packaging, NuSpec metadata, and `PackageValidation` regressions will now surface on PRs instead of only at tag time.

### 3. Tag-format guard on publish
- `publish.yml` now runs a pwsh step that fails fast if `github.ref_name` doesn't match `^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$`. This would have rejected the malformed `v.0.1.0-alpha.{9,10,11}` tags currently in the repo (note the stray `.` after `v`), which MinVer can't parse and would silently produce a `0.0.0-alpha.0.<height>` package version.

## Not in this PR

- Cleanup of the existing malformed `v.0.1.0-alpha.{9,10,11}` tags — destructive, separate decision.
- Other audit items (CPM pin staleness for the sample, TestSupport version axis, over-broad publish glob, package validation baseline, package metadata polish) — separate PRs.