### PR TITLE
Sample: bump KlutzyNinja.Touki to 0.2.0-alpha.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <!-- Referencing our own package for the sample project to document consumption. -->
-    <PackageVersion Include="KlutzyNinja.Touki" Version="0.1.0-alpha.8.11" />
+    <PackageVersion Include="KlutzyNinja.Touki" Version="0.2.0-alpha.1" />
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/sample/GlobalUsings.cs
+++ b/sample/GlobalUsings.cs
@@ -41,8 +41,5 @@ global using Touki.Exceptions;
 global using Touki.Interop;
 global using Touki.Io;
 global using Touki.Text;
-#if NETFRAMEWORK
-global using Framework.Touki;
-#endif
 
 #pragma warning restore IDE0005 // Using directive is unnecessary.


### PR DESCRIPTION
Bumps the sample's pinned `KlutzyNinja.Touki` from the long-stale
`0.1.0-alpha.8.11` to the just-published `0.2.0-alpha.1`, and drops a
namespace fallback that no longer exists.

## Changes

- `Directory.Packages.props`: `KlutzyNinja.Touki` 0.1.0-alpha.8.11 → 0.2.0-alpha.1.
- `sample/GlobalUsings.cs`: remove `global using Framework.Touki;` (net472
  fallback). The `Framework.Touki.*` namespace was reorganized away in the
  polyfill restructuring; framework-only Touki code now lives under
  `Touki.*`. Without this drop, the sample fails to compile on net472
  against 0.2.0-alpha.1 with `CS0246 'The type or namespace name Framework
  could not be found'`.

## Verification

- `dotnet build sample/sample.csproj --force` clean for both `net10.0` and
  `net472`.
- The new `dotnet pack` PR step (added in #137) will exercise the full
  graph against the bumped version.