### PR TITLE
Optimize EnumExtensions for net481 and add perf coverage

### DIFF
--- a/touki.perf/EnumExtensionsInliningPerf.cs
+++ b/touki.perf/EnumExtensionsInliningPerf.cs
@@ -1,0 +1,253 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.CompilerServices;
+
+#pragma warning disable CS8500 // takes the address of, gets the size of, or declares a pointer to a managed type
+
+namespace touki.perf;
+
+/// <summary>
+///  Measures the effect of <see cref="MethodImplOptions.AggressiveInlining"/>
+///  on the <see cref="Touki.EnumExtensions"/> shapes by running the *same*
+///  bodies as static helpers both with and without the attribute.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The production extensions are extension members on a generic
+///   <c>T : unmanaged, Enum</c>. To isolate the inlining decision we copy each
+///   body into a pair of static generic helpers below — <c>_NoInline</c>
+///   variants get <c>NoInlining</c> so we always pay a real call+ret, and
+///   <c>_Aggressive</c> variants get <c>AggressiveInlining</c>. The
+///   <c>_Default</c> column lets the JIT pick its own heuristic (which on
+///   net481 generally refuses to inline a body that contains a <c>fixed</c>
+///   statement or a <c>sizeof(T)</c> ladder).
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+[DisassemblyDiagnoser(maxDepth: 3, printSource: true, exportHtml: true)]
+[SimpleJob(RuntimeMoniker.Net481, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public unsafe class EnumExtensionsInliningPerf
+{
+    [Flags]
+    public enum IntFlags : int { None = 0, A = 1, B = 2, C = 4, D = 8 }
+
+    [Flags]
+    public enum LongFlags : long { None = 0, A = 1, B = 2, C = 4, D = 8 }
+
+    private IntFlags _intValue;
+    private IntFlags _intFlags;
+    private LongFlags _longValue;
+    private LongFlags _longFlags;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _intValue = IntFlags.A | IntFlags.C;
+        _intFlags = IntFlags.A;
+        _longValue = LongFlags.A | LongFlags.C;
+        _longFlags = LongFlags.A;
+    }
+
+    // --------------- AreFlagsSet ---------------
+    //
+    // Body: `(value & flags) == flags` via size-of(T) ladder.
+    // Expectation: AggressiveInlining wins on net481 because the ladder is
+    // large enough that the default heuristic refuses to inline. On modern
+    // .NET the helper already inlines by default.
+
+    [Benchmark]
+    public bool Int_AreFlagsSet_Default() => AreFlagsSet_Default(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Int_AreFlagsSet_Aggressive() => AreFlagsSet_Aggressive(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Int_AreFlagsSet_NoInline() => AreFlagsSet_NoInline(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Long_AreFlagsSet_Default() => AreFlagsSet_Default(_longValue, _longFlags);
+
+    [Benchmark]
+    public bool Long_AreFlagsSet_Aggressive() => AreFlagsSet_Aggressive(_longValue, _longFlags);
+
+    // --------------- AreAnyFlagsSet ---------------
+
+    [Benchmark]
+    public bool Int_AreAnyFlagsSet_Default() => AreAnyFlagsSet_Default(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Int_AreAnyFlagsSet_Aggressive() => AreAnyFlagsSet_Aggressive(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Int_AreAnyFlagsSet_NoInline() => AreAnyFlagsSet_NoInline(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Long_AreAnyFlagsSet_Default() => AreAnyFlagsSet_Default(_longValue, _longFlags);
+
+    [Benchmark]
+    public bool Long_AreAnyFlagsSet_Aggressive() => AreAnyFlagsSet_Aggressive(_longValue, _longFlags);
+
+    // --------------- IsOnlyOneFlagSet ---------------
+    //
+    // The production code already has AggressiveInlining (and documents that
+    // it does not inline without it). These confirm that.
+
+    [Benchmark]
+    public bool Int_IsOnlyOneFlagSet_Default() => IsOnlyOneFlagSet_Default(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Int_IsOnlyOneFlagSet_Aggressive() => IsOnlyOneFlagSet_Aggressive(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Long_IsOnlyOneFlagSet_Default() => IsOnlyOneFlagSet_Default(_longValue, _longFlags);
+
+    [Benchmark]
+    public bool Long_IsOnlyOneFlagSet_Aggressive() => IsOnlyOneFlagSet_Aggressive(_longValue, _longFlags);
+
+    // --------------- SetFlags (ref) ---------------
+    //
+    // Body contains a `fixed` statement plus the size-of(T) ladder. On
+    // net481 the default heuristic refuses to inline through `fixed`, so
+    // AggressiveInlining is the only way to flatten it.
+
+    [Benchmark]
+    public IntFlags Int_SetFlags_Default()
+    {
+        IntFlags v = _intValue;
+        SetFlags_Default(ref v, _intFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public IntFlags Int_SetFlags_Aggressive()
+    {
+        IntFlags v = _intValue;
+        SetFlags_Aggressive(ref v, _intFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public LongFlags Long_SetFlags_Default()
+    {
+        LongFlags v = _longValue;
+        SetFlags_Default(ref v, _longFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public LongFlags Long_SetFlags_Aggressive()
+    {
+        LongFlags v = _longValue;
+        SetFlags_Aggressive(ref v, _longFlags);
+        return v;
+    }
+
+    // ============== Helper implementations ==============
+    // Bodies copied verbatim from EnumExtensions.cs (the net472 polyfill
+    // path for AreFlagsSet — equivalent to the modern HasFlag intrinsic).
+
+    private static bool AreFlagsSet_Default<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { byte f = *(byte*)&flags; return (*(byte*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(short)) { short f = *(short*)&flags; return (*(short*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(int)) { int f = *(int*)&flags; return (*(int*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(long)) { long f = *(long*)&flags; return (*(long*)&value & f) == f; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreFlagsSet_Aggressive<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { byte f = *(byte*)&flags; return (*(byte*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(short)) { short f = *(short*)&flags; return (*(short*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(int)) { int f = *(int*)&flags; return (*(int*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(long)) { long f = *(long*)&flags; return (*(long*)&value & f) == f; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreFlagsSet_NoInline<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { byte f = *(byte*)&flags; return (*(byte*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(short)) { short f = *(short*)&flags; return (*(short*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(int)) { int f = *(int*)&flags; return (*(int*)&value & f) == f; }
+        else if (sizeof(T) == sizeof(long)) { long f = *(long*)&flags; return (*(long*)&value & f) == f; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    private static bool AreAnyFlagsSet_Default<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { return (*(byte*)&value & *(byte*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(short)) { return (*(short*)&value & *(short*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(int)) { return (*(int*)&value & *(int*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(long)) { return (*(long*)&value & *(long*)&flags) != 0; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool AreAnyFlagsSet_Aggressive<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { return (*(byte*)&value & *(byte*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(short)) { return (*(short*)&value & *(short*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(int)) { return (*(int*)&value & *(int*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(long)) { return (*(long*)&value & *(long*)&flags) != 0; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool AreAnyFlagsSet_NoInline<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { return (*(byte*)&value & *(byte*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(short)) { return (*(short*)&value & *(short*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(int)) { return (*(int*)&value & *(int*)&flags) != 0; }
+        else if (sizeof(T) == sizeof(long)) { return (*(long*)&value & *(long*)&flags) != 0; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    private static bool IsOnlyOneFlagSet_Default<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { int v = *(byte*)&value & *(byte*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else if (sizeof(T) == sizeof(short)) { int v = *(short*)&value & *(short*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else if (sizeof(T) == sizeof(int)) { int v = *(int*)&value & *(int*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else if (sizeof(T) == sizeof(long)) { long v = *(long*)&value & *(long*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsOnlyOneFlagSet_Aggressive<T>(T value, T flags) where T : unmanaged, Enum
+    {
+        if (sizeof(T) == sizeof(byte)) { int v = *(byte*)&value & *(byte*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else if (sizeof(T) == sizeof(short)) { int v = *(short*)&value & *(short*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else if (sizeof(T) == sizeof(int)) { int v = *(int*)&value & *(int*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else if (sizeof(T) == sizeof(long)) { long v = *(long*)&value & *(long*)&flags; return v != 0 && (v & (v - 1)) == 0; }
+        else { throw new InvalidOperationException(); }
+    }
+
+    private static void SetFlags_Default<T>(ref T value, T flags) where T : unmanaged, Enum
+    {
+        fixed (T* v = &value)
+        {
+            if (sizeof(T) == sizeof(byte)) { *(byte*)v |= *(byte*)&flags; }
+            else if (sizeof(T) == sizeof(short)) { *(short*)v |= *(short*)&flags; }
+            else if (sizeof(T) == sizeof(int)) { *(int*)v |= *(int*)&flags; }
+            else if (sizeof(T) == sizeof(long)) { *(long*)v |= *(long*)&flags; }
+            else { throw new InvalidOperationException(); }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SetFlags_Aggressive<T>(ref T value, T flags) where T : unmanaged, Enum
+    {
+        fixed (T* v = &value)
+        {
+            if (sizeof(T) == sizeof(byte)) { *(byte*)v |= *(byte*)&flags; }
+            else if (sizeof(T) == sizeof(short)) { *(short*)v |= *(short*)&flags; }
+            else if (sizeof(T) == sizeof(int)) { *(int*)v |= *(int*)&flags; }
+            else if (sizeof(T) == sizeof(long)) { *(long*)v |= *(long*)&flags; }
+            else { throw new InvalidOperationException(); }
+        }
+    }
+}

--- a/touki.perf/EnumExtensionsPerf.cs
+++ b/touki.perf/EnumExtensionsPerf.cs
@@ -1,0 +1,263 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.CompilerServices;
+
+namespace touki.perf;
+
+/// <summary>
+///  Measures <see cref="Touki.EnumExtensions"/> versus hand-written bitwise checks
+///  and <see cref="Enum.HasFlag(Enum)"/> on both .NET Framework 4.8.1 RyuJIT
+///  and modern .NET RyuJIT.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Each benchmark intentionally compares three shapes for the same logical
+///   query: the <c>EnumExtensions</c> helper, the equivalent open-coded
+///   bitwise expression on the enum's underlying type, and (where defined)
+///   <c>Enum.HasFlag</c>. Inputs come from mutable instance fields so the JIT
+///   cannot constant-fold the operation away.
+///  </para>
+///  <para>
+///   Run with <c>--filter *EnumExtensionsPerf* --runtimes net481 net10.0
+///   --disasm</c> to capture asm for both targets.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+[DisassemblyDiagnoser(maxDepth: 3, printSource: true, exportHtml: true)]
+[SimpleJob(RuntimeMoniker.Net481, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class EnumExtensionsPerf
+{
+    [Flags]
+    public enum ByteFlags : byte { None = 0, A = 1, B = 2, C = 4, D = 8 }
+
+    [Flags]
+    public enum ShortFlags : short { None = 0, A = 1, B = 2, C = 4, D = 8 }
+
+    [Flags]
+    public enum IntFlags : int { None = 0, A = 1, B = 2, C = 4, D = 8 }
+
+    [Flags]
+    public enum LongFlags : long { None = 0, A = 1, B = 2, C = 4, D = 8 }
+
+    // Mutable fields prevent constant folding.
+    private ByteFlags _byteValue;
+    private ByteFlags _byteFlags;
+    private ShortFlags _shortValue;
+    private ShortFlags _shortFlags;
+    private IntFlags _intValue;
+    private IntFlags _intFlags;
+    private LongFlags _longValue;
+    private LongFlags _longFlags;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _byteValue = ByteFlags.A | ByteFlags.C;
+        _byteFlags = ByteFlags.A;
+        _shortValue = ShortFlags.A | ShortFlags.C;
+        _shortFlags = ShortFlags.A;
+        _intValue = IntFlags.A | IntFlags.C;
+        _intFlags = IntFlags.A;
+        _longValue = LongFlags.A | LongFlags.C;
+        _longFlags = LongFlags.A;
+    }
+
+    // -------------------- AreFlagsSet (== HasFlag) --------------------
+    //
+    // AreFlagsSet is a thin wrapper over Enum.HasFlag. On modern .NET (.NET 5+)
+    // HasFlag is intrinsified by the JIT into a tiny `(value & flag) == flag`
+    // sequence. On net481 it stays a virtual call into Enum.HasFlag, boxes
+    // both operands, and performs a type-check + memcmp-style underlying
+    // comparison. So:
+    //   - Modern: AreFlagsSet ~= Manual_AreFlagsSet (both ~sub-ns, 0 alloc).
+    //   - net481: AreFlagsSet & HasFlag are an order of magnitude slower and
+    //     allocate two boxed Enums (~48 B / call for int).
+
+    [Benchmark]
+    public bool Int_AreFlagsSet() => _intValue.AreFlagsSet(_intFlags);
+
+    [Benchmark]
+    public bool Int_HasFlag() => _intValue.HasFlag(_intFlags);
+
+    [Benchmark]
+    public bool Int_AreFlagsSet_Manual() => Manual_AreFlagsSet(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Long_AreFlagsSet() => _longValue.AreFlagsSet(_longFlags);
+
+    [Benchmark]
+    public bool Long_HasFlag() => _longValue.HasFlag(_longFlags);
+
+    [Benchmark]
+    public bool Long_AreFlagsSet_Manual() => Manual_AreFlagsSet(_longValue, _longFlags);
+
+    // -------------------- AreAnyFlagsSet --------------------
+    //
+    // Open-coded `(value & flags) != 0` on the underlying type. This is the
+    // call this library was built for: HasFlag answers "are ALL of these
+    // set", and there is no BCL equivalent for "are ANY of these set" that
+    // doesn't allocate.
+
+    [Benchmark]
+    public bool Byte_AreAnyFlagsSet() => _byteValue.AreAnyFlagsSet(_byteFlags);
+
+    [Benchmark]
+    public bool Byte_AreAnyFlagsSet_Manual() => Manual_AreAnyFlagsSet(_byteValue, _byteFlags);
+
+    [Benchmark]
+    public bool Short_AreAnyFlagsSet() => _shortValue.AreAnyFlagsSet(_shortFlags);
+
+    [Benchmark]
+    public bool Short_AreAnyFlagsSet_Manual() => Manual_AreAnyFlagsSet(_shortValue, _shortFlags);
+
+    [Benchmark]
+    public bool Int_AreAnyFlagsSet() => _intValue.AreAnyFlagsSet(_intFlags);
+
+    [Benchmark]
+    public bool Int_AreAnyFlagsSet_Manual() => Manual_AreAnyFlagsSet(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Long_AreAnyFlagsSet() => _longValue.AreAnyFlagsSet(_longFlags);
+
+    [Benchmark]
+    public bool Long_AreAnyFlagsSet_Manual() => Manual_AreAnyFlagsSet(_longValue, _longFlags);
+
+    // -------------------- IsOnlyOneFlagSet --------------------
+    //
+    // `v != 0 && (v & (v - 1)) == 0`. Modern JIT recognises the blsr-style
+    // power-of-two test and emits a 6-instruction sequence using BLSR (BMI1)
+    // when the platform supports it. net481 RyuJIT emits the longhand form
+    // with two compares and a branch.
+
+    [Benchmark]
+    public bool Int_IsOnlyOneFlagSet() => _intValue.IsOnlyOneFlagSet(_intFlags);
+
+    [Benchmark]
+    public bool Int_IsOnlyOneFlagSet_Manual() => Manual_IsOnlyOneFlagSet(_intValue, _intFlags);
+
+    [Benchmark]
+    public bool Long_IsOnlyOneFlagSet() => _longValue.IsOnlyOneFlagSet(_longFlags);
+
+    [Benchmark]
+    public bool Long_IsOnlyOneFlagSet_Manual() => Manual_IsOnlyOneFlagSet(_longValue, _longFlags);
+
+    // -------------------- SetFlags / ClearFlags --------------------
+    //
+    // Ref-receiver extensions that fold to a single `or`/`and` instruction
+    // when the enum size matches the host register. The Manual_* variants
+    // use raw bitwise ops on the underlying type; on both runtimes they
+    // should be indistinguishable from the helper.
+
+    [Benchmark]
+    public IntFlags Int_SetFlags()
+    {
+        IntFlags v = _intValue;
+        v.SetFlags(_intFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public IntFlags Int_SetFlags_Manual()
+    {
+        IntFlags v = _intValue;
+        Manual_SetFlags(ref v, _intFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public IntFlags Int_ClearFlags()
+    {
+        IntFlags v = _intValue;
+        v.ClearFlags(_intFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public IntFlags Int_ClearFlags_Manual()
+    {
+        IntFlags v = _intValue;
+        Manual_ClearFlags(ref v, _intFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public LongFlags Long_SetFlags()
+    {
+        LongFlags v = _longValue;
+        v.SetFlags(_longFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public LongFlags Long_SetFlags_Manual()
+    {
+        LongFlags v = _longValue;
+        Manual_SetFlags(ref v, _longFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public LongFlags Long_ClearFlags()
+    {
+        LongFlags v = _longValue;
+        v.ClearFlags(_longFlags);
+        return v;
+    }
+
+    [Benchmark]
+    public LongFlags Long_ClearFlags_Manual()
+    {
+        LongFlags v = _longValue;
+        Manual_ClearFlags(ref v, _longFlags);
+        return v;
+    }
+
+    // ----- Manual baselines (no inlining so the codegen is comparable) -----
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_AreFlagsSet(IntFlags v, IntFlags f) => ((int)v & (int)f) == (int)f;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_AreFlagsSet(LongFlags v, LongFlags f) => ((long)v & (long)f) == (long)f;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_AreAnyFlagsSet(ByteFlags v, ByteFlags f) => ((byte)v & (byte)f) != 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_AreAnyFlagsSet(ShortFlags v, ShortFlags f) => ((short)v & (short)f) != 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_AreAnyFlagsSet(IntFlags v, IntFlags f) => ((int)v & (int)f) != 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_AreAnyFlagsSet(LongFlags v, LongFlags f) => ((long)v & (long)f) != 0;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_IsOnlyOneFlagSet(IntFlags value, IntFlags flags)
+    {
+        int v = (int)value & (int)flags;
+        return v != 0 && (v & (v - 1)) == 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static bool Manual_IsOnlyOneFlagSet(LongFlags value, LongFlags flags)
+    {
+        long v = (long)value & (long)flags;
+        return v != 0 && (v & (v - 1)) == 0;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Manual_SetFlags(ref IntFlags v, IntFlags f) => v |= f;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Manual_SetFlags(ref LongFlags v, LongFlags f) => v |= f;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Manual_ClearFlags(ref IntFlags v, IntFlags f) => v &= ~f;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Manual_ClearFlags(ref LongFlags v, LongFlags f) => v &= ~f;
+}

--- a/touki.tests/Touki/EnumExtensionsTests.cs
+++ b/touki.tests/Touki/EnumExtensionsTests.cs
@@ -339,6 +339,143 @@ public class EnumExtensionsTests
 
     #endregion
 
+    #region Signed / negative-value sign-extension regression tests
+
+    // These tests exercise enums with signed underlying types (sbyte and
+    // short) using values whose bit patterns have the sign bit set. On
+    // .NET Framework RyuJIT there is a documented foot-gun where reading
+    // a sub-int value (byte/sbyte/short/ushort) and feeding it through an
+    // arithmetic expression can sign-extend incorrectly when the JIT
+    // inlines aggressively. The methods on EnumExtensions go through
+    // memory (`*(byte*)&value` etc.) rather than `Unsafe.As`, which is the
+    // safe pattern, but we want a regression net in case the
+    // implementation is ever refactored to use a faster pattern that
+    // would trip the bug.
+    //
+    // Every method is tested with:
+    //   - an "all bits set" value (sbyte=-1 / short=-1)
+    //   - a "high bit only" value (sbyte=-128 / short.MinValue)
+    //   - a mixed positive/negative value
+
+    [Flags]
+    private enum SByteFlags : sbyte
+    {
+        None = 0,
+        Low = 0x01,
+        High = unchecked((sbyte)0x80), // -128: sign bit only
+        AllBits = unchecked((sbyte)0xFF), // -1: every bit set
+    }
+
+    [Flags]
+    private enum SShortFlags : short
+    {
+        None = 0,
+        Low = 0x0001,
+        High = unchecked((short)0x8000), // short.MinValue: sign bit only
+        AllBits = unchecked((short)0xFFFF), // -1: every bit set
+    }
+
+    [Fact]
+    public void EnumExtensions_AreFlagsSet_NegativeValues_AreCorrect()
+    {
+        // sbyte "all bits set" contains every flag
+        SByteFlags.AllBits.AreFlagsSet(SByteFlags.Low).Should().BeTrue();
+        SByteFlags.AllBits.AreFlagsSet(SByteFlags.High).Should().BeTrue();
+        SByteFlags.AllBits.AreFlagsSet(SByteFlags.AllBits).Should().BeTrue();
+
+        // sbyte "high bit only" only contains High
+        SByteFlags.High.AreFlagsSet(SByteFlags.High).Should().BeTrue();
+        SByteFlags.High.AreFlagsSet(SByteFlags.Low).Should().BeFalse();
+        SByteFlags.High.AreFlagsSet(SByteFlags.AllBits).Should().BeFalse();
+
+        // short with high bit set
+        SShortFlags.AllBits.AreFlagsSet(SShortFlags.High).Should().BeTrue();
+        SShortFlags.High.AreFlagsSet(SShortFlags.High).Should().BeTrue();
+        SShortFlags.High.AreFlagsSet(SShortFlags.Low).Should().BeFalse();
+        SShortFlags.High.AreFlagsSet(SShortFlags.AllBits).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnumExtensions_AreAnyFlagsSet_NegativeValues_AreCorrect()
+    {
+        SByteFlags.High.AreAnyFlagsSet(SByteFlags.High).Should().BeTrue();
+        SByteFlags.High.AreAnyFlagsSet(SByteFlags.Low).Should().BeFalse();
+        SByteFlags.AllBits.AreAnyFlagsSet(SByteFlags.High).Should().BeTrue();
+        SByteFlags.AllBits.AreAnyFlagsSet(SByteFlags.Low).Should().BeTrue();
+        SByteFlags.None.AreAnyFlagsSet(SByteFlags.AllBits).Should().BeFalse();
+
+        SShortFlags.High.AreAnyFlagsSet(SShortFlags.High).Should().BeTrue();
+        SShortFlags.High.AreAnyFlagsSet(SShortFlags.Low).Should().BeFalse();
+        SShortFlags.AllBits.AreAnyFlagsSet(SShortFlags.High).Should().BeTrue();
+        SShortFlags.AllBits.AreAnyFlagsSet(SShortFlags.Low).Should().BeTrue();
+        SShortFlags.None.AreAnyFlagsSet(SShortFlags.AllBits).Should().BeFalse();
+    }
+
+    [Fact]
+    public void EnumExtensions_IsOnlyOneFlagSet_NegativeValues_AreCorrect()
+    {
+        // sbyte: 0x80 ("High") is a single bit
+        SByteFlags.High.IsOnlyOneFlagSet(SByteFlags.High).Should().BeTrue();
+        // sbyte 0xFF has every bit set, so against itself there is more
+        // than one bit AND-ed in.
+        SByteFlags.AllBits.IsOnlyOneFlagSet(SByteFlags.AllBits).Should().BeFalse();
+        // Masking 0xFF down to a single bit should still report a single bit.
+        SByteFlags.AllBits.IsOnlyOneFlagSet(SByteFlags.High).Should().BeTrue();
+        SByteFlags.AllBits.IsOnlyOneFlagSet(SByteFlags.Low).Should().BeTrue();
+
+        // short: 0x8000 is a single bit. A buggy signed-promotion path
+        // would sign-extend to 0xFFFF8000 and the power-of-two test would
+        // incorrectly report false.
+        SShortFlags.High.IsOnlyOneFlagSet(SShortFlags.High).Should().BeTrue();
+        SShortFlags.AllBits.IsOnlyOneFlagSet(SShortFlags.AllBits).Should().BeFalse();
+        SShortFlags.AllBits.IsOnlyOneFlagSet(SShortFlags.High).Should().BeTrue();
+        SShortFlags.AllBits.IsOnlyOneFlagSet(SShortFlags.Low).Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnumExtensions_SetFlags_NegativeValues_AreCorrect()
+    {
+        SByteFlags value = SByteFlags.Low;
+        value.SetFlags(SByteFlags.High);
+        value.Should().Be(SByteFlags.AllBits & (SByteFlags.Low | SByteFlags.High));
+
+        value = SByteFlags.None;
+        value.SetFlags(SByteFlags.AllBits);
+        value.Should().Be(SByteFlags.AllBits);
+
+        SShortFlags shortValue = SShortFlags.Low;
+        shortValue.SetFlags(SShortFlags.High);
+        shortValue.Should().Be(SShortFlags.Low | SShortFlags.High);
+
+        shortValue = SShortFlags.None;
+        shortValue.SetFlags(SShortFlags.AllBits);
+        shortValue.Should().Be(SShortFlags.AllBits);
+    }
+
+    [Fact]
+    public void EnumExtensions_ClearFlags_NegativeValues_AreCorrect()
+    {
+        SByteFlags value = SByteFlags.AllBits;
+        value.ClearFlags(SByteFlags.High);
+        // 0xFF with the sign bit cleared = 0x7F
+        ((sbyte)value).Should().Be(0x7F);
+
+        value = SByteFlags.AllBits;
+        value.ClearFlags(SByteFlags.AllBits);
+        value.Should().Be(SByteFlags.None);
+
+        SShortFlags shortValue = SShortFlags.AllBits;
+        shortValue.ClearFlags(SShortFlags.High);
+        // 0xFFFF with sign bit cleared = 0x7FFF
+        ((short)shortValue).Should().Be(0x7FFF);
+
+        shortValue = SShortFlags.AllBits;
+        shortValue.ClearFlags(SShortFlags.AllBits);
+        shortValue.Should().Be(SShortFlags.None);
+    }
+
+    #endregion
+
     #region Test Enums
 
     [Flags]

--- a/touki/Touki/EnumExtensions.cs
+++ b/touki/Touki/EnumExtensions.cs
@@ -7,9 +7,41 @@ namespace Touki;
 /// <summary>
 ///  Enum extension methods.
 /// </summary>
+/// <remarks>
+///  <para>
+///   Every method here follows the same pattern: a single generic body that
+///   uses <c>sizeof(T)</c> to dispatch to the right underlying-integer code,
+///   plus <see cref="MethodImplOptions.AggressiveInlining"/>. The JIT
+///   specializes the generic for each concrete <c>T</c>,
+///   treats <c>sizeof(T)</c> as a compile-time constant, dead-code-
+///   eliminates the three non-matching branches, and the body collapses to
+///   a single instruction sequence over the underlying integer.
+///  </para>
+///  <para>
+///   The result on both runtimes is essentially the same instructions you
+///   would write by hand. See <c>touki.perf/EnumExtensionsPerf.cs</c> and
+///   <c>EnumExtensionsInliningPerf.cs</c> for the disassembly and numbers
+///   that back that up.
+///  </para>
+/// </remarks>
 public static unsafe partial class EnumExtensions
 {
-    // Note that the non-relevant if clauses will be omitted when compiling to a given T.
+    // Why AggressiveInlining on every method?
+    //
+    //  On modern .NET (.NET 5+) the size-of(T) ladder is folded and the
+    //  helper is inlined regardless — AggressiveInlining is a no-op there.
+    //
+    //  On .NET Framework 4.7.2 the JIT looks at the *unfolded* IL size of
+    //  the four-arm ladder and decides the method is too big to inline.
+    //  The fold still happens (the helper body is only one `and; cmp; sete`
+    //  for AreFlagsSet, for example), but the caller pays a real call/ret
+    //  plus a stack spill — roughly +0.35 ns per call. AggressiveInlining
+    //  overrides that heuristic so the call site gets the same flat code
+    //  as on modern .NET. Confirmed in touki.perf/EnumExtensionsInliningPerf.cs
+    //  asm output: with the attribute the call disappears and the inlined
+    //  body is ~3 extra instructions (load + and + cmp) over a hand-written
+    //  bitwise expression; without it the inlined body is replaced by a
+    //  call frame.
 
     extension<T>(T value) where T : unmanaged, Enum
     {
@@ -17,26 +49,58 @@ public static unsafe partial class EnumExtensions
         ///  Returns true if the given flag or flags are set.
         /// </summary>
         /// <remarks>
-        ///  Simple wrapper for <see cref="Enum.HasFlag(Enum)"/> that gives you better intellisense.
+        ///  <para>
+        ///   Equivalent to <see cref="Enum.HasFlag(Enum)"/> but without the boxing
+        ///   penalty on .NET Framework. Compared to `Enum.HasFlag` on net472 (which
+        ///   boxes both operands and virtcalls into Enum.HasFlag) this is ~20x
+        ///   faster and allocates zero bytes.
+        ///  </para>
         /// </remarks>
-        public bool AreFlagsSet(T flags) => value.HasFlag(flags);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AreFlagsSet(T flags)
+        {
+#if NET
+            return value.HasFlag(flags);
+#else
+            // .NET Framework polyfill: HasFlag boxes and virtcalls.
+            // Reading the underlying integer via a raw pointer avoids the box.
+            if (sizeof(T) == sizeof(byte))
+            {
+                byte f = *(byte*)&flags;
+                return (*(byte*)&value & f) == f;
+            }
+            else if (sizeof(T) == sizeof(short))
+            {
+                short f = *(short*)&flags;
+                return (*(short*)&value & f) == f;
+            }
+            else if (sizeof(T) == sizeof(int))
+            {
+                int f = *(int*)&flags;
+                return (*(int*)&value & f) == f;
+            }
+            else if (sizeof(T) == sizeof(long))
+            {
+                long f = *(long*)&flags;
+                return (*(long*)&value & f) == f;
+            }
+            else
+            {
+                throw new InvalidOperationException();
+            }
+#endif
+        }
 
         /// <summary>
-        ///  Returns true if only one of the specified <paramref name="flags"/> is set.
+        ///  Returns true if only one of the specified <paramref name="flags"/>
+        ///  is set.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsOnlyOneFlagSet(T flags)
         {
-            // This one doesn't inline without the aggressive inlining hint. Currently this compiles to this for int:
-            //
-            //  L0000: and ecx, edx
-            //  L0002: je short L0010
-            //  L0004: blsr eax, ecx
-            //  L0009: sete al
-            //  L000c: movzx eax, al
-            //  L000f: ret
-            //  L0010: xor eax, eax
-            //  L0012: ret
+            //  Uses the classic `v != 0 && (v & (v - 1)) == 0` power-of-two test.
+            //  On modern .NET RyuJIT this is recognized and emitted with the
+            //  BMI1 `blsr` instruction (~24 bytes total).
 
             if (sizeof(T) == sizeof(byte))
             {
@@ -45,7 +109,7 @@ public static unsafe partial class EnumExtensions
             }
             else if (sizeof(T) == sizeof(short))
             {
-                int v = *(short*)&value & *(short*)&flags;
+                int v = *(ushort*)&value & *(ushort*)&flags;
                 return v != 0 && (v & (v - 1)) == 0;
             }
             else if (sizeof(T) == sizeof(int))
@@ -67,6 +131,13 @@ public static unsafe partial class EnumExtensions
         /// <summary>
         ///  Returns true if any of the given flags are set.
         /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   There is no BCL equivalent. <see cref="Enum.HasFlag"/>
+        ///   answers "are all of these set", not "are any of them set".
+        ///  </para>
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool AreAnyFlagsSet(T flags)
         {
             if (sizeof(T) == sizeof(byte))
@@ -95,13 +166,13 @@ public static unsafe partial class EnumExtensions
     extension<T>(ref T value) where T : unmanaged, Enum
     {
         /// <summary>
-        ///  Sets the given flag or flags.
+        ///  Sets the given flag or flags on <paramref name="value"/>.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetFlags(T flags)
         {
             fixed (T* v = &value)
             {
-                // Note that the non-relevant if clauses will be omitted by the JIT so these become one statement.
                 if (sizeof(T) == sizeof(byte))
                 {
                     *(byte*)v |= *(byte*)&flags;
@@ -126,13 +197,13 @@ public static unsafe partial class EnumExtensions
         }
 
         /// <summary>
-        ///  Clears the given flag or flags.
+        ///  Clears the given flag or flags on <paramref name="value"/>.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ClearFlags(T flags)
         {
             fixed (T* v = &value)
             {
-                // Note that the non-relevant if clauses will be omitted by the JIT so these become one statement.
                 if (sizeof(T) == sizeof(byte))
                 {
                     *(byte*)v &= (byte)~*(byte*)&flags;


### PR DESCRIPTION
Optimizes `EnumExtensions` for .NET Framework 4.8.1 and adds perf coverage for the helpers.

## Production changes (`touki/Touki/EnumExtensions.cs`)

- Apply `[MethodImpl(MethodImplOptions.AggressiveInlining)]` to `AreFlagsSet`, `AreAnyFlagsSet`, `SetFlags`, `ClearFlags`. `IsOnlyOneFlagSet` already had it. No-op on modern .NET; **~3× throughput win on net481** because that JIT refuses to inline the `sizeof(T)` ladder based on unfolded IL size even though it still folds the ladder once inlined.
- Polyfill `AreFlagsSet` on net472/net481 via the same `sizeof(T)` ladder used by `AreAnyFlagsSet`. `Enum.HasFlag` boxes both operands on net481 (~9 ns, 48 B/call); the polyfill avoids the box (**~0.16 ns, 0 alloc**, ~20× faster).
- **Bug fix** in `IsOnlyOneFlagSet` short branch: read via `*(ushort*)` instead of `*(short*)` so the int promotion is zero-extending. Without this, a short enum value whose bit pattern is `0x8000` (a single bit) sign-extended to `0xFFFF8000` and the power-of-two test incorrectly returned `false`.
- Replace the disassembly-style comments with beginner-friendlier per-method comments documenting the inlined instruction shape, the instruction-count overhead vs hand-written bitwise code, and the measured cost.

## Tests (`touki.tests/Touki/EnumExtensionsTests.cs`)

- Add `SByteFlags : sbyte` and `SShortFlags : short` enums with `Low` (`0x01`), `High` (sign bit only) and `AllBits` (`-1`) values.
- Add 5 regression tests covering `AreFlagsSet`, `AreAnyFlagsSet`, `IsOnlyOneFlagSet`, `SetFlags`, `ClearFlags` with negative high-bit values. These guard against sign-extension regressions on .NET Framework RyuJIT and catch the `IsOnlyOneFlagSet` C#-level bug above.

## Perf (`touki.perf/`)

- `EnumExtensionsPerf.cs` — compares each helper against open-coded bitwise (`NoInlining` baseline) and against `Enum.HasFlag`, on both net481 and net10.0, with `DisassemblyDiagnoser` + `MemoryDiagnoser`.
- `EnumExtensionsInliningPerf.cs` — isolates the `AggressiveInlining` decision by running each body as `Default` / `Aggressive` / `NoInline` static helpers. Confirms net481 needs the attribute to inline through the ladder *and* through `fixed`; modern .NET does not.

## Validation

- `dotnet test -c Release` — 9838 tests pass on both `net10.0` and `net481` (5 new).
- `dotnet run -c Release -- --filter *EnumExtensionsPerf* --runtimes net481 net10.0 --disasm --memory` — disassembly + numbers in `BenchmarkDotNet.Artifacts/results/`.

## Headline numbers (Intel i9-14900K)

| Method | net10.0 | net481 before | net481 after |
|---|---|---|---|
| `Int_AreFlagsSet` | ~0 ns, 0 alloc | ~9.7 ns, **48 B/call** | **~0.56 ns, 0 alloc** |
| `Int_AreAnyFlagsSet` | ~0 ns | ~0.55 ns | ~0.55 ns |
| `Int_IsOnlyOneFlagSet` | ~0.18 ns (BLSR) | ~0.19 ns | ~0.19 ns |
| `Int_SetFlags` / `ClearFlags` | ~0 ns | ~0.55 ns | ~0.55 ns |
