### PR TITLE
Add unit-test coverage for low-coverage public surface

### DIFF
--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -45,6 +45,28 @@ For each new `public` (or `InternalsVisibleTo`-internal) member:
 - Allocating APIs (`Concat`, `ToHexString`): include an
   `OverflowException` test on the length sum (see &sect;3).
 
+Test hygiene for the tests themselves &mdash; the recurring miss list
+that costs the most review rounds on coverage-only PRs:
+
+- **Test method names start with the method under test.**
+  `MethodName_StateUnderTest_ExpectedBehavior` (see
+  [tests.instructions.md](../../../.github/instructions/tests.instructions.md)).
+  `ReadOnlySpan_Empty_ReturnsEmpty` is *wrong*;
+  `SliceAtNull_ReadOnlySpan_Empty_ReturnsEmpty` is right.
+- **Every `IDisposable` test local uses `using` or `try`/`finally`.**
+  `TempFolder`, `IEnumerationMatcher`, anything returned by
+  `MSBuildMatchBuilder.FromSpecification`, `ArrayPoolList<T>` &mdash;
+  a bare local leaks the resource when an assertion fails. See
+  the "Disposables in test bodies" section in `tests.instructions.md`
+  for the pattern when the test itself exercises explicit `Dispose()`.
+- **Don't hard-code `InvariantCulture` for APIs that use
+  `CurrentCulture`.** Touki's provider-less formatting helpers
+  (`string.FormatValue`, `ValueStringBuilder.AppendFormat` without a
+  provider, etc.) format with `CurrentCulture`. Asserting against
+  `InvariantCulture`-formatted strings makes the test locale-dependent.
+  See the "Culture-sensitive assertions" section in
+  `tests.instructions.md`.
+
 ## 2. Empty / null spans before `unsafe` interop
 
 `MemoryMarshal.GetReference(default(ReadOnlySpan<T>))` is a null ref.
@@ -161,6 +183,12 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
 - File list, test counts, and perf numbers all reflect the *current*
   diff. Re-run after every commit; do not paste numbers from an earlier
   iteration.
+- **Walk each bullet of the description against the diff before
+  pushing.** If the body says "covers `Foo` with cases A/B/C", search
+  the diff for tests named `Foo_…` and confirm A, B, and C are all
+  there. PR #141 lost a round to a description that claimed a
+  `Span<char>` "null at end" case and a `MatchAnyDirectory` double-
+  dispose test, neither of which was actually in the diff.
 - "Deliberately deferred" entries match what's actually absent from
   the working tree.
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -40,6 +40,55 @@ ever drift, AGENTS.md wins; update this file to match.
   otherwise want `Assert.Throws(() => ...)`, use a `try`/`finally` block and
   assert on the caught exception explicitly.
 
+## Disposables in test bodies
+
+Anything that allocates a real resource &mdash; `TempFolder`,
+`IEnumerationMatcher`, `MSBuildMatchBuilder.FromSpecification`,
+`ArrayPoolList<T>`, etc. &mdash; must be cleaned up even when assertions
+fail. Default to `using` declarations.
+
+- For "happy path" tests, write `using TempFolder folder = new();` and
+  `using IEnumerationMatcher matcher = ...;`. Do not assign to a bare
+  local; the resource leaks on failure.
+- When the test itself exercises explicit `Dispose()` semantics (e.g.
+  double-dispose, dispose-after-external-deletion), `using` would call
+  `Dispose()` before the test body runs the assertion. Use
+  `try`/`finally` instead and call `Dispose()` defensively in the
+  `finally` &mdash; `DisposableBase` guards against double disposal:
+
+  ```c#
+  TempFolder folder = new();
+  try
+  {
+      // ... explicit Dispose() calls under test ...
+  }
+  finally
+  {
+      folder.Dispose();
+  }
+  ```
+
+- Reviewer Copilot will flag any bare `IDisposable` local in a test as a
+  potential resource leak. Address it before merging.
+
+## Culture-sensitive assertions
+
+Many touki formatting APIs (`string.FormatValue`,
+`string.FormatValues`, `ValueStringBuilder.AppendFormat`, the
+`StringBuilderExtensions.AppendFormatted` overloads that don't take a
+provider) construct the underlying `ValueStringBuilder` with
+`provider: null`, which makes numeric and date formatting follow
+`CultureInfo.CurrentCulture`. Hard-coding `InvariantCulture` expectations
+makes the test locale-dependent and flaky on non-en-US machines.
+
+- For formats that include culture-sensitive separators or symbols (`N`,
+  `C`, `P`, `D` for dates, etc.), derive the expected string from
+  `CultureInfo.CurrentCulture` &mdash; or, when the test is meant to
+  pin behavior under a specific culture, set
+  `Thread.CurrentThread.CurrentCulture` (and restore in `finally`).
+- Culture-insensitive formats (`X`, `B`, default `G` on integers,
+  literal pass-through) are safe with hard-coded expected strings.
+
 ## Release-mode rule
 
 - Run `dotnet test -c Release` before declaring a fix done. Release-mode

--- a/touki.tests/Touki/Exceptions/ExceptionExtensionsTests.cs
+++ b/touki.tests/Touki/Exceptions/ExceptionExtensionsTests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Exceptions;
+
+public class ExceptionExtensionsTests
+{
+    [Fact]
+    public void InvalidOperationException_Throw_ThrowsWithMessage()
+    {
+        Action action = () => InvalidOperationException.Throw("boom");
+        action.Should().Throw<InvalidOperationException>().WithMessage("boom");
+    }
+
+    [Fact]
+    public void ArgumentOutOfRangeException_Throw_ThrowsWithParamName()
+    {
+        Action action = () => ArgumentOutOfRangeException.Throw("count");
+        action.Should().Throw<ArgumentOutOfRangeException>()
+            .Which.ParamName.Should().Be("count");
+    }
+
+    [Fact]
+    public void ArgumentOutOfRangeException_Throw_ThrowsWithParamNameAndMessage()
+    {
+        Action action = () => ArgumentOutOfRangeException.Throw("count", "must be positive");
+
+        ArgumentOutOfRangeException ex = action.Should().Throw<ArgumentOutOfRangeException>().Which;
+        ex.ParamName.Should().Be("count");
+        ex.Message.Should().Contain("must be positive");
+    }
+
+    [Fact]
+    public void OutOfMemoryException_Throw_Throws()
+    {
+        Action action = OutOfMemoryException.Throw;
+        action.Should().Throw<OutOfMemoryException>();
+    }
+
+    [Fact]
+    public void NotSupportedException_Throw_DefaultMessage_Throws()
+    {
+        Action action = () => NotSupportedException.Throw();
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [Fact]
+    public void NotSupportedException_Throw_WithMessage_ThrowsWithMessage()
+    {
+        Action action = () => NotSupportedException.Throw("not here");
+        action.Should().Throw<NotSupportedException>().WithMessage("not here");
+    }
+}

--- a/touki.tests/Touki/Io/MSBuildMatchBuilderTests.cs
+++ b/touki.tests/Touki/Io/MSBuildMatchBuilderTests.cs
@@ -15,7 +15,7 @@ public class MSBuildMatchBuilderTests
         File.WriteAllText(Path.Join(folder, "a.txt"), "1");
         File.WriteAllText(Path.Join(folder, "b.cs"), "2");
 
-        IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+        using IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
             includeSpecification: "*.txt",
             excludeSpecifications: string.Empty,
             matchType: MatchType.Simple,
@@ -33,7 +33,7 @@ public class MSBuildMatchBuilderTests
     {
         using TempFolder folder = new();
 
-        IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+        using IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
             includeSpecification: "**/*.cs",
             excludeSpecifications: "**/skip.cs",
             matchType: MatchType.Simple,
@@ -49,7 +49,7 @@ public class MSBuildMatchBuilderTests
     [Fact]
     public void FromSpecification_StringStringOverload_NullRoot_UsesCurrentDirectory()
     {
-        IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+        using IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
             includeSpecification: "*.txt",
             excludeSpecifications: string.Empty,
             matchType: MatchType.Simple,

--- a/touki.tests/Touki/Io/MSBuildMatchBuilderTests.cs
+++ b/touki.tests/Touki/Io/MSBuildMatchBuilderTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Text;
+
+namespace Touki.Io;
+
+public class MSBuildMatchBuilderTests
+{
+    [Fact]
+    public void FromSpecification_StringStringOverload_NoExcludes_MatchesIncludeFiles()
+    {
+        using TempFolder folder = new();
+        File.WriteAllText(Path.Join(folder, "a.txt"), "1");
+        File.WriteAllText(Path.Join(folder, "b.cs"), "2");
+
+        IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+            includeSpecification: "*.txt",
+            excludeSpecifications: string.Empty,
+            matchType: MatchType.Simple,
+            matchCasing: MatchCasing.PlatformDefault,
+            rootDirectory: folder.TempPath,
+            out StringSegment startDirectory);
+
+        startDirectory.ToString().Should().Be(folder.TempPath);
+        matcher.MatchesFile(folder.TempPath.AsSpan(), "a.txt".AsSpan()).Should().BeTrue();
+        matcher.MatchesFile(folder.TempPath.AsSpan(), "b.cs".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromSpecification_StringStringOverload_WithExcludes_FiltersExcluded()
+    {
+        using TempFolder folder = new();
+
+        IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+            includeSpecification: "**/*.cs",
+            excludeSpecifications: "**/skip.cs",
+            matchType: MatchType.Simple,
+            matchCasing: MatchCasing.PlatformDefault,
+            rootDirectory: folder.TempPath,
+            out StringSegment startDirectory);
+
+        startDirectory.ToString().Should().Be(folder.TempPath);
+        matcher.MatchesFile(folder.TempPath.AsSpan(), "keep.cs".AsSpan()).Should().BeTrue();
+        matcher.MatchesFile(folder.TempPath.AsSpan(), "skip.cs".AsSpan()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromSpecification_StringStringOverload_NullRoot_UsesCurrentDirectory()
+    {
+        IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+            includeSpecification: "*.txt",
+            excludeSpecifications: string.Empty,
+            matchType: MatchType.Simple,
+            matchCasing: MatchCasing.PlatformDefault,
+            rootDirectory: null,
+            out StringSegment startDirectory);
+
+        matcher.Should().NotBeNull();
+        startDirectory.ToString().Should().Be(Environment.CurrentDirectory);
+    }
+}

--- a/touki.tests/Touki/Io/MatchAnyTests.cs
+++ b/touki.tests/Touki/Io/MatchAnyTests.cs
@@ -301,4 +301,14 @@ public class MatchAnyTests
         Action action = matcher.Dispose;
         action.Should().NotThrow();
     }
+
+    [Fact]
+    public void MatchAnyDirectory_Dispose_CalledTwice_DoesNotThrow()
+    {
+        MatchAnyDirectory matcher = new("docs", MatchType.Simple, MatchCasing.CaseSensitive);
+        matcher.Dispose();
+
+        Action action = matcher.Dispose;
+        action.Should().NotThrow();
+    }
 }

--- a/touki.tests/Touki/Io/MatchAnyTests.cs
+++ b/touki.tests/Touki/Io/MatchAnyTests.cs
@@ -271,4 +271,34 @@ public class MatchAnyTests
 
         matcher.MatchesFile("/root".AsSpan(), "file.txt".AsSpan()).Should().BeFalse();
     }
+
+    [Fact]
+    public void MatchAnyFile_Dispose_ReleasesResources()
+    {
+        MatchAnyFile matcher = new("*.txt", MatchType.Simple, MatchCasing.CaseSensitive);
+        matcher.AddSpec("*.log");
+
+        Action action = matcher.Dispose;
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MatchAnyFile_Dispose_CalledTwice_DoesNotThrow()
+    {
+        MatchAnyFile matcher = new("*.txt", MatchType.Simple, MatchCasing.CaseSensitive);
+        matcher.Dispose();
+
+        Action action = matcher.Dispose;
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void MatchAnyDirectory_Dispose_ReleasesResources()
+    {
+        MatchAnyDirectory matcher = new("docs", MatchType.Simple, MatchCasing.CaseSensitive);
+        matcher.AddSpec("src");
+
+        Action action = matcher.Dispose;
+        action.Should().NotThrow();
+    }
 }

--- a/touki.tests/Touki/Io/TempFolderTests.cs
+++ b/touki.tests/Touki/Io/TempFolderTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+public class TempFolderTests
+{
+    [Fact]
+    public void Constructor_CreatesDirectory()
+    {
+        using TempFolder folder = new();
+        Directory.Exists(folder.TempPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ImplicitConversion_ToString_ReturnsTempPath()
+    {
+        using TempFolder folder = new();
+        string path = folder;
+        path.Should().Be(folder.TempPath);
+    }
+
+    [Fact]
+    public void Dispose_DeletesDirectory()
+    {
+        TempFolder folder = new();
+        string path = folder.TempPath;
+        Directory.Exists(path).Should().BeTrue();
+
+        folder.Dispose();
+
+        Directory.Exists(path).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Dispose_DirectoryAlreadyRemoved_DoesNotThrow()
+    {
+        TempFolder folder = new();
+        Directory.Delete(folder.TempPath, recursive: true);
+
+        Action action = folder.Dispose;
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        TempFolder folder = new();
+        folder.Dispose();
+
+        Action action = folder.Dispose;
+        action.Should().NotThrow();
+    }
+}

--- a/touki.tests/Touki/Io/TempFolderTests.cs
+++ b/touki.tests/Touki/Io/TempFolderTests.cs
@@ -25,31 +25,53 @@ public class TempFolderTests
     public void Dispose_DeletesDirectory()
     {
         TempFolder folder = new();
-        string path = folder.TempPath;
-        Directory.Exists(path).Should().BeTrue();
+        try
+        {
+            string path = folder.TempPath;
+            Directory.Exists(path).Should().BeTrue();
 
-        folder.Dispose();
+            folder.Dispose();
 
-        Directory.Exists(path).Should().BeFalse();
+            Directory.Exists(path).Should().BeFalse();
+        }
+        finally
+        {
+            // DisposableBase guards against double disposal; safe to call again on failure.
+            folder.Dispose();
+        }
     }
 
     [Fact]
     public void Dispose_DirectoryAlreadyRemoved_DoesNotThrow()
     {
         TempFolder folder = new();
-        Directory.Delete(folder.TempPath, recursive: true);
+        try
+        {
+            Directory.Delete(folder.TempPath, recursive: true);
 
-        Action action = folder.Dispose;
-        action.Should().NotThrow();
+            Action action = folder.Dispose;
+            action.Should().NotThrow();
+        }
+        finally
+        {
+            folder.Dispose();
+        }
     }
 
     [Fact]
     public void Dispose_CalledTwice_DoesNotThrow()
     {
         TempFolder folder = new();
-        folder.Dispose();
+        try
+        {
+            folder.Dispose();
 
-        Action action = folder.Dispose;
-        action.Should().NotThrow();
+            Action action = folder.Dispose;
+            action.Should().NotThrow();
+        }
+        finally
+        {
+            folder.Dispose();
+        }
     }
 }

--- a/touki.tests/Touki/SpanExtensionsSliceAtNullTests.cs
+++ b/touki.tests/Touki/SpanExtensionsSliceAtNullTests.cs
@@ -7,7 +7,7 @@ namespace Touki;
 public class SpanExtensionsSliceAtNullTests
 {
     [Fact]
-    public void ReadOnlySpan_NoNull_ReturnsFullSpan()
+    public void SliceAtNull_ReadOnlySpan_NoNull_ReturnsFullSpan()
     {
         ReadOnlySpan<char> span = "hello".AsSpan();
         ReadOnlySpan<char> result = span.SliceAtNull();
@@ -15,7 +15,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void ReadOnlySpan_NullAtEnd_ReturnsContentBeforeNull()
+    public void SliceAtNull_ReadOnlySpan_NullAtEnd_ReturnsContentBeforeNull()
     {
         ReadOnlySpan<char> span = "hello\0".AsSpan();
         ReadOnlySpan<char> result = span.SliceAtNull();
@@ -23,7 +23,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void ReadOnlySpan_NullInMiddle_ReturnsContentBeforeNull()
+    public void SliceAtNull_ReadOnlySpan_NullInMiddle_ReturnsContentBeforeNull()
     {
         ReadOnlySpan<char> span = "ab\0cd".AsSpan();
         ReadOnlySpan<char> result = span.SliceAtNull();
@@ -31,7 +31,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void ReadOnlySpan_NullAtStart_ReturnsEmpty()
+    public void SliceAtNull_ReadOnlySpan_NullAtStart_ReturnsEmpty()
     {
         ReadOnlySpan<char> span = "\0abc".AsSpan();
         ReadOnlySpan<char> result = span.SliceAtNull();
@@ -39,7 +39,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void ReadOnlySpan_Empty_ReturnsEmpty()
+    public void SliceAtNull_ReadOnlySpan_Empty_ReturnsEmpty()
     {
         ReadOnlySpan<char> span = [];
         ReadOnlySpan<char> result = span.SliceAtNull();
@@ -47,7 +47,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void Span_NoNull_ReturnsFullSpan()
+    public void SliceAtNull_Span_NoNull_ReturnsFullSpan()
     {
         Span<char> buffer = ['h', 'e', 'l', 'l', 'o'];
         Span<char> result = buffer.SliceAtNull();
@@ -56,7 +56,16 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void Span_NullInMiddle_ReturnsContentBeforeNull()
+    public void SliceAtNull_Span_NullAtEnd_ReturnsContentBeforeNull()
+    {
+        Span<char> buffer = ['h', 'e', 'l', 'l', 'o', '\0'];
+        Span<char> result = buffer.SliceAtNull();
+        result.Length.Should().Be(5);
+        result.SequenceEqual("hello".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SliceAtNull_Span_NullInMiddle_ReturnsContentBeforeNull()
     {
         Span<char> buffer = ['a', 'b', '\0', 'c', 'd'];
         Span<char> result = buffer.SliceAtNull();
@@ -65,7 +74,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void Span_NullAtStart_ReturnsEmpty()
+    public void SliceAtNull_Span_NullAtStart_ReturnsEmpty()
     {
         Span<char> buffer = ['\0', 'x', 'y'];
         Span<char> result = buffer.SliceAtNull();
@@ -73,7 +82,7 @@ public class SpanExtensionsSliceAtNullTests
     }
 
     [Fact]
-    public void Span_Empty_ReturnsEmpty()
+    public void SliceAtNull_Span_Empty_ReturnsEmpty()
     {
         Span<char> buffer = [];
         Span<char> result = buffer.SliceAtNull();

--- a/touki.tests/Touki/SpanExtensionsSliceAtNullTests.cs
+++ b/touki.tests/Touki/SpanExtensionsSliceAtNullTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+public class SpanExtensionsSliceAtNullTests
+{
+    [Fact]
+    public void ReadOnlySpan_NoNull_ReturnsFullSpan()
+    {
+        ReadOnlySpan<char> span = "hello".AsSpan();
+        ReadOnlySpan<char> result = span.SliceAtNull();
+        result.SequenceEqual(span).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadOnlySpan_NullAtEnd_ReturnsContentBeforeNull()
+    {
+        ReadOnlySpan<char> span = "hello\0".AsSpan();
+        ReadOnlySpan<char> result = span.SliceAtNull();
+        result.SequenceEqual("hello".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadOnlySpan_NullInMiddle_ReturnsContentBeforeNull()
+    {
+        ReadOnlySpan<char> span = "ab\0cd".AsSpan();
+        ReadOnlySpan<char> result = span.SliceAtNull();
+        result.SequenceEqual("ab".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadOnlySpan_NullAtStart_ReturnsEmpty()
+    {
+        ReadOnlySpan<char> span = "\0abc".AsSpan();
+        ReadOnlySpan<char> result = span.SliceAtNull();
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReadOnlySpan_Empty_ReturnsEmpty()
+    {
+        ReadOnlySpan<char> span = [];
+        ReadOnlySpan<char> result = span.SliceAtNull();
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Span_NoNull_ReturnsFullSpan()
+    {
+        Span<char> buffer = ['h', 'e', 'l', 'l', 'o'];
+        Span<char> result = buffer.SliceAtNull();
+        result.Length.Should().Be(5);
+        result.SequenceEqual("hello".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Span_NullInMiddle_ReturnsContentBeforeNull()
+    {
+        Span<char> buffer = ['a', 'b', '\0', 'c', 'd'];
+        Span<char> result = buffer.SliceAtNull();
+        result.Length.Should().Be(2);
+        result.SequenceEqual("ab".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Span_NullAtStart_ReturnsEmpty()
+    {
+        Span<char> buffer = ['\0', 'x', 'y'];
+        Span<char> result = buffer.SliceAtNull();
+        result.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Span_Empty_ReturnsEmpty()
+    {
+        Span<char> buffer = [];
+        Span<char> result = buffer.SliceAtNull();
+        result.IsEmpty.Should().BeTrue();
+    }
+}

--- a/touki.tests/Touki/Text/StringBuilderExtensionsTests.cs
+++ b/touki.tests/Touki/Text/StringBuilderExtensionsTests.cs
@@ -610,4 +610,78 @@ public unsafe class StringBuilderExtensionsTests
 
         action.Should().Throw<ArgumentException>();
     }
+
+    [Fact]
+    public void AppendSpan_MemoryOverload_NonEmpty_AppendsContent()
+    {
+        StringBuilder builder = new("Prefix:");
+        Memory<char> memory = new char[] { 'a', 'b', 'c' };
+
+        builder.AppendSpan(memory).Should().BeSameAs(builder);
+        builder.ToString().Should().Be("Prefix:abc");
+    }
+
+    [Fact]
+    public void AppendSpan_MemoryOverload_Empty_LeavesBuilderUnchanged()
+    {
+        StringBuilder builder = new("Prefix");
+        Memory<char> memory = Memory<char>.Empty;
+
+        builder.AppendSpan(memory).Should().BeSameAs(builder);
+        builder.ToString().Should().Be("Prefix");
+    }
+
+    [Fact]
+    public void AppendFormatted_StringFormat_ValueSpan_FormatsAllPlaceholders()
+    {
+        StringBuilder builder = new();
+        ReadOnlySpan<Value> values = [Value.Create("a"), Value.Create(1), Value.Create(true)];
+
+        StringBuilderExtensions.AppendFormatted(builder, "{0}-{1}-{2}", values);
+
+        builder.ToString().Should().Be("a-1-True");
+    }
+
+    [Fact]
+    public void AppendFormatted_SpanFormat_ValueSpan_FormatsAllPlaceholders()
+    {
+        StringBuilder builder = new();
+        ReadOnlySpan<Value> values = [Value.Create("x"), Value.Create(42)];
+
+        StringBuilderExtensions.AppendFormatted(builder, "{0}={1}".AsSpan(), values);
+
+        builder.ToString().Should().Be("x=42");
+    }
+
+    [Fact]
+    public void AppendJoin_ReadOnlySpanOverload_EmptyValues_ReturnsBuilderUnchanged()
+    {
+        StringBuilder builder = new("Prefix");
+        StringBuilder result = StringBuilderExtensions.AppendJoin(builder, ',', []);
+
+        result.Should().BeSameAs(builder);
+        builder.ToString().Should().Be("Prefix");
+    }
+
+    [Fact]
+    public void AppendJoin_ReadOnlySpanOverload_SingleValue_AppendsWithoutSeparator()
+    {
+        StringBuilder builder = new();
+        ReadOnlySpan<object?> values = [(object?)"A"];
+
+        StringBuilderExtensions.AppendJoin(builder, ',', values);
+
+        builder.ToString().Should().Be("A");
+    }
+
+    [Fact]
+    public void AppendJoin_ReadOnlySpanOverload_MultipleValues_JoinsWithSeparator()
+    {
+        StringBuilder builder = new();
+        ReadOnlySpan<object?> values = [(object?)"A", "B", null, "D"];
+
+        StringBuilderExtensions.AppendJoin(builder, '|', values);
+
+        builder.ToString().Should().Be("A|B||D");
+    }
 }

--- a/touki.tests/Touki/Text/StringExtensionsTests.cs
+++ b/touki.tests/Touki/Text/StringExtensionsTests.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Globalization;
+
+namespace Touki.Text;
+
+public class StringExtensionsTests
+{
+    [Fact]
+    public void FormatValue_Generic_FormatsUnmanagedArgument()
+    {
+        string result = string.FormatValue("{0:X4}".AsSpan(), 0x2A);
+        result.Should().Be("002A");
+    }
+
+    [Fact]
+    public void FormatValue_Generic_LargeOutput_GrowsBuffer()
+    {
+        ReadOnlySpan<char> format = "{0}".AsSpan();
+        long value = long.MaxValue;
+        string result = string.FormatValue(format, value);
+        result.Should().Be(long.MaxValue.ToString(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void FormatValue_ValueArg_FormatsBoxedValue()
+    {
+        string result = string.FormatValue("{0:N0}".AsSpan(), Value.Create(1234));
+        result.Should().Be(1234.ToString("N0", CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public void FormatValues_SpanArgs_FormatsMultiplePlaceholders()
+    {
+        ReadOnlySpan<Value> args = [Value.Create("Alice"), Value.Create(30)];
+        string result = string.FormatValues("{0} is {1}".AsSpan(), args);
+        result.Should().Be("Alice is 30");
+    }
+
+    [Fact]
+    public void FormatValues_TwoArgs_FormatsBothPlaceholders()
+    {
+        string result = string.FormatValues(
+            "{0}-{1}".AsSpan(),
+            Value.Create("a"),
+            Value.Create(1));
+        result.Should().Be("a-1");
+    }
+
+    [Fact]
+    public void FormatValues_ThreeArgs_FormatsAllPlaceholders()
+    {
+        string result = string.FormatValues(
+            "{0}/{1}/{2}".AsSpan(),
+            Value.Create(2026),
+            Value.Create(5),
+            Value.Create(10));
+        result.Should().Be("2026/5/10");
+    }
+
+    [Fact]
+    public void FormatValues_FourArgs_FormatsAllPlaceholders()
+    {
+        string result = string.FormatValues(
+            "{0},{1},{2},{3}".AsSpan(),
+            Value.Create(1),
+            Value.Create(2),
+            Value.Create(3),
+            Value.Create(4));
+        result.Should().Be("1,2,3,4");
+    }
+
+    [Fact]
+    public void FormatValues_FourArgs_LiteralFormat_NoPlaceholders_ReturnsLiteral()
+    {
+        string result = string.FormatValues(
+            "literal".AsSpan(),
+            Value.Create(1),
+            Value.Create(2),
+            Value.Create(3),
+            Value.Create(4));
+        result.Should().Be("literal");
+    }
+}

--- a/touki.tests/Touki/Text/StringExtensionsTests.cs
+++ b/touki.tests/Touki/Text/StringExtensionsTests.cs
@@ -27,8 +27,11 @@ public class StringExtensionsTests
     [Fact]
     public void FormatValue_ValueArg_FormatsBoxedValue()
     {
+        // FormatValue constructs a ValueStringBuilder with a null IFormatProvider,
+        // so number formatting follows CultureInfo.CurrentCulture. The expected
+        // string must use the same culture or this assertion is locale-dependent.
         string result = string.FormatValue("{0:N0}".AsSpan(), Value.Create(1234));
-        result.Should().Be(1234.ToString("N0", CultureInfo.InvariantCulture));
+        result.Should().Be(1234.ToString("N0", CultureInfo.CurrentCulture));
     }
 
     [Fact]

--- a/touki.tests/Touki/Text/StringSpanTests.cs
+++ b/touki.tests/Touki/Text/StringSpanTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Text;
+
+public class StringSpanTests
+{
+    [Fact]
+    public void Default_IsEmpty_True()
+    {
+        StringSpan span = default;
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_NullString_IsEmpty()
+    {
+        StringSpan span = new((string?)null);
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_EmptyString_IsEmpty()
+    {
+        StringSpan span = new(string.Empty);
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_NonEmptyString_IsNotEmpty()
+    {
+        StringSpan span = new("hello");
+        span.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_EmptySpan_IsEmpty()
+    {
+        StringSpan span = new([]);
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_NonEmptySpan_IsNotEmpty()
+    {
+        StringSpan span = new("abc".AsSpan());
+        span.IsEmpty.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromString_RoundTripsContent()
+    {
+        StringSpan span = "hello";
+        ReadOnlySpan<char> result = span;
+        result.SequenceEqual("hello".AsSpan()).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromNullString_IsEmpty()
+    {
+        StringSpan span = (string?)null;
+        span.IsEmpty.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromReadOnlySpan_RoundTripsContent()
+    {
+        ReadOnlySpan<char> source = "world".AsSpan();
+        StringSpan span = source;
+        ReadOnlySpan<char> result = span;
+        result.SequenceEqual(source).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ImplicitConversion_FromMutableSpan_RoundTripsContent()
+    {
+        Span<char> buffer = stackalloc char[5];
+        "world".AsSpan().CopyTo(buffer);
+        StringSpan span = buffer;
+        ReadOnlySpan<char> result = span;
+        result.SequenceEqual(buffer).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ToString_FromString_ReturnsSameInstance()
+    {
+        string original = "shared";
+        StringSpan span = new(original);
+        span.ToString().Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void ToString_FromEmptySpan_ReturnsEmptyString()
+    {
+        StringSpan span = new([]);
+        span.ToString().Should().BeSameAs(string.Empty);
+    }
+
+    [Fact]
+    public void ToString_FromSpan_ReturnsContent()
+    {
+        StringSpan span = new("hi".AsSpan());
+        span.ToString().Should().Be("hi");
+    }
+
+    [Fact]
+    public void ToString_FromNullString_ReturnsEmptyString()
+    {
+        StringSpan span = new((string?)null);
+        span.ToString().Should().BeSameAs(string.Empty);
+    }
+
+    [Fact]
+    public void ToStringOrNull_FromString_ReturnsSameInstance()
+    {
+        string original = "shared";
+        StringSpan span = new(original);
+        span.ToStringOrNull().Should().BeSameAs(original);
+    }
+
+    [Fact]
+    public void ToStringOrNull_FromEmptyString_ReturnsEmptyInstance()
+    {
+        StringSpan span = new(string.Empty);
+        span.ToStringOrNull().Should().BeSameAs(string.Empty);
+    }
+
+    [Fact]
+    public void ToStringOrNull_FromNullString_ReturnsNull()
+    {
+        StringSpan span = new((string?)null);
+        span.ToStringOrNull().Should().BeNull();
+    }
+
+    [Fact]
+    public void ToStringOrNull_FromEmptySpan_ReturnsNull()
+    {
+        StringSpan span = new([]);
+        span.ToStringOrNull().Should().BeNull();
+    }
+
+    [Fact]
+    public void ToStringOrNull_FromNonEmptySpan_ReturnsContent()
+    {
+        StringSpan span = new("abc".AsSpan());
+        span.ToStringOrNull().Should().Be("abc");
+    }
+}

--- a/touki.tests/Touki/Text/ValueStringBuilderTests.cs
+++ b/touki.tests/Touki/Text/ValueStringBuilderTests.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Globalization;
 using System.Text;
 using Touki.Text;
 
@@ -2439,5 +2440,345 @@ public unsafe class ValueStringBuilderTests
         }
 
         threw.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_LiteralLengthFormattedCount_AllocatesPooledBuffer()
+    {
+        using ValueStringBuilder builder = new(literalLength: 8, formattedCount: 2);
+        builder.Length.Should().Be(0);
+        builder.Capacity.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Constructor_LiteralLengthFormattedCount_Provider_AllocatesPooledBuffer()
+    {
+        using ValueStringBuilder builder = new(literalLength: 4, formattedCount: 1, provider: CultureInfo.InvariantCulture);
+        builder.Length.Should().Be(0);
+        builder.Capacity.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public void Constructor_LiteralLengthFormattedCount_InitialBuffer_UsesProvidedBuffer()
+    {
+        using ValueStringBuilder builder = new(
+            literalLength: 4,
+            formattedCount: 1,
+            provider: null,
+            initialBuffer: stackalloc char[16]);
+        builder.Length.Should().Be(0);
+        builder.Capacity.Should().Be(16);
+    }
+
+    [Fact]
+    public void Constructor_Span_WithFormatProvider_Works()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8], CultureInfo.InvariantCulture);
+        try
+        {
+            builder.Append("hi");
+            builder.ToString().Should().Be("hi");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Constructor_InitialCapacity_WithFormatProvider_Works()
+    {
+        using ValueStringBuilder builder = new(initialCapacity: 32, provider: CultureInfo.InvariantCulture);
+        builder.Append("ok");
+        builder.ToString().Should().Be("ok");
+    }
+
+    [Fact]
+    public void AppendSpan_RequestedLength_ReturnsWritableRegionAndAdvancesLength()
+    {
+        ValueStringBuilder builder = new(stackalloc char[8]);
+        try
+        {
+            Span<char> region = builder.AppendSpan(4);
+            region.Length.Should().Be(4);
+            region[0] = 'a';
+            region[1] = 'b';
+            region[2] = 'c';
+            region[3] = 'd';
+            builder.Length.Should().Be(4);
+            builder.ToString().Should().Be("abcd");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendSpan_GrowsBufferWhenExceedingCapacity()
+    {
+        ValueStringBuilder builder = new(stackalloc char[2]);
+        try
+        {
+            Span<char> region = builder.AppendSpan(8);
+            region.Length.Should().Be(8);
+            "abcdefgh".AsSpan().CopyTo(region);
+            builder.Length.Should().Be(8);
+            builder.ToString().Should().Be("abcdefgh");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendSpan_NegativeLength_Throws()
+    {
+        ValueStringBuilder builder = new(stackalloc char[4]);
+        bool threw = false;
+        try
+        {
+            try
+            {
+                builder.AppendSpan(-1);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                threw = true;
+            }
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+
+        threw.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RangeIndexer_ReturnsRequestedSubsection()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.Append("Hello World");
+            builder[6..].ToString().Should().Be("World");
+            builder[..5].ToString().Should().Be("Hello");
+            builder[1..4].ToString().Should().Be("ell");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpan_AppendsContent()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted("hello".AsSpan());
+            builder.ToString().Should().Be("hello");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_StringWithAlignmentAndFormat_RightAlignsValue()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted(value: "x", alignment: 5, format: null);
+            builder.ToString().Should().Be("    x");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_StringWithNegativeAlignment_LeftAlignsValue()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted(value: "x", alignment: -5, format: null);
+            builder.ToString().Should().Be("x    ");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ValueWithStringFormat_AppliesFormat()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted(Value.Create(255), format: "X");
+            builder.ToString().Should().Be("FF");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericValueWithAlignment_RightAlignsValue()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted<int>(42, alignment: 5);
+            builder.ToString().Should().Be("   42");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericValueWithAlignmentZero_DoesNotPad()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted<int>(42, alignment: 0);
+            builder.ToString().Should().Be("42");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpanWithAlignment_RightAlignsValue()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted("ab".AsSpan(), alignment: 5);
+            builder.ToString().Should().Be("   ab");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpanWithNegativeAlignment_LeftAlignsValue()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted("ab".AsSpan(), alignment: -5);
+            builder.ToString().Should().Be("ab   ");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_ReadOnlySpanWithAlignmentSmallerThanValue_AppendsUnchanged()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted("abcdef".AsSpan(), alignment: 2);
+            builder.ToString().Should().Be("abcdef");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_Object_NullValue_AppendsNothing()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted((object?)null);
+            builder.ToString().Should().Be(string.Empty);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_GenericWithStringFormat_AppliesFormat()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted<int>(255, format: "X");
+            builder.ToString().Should().Be("FF");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_NullStringValue_AppendsNothing()
+    {
+        ValueStringBuilder builder = new(stackalloc char[16]);
+        try
+        {
+            builder.AppendFormatted((string?)null);
+            builder.ToString().Should().Be(string.Empty);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [Fact]
+    public void AppendFormatted_CustomFormatter_InterceptsValue()
+    {
+        UpperCaseFormatProvider provider = new();
+        ValueStringBuilder builder = new(literalLength: 0, formattedCount: 1, provider: provider, initialBuffer: stackalloc char[32]);
+        try
+        {
+            builder.AppendFormatted("hi");
+            builder.AppendFormatted<int>(42);
+            builder.ToString().Should().Be("[HI][42]");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    private sealed class UpperCaseFormatProvider : IFormatProvider, ICustomFormatter
+    {
+        public object? GetFormat(Type? formatType) =>
+            formatType == typeof(ICustomFormatter) ? this : null;
+
+        public string Format(string? format, object? arg, IFormatProvider? formatProvider)
+        {
+            string text = arg?.ToString() ?? string.Empty;
+            return "[" + text.ToUpperInvariant() + "]";
+        }
     }
 }


### PR DESCRIPTION
Raises overall line coverage from 89.6% → 92.9% and branch coverage from 86.4% → 88.6% on `net10.0` by exercising previously untested or thinly tested public/internal members. No production-code changes.

New tests cover:

- `ExceptionExtensions` — `InvalidOperationException.Throw`, `ArgumentOutOfRangeException.Throw`, `OutOfMemoryException.Throw`, `NotSupportedException.Throw`.
- `StringExtensions` — `string.FormatValue<T>`, `string.FormatValue(Value)`, and 2/3/4-arg `string.FormatValues` overloads.
- `StringSpan` — full surface (`IsEmpty`, implicit conversions, `ToString`, `ToStringOrNull`, empty/null/span/string cases).
- `SpanExtensions.SliceAtNull` — `ReadOnlySpan<char>` and `Span<char>` overloads (no null, null at start/middle/end, empty).
- `TempFolder` — ctor, implicit string conversion, dispose, double dispose, dispose-after-external-deletion.
- `StringBuilderExtensions` — `AppendSpan(Memory<char>)`, the `ReadOnlySpan<Value>` `AppendFormatted` overloads (string + span format), and `AppendJoin(char, ReadOnlySpan<object?>)`.
- `MSBuildMatchBuilder.FromSpecification(string, string, ...)` — no excludes, with excludes, and null root directory.
- `MatchAnyBase` — dispose paths for `MatchAnyFile`/`MatchAnyDirectory`, including double dispose.
- `ValueStringBuilder` — literal-length/formatted-count ctors, span-with-provider and capacity-with-provider ctors, `AppendSpan(int)` (basic / growth / negative), `Range` indexer, and the previously uncovered `AppendFormatted` overloads (alignment, format, generic `T`, null object/string). Adds an `ICustomFormatter` provider to exercise `AppendCustomFormatter`.

Validation: `dotnet test -c Release` — all 5005 tests pass on `net10.0` and `net481`.