### PR TITLE
Document and adopt Touki.EnumExtensions for flag manipulation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -185,6 +185,11 @@ license to skip the conversation.
 
 - Ensure code is cross-compatible with both .NET 10 and .NET Framework 4.7.2.
 - Check `GlobalUsings.cs` for global usings and don't add unnecessary usings.
+- **Prefer `Touki.EnumExtensions` over hand-written enum bitwise code** in
+  production library code. `AreFlagsSet`, `AreAnyFlagsSet`,
+  `IsOnlyOneFlagSet`, `SetFlags`, `ClearFlags` inline to the same
+  instructions as `&`/`|`/`==` on both TFMs and avoid the `Enum.HasFlag`
+  boxing penalty on net472/net481 (~20&times; faster, zero alloc).
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
   prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,11 @@ license to skip the conversation.
 
 - Ensure code is cross-compatible with both .NET 10 and .NET Framework 4.7.2.
 - Check `GlobalUsings.cs` for global usings and don't add unnecessary usings.
+- **Prefer `Touki.EnumExtensions` over hand-written enum bitwise code** in
+  production library code. `AreFlagsSet`, `AreAnyFlagsSet`,
+  `IsOnlyOneFlagSet`, `SetFlags`, `ClearFlags` inline to the same
+  instructions as `&`/`|`/`==` on both TFMs and avoid the `Enum.HasFlag`
+  boxing penalty on net472/net481 (~20&times; faster, zero alloc).
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
   prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,

--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -114,6 +114,10 @@ internal bool SingleVerticalBorderAdded
 1. Use Pascal Casing to name all types. The only exception is for interop types, which should match the native casing.
 1. Consider [primary constructors](https://learn.microsoft.com/dotnet/csharp/programming-guide/classes-and-structs/instance-constructors#primary-constructors) for "simple" structs and classes where there is only one constructor with no logic other than field assignment.
 
+### Enums
+
+1. Prefer the [`Touki.EnumExtensions`](../touki/Touki/EnumExtensions.cs) helpers (`AreFlagsSet`, `AreAnyFlagsSet`, `IsOnlyOneFlagSet`, `SetFlags`, `ClearFlags`) over hand-written `&`/`|` on flag enums. They inline to the same instructions on both TFMs and avoid `Enum.HasFlag` boxing on net472/net481 (~20&times; faster).
+
 ### Fields
 
 1. Type constants, statics, and fields should be specified at the top within the type declaration.

--- a/touki/Framework/Polyfills/System/SpanExtensions.SplitRanges.cs
+++ b/touki/Framework/Polyfills/System/SpanExtensions.SplitRanges.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Touki;
+
 namespace System;
 
 public static partial class SpanExtensions
@@ -323,7 +325,7 @@ public static partial class SpanExtensions
             }
         }
 
-        if ((options & StringSplitOptions.RemoveEmptyEntries) != 0 && trimmedStart == trimmedEnd)
+        if (options.AreAnyFlagsSet(StringSplitOptions.RemoveEmptyEntries) && trimmedStart == trimmedEnd)
         {
             return false;
         }


### PR DESCRIPTION
Documents the convention to use `Touki.EnumExtensions` for flag enum manipulation and migrates the one production callsite.

## Changes

- **`AGENTS.md`** / **`.github/copilot-instructions.md`** (mirror regenerated): one-bullet guidance under "General guidance" preferring `Touki.EnumExtensions` over hand-written `&`/`|` on flag enums, citing the headline reason (avoids `Enum.HasFlag` boxing on net472/net481, ~20× faster).
- **`docs/coding_guidelines.md`**: new "Enums" rule pointing at the helpers.
- **`touki/Framework/Polyfills/System/SpanExtensions.SplitRanges.cs`**: migrated `(options & StringSplitOptions.RemoveEmptyEntries) != 0` to `options.AreAnyFlagsSet(StringSplitOptions.RemoveEmptyEntries)` and added `using Touki;`. The neighbouring `((int)options & 2) != 0` is intentionally kept — it's a documented workaround for `StringSplitOptions.TrimEntries` not being defined at compile time on the net481 System.Memory package.

This was the **only** production callsite in `touki/`. The library has no `[Flags]` enums of its own; other `&`/`|` matches in the production code are integer bit hackery (mantissa/exponent encodings, length alignment) or `BindingFlags` argument construction for reflection — none are candidates.

## Validation

- `dotnet build -c Release` — both TFMs clean.
- `dotnet test -c Release` — 9838 tests pass on both `net10.0` and `net481`.
- `pwsh tools/Validate-AgentFiles.ps1` — agent-file validation passes.