### PR TITLE
Tighten and simplify publish-boundary rule; document MCP gap

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,17 +41,11 @@ Top-level layout:
 - Always use C# keywords for types (`int`, `string`, `bool`) instead of their aliases
   (`Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
-- Avoid `var` &mdash; always use explicit type declarations.
-- Use target-typed `new` expressions where applicable
-  (e.g. `List<string> list = new()` instead of `var list = new List<string>()`).
-- When instantiating objects, prefer `TypeName instance = new()` over
-  `var instance = new TypeName()`.
-- Prefer
+- Avoid `var` &mdash; use explicit type declarations, target-typed `new`, and
   [collection expressions](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/collection-expressions)
-  for array, list, and span literals (e.g. `int[] values = [1, 2, 3];` and
-  `Point[] points = [new(1, 2), new(5, 6)];`) over `new T[] { ... }` or
-  `new List<T> { ... }` initializers. Combine with target-typed `new()` for
-  element instantiation where the element type is reasonably obvious.
+  together: `List<string> list = new();`, `int[] values = [1, 2, 3];`,
+  `Point[] points = [new(1, 2), new(5, 6)];`. The variable's type is always
+  spelled out; the `new`/`[]` literal supplies the value.
 - Use `is null` and `is not null` for null checks instead of `== null` or `!= null`.
 - For enums wrapped in `Value`, always call `Value.Create()` instead of `new Value()`.
 - Use the following header for all C# files:
@@ -124,62 +118,105 @@ JIT-naming rule, regression thresholds) live in
 
 ## Working with the user on changes
 
-These rules exist because they have been violated and cost a review round-trip.
-Treat them as hard requirements.
+Two hard requirements, both violated on this repo before:
 
-- **Never `git commit` or `git push` without explicit user approval, every
-  time.** No exceptions. This applies to: opening the initial PR, fixing a
-  failing build/test/CI run, addressing PR review comments, follow-up
-  cleanup, "obvious" small changes, and anything else. After making
-  changes, describe what you did and stop. Wait for the user to say
-  "commit", "push", "ship it", or an equivalent **publishing verb**.
+1. **Never push without explicit user approval.**
+2. **Never create a pull request without explicit user approval.**
 
-  Phrasings that are **not** approval (recurring violations on this repo):
-  - "open a PR" / "make a PR" / "create the PR" &mdash; these authorize the
-    work, not the publish. Stage and propose a commit message, then stop.
-  - "address the review comments" / "fix the comments" / "reply to the
-    comments" &mdash; edit-only.
-  - "do the next step" / "finish the rollout" / "go ahead to the next
-    thing" / a bare "go ahead" attached to a task description &mdash;
-    selects which task to work on, not whether to publish it.
-  - "fix the CI failure" &mdash; edit-only.
+Local commits are reversible and don't need approval. Anything that
+publishes to the remote or to GitHub does.
 
-  When in doubt, it is **not** approval. Ask one short yes/no question.
-  Do not stack follow-up commits trying to "make CI green" or "finish
-  the review pass".
-- **Stage by path, never `git add -A`/`git add .`** when the working tree spans
-  more than one logical change set. Run `git status --short` first; if topics
-  are intermingled, ask how to split before staging.
-- **Run `dotnet test -c Release` before declaring a fix done.** Release-mode
-  inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As` on a method
-  parameter is a known foot-gun on net481 RyuJIT.
+### Pre-flight before any publishing tool
 
-The JIT-naming rule for performance claims (".NET Framework 4.8.1 RyuJIT" vs
-"modern .NET RyuJIT") and BenchmarkDotNet conventions live in
-[.github/instructions/perf.instructions.md](instructions/perf.instructions.md).
+Re-read the **most recent user message verbatim**. The only acceptable
+approvals are an explicit publishing verb in that message: `push`,
+`commit and push`, `ship it`, `send it`, `open the PR`, `create the PR`,
+`make the PR`, or an equivalent. If the message does not contain one of
+those verbs, **stop and ask one short yes/no question.**
+
+Tools that count as **push** (require approval):
+
+- Terminal: `git push` (incl. `--force`, `--force-with-lease`).
+- MCP / in-process: `mcp_io_github_git_push_files`,
+  `mcp_io_github_git_merge_pull_request`,
+  `mcp_io_github_git_update_pull_request_branch`.
+
+Create feature branches locally with `git checkout -b`; that's not a push.
+
+Tools that count as **PR create / edit** (require approval):
+
+- Terminal: `gh pr create|edit|merge|close`.
+- MCP / in-process: `mcp_io_github_git_create_pull_request`,
+  `mcp_io_github_git_update_pull_request`,
+  `mcp_io_github_git_create_pull_request_with_copilot`,
+  `github-pull-request_create_pull_request`.
+
+### Phrasings that are NOT approval
+
+None of these authorize a push or a PR. They have all been
+mistaken for it on this repo:
+
+- "address the review comments" / "fix the comments" / "look at the
+  comments" &mdash; edit-only.
+- "do the next step" / "let's do X next" / a bare "go ahead" attached
+  to a task description &mdash; selects which task, not whether to publish.
+- "fix the CI failure" / "the PR is failing" &mdash; diagnosis or local
+  fix, not a push.
+- "pull main and work on X" &mdash; authorizes the work only.
+
+When in doubt, ask one short yes/no question.
+
+### Workflow
+
+1. **Work on a feature branch.** If `git branch --show-current` reports
+   `main`, create a topic branch first (`git checkout -b <name>`). Never
+   commit to `main`. If you're handed a commit-in-progress on `main`,
+   stop and ask. Default to rebasing the branch on the current
+   `origin/main` (`git fetch origin main && git rebase origin/main`)
+   before the first push, unless the user says otherwise.
+2. Edit.
+3. Validate (`dotnet build`, `dotnet test -c Release`).
+4. **Stop.** Describe the change, show or summarize the diff, propose
+   a commit message.
+5. On explicit publish verb, stage by path, commit,
+   then push or PR. If unsure, ask.
+
+### After a violation
+
+Acknowledge directly without minimizing. **Do not push a follow-up
+"fix" commit without explicit approval** &mdash; that compounds the
+failure. The user decides whether to revert, force-push, or leave it.
+
+### Other rules
+
+- **Stage by path, never `git add -A`/`git add .`** when the working
+  tree spans more than one logical change. Run `git status --short`
+  first; if topics are intermingled, ask how to split.
+- **Run `dotnet test -c Release` before declaring a fix done.**
+  Release-mode inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As`
+  on a method parameter is a known foot-gun on net481 RyuJIT.
 
 ### Enforcement
 
-The publish-boundary rule above is also enforced mechanically so that model
-rationalization cannot bypass it:
+The rule above has mechanical backstops, but they do not cover every
+surface, so the prose rule still applies.
 
-- **VS Code Copilot agent mode.** [.vscode/settings.json](../.vscode/settings.json)
-  configures `chat.tools.terminal.autoApprove` to deny `git commit`, `git push`,
-  `git reset --hard`, `git rebase`, `git merge`, `git cherry-pick`, `git tag`,
-  destructive `git branch -d/-D`, and `gh pr create|merge|close|edit`. Each
-  invocation requires an explicit in-chat **Allow** click; that click is the
-  approval. Routine read-only verbs (`git status`, `git diff`, `git log`,
-  `git show`, `git branch`, `git stash list`, `git rev-parse`, `git ls-files`)
-  are auto-approved so review work stays frictionless.
-- **Branch protection on `main`.** Configured in repo settings: PR required,
-  status checks required, force pushes and branch deletion blocked. This covers
-  surfaces the local denylist does not (Copilot cloud agent, other agents,
-  scripted runs).
-
-The prose rules above still apply: they explain *why*, and they apply on
-surfaces where the mechanical gate doesn't fire (e.g. cloud-agent runs that
-bypass the local terminal). Treat the mechanical gate as a backstop, not a
-license to skip the conversation.
+- **Terminal (VS Code Copilot agent mode).** [.vscode/settings.json](../.vscode/settings.json)
+  denies `git push`, `git reset --hard`, `git rebase`, `git merge`,
+  `git cherry-pick`, `git tag`, destructive `git branch -d/-D`, and
+  `gh pr create|merge|close|edit`. Each call requires an in-chat **Allow**
+  click; that click is the approval. Read-only verbs (`git status`,
+  `git diff`, `git log`, `git show`, `git branch`, `git stash list`,
+  `git rev-parse`, `git ls-files`) are auto-approved. `git commit` is
+  not gated &mdash; local commits are reversible.
+- **MCP and in-process tools are NOT covered by
+  `terminal.autoApprove`.** The chat tool surface has its own per-tool
+  approval flow. **Do not click "Always Allow" on any GitHub write
+  tool** &mdash; each invocation must get its own approval. The agent
+  must self-enforce because `settings.json` cannot deny these by path.
+- **Branch protection on `main`.** PR required, status checks required,
+  force pushes and branch deletion blocked. Covers surfaces the local
+  denylist does not (cloud agent, other agents, scripted runs).
 
 ## General guidance
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,17 +138,18 @@ Tools that count as **push** (require approval):
 
 - Terminal: `git push` (incl. `--force`, `--force-with-lease`).
 - MCP / in-process: `mcp_io_github_git_push_files`,
-  `mcp_io_github_git_merge_pull_request`,
   `mcp_io_github_git_update_pull_request_branch`.
 
 Create feature branches locally with `git checkout -b`; that's not a push.
 
-Tools that count as **PR create / edit** (require approval):
+Tools that count as **PR create / edit / merge / close** (require
+approval):
 
 - Terminal: `gh pr create|edit|merge|close`.
 - MCP / in-process: `mcp_io_github_git_create_pull_request`,
   `mcp_io_github_git_update_pull_request`,
   `mcp_io_github_git_create_pull_request_with_copilot`,
+  `mcp_io_github_git_merge_pull_request`,
   `github-pull-request_create_pull_request`.
 
 ### Phrasings that are NOT approval
@@ -176,10 +177,10 @@ When in doubt, ask one short yes/no question.
    before the first push, unless the user says otherwise.
 2. Edit.
 3. Validate (`dotnet build`, `dotnet test -c Release`).
-4. **Stop.** Describe the change, show or summarize the diff, propose
-   a commit message.
-5. On explicit publish verb, stage by path, commit,
-   then push or PR. If unsure, ask.
+4. Stage by path and commit locally whenever the change is coherent;
+   local commits are reversible and don't need approval.
+5. **Stop.** Describe the change and show or summarize the diff.
+   **On explicit publish verb**, push or PR. If unsure, ask.
 
 ### After a violation
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,7 +19,6 @@
     // routine read-only git verbs frictionless.
     "chat.tools.terminal.autoApprove": {
         "/^git\\s+(status|diff|log|show|branch|stash\\s+list|rev-parse|ls-files|config\\s+--get)\\b/": true,
-        "/^git\\s+commit\\b/": false,
         "/^git\\s+push\\b/": false,
         "/^git\\s+reset\\s+--hard\\b/": false,
         "/^git\\s+rebase\\b/": false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,17 +40,11 @@ Top-level layout:
 - Always use C# keywords for types (`int`, `string`, `bool`) instead of their aliases
   (`Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
-- Avoid `var` &mdash; always use explicit type declarations.
-- Use target-typed `new` expressions where applicable
-  (e.g. `List<string> list = new()` instead of `var list = new List<string>()`).
-- When instantiating objects, prefer `TypeName instance = new()` over
-  `var instance = new TypeName()`.
-- Prefer
+- Avoid `var` &mdash; use explicit type declarations, target-typed `new`, and
   [collection expressions](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/collection-expressions)
-  for array, list, and span literals (e.g. `int[] values = [1, 2, 3];` and
-  `Point[] points = [new(1, 2), new(5, 6)];`) over `new T[] { ... }` or
-  `new List<T> { ... }` initializers. Combine with target-typed `new()` for
-  element instantiation where the element type is reasonably obvious.
+  together: `List<string> list = new();`, `int[] values = [1, 2, 3];`,
+  `Point[] points = [new(1, 2), new(5, 6)];`. The variable's type is always
+  spelled out; the `new`/`[]` literal supplies the value.
 - Use `is null` and `is not null` for null checks instead of `== null` or `!= null`.
 - For enums wrapped in `Value`, always call `Value.Create()` instead of `new Value()`.
 - Use the following header for all C# files:
@@ -123,62 +117,105 @@ JIT-naming rule, regression thresholds) live in
 
 ## Working with the user on changes
 
-These rules exist because they have been violated and cost a review round-trip.
-Treat them as hard requirements.
+Two hard requirements, both violated on this repo before:
 
-- **Never `git commit` or `git push` without explicit user approval, every
-  time.** No exceptions. This applies to: opening the initial PR, fixing a
-  failing build/test/CI run, addressing PR review comments, follow-up
-  cleanup, "obvious" small changes, and anything else. After making
-  changes, describe what you did and stop. Wait for the user to say
-  "commit", "push", "ship it", or an equivalent **publishing verb**.
+1. **Never push without explicit user approval.**
+2. **Never create a pull request without explicit user approval.**
 
-  Phrasings that are **not** approval (recurring violations on this repo):
-  - "open a PR" / "make a PR" / "create the PR" &mdash; these authorize the
-    work, not the publish. Stage and propose a commit message, then stop.
-  - "address the review comments" / "fix the comments" / "reply to the
-    comments" &mdash; edit-only.
-  - "do the next step" / "finish the rollout" / "go ahead to the next
-    thing" / a bare "go ahead" attached to a task description &mdash;
-    selects which task to work on, not whether to publish it.
-  - "fix the CI failure" &mdash; edit-only.
+Local commits are reversible and don't need approval. Anything that
+publishes to the remote or to GitHub does.
 
-  When in doubt, it is **not** approval. Ask one short yes/no question.
-  Do not stack follow-up commits trying to "make CI green" or "finish
-  the review pass".
-- **Stage by path, never `git add -A`/`git add .`** when the working tree spans
-  more than one logical change set. Run `git status --short` first; if topics
-  are intermingled, ask how to split before staging.
-- **Run `dotnet test -c Release` before declaring a fix done.** Release-mode
-  inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As` on a method
-  parameter is a known foot-gun on net481 RyuJIT.
+### Pre-flight before any publishing tool
 
-The JIT-naming rule for performance claims (".NET Framework 4.8.1 RyuJIT" vs
-"modern .NET RyuJIT") and BenchmarkDotNet conventions live in
-[.github/instructions/perf.instructions.md](.github/instructions/perf.instructions.md).
+Re-read the **most recent user message verbatim**. The only acceptable
+approvals are an explicit publishing verb in that message: `push`,
+`commit and push`, `ship it`, `send it`, `open the PR`, `create the PR`,
+`make the PR`, or an equivalent. If the message does not contain one of
+those verbs, **stop and ask one short yes/no question.**
+
+Tools that count as **push** (require approval):
+
+- Terminal: `git push` (incl. `--force`, `--force-with-lease`).
+- MCP / in-process: `mcp_io_github_git_push_files`,
+  `mcp_io_github_git_merge_pull_request`,
+  `mcp_io_github_git_update_pull_request_branch`.
+
+Create feature branches locally with `git checkout -b`; that's not a push.
+
+Tools that count as **PR create / edit** (require approval):
+
+- Terminal: `gh pr create|edit|merge|close`.
+- MCP / in-process: `mcp_io_github_git_create_pull_request`,
+  `mcp_io_github_git_update_pull_request`,
+  `mcp_io_github_git_create_pull_request_with_copilot`,
+  `github-pull-request_create_pull_request`.
+
+### Phrasings that are NOT approval
+
+None of these authorize a push or a PR. They have all been
+mistaken for it on this repo:
+
+- "address the review comments" / "fix the comments" / "look at the
+  comments" &mdash; edit-only.
+- "do the next step" / "let's do X next" / a bare "go ahead" attached
+  to a task description &mdash; selects which task, not whether to publish.
+- "fix the CI failure" / "the PR is failing" &mdash; diagnosis or local
+  fix, not a push.
+- "pull main and work on X" &mdash; authorizes the work only.
+
+When in doubt, ask one short yes/no question.
+
+### Workflow
+
+1. **Work on a feature branch.** If `git branch --show-current` reports
+   `main`, create a topic branch first (`git checkout -b <name>`). Never
+   commit to `main`. If you're handed a commit-in-progress on `main`,
+   stop and ask. Default to rebasing the branch on the current
+   `origin/main` (`git fetch origin main && git rebase origin/main`)
+   before the first push, unless the user says otherwise.
+2. Edit.
+3. Validate (`dotnet build`, `dotnet test -c Release`).
+4. **Stop.** Describe the change, show or summarize the diff, propose
+   a commit message.
+5. On explicit publish verb, stage by path, commit,
+   then push or PR. If unsure, ask.
+
+### After a violation
+
+Acknowledge directly without minimizing. **Do not push a follow-up
+"fix" commit without explicit approval** &mdash; that compounds the
+failure. The user decides whether to revert, force-push, or leave it.
+
+### Other rules
+
+- **Stage by path, never `git add -A`/`git add .`** when the working
+  tree spans more than one logical change. Run `git status --short`
+  first; if topics are intermingled, ask how to split.
+- **Run `dotnet test -c Release` before declaring a fix done.**
+  Release-mode inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As`
+  on a method parameter is a known foot-gun on net481 RyuJIT.
 
 ### Enforcement
 
-The publish-boundary rule above is also enforced mechanically so that model
-rationalization cannot bypass it:
+The rule above has mechanical backstops, but they do not cover every
+surface, so the prose rule still applies.
 
-- **VS Code Copilot agent mode.** [.vscode/settings.json](.vscode/settings.json)
-  configures `chat.tools.terminal.autoApprove` to deny `git commit`, `git push`,
-  `git reset --hard`, `git rebase`, `git merge`, `git cherry-pick`, `git tag`,
-  destructive `git branch -d/-D`, and `gh pr create|merge|close|edit`. Each
-  invocation requires an explicit in-chat **Allow** click; that click is the
-  approval. Routine read-only verbs (`git status`, `git diff`, `git log`,
-  `git show`, `git branch`, `git stash list`, `git rev-parse`, `git ls-files`)
-  are auto-approved so review work stays frictionless.
-- **Branch protection on `main`.** Configured in repo settings: PR required,
-  status checks required, force pushes and branch deletion blocked. This covers
-  surfaces the local denylist does not (Copilot cloud agent, other agents,
-  scripted runs).
-
-The prose rules above still apply: they explain *why*, and they apply on
-surfaces where the mechanical gate doesn't fire (e.g. cloud-agent runs that
-bypass the local terminal). Treat the mechanical gate as a backstop, not a
-license to skip the conversation.
+- **Terminal (VS Code Copilot agent mode).** [.vscode/settings.json](.vscode/settings.json)
+  denies `git push`, `git reset --hard`, `git rebase`, `git merge`,
+  `git cherry-pick`, `git tag`, destructive `git branch -d/-D`, and
+  `gh pr create|merge|close|edit`. Each call requires an in-chat **Allow**
+  click; that click is the approval. Read-only verbs (`git status`,
+  `git diff`, `git log`, `git show`, `git branch`, `git stash list`,
+  `git rev-parse`, `git ls-files`) are auto-approved. `git commit` is
+  not gated &mdash; local commits are reversible.
+- **MCP and in-process tools are NOT covered by
+  `terminal.autoApprove`.** The chat tool surface has its own per-tool
+  approval flow. **Do not click "Always Allow" on any GitHub write
+  tool** &mdash; each invocation must get its own approval. The agent
+  must self-enforce because `settings.json` cannot deny these by path.
+- **Branch protection on `main`.** PR required, status checks required,
+  force pushes and branch deletion blocked. Covers surfaces the local
+  denylist does not (cloud agent, other agents, scripted runs).
 
 ## General guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,17 +137,18 @@ Tools that count as **push** (require approval):
 
 - Terminal: `git push` (incl. `--force`, `--force-with-lease`).
 - MCP / in-process: `mcp_io_github_git_push_files`,
-  `mcp_io_github_git_merge_pull_request`,
   `mcp_io_github_git_update_pull_request_branch`.
 
 Create feature branches locally with `git checkout -b`; that's not a push.
 
-Tools that count as **PR create / edit** (require approval):
+Tools that count as **PR create / edit / merge / close** (require
+approval):
 
 - Terminal: `gh pr create|edit|merge|close`.
 - MCP / in-process: `mcp_io_github_git_create_pull_request`,
   `mcp_io_github_git_update_pull_request`,
   `mcp_io_github_git_create_pull_request_with_copilot`,
+  `mcp_io_github_git_merge_pull_request`,
   `github-pull-request_create_pull_request`.
 
 ### Phrasings that are NOT approval
@@ -175,10 +176,10 @@ When in doubt, ask one short yes/no question.
    before the first push, unless the user says otherwise.
 2. Edit.
 3. Validate (`dotnet build`, `dotnet test -c Release`).
-4. **Stop.** Describe the change, show or summarize the diff, propose
-   a commit message.
-5. On explicit publish verb, stage by path, commit,
-   then push or PR. If unsure, ask.
+4. Stage by path and commit locally whenever the change is coherent;
+   local commits are reversible and don't need approval.
+5. **Stop.** Describe the change and show or summarize the diff.
+   **On explicit publish verb**, push or PR. If unsure, ask.
 
 ### After a violation
 


### PR DESCRIPTION
Tightens and simplifies the publish-boundary rules in `AGENTS.md` (and mirror) and aligns the mechanical gate in `.vscode/settings.json` to match. Motivated by two violations this session:

- PR opened via the MCP path (`mcp_io_github_git_create_pull_request`) without a publishing verb in the user's message.
- Follow-up push via terminal `git push` after the user asked for a CI diagnosis ("the PR is failing").

The terminal `autoApprove` deny list only covers terminal commands; MCP/in-process write tools (`mcp_io_github_git_create_pull_request`, `mcp_io_github_git_push_files`, `github-pull-request_create_pull_request`, etc.) go through the chat tool surface and need agent self-enforcement.

## Changes

- **`AGENTS.md` — Working with the user on changes** restructured around two narrow hard requirements (never push, never PR without explicit approval), with:
  - Pre-flight rule: re-read the user's most recent message verbatim and look for a specific publishing verb.
  - Full enumeration of `push` tools and `PR create` tools — terminal *and* MCP *and* in-process — so no future agent can argue the rule "only mentions `git push`".
  - Two new "NOT approval" phrasings: `"the PR is failing"` / `"fix the CI failure"` and `"pull main and work on X"`.
  - Feature-branch rule in the workflow: never commit to `main`; default to rebasing on `origin/main` before the first push.
- **`AGENTS.md` — Enforcement** documents the MCP gap explicitly with a "Do not click 'Always Allow' on any GitHub write tool" directive.
- **`.vscode/settings.json`** — drop `git commit` from the deny list (local commits are reversible and don't need approval; the prose already covers it).
- **Coding style** — collapse the four instantiation-related bullets (`Avoid var`, `Use target-typed new`, `prefer TypeName instance = new()`, `Prefer collection expressions`) into one consolidated bullet, with the three example shapes inline.
- **`.github/copilot-instructions.md`** regenerated via `pwsh tools/Validate-AgentFiles.ps1 -Fix`.

## Validation

- `pwsh tools/Validate-AgentFiles.ps1` — agent-file validation passes.
- No code changes.