### PR TITLE
Coverage: exclude generator output by source path instead of [GeneratedCode]

### DIFF
--- a/.config/coverage.settings.xml
+++ b/.config/coverage.settings.xml
@@ -14,11 +14,21 @@
     <Attributes>
       <Exclude>
         <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
-        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <!--
+          GeneratedCodeAttribute is intentionally NOT excluded here. The BCL coverage collector
+          applies attribute filters per-member, so excluding it hides the user-authored half of
+          any partial type whose generated half stamps [GeneratedCode] on every member
+          (e.g. CsWin32 partials like HRESULT, BSTR, PWSTR). Generator output is excluded by
+          source path below instead.
+        -->
       </Exclude>
     </Attributes>
     <Sources>
       <Exclude>
+        <!-- Anything written under an obj/ tree (build intermediates including generator output). -->
+        <Source>.*[\\/]obj[\\/].*</Source>
+        <!-- Roslyn source-generator output convention. -->
+        <Source>.*\.g\.cs$</Source>
         <!-- Auto-generated string resource accessors from Microsoft.CodeAnalysis.ResxSourceGenerator. -->
         <Source>.*[\\/]SR\.Designer\.cs$</Source>
         <Source>.*[\\/]SRF\.Designer\.cs$</Source>


### PR DESCRIPTION
Mirrors the fix from [madowaku#8](https://github.com/JeremyKuhne/madowaku/pull/8).

## Problem

`.config/coverage.settings.xml` was excluding `System.CodeDom.Compiler.GeneratedCodeAttribute` under `<Attributes><Exclude>`. The Microsoft.CodeCoverage collector applies attribute filters **per member**, so when a partial type's generator-emitted half stamps `[GeneratedCode]` on every member, the user-authored half of the same type silently disappears from coverage too.

In madowaku this hid the entire user-authored API surface over CsWin32 partials (`BSTR`, `HRESULT`, `FILETIME`, `PWSTR`, `VARIANT`, ...).

## Status in touki

touki doesn't currently author partials over CsWin32 types, so this fix changes no numbers today (line coverage stays at 93.0%, branch at 87.7% locally). The point is to remove the latent foot-gun before it bites — `HResultException` and friends are plausible places to grow such partials.

## Change

Drop the `GeneratedCodeAttribute` attribute exclude. Replace it with source-path excludes that catch generator output explicitly:

- `**/obj/**` — build intermediates, including generator output
- `*.g.cs` — Roslyn source-generator convention
- Existing `SR.Designer.cs` / `SRF.Designer.cs` excludes are kept

A comment in the file documents why `GeneratedCodeAttribute` is intentionally not excluded.

`ExcludeFromCodeCoverageAttribute` remains as the single intentional opt-out path.
