### PR TITLE
Repo hygiene: ignore *.lscache and restore 80% patch coverage gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,8 @@ _pkginfo.txt
 *.[Cc]ache
 # but keep track of directories ending in .cache
 !?*.[Cc]ache/
+# Language service cache files
+*.lscache
 
 # Others
 ClientBin/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,6 @@
 # Codecov configuration. Initial gates after a stable baseline has been confirmed:
 #   - project: auto target with a 1% threshold (tolerate small drops on noisy PRs)
-#   - patch:   60% of changed lines must be covered. The 80% bar was tightened
-#              prematurely; PRs that introduce Win32 / native-interop shims with
-#              dense defensive failure paths cannot reasonably hit it without
-#              fault-injection harnesses. Revisit once such code is stabilised.
+#   - patch:   80% of changed lines must be covered.
 #
 # Both statuses are now blocking (informational removed). Adjust here when the
 # floor needs to be ratcheted up or down.
@@ -21,7 +18,7 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: 60%
+        target: 80%
         threshold: 0%
 
 comment:


### PR DESCRIPTION
Two small repo-hygiene tweaks.

## .gitignore

Add `*.lscache` (language-service cache files emitted by tooling — `touki/touki.csproj.lscache`, `sample/sample.csproj.lscache`, etc.) to the Visual Studio cache section. No matching files are currently tracked, so this is purely preventative.

## codecov.yml

Restore the patch-coverage target from 60% back to 80% and remove the stale rationale comment that referenced a temporary relaxation for Win32 / native-interop work.

Project status unchanged (`auto` target with a 1% threshold).
