### PR TITLE
ci: split Windows build into Debug/Release matrix

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,10 +21,11 @@ concurrency:
 jobs:
   # The Windows build runs Debug and Release on two parallel runners.
   # Coverage, pack, and Codecov are Release-only and gated by `matrix.configuration`.
-  # The `build` aggregator below depends on both legs and keeps the
-  # `.NET / build` status-check name stable for branch protection.
+  # The `build` aggregator below depends on this matrix plus the macOS and
+  # Linux jobs and keeps the `.NET / build` status-check name stable for
+  # branch protection.
   build-matrix:
-    name: ".NET / build (${{ matrix.configuration }})"
+    name: ".NET / build (Windows / ${{ matrix.configuration }})"
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -141,26 +142,38 @@ jobs:
         retention-days: 14
 
   # Aggregator: preserves the `.NET / build` status-check name so branch
-  # protection on `main` doesn't have to be updated. `needs.build-matrix.result`
-  # is `success` only when every matrix leg succeeded; any other state fails
-  # the aggregator and (transitively) the required check.
+  # protection on `main` doesn't have to be updated. `needs.<job>.result` is
+  # `success` only when every upstream job (and every matrix leg of
+  # `build-matrix`) succeeded; any other state fails the aggregator and
+  # (transitively) the required check.
   build:
     name: ".NET / build"
     runs-on: ubuntu-latest
-    needs: build-matrix
+    needs: [build-matrix, macos-build, linux-build]
     if: always()
     steps:
-    - name: Verify matrix legs
+    - name: Verify upstream jobs
       run: |
-        result='${{ needs.build-matrix.result }}'
-        echo "build-matrix result: $result"
-        if [ "$result" != "success" ]; then
-          echo "::error::One or more build-matrix legs did not succeed (result: $result)."
+        results=(
+          "build-matrix=${{ needs.build-matrix.result }}"
+          "macos-build=${{ needs.macos-build.result }}"
+          "linux-build=${{ needs.linux-build.result }}"
+        )
+        failed=0
+        for r in "${results[@]}"; do
+          echo "$r"
+          case "$r" in
+            *=success) ;;
+            *) failed=1 ;;
+          esac
+        done
+        if [ "$failed" -ne 0 ]; then
+          echo "::error::One or more upstream jobs did not succeed."
           exit 1
         fi
 
   macos-build:
-    name: ".NET / macos"
+    name: ".NET / build (macOS / Release)"
     runs-on: macos-latest
 
     # The repo pins Platform=x64 in Directory.Build.props for the Windows-focused
@@ -211,7 +224,7 @@ jobs:
         retention-days: 14
 
   linux-build:
-    name: ".NET / linux"
+    name: ".NET / build (Linux / Release)"
     runs-on: ubuntu-latest
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,9 +19,17 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: ".NET / build"
+  # The Windows build runs Debug and Release on two parallel runners.
+  # Coverage, pack, and Codecov are Release-only and gated by `matrix.configuration`.
+  # The `build` aggregator below depends on both legs and keeps the
+  # `.NET / build` status-check name stable for branch protection.
+  build-matrix:
+    name: ".NET / build (${{ matrix.configuration }})"
     runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Release]
     env:
       # Co-locate the NuGet cache inside the workspace so actions/cache can
       # restore/save it reliably on every OS, avoiding ~/.nuget path quirks
@@ -43,38 +51,36 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
-    - name: Build release
-      run: dotnet build --configuration Release --no-restore
-    - name: Pack (release)
+      run: dotnet build --configuration ${{ matrix.configuration }} --no-restore
+    - name: Pack
+      if: matrix.configuration == 'Release'
       run: dotnet pack --configuration Release --no-build -o ./artifacts/packages
     - name: Test
       run: |
-        $resultsDir = Join-Path $PWD.Path 'artifacts/test-results/debug'
+        $configuration = '${{ matrix.configuration }}'
+        $resultsDir = Join-Path $PWD.Path "artifacts/test-results/$($configuration.ToLower())"
         New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 
-        dotnet test --no-build `
-          -p:TestingPlatformCaptureOutput=false `
-          -- `
-          --results-directory "$resultsDir" `
-          --report-xunit-trx `
-          --show-live-output on
-    - name: Test release
-      run: |
-        $resultsDir = Join-Path $PWD.Path 'artifacts/test-results/release'
-        New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+        # MTP args appended only on Release: coverage instrumentation slows tests
+        # and Codecov only consumes the Release run.
+        $extraArgs = @()
+        if ($configuration -eq 'Release') {
+          $extraArgs = @(
+            '--coverage',
+            '--coverage-output-format', 'cobertura',
+            '--coverage-settings', "$PWD/.config/coverage.settings.xml"
+          )
+        }
 
-        dotnet test -c Release --no-build `
+        dotnet test -c $configuration --no-build `
           -p:TestingPlatformCaptureOutput=false `
           -- `
           --results-directory "$resultsDir" `
           --report-xunit-trx `
           --show-live-output on `
-          --coverage `
-          --coverage-output-format cobertura `
-          --coverage-settings "$PWD/.config/coverage.settings.xml"
+          @extraArgs
     - name: Generate coverage report
-      if: always()
+      if: always() && matrix.configuration == 'Release'
       run: |
         $reportGeneratorVersion = '5.5.9'
         if (dotnet tool list -g | Select-String -SimpleMatch 'dotnet-reportgenerator-globaltool') {
@@ -109,7 +115,7 @@ jobs:
             Add-Content -Path $env:GITHUB_STEP_SUMMARY
         }
     - name: Upload coverage report
-      if: always()
+      if: always() && matrix.configuration == 'Release'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
@@ -117,7 +123,7 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
     - name: Upload coverage to Codecov
-      if: always()
+      if: always() && matrix.configuration == 'Release'
       uses: codecov/codecov-action@v5
       with:
         files: artifacts/coverage/Cobertura.xml
@@ -128,11 +134,30 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: mtp-logs
+        name: mtp-logs-${{ matrix.configuration }}
         path: |
           artifacts/test-results/**/*.trx
         if-no-files-found: warn
         retention-days: 14
+
+  # Aggregator: preserves the `.NET / build` status-check name so branch
+  # protection on `main` doesn't have to be updated. `needs.build-matrix.result`
+  # is `success` only when every matrix leg succeeded; any other state fails
+  # the aggregator and (transitively) the required check.
+  build:
+    name: ".NET / build"
+    runs-on: ubuntu-latest
+    needs: build-matrix
+    if: always()
+    steps:
+    - name: Verify matrix legs
+      run: |
+        result='${{ needs.build-matrix.result }}'
+        echo "build-matrix result: $result"
+        if [ "$result" != "success" ]; then
+          echo "::error::One or more build-matrix legs did not succeed (result: $result)."
+          exit 1
+        fi
 
   macos-build:
     name: ".NET / macos"


### PR DESCRIPTION
Follow-up to #150. Splits the Windows `build` job into two parallel runs, renames every build/test leg to make OS + configuration explicit, and adds an aggregator that preserves the existing required-check name.

## Job name changes

| Job ID | Before this PR | After this PR |
| --- | --- | --- |
| `build-matrix` (Debug) | `.NET / build` (sequential) | `.NET / build (Windows / Debug)` |
| `build-matrix` (Release) | `.NET / build` (sequential) | `.NET / build (Windows / Release)` |
| `macos-build` | `.NET / macos` | `.NET / build (macOS / Release)` |
| `linux-build` | `.NET / linux` | `.NET / build (Linux / Release)` |
| `build` (aggregator) | &mdash; | `.NET / build` |

## Windows: Debug / Release matrix

`build` is replaced by **`build-matrix`** &mdash; the same job, but with `strategy.matrix.configuration: [Debug, Release]`. The two legs run on independent `windows-latest` runners.

Release-only steps are gated by `matrix.configuration`:

| Step | Debug | Release |
| --- | --- | --- |
| `dotnet build` | &#x2713; | &#x2713; |
| `dotnet pack` | &mdash; | &#x2713; |
| `dotnet test` | &#x2713; | &#x2713; |
| `--coverage` / `--coverage-output-format` / `--coverage-settings` | &mdash; | &#x2713; |
| Generate coverage report (ReportGenerator) | &mdash; | &#x2713; |
| Upload coverage artifact | &mdash; | &#x2713; |
| Upload to Codecov | &mdash; | &#x2713; |
| Upload raw `*.trx` logs | &#x2713; | &#x2713; |

The coverage / Codecov gates are `if: always() && matrix.configuration == 'Release'` so failures earlier in the Release leg still upload whatever coverage was produced (matching the prior behavior of `if: always()`).

In the test step, the conditional `--coverage*` MTP args are accumulated into a pwsh array and passed via splat:

```pwsh
$extraArgs = @()
if ($configuration -eq 'Release') {
  $extraArgs = @('--coverage', '--coverage-output-format', 'cobertura', '--coverage-settings', "$PWD/.config/coverage.settings.xml")
}

dotnet test -c $configuration --no-build ` ... ` @extraArgs
```

Empty splat on Debug expands to zero arguments.

## Aggregator job: `build`

A small `ubuntu-latest` job named `.NET / build` that depends on **all three** upstream jobs:

```yaml
build:
  name: ".NET / build"
  runs-on: ubuntu-latest
  needs: [build-matrix, macos-build, linux-build]
  if: always()
  steps:
  - name: Verify upstream jobs
    run: |
      results=(
        "build-matrix=${{ needs.build-matrix.result }}"
        "macos-build=${{ needs.macos-build.result }}"
        "linux-build=${{ needs.linux-build.result }}"
      )
      failed=0
      for r in "${results[@]}"; do
        echo "$r"
        case "$r" in
          *=success) ;;
          *) failed=1 ;;
        esac
      done
      if [ "$failed" -ne 0 ]; then
        echo "::error::One or more upstream jobs did not succeed."
        exit 1
      fi
```

`needs.<job>.result` for a matrix job is the highest-priority leg outcome (`failure > cancelled > success > skipped`), so the aggregator is green only when every upstream job (and every matrix leg of `build-matrix`) is green.

## Branch-protection impact

The current required checks on `main` likely include `.NET / build`, `.NET / macos`, and `.NET / linux`. After this PR merges:

- `.NET / build` continues to work &mdash; the aggregator job now provides it, and covers Windows + macOS + Linux.
- `.NET / macos` and `.NET / linux` will be stale check names; the PR check page will report them as never reported. **They should be removed from branch protection** (or just rely on `.NET / build` for everything since the aggregator now covers them).

This change is intentional &mdash; the goal is to make the required check surface simple: one check (`.NET / build`) gates everything.

## Artifact naming

- `coverage-report` &mdash; unchanged (Release-only writer).
- `mtp-logs` &rarr; `mtp-logs-Debug` and `mtp-logs-Release`. `actions/upload-artifact@v4` requires unique names within a workflow run, so each matrix leg gets its own.

I checked the repo for references to the old `mtp-logs` artifact name and found none, but if anything outside the repo consumes it the new names will need to be picked up.

## Validation caveats

The pwsh splat (`@extraArgs` at the tail of a backtick-continued `dotnet test`) is the only piece not validated locally. Behavior is well documented and an empty array splats to no arguments, but the first CI run on this PR is what proves it. If the Debug leg fails on the test step it will be a single-line fix.

## Out of scope

- macOS / Linux jobs unchanged structurally (still single-config, Release).
- `publish.yml` not changed.