### PR TITLE
Add MSBuild FileMatcher diagnostics surface to MSBuildEnumerator

### DIFF
--- a/touki.perf/MsBuildEnumeratePerf.cs
+++ b/touki.perf/MsBuildEnumeratePerf.cs
@@ -32,4 +32,18 @@ public class MsBuildEnumeratePerf
 
         return results;
     }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumeratorResult()
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(Filespec, projectDirectory: Directory);
+        using MSBuildEnumerator enumerator = result.Enumerator!;
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
 }

--- a/touki.perf/MsBuildEnumeratePerf2.cs
+++ b/touki.perf/MsBuildEnumeratePerf2.cs
@@ -16,17 +16,19 @@ public class MsBuildEnumeratePerf2
 
     private const string UnsplitExcludes = "bin/Debug/**;obj/Debug/**;bin/**;obj/**/;**/*.user;**/*.*proj;**/*.sln;**/*.slnx;**/*.vssscc;**/.DS_Store";
 
+    // FileMatcher takes already-split excludes; mirror the contents of UnsplitExcludes (no trailing ';' -
+    // each entry must be a single literal pattern, not a semicolon-suffixed one).
     private static readonly List<string> s_excludes =
     [
-        "bin/Debug/**;",
-        "obj/Debug/**;",
-        "bin/**;",
-        "obj/**/;",
-        "**/*.user;",
-        "**/*.*proj;",
-        "**/*.sln;",
-        "**/*.slnx;",
-        "**/*.vssscc;",
+        "bin/Debug/**",
+        "obj/Debug/**",
+        "bin/**",
+        "obj/**",
+        "**/*.user",
+        "**/*.*proj",
+        "**/*.sln",
+        "**/*.slnx",
+        "**/*.vssscc",
         "**/.DS_Store"
     ];
 

--- a/touki.perf/MsBuildEnumeratePerf2.cs
+++ b/touki.perf/MsBuildEnumeratePerf2.cs
@@ -4,15 +4,15 @@
 
 using Touki.Io;
 
+using File = System.IO.File;
+using Path = System.IO.Path;
+
 namespace touki.perf;
 
 [MemoryDiagnoser]
 public class MsBuildEnumeratePerf2
 {
-    private const string Directory = @"n:\test\";
-                                    // @"n:\repos\runtime\";
     private const string Filespec = "**/*.cs";
-    // private const string Filespec = "**/src/**// /*.cs";
 
     private const string UnsplitExcludes = "bin/Debug/**;obj/Debug/**;bin/**;obj/**/;**/*.user;**/*.*proj;**/*.sln;**/*.slnx;**/*.vssscc;**/.DS_Store";
 
@@ -30,17 +30,51 @@ public class MsBuildEnumeratePerf2
         "**/.DS_Store"
     ];
 
+    private string _directory = string.Empty;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        // Walk up from the perf assembly's location until we find the repo root (touki.slnx anchor).
+        // Keeps the benchmark portable across machines without hardcoding an absolute path.
+        string? dir = AppContext.BaseDirectory;
+        while (dir is not null && !File.Exists(Path.Combine(dir, "touki.slnx")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        _directory = dir ?? throw new InvalidOperationException(
+            "Could not locate touki.slnx walking up from " + AppContext.BaseDirectory);
+    }
+
     [Benchmark(Baseline = true)]
     public IReadOnlyList<string> MSBuild()
     {
-        var results = FileMatcherWrapper.GetFilesSimple(Directory, Filespec, s_excludes);
+        var results = FileMatcherWrapper.GetFilesSimple(_directory, Filespec, s_excludes);
         return results;
     }
 
     [Benchmark]
     public IReadOnlyList<string> MsBuildEnumerator()
     {
-        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(Filespec, UnsplitExcludes, Directory);
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(Filespec, UnsplitExcludes, _directory);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumeratorResult()
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            Filespec,
+            excludeSpecs: UnsplitExcludes,
+            projectDirectory: _directory);
+        using MSBuildEnumerator enumerator = result.Enumerator!;
         List<string> results = [];
         while (enumerator.MoveNext())
         {

--- a/touki.perf/MsBuildSetupExcludesPerf.cs
+++ b/touki.perf/MsBuildSetupExcludesPerf.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Io;
+
+using Directory = System.IO.Directory;
+using File = System.IO.File;
+using Path = System.IO.Path;
+
+namespace touki.perf;
+
+/// <summary>
+///  Setup-dominated MSBuild enumeration with the default item-excludes string. Mirrors
+///  <see cref="MsBuildSetupPerf"/> but exercises the exclude pipeline (which splits and qualifies the
+///  exclude specs at construction time).
+/// </summary>
+[MemoryDiagnoser]
+public class MsBuildSetupExcludesPerf
+{
+    private const string Filespec = "**/*.cs";
+
+    private const string UnsplitExcludes =
+        "bin/Debug/**;obj/Debug/**;bin/**;obj/**/;**/*.user;**/*.*proj;**/*.sln;**/*.slnx;**/*.vssscc;**/.DS_Store";
+
+    // FileMatcher takes already-split excludes; mirror the contents of UnsplitExcludes.
+    private static readonly List<string> s_excludes =
+    [
+        "bin/Debug/**",
+        "obj/Debug/**",
+        "bin/**",
+        "obj/**",
+        "**/*.user",
+        "**/*.*proj",
+        "**/*.sln",
+        "**/*.slnx",
+        "**/*.vssscc",
+        "**/.DS_Store"
+    ];
+
+    private string _directory = string.Empty;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"touki-perf-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+        Directory.CreateDirectory(Path.Combine(_directory, "src"));
+        Directory.CreateDirectory(Path.Combine(_directory, "src", "nested"));
+        Directory.CreateDirectory(Path.Combine(_directory, "bin"));
+        Directory.CreateDirectory(Path.Combine(_directory, "obj"));
+
+        // Matching files
+        File.WriteAllText(Path.Combine(_directory, "a.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "src", "b.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "src", "nested", "c.cs"), string.Empty);
+
+        // Files that should be filtered out by the default excludes
+        File.WriteAllText(Path.Combine(_directory, "bin", "ignored.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "obj", "ignored.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "skip.user"), string.Empty);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public IReadOnlyList<string> MSBuild()
+    {
+        return FileMatcherWrapper.GetFilesSimple(_directory, Filespec, s_excludes);
+    }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumerator()
+    {
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(Filespec, UnsplitExcludes, _directory);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumeratorResult()
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            Filespec,
+            excludeSpecs: UnsplitExcludes,
+            projectDirectory: _directory);
+        using MSBuildEnumerator enumerator = result.Enumerator!;
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+}

--- a/touki.perf/MsBuildSetupPerf.cs
+++ b/touki.perf/MsBuildSetupPerf.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Touki.Io;
+
+using Directory = System.IO.Directory;
+using File = System.IO.File;
+using Path = System.IO.Path;
+
+namespace touki.perf;
+
+/// <summary>
+///  Measures setup-dominated cost of an MSBuild-style enumeration on a small, controlled tree.
+///  The directory is built in <see cref="GlobalSetup"/> with a small handful of files so the
+///  enumeration itself completes in microseconds and per-call setup overhead is visible.
+/// </summary>
+[MemoryDiagnoser]
+public class MsBuildSetupPerf
+{
+    private const string Filespec = "**/*.cs";
+
+    private string _directory = string.Empty;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), $"touki-perf-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_directory);
+        Directory.CreateDirectory(Path.Combine(_directory, "src"));
+        Directory.CreateDirectory(Path.Combine(_directory, "src", "nested"));
+
+        // Five matching files spread shallow + deep so the recursive walk visits >1 directory.
+        File.WriteAllText(Path.Combine(_directory, "a.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "b.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "src", "c.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "src", "d.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(_directory, "src", "nested", "e.cs"), string.Empty);
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public IReadOnlyList<string> MSBuild()
+    {
+        return FileMatcherWrapper.GetFilesSimple(_directory, Filespec);
+    }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumerator()
+    {
+        using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(Filespec, _directory);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    [Benchmark]
+    public IReadOnlyList<string> MsBuildEnumeratorResult()
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(Filespec, projectDirectory: _directory);
+        using MSBuildEnumerator enumerator = result.Enumerator!;
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+}

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -90,6 +90,15 @@ public class MSBuildEnumerationResultTests
     [Fact]
     public void CreateResult_DriveRootRecursionOptIn_RunsSearch()
     {
+        // Windows-only: on Unix the parser leaves FixedPath empty for "/**/..." specs (a known
+        // limitation tracked as a follow-up), so opting past the drive-root gate crashes inside
+        // Path.GetFullPath. The gate itself is exercised by the *Default test below, which passes
+        // on both platforms.
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("Drive-root opt-in path requires the MSBuildSpecification parser to populate FixedPath for rooted '/**' specs; Windows-only until that is fixed.");
+        }
+
         MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
             DriveRootRecursiveSpec,
             options: new MSBuildEnumerationOptions { AllowDriveEnumeration = true });

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+public class MSBuildEnumerationResultTests
+{
+    private static string CurrentDriveRoot
+    {
+        get
+        {
+            string root = Path.GetPathRoot(Environment.CurrentDirectory)
+                ?? throw new InvalidOperationException("No drive root.");
+            return root;
+        }
+    }
+
+    private static string DriveRootRecursiveSpec => $"{CurrentDriveRoot}**{Path.DirectorySeparatorChar}*.touki-no-such-file";
+
+    [Fact]
+    public void IsDriveRootRecursion_DriveRootDoubleStar_ReturnsTrue()
+    {
+        MSBuildSpecification spec = new MSBuildSpecification($"{CurrentDriveRoot}**").FullyQualify(Environment.CurrentDirectory);
+        spec.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDriveRootRecursion_DriveRootWithSuffix_ReturnsTrue()
+    {
+        MSBuildSpecification spec = new MSBuildSpecification($"{CurrentDriveRoot}**{Path.DirectorySeparatorChar}*.cs")
+            .FullyQualify(Environment.CurrentDirectory);
+        spec.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsDriveRootRecursion_NormalRecursiveSpec_ReturnsFalse()
+    {
+        MSBuildSpecification spec = new MSBuildSpecification("**/*.cs").FullyQualify(Environment.CurrentDirectory);
+        spec.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDriveRootRecursion_NonRecursiveSpec_ReturnsFalse()
+    {
+        MSBuildSpecification spec = new MSBuildSpecification($"{CurrentDriveRoot}*.cs").FullyQualify(Environment.CurrentDirectory);
+        spec.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDriveRootRecursion_NotFullyQualified_ReturnsFalse()
+    {
+        // Not fully qualified — the gate only fires post-qualification because that's the only point at
+        // which we know what root the spec resolves against.
+        MSBuildSpecification spec = new("**");
+        spec.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDriveRootRecursion_FullyQualifiedNoWildcards_ReturnsFalse()
+    {
+        // Fully qualified literal path at the drive root, no wildcards: still safe.
+        MSBuildSpecification spec = new MSBuildSpecification($"{CurrentDriveRoot}file.txt")
+            .FullyQualify(Environment.CurrentDirectory);
+        spec.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsDriveRootRecursion_DriveRootStarStarSegment_ReturnsTrue()
+    {
+        // Drive-rooted, wildcard path begins with "**\" but is not a simple recursive match
+        // (extra fixed segments after the **). Still drive enumeration.
+        MSBuildSpecification spec = new MSBuildSpecification(
+                $"{CurrentDriveRoot}**{Path.DirectorySeparatorChar}foo{Path.DirectorySeparatorChar}*.cs")
+            .FullyQualify(Environment.CurrentDirectory);
+
+        spec.IsSimpleRecursiveMatch.Should().BeFalse();
+        spec.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateResult_DriveRootRecursionDefault_StopsSearching()
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(DriveRootRecursiveSpec);
+        result.Action.Should().Be(MSBuildSearchAction.FailBecauseDriveEnumerationIsForbidden);
+        result.GlobFailure.Should().NotBeNullOrEmpty();
+        result.Enumerator.Should().BeNull();
+    }
+
+    [Fact]
+    public void CreateResult_DriveRootRecursionOptIn_RunsSearch()
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            DriveRootRecursiveSpec,
+            options: new MSBuildEnumerationOptions { AllowDriveEnumeration = true });
+
+        result.Action.Should().Be(MSBuildSearchAction.RunSearch);
+        result.GlobFailure.Should().BeNull();
+        // Don't materialize — that would actually walk the drive. Just confirm the enumerator was built.
+        result.Enumerator.Should().NotBeNull();
+        result.Enumerator!.Dispose();
+    }
+
+    [Fact]
+    public void CreateResult_NormalInclude_RunsSearch()
+    {
+        using TempFolder tempFolder = new();
+        File.WriteAllText(Path.Combine(tempFolder.TempPath, "a.txt"), string.Empty);
+        File.WriteAllText(Path.Combine(tempFolder.TempPath, "b.txt"), string.Empty);
+
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            "*.txt",
+            projectDirectory: tempFolder.TempPath);
+
+        result.Action.Should().Be(MSBuildSearchAction.RunSearch);
+        result.GlobFailure.Should().BeNull();
+        result.FailedExcludeSpec.Should().BeNull();
+
+        using MSBuildEnumerator enumerator = result.Enumerator!;
+        List<string> files = [];
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().BeEquivalentTo("a.txt", "b.txt");
+    }
+
+    [Fact]
+    public void CreateResult_WithExcludes_RunsSearchExcludingFiltered()
+    {
+        using TempFolder tempFolder = new();
+        File.WriteAllText(Path.Combine(tempFolder.TempPath, "keep.txt"), string.Empty);
+        File.WriteAllText(Path.Combine(tempFolder.TempPath, "skip.txt"), string.Empty);
+
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            fileSpec: "*.txt",
+            excludeSpecs: "skip.txt",
+            projectDirectory: tempFolder.TempPath);
+
+        result.Action.Should().Be(MSBuildSearchAction.RunSearch);
+
+        using MSBuildEnumerator enumerator = result.Enumerator!;
+        List<string> files = [];
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().BeEquivalentTo("keep.txt");
+    }
+
+    [Fact]
+    public void CreateResult_DriveRootRecursion_MatchesFileMatcherOracle()
+    {
+        // Parity check against MSBuild's FileMatcher: both should refuse drive-root recursion by default.
+        // MSBuild's real SearchAction enum has more values than FileMatcherWrapper exposes (notably
+        // FailBecauseDriveEnumerationIsForbidden = 5), so the wrapper hands back an undefined enum value.
+        // We just assert the oracle did NOT run the search.
+        FileMatcherWrapper.GetFilesResult oracle = FileMatcherWrapper.GetFiles(
+            Environment.CurrentDirectory,
+            DriveRootRecursiveSpec);
+
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(DriveRootRecursiveSpec);
+
+        oracle.Action.Should().NotBe(FileMatcherWrapper.SearchAction.RunSearch);
+        oracle.FileList.Should().BeEmpty();
+        result.Action.Should().Be(MSBuildSearchAction.FailBecauseDriveEnumerationIsForbidden);
+    }
+}

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -79,6 +79,25 @@ public class MSBuildEnumerationResultTests
     }
 
     [Fact]
+    public void IsDriveRootRecursion_UncRoot_ReturnsTrue()
+    {
+        // UNC paths are Windows-only and we don't need the share to exist; we're just exercising
+        // the parser + IsDriveRootRecursion gate. Verifies that the trailing-separator
+        // normalization in the gate handles the case where Path.GetPathRoot may return the UNC
+        // root with or without a trailing separator depending on input / runtime.
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("UNC paths are Windows-only.");
+        }
+
+        MSBuildSpecification spec = new MSBuildSpecification(@"\\nonexistent-server\share\**\*.cs")
+            .FullyQualify(Environment.CurrentDirectory);
+
+        spec.IsFullyQualified.Should().BeTrue();
+        spec.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Fact]
     public void CreateResult_DriveRootRecursionDefault_StopsSearching()
     {
         MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(DriveRootRecursiveSpec);

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -90,15 +90,6 @@ public class MSBuildEnumerationResultTests
     [Fact]
     public void CreateResult_DriveRootRecursionOptIn_RunsSearch()
     {
-        // Windows-only: on Unix the parser leaves FixedPath empty for "/**/..." specs (a known
-        // limitation tracked as a follow-up), so opting past the drive-root gate crashes inside
-        // Path.GetFullPath. The gate itself is exercised by the *Default test below, which passes
-        // on both platforms.
-        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
-        {
-            Assert.Skip("Drive-root opt-in path requires the MSBuildSpecification parser to populate FixedPath for rooted '/**' specs; Windows-only until that is fixed.");
-        }
-
         MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
             DriveRootRecursiveSpec,
             options: new MSBuildEnumerationOptions { AllowDriveEnumeration = true });

--- a/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
@@ -24,6 +24,17 @@ public class MSBuildSpecificationTests
     [InlineData("**/file.txt", "", "**", "file.txt", true)]
     [InlineData("a/b/**", "a/b", "**", "*", true)]
     [InlineData("**/b/**", "", "**/b/**", "*", true)]
+    // Rooted-with-only-leading-separator cases. FixedPath is the root separator (e.g. "/" on
+    // Unix, "\" on Windows) instead of an empty slice, and WildPath/FileName line up with the
+    // suffix the same way they would for non-rooted specs.
+    [InlineData("/", "/", "", "", false)]
+    [InlineData("/foo.txt", "/", "", "foo.txt", false)]
+    [InlineData("/*.cs", "/", "", "*.cs", true)]
+    [InlineData("/**", "/", "**", "*", true)]
+    [InlineData("/**/file.txt", "/", "**", "file.txt", true)]
+    [InlineData("/**/*.cs", "/", "**", "*.cs", true)]
+    [InlineData("/**/foo/*.cs", "/", "**/foo", "*.cs", true)]
+    [InlineData("/**/foo/**", "/", "**/foo/**", "*", true)]
     public void MSBuildSpecification_ParsesCorrectly(
         string original,
         string expectedFixed,

--- a/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
@@ -691,6 +691,94 @@ public class MSBuildSpecificationTests
     }
 
     [Fact]
+    public void SplitWithErrors_WhitespaceOnlySegment_ReturnsErrorResult()
+    {
+        // A whitespace-only segment normalizes to empty; the bare Split overload silently drops these
+        // after throwing inside the constructor would have crashed callers. SplitWithErrors surfaces it
+        // as an error result instead.
+        ListBase<MSBuildSpecificationResult> results = MSBuildSpecification.SplitWithErrors(
+            "  ;file.txt;\t;*.cs",
+            ignoreCase: false);
+
+        try
+        {
+            results.Count.Should().Be(4);
+
+            results[0].IsError.Should().BeTrue();
+            results[0].Original.ToString().Should().Be("  ");
+            results[0].ErrorReason.Should().NotBeNullOrEmpty();
+            results[0].Specification.Should().BeNull();
+
+            results[1].IsError.Should().BeTrue();
+            results[1].Original.ToString().Should().Be("\t");
+
+            results[2].IsError.Should().BeFalse();
+            results[2].Specification!.Normalized.ToString().Should().Be("file.txt");
+
+            results[3].IsError.Should().BeFalse();
+            results[3].Specification!.Normalized.ToString().Should().Be("*.cs");
+        }
+        finally
+        {
+            results.Dispose();
+        }
+    }
+
+    [Fact]
+    public void SplitWithErrors_NoErrors_ReturnsParsedResults()
+    {
+        ListBase<MSBuildSpecificationResult> results = MSBuildSpecification.SplitWithErrors(
+            "file.txt;*.cs;docs/**",
+            ignoreCase: false);
+
+        try
+        {
+            results.Count.Should().Be(3);
+            results.Should().OnlyContain(r => !r.IsError);
+            results.Select(r => r.Specification!.Normalized.ToString()).Should().Equal(
+                "file.txt",
+                "*.cs",
+                Sep("docs/**"));
+        }
+        finally
+        {
+            results.Dispose();
+        }
+    }
+
+    [Fact]
+    public void SplitWithErrors_EmptyInput_ReturnsEmptyList()
+    {
+        ListBase<MSBuildSpecificationResult> results = MSBuildSpecification.SplitWithErrors("", ignoreCase: false);
+        try
+        {
+            results.Count.Should().Be(0);
+        }
+        finally
+        {
+            results.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Split_WhitespaceOnlySegment_SilentlyDropped()
+    {
+        // Documents back-compat: the original Split overload continues to silently drop empty-normalize
+        // segments (rather than throw, which the old code path did before SplitCore was factored out).
+        ListBase<MSBuildSpecification> specs = MSBuildSpecification.Split("  ;file.txt;\t;*.cs", ignoreCase: false);
+        try
+        {
+            specs.Count.Should().Be(2);
+            specs[0].Normalized.ToString().Should().Be("file.txt");
+            specs[1].Normalized.ToString().Should().Be("*.cs");
+        }
+        finally
+        {
+            specs.Dispose();
+        }
+    }
+
+    [Fact]
     public void UnescapeSegment_NoEscapeCharacters_ReturnsSameSegment()
     {
         string original = "HelloWorld";

--- a/touki/Touki/Io/MSBuildEnumerationOptions.cs
+++ b/touki/Touki/Io/MSBuildEnumerationOptions.cs
@@ -10,23 +10,13 @@ namespace Touki.Io;
 /// </summary>
 public sealed class MSBuildEnumerationOptions
 {
-    internal static EnumerationOptions DefaultEnumerationOptions { get; } = new()
-    {
-        MatchType = MatchType.Simple,
-        MatchCasing = MatchCasing.PlatformDefault,
-        IgnoreInaccessible = true,
-        RecurseSubdirectories = true
-    };
-
-    /// <summary>
-    ///  Shared default instance: stock enumeration options with drive enumeration disallowed.
-    /// </summary>
-    public static MSBuildEnumerationOptions Default { get; } = new();
-
     /// <summary>
     ///  Underlying filesystem enumeration options (match type, casing, recursion, etc.).
+    ///  Each <see cref="MSBuildEnumerationOptions"/> instance gets its own fresh
+    ///  <see cref="EnumerationOptions"/> when constructed without an explicit value, so mutating it
+    ///  never bleeds into unrelated callers.
     /// </summary>
-    public EnumerationOptions EnumerationOptions { get; init; } = DefaultEnumerationOptions;
+    public EnumerationOptions EnumerationOptions { get; init; } = CreateDefaultEnumerationOptions();
 
     /// <summary>
     ///  When <see langword="false"/> (the default) an include that would recursively enumerate an entire
@@ -37,4 +27,12 @@ public sealed class MSBuildEnumerationOptions
     ///  <c>MSBUILDDISABLEDRIVEENUMERATIONONWILDCARDS</c>.
     /// </summary>
     public bool AllowDriveEnumeration { get; init; }
+
+    private static EnumerationOptions CreateDefaultEnumerationOptions() => new()
+    {
+        MatchType = MatchType.Simple,
+        MatchCasing = MatchCasing.PlatformDefault,
+        IgnoreInaccessible = true,
+        RecurseSubdirectories = true
+    };
 }

--- a/touki/Touki/Io/MSBuildEnumerationOptions.cs
+++ b/touki/Touki/Io/MSBuildEnumerationOptions.cs
@@ -5,7 +5,7 @@
 namespace Touki.Io;
 
 /// <summary>
-///  Configuration for <see cref="MSBuildEnumerator.CreateResult(string, string?, string?, MSBuildEnumerationOptions?)"/>.
+///  Configuration for <see cref="MSBuildEnumerator.CreateResult"/>.
 ///  Composes a standard <see cref="EnumerationOptions"/> with Touki-specific safety flags.
 /// </summary>
 public sealed class MSBuildEnumerationOptions

--- a/touki/Touki/Io/MSBuildEnumerationOptions.cs
+++ b/touki/Touki/Io/MSBuildEnumerationOptions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Configuration for <see cref="MSBuildEnumerator.CreateResult(string, string?, string?, MSBuildEnumerationOptions?)"/>.
+///  Composes a standard <see cref="EnumerationOptions"/> with Touki-specific safety flags.
+/// </summary>
+public sealed class MSBuildEnumerationOptions
+{
+    internal static EnumerationOptions DefaultEnumerationOptions { get; } = new()
+    {
+        MatchType = MatchType.Simple,
+        MatchCasing = MatchCasing.PlatformDefault,
+        IgnoreInaccessible = true,
+        RecurseSubdirectories = true
+    };
+
+    /// <summary>
+    ///  Shared default instance: stock enumeration options with drive enumeration disallowed.
+    /// </summary>
+    public static MSBuildEnumerationOptions Default { get; } = new();
+
+    /// <summary>
+    ///  Underlying filesystem enumeration options (match type, casing, recursion, etc.).
+    /// </summary>
+    public EnumerationOptions EnumerationOptions { get; init; } = DefaultEnumerationOptions;
+
+    /// <summary>
+    ///  When <see langword="false"/> (the default) an include that would recursively enumerate an entire
+    ///  drive or share (e.g. <c>C:\**</c>, <c>/**</c>, <c>\\server\share\**</c>) is refused; the
+    ///  resulting <see cref="MSBuildEnumerationResult.Action"/> is
+    ///  <see cref="MSBuildSearchAction.FailBecauseDriveEnumerationIsForbidden"/>. Set to
+    ///  <see langword="true"/> to opt in. Matches MSBuild's default behavior of
+    ///  <c>MSBUILDDISABLEDRIVEENUMERATIONONWILDCARDS</c>.
+    /// </summary>
+    public bool AllowDriveEnumeration { get; init; }
+}

--- a/touki/Touki/Io/MSBuildEnumerationResult.cs
+++ b/touki/Touki/Io/MSBuildEnumerationResult.cs
@@ -5,7 +5,7 @@
 namespace Touki.Io;
 
 /// <summary>
-///  Whole-search result returned by <see cref="MSBuildEnumerator.CreateResult(string, string?, string?, MSBuildEnumerationOptions?)"/>.
+///  Whole-search result returned by <see cref="MSBuildEnumerator.CreateResult"/>.
 ///  Mirrors the 4-tuple returned by MSBuild's internal <c>FileMatcher.GetFiles</c>.
 /// </summary>
 /// <remarks>

--- a/touki/Touki/Io/MSBuildEnumerationResult.cs
+++ b/touki/Touki/Io/MSBuildEnumerationResult.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Whole-search result returned by <see cref="MSBuildEnumerator.CreateResult(string, string?, string?, MSBuildEnumerationOptions?)"/>.
+///  Mirrors the 4-tuple returned by MSBuild's internal <c>FileMatcher.GetFiles</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   When <see cref="Action"/> is <see cref="MSBuildSearchAction.RunSearch"/>, <see cref="Enumerator"/>
+///   is non-<see langword="null"/>; iterate it (and dispose it) to consume matches. For any other action
+///   <see cref="Enumerator"/> is <see langword="null"/> and <see cref="GlobFailure"/> or
+///   <see cref="FailedExcludeSpec"/> describe why the search was abandoned.
+///  </para>
+/// </remarks>
+public readonly struct MSBuildEnumerationResult
+{
+    /// <summary>
+    ///  Lazy enumerator over matched files. <see langword="null"/> when <see cref="Action"/> is not
+    ///  <see cref="MSBuildSearchAction.RunSearch"/>. The caller owns disposal.
+    /// </summary>
+    public MSBuildEnumerator? Enumerator { get; }
+
+    /// <summary>
+    ///  Disposition of the enumeration. <see cref="MSBuildSearchAction.RunSearch"/> for the normal path.
+    /// </summary>
+    public MSBuildSearchAction Action { get; }
+
+    /// <summary>
+    ///  When an exclude spec was responsible for stopping the search, the original spec text; otherwise
+    ///  <see langword="null"/>.
+    /// </summary>
+    public string? FailedExcludeSpec { get; }
+
+    /// <summary>
+    ///  Human-readable failure description when the include spec itself could not be evaluated; otherwise
+    ///  <see langword="null"/>.
+    /// </summary>
+    public string? GlobFailure { get; }
+
+    internal MSBuildEnumerationResult(
+        MSBuildEnumerator? enumerator,
+        MSBuildSearchAction action,
+        string? failedExcludeSpec,
+        string? globFailure)
+    {
+        Enumerator = enumerator;
+        Action = action;
+        FailedExcludeSpec = failedExcludeSpec;
+        GlobFailure = globFailure;
+    }
+}

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -156,12 +156,15 @@ public class MSBuildEnumerator : MatchEnumerator<string>
     ///  excludes.
     /// </param>
     /// <param name="projectDirectory">
-    ///  The project directory. Results are returned relative to this directory when the include is not
-    ///  fully qualified. When <see langword="null"/>, <see cref="Environment.CurrentDirectory"/> is used.
+    ///  The project directory used to resolve a non-rooted include spec. When <see langword="null"/>,
+    ///  <see cref="Environment.CurrentDirectory"/> is used to resolve the spec, but absolute paths are
+    ///  returned in <see cref="MSBuildEnumerationResult.Enumerator"/> (paths are stripped to be relative
+    ///  to <paramref name="projectDirectory"/> only when a non-<see langword="null"/> value is supplied
+    ///  and the include spec is not fully qualified).
     /// </param>
     /// <param name="options">
-    ///  Enumeration options and Touki-specific safety flags. <see langword="null"/> selects
-    ///  <see cref="MSBuildEnumerationOptions.Default"/>.
+    ///  Enumeration options and Touki-specific safety flags. <see langword="null"/> selects a fresh
+    ///  <see cref="MSBuildEnumerationOptions"/> with default values.
     /// </param>
     /// <remarks>
     ///  <para>
@@ -177,7 +180,7 @@ public class MSBuildEnumerator : MatchEnumerator<string>
     {
         ArgumentNullException.ThrowIfNull(fileSpec);
 
-        options ??= MSBuildEnumerationOptions.Default;
+        options ??= new MSBuildEnumerationOptions();
         EnumerationOptions enumOptions = options.EnumerationOptions;
         string rootDirectory = projectDirectory ?? Environment.CurrentDirectory;
 

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -146,6 +146,94 @@ public class MSBuildEnumerator : MatchEnumerator<string>
             options);
     }
 
+    /// <summary>
+    ///  Builds an enumeration result for the given include / exclude specifications, mirroring the
+    ///  4-tuple returned by MSBuild's internal <c>FileMatcher.GetFiles</c>.
+    /// </summary>
+    /// <param name="fileSpec">The include specification.</param>
+    /// <param name="excludeSpecs">
+    ///  Optional semicolon-separated exclude specifications. <see langword="null"/> or empty means no
+    ///  excludes.
+    /// </param>
+    /// <param name="projectDirectory">
+    ///  The project directory. Results are returned relative to this directory when the include is not
+    ///  fully qualified. When <see langword="null"/>, <see cref="Environment.CurrentDirectory"/> is used.
+    /// </param>
+    /// <param name="options">
+    ///  Enumeration options and Touki-specific safety flags. <see langword="null"/> selects
+    ///  <see cref="MSBuildEnumerationOptions.Default"/>.
+    /// </param>
+    /// <remarks>
+    ///  <para>
+    ///   On the <see cref="MSBuildSearchAction.RunSearch"/> path the caller owns the
+    ///   <see cref="MSBuildEnumerationResult.Enumerator"/> and must dispose it after iteration.
+    ///  </para>
+    /// </remarks>
+    public static MSBuildEnumerationResult CreateResult(
+        string fileSpec,
+        string? excludeSpecs = null,
+        string? projectDirectory = null,
+        MSBuildEnumerationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(fileSpec);
+
+        options ??= MSBuildEnumerationOptions.Default;
+        EnumerationOptions enumOptions = options.EnumerationOptions;
+        string rootDirectory = projectDirectory ?? Environment.CurrentDirectory;
+
+        // Parse once. The Create overloads parse a second time and FullyQualify a third time through
+        // MSBuildMatchBuilder; CreateResult avoids that by driving the match builder directly with the
+        // already-qualified include.
+        MSBuildSpecification include = new MSBuildSpecification(fileSpec).FullyQualify(rootDirectory);
+
+        if (!options.AllowDriveEnumeration && include.IsDriveRootRecursion)
+        {
+            return new MSBuildEnumerationResult(
+                enumerator: null,
+                action: MSBuildSearchAction.FailBecauseDriveEnumerationIsForbidden,
+                failedExcludeSpec: null,
+                globFailure:
+                    $"Drive enumeration is not allowed for '{fileSpec}'. Set " +
+                    $"{nameof(MSBuildEnumerationOptions)}.{nameof(MSBuildEnumerationOptions.AllowDriveEnumeration)} = true to override.");
+        }
+
+        bool ignoreCase = Paths.GetFinalCasing(enumOptions.MatchCasing) == MatchCasing.CaseInsensitive;
+        ListBase<MSBuildSpecification> excludes = string.IsNullOrEmpty(excludeSpecs)
+            ? EmptyList<MSBuildSpecification>.Instance
+            : MSBuildSpecification.Split(excludeSpecs!, ignoreCase);
+
+        try
+        {
+            IEnumerationMatcher matcher = MSBuildMatchBuilder.FromSpecification(
+                include,
+                excludes,
+                enumOptions.MatchType,
+                enumOptions.MatchCasing,
+                rootDirectory,
+                out StringSegment startDirectory);
+
+            MSBuildEnumerator enumerator = new(
+                matcher,
+                projectDirectory,
+                stripProjectDirectory: !Path.IsPathFullyQualified(fileSpec),
+                startDirectory.ToString(),
+                enumOptions);
+
+            return new MSBuildEnumerationResult(
+                enumerator: enumerator,
+                action: MSBuildSearchAction.RunSearch,
+                failedExcludeSpec: null,
+                globFailure: null);
+        }
+        finally
+        {
+            if (excludes is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
+        }
+    }
+
     /// <inheritdoc/>
     protected override bool ShouldIncludeEntry(ref FileSystemEntry entry) =>
         !entry.IsDirectory && base.ShouldIncludeEntry(ref entry);

--- a/touki/Touki/Io/MSBuildSearchAction.cs
+++ b/touki/Touki/Io/MSBuildSearchAction.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Mirrors MSBuild's internal <c>FileMatcher.SearchAction</c> enum, returned as part of
+///  <see cref="MSBuildEnumerationResult"/>. Numeric values match MSBuild's enum so oracle parity with
+///  <c>FileMatcher</c> is a direct compare.
+/// </summary>
+public enum MSBuildSearchAction
+{
+    /// <summary>
+    ///  Normal enumeration ran (or will run lazily) to completion.
+    /// </summary>
+    RunSearch = 0,
+
+    /// <summary>
+    ///  The input could not be evaluated as a glob and should be surfaced to the caller as a literal
+    ///  file spec string rather than expanded.
+    /// </summary>
+    ReturnFileSpec = 1,
+
+    /// <summary>
+    ///  Enumeration was abandoned and the caller should treat the result as an empty list.
+    /// </summary>
+    ReturnEmptyList = 2,
+
+    /// <summary>
+    ///  A path encountered during enumeration exceeded the platform's maximum path length.
+    /// </summary>
+    FailBecauseFileTooLong = 3,
+
+    /// <summary>
+    ///  A subdirectory encountered during enumeration exceeded the platform's maximum path length.
+    /// </summary>
+    FailBecauseSubdirectoryTooLong = 4,
+
+    /// <summary>
+    ///  The include or exclude spec would recursively enumerate an entire drive or share
+    ///  (e.g. <c>C:\**</c>, <c>/**</c>, <c>\\server\share\**</c>) and drive enumeration is disabled.
+    /// </summary>
+    FailBecauseDriveEnumerationIsForbidden = 5,
+
+    /// <summary>
+    ///  Reserved for parity with MSBuild's logging-only drive-enumeration outcome. Not currently
+    ///  produced by this library.
+    /// </summary>
+    LogDriveEnumerationWildcard = 6,
+}

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -255,6 +255,44 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     }
 
     /// <summary>
+    ///  <see langword="true"/> when this specification is fully qualified and its <see cref="FixedPath"/>
+    ///  is a filesystem root (e.g. <c>C:\</c>, <c>\\server\share</c>, <c>/</c>) while its
+    ///  <see cref="WildPath"/> begins with the recursive <c>**</c> wildcard.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   MSBuild's <c>FileMatcher</c> treats this as a forbidden pattern by default
+    ///   (<c>SearchAction.FailBecauseDriveEnumerationIsForbidden</c>) because it would walk an entire
+    ///   drive or share. <see cref="MSBuildEnumerator.CreateResult(string, string?, string?, MSBuildEnumerationOptions?)"/>
+    ///   surfaces it as <see cref="MSBuildSearchAction.FailBecauseDriveEnumerationIsForbidden"/> unless
+    ///   the caller opts in via <see cref="MSBuildEnumerationOptions.AllowDriveEnumeration"/>.
+    ///  </para>
+    /// </remarks>
+    public bool IsDriveRootRecursion
+    {
+        get
+        {
+            if (!IsFullyQualified || !HasAnyWildCards || FixedPath.IsEmpty)
+            {
+                return false;
+            }
+
+            if (!IsSimpleRecursiveMatch
+                && !(WildPath.Length >= 2
+                    && WildPath[0] == '*'
+                    && WildPath[1] == '*'
+                    && (WildPath.Length == 2 || WildPath[2] == Path.DirectorySeparatorChar)))
+            {
+                return false;
+            }
+
+            ReadOnlySpan<char> fixedSpan = FixedPath.AsSpan();
+            ReadOnlySpan<char> rootSpan = Path.GetPathRoot(fixedSpan);
+            return rootSpan.Length > 0 && rootSpan.Length == fixedSpan.Length;
+        }
+    }
+
+    /// <summary>
     ///  Unescapes the given <paramref name="specification"/> if needed. `%` is used to escape special characters
     ///  in MSBuild strings, such as `*`, `?`, and `%`.
     /// </summary>
@@ -427,10 +465,51 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
         bool ignoreCase)
     {
         SingleOptimizedList<MSBuildSpecification, ArrayPoolList<MSBuildSpecification>> splitSpecs = [];
+        SplitCore(specs, ignoreCase, splitSpecs, errorResults: null);
+        return splitSpecs;
+    }
 
+    /// <summary>
+    ///  Splits semicolon-separated MSBuild specifications, returning per-spec results that distinguish
+    ///  successfully parsed specifications from "error" specs that MSBuild's <c>FileMatcher</c> would
+    ///  surface as literal strings rather than evaluating as globs.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Unlike <see cref="Split(StringSegment, bool)"/>, this overload preserves error specs in the
+    ///   returned list rather than silently dropping or throwing on them. Currently the only classified
+    ///   error class is "spec normalizes to empty" (e.g. whitespace-only segments); additional MSBuild
+    ///   error classes (drive-root recursion, illegal characters, malformed <c>**</c>) will be added as
+    ///   support for them lands.
+    ///  </para>
+    /// </remarks>
+    public static ListBase<MSBuildSpecificationResult> SplitWithErrors(
+        StringSegment specs,
+        bool ignoreCase)
+    {
+        SingleOptimizedList<MSBuildSpecification, ArrayPoolList<MSBuildSpecification>> splitSpecs = [];
+        SingleOptimizedList<MSBuildSpecificationResult, ArrayPoolList<MSBuildSpecificationResult>> results = [];
+
+        SplitCore(specs, ignoreCase, splitSpecs, errorResults: results);
+
+        for (int i = 0; i < splitSpecs.Count; i++)
+        {
+            results.Add(MSBuildSpecificationResult.FromSpecification(splitSpecs[i]));
+        }
+
+        splitSpecs.Dispose();
+        return results;
+    }
+
+    private static void SplitCore(
+        StringSegment specs,
+        bool ignoreCase,
+        ListBase<MSBuildSpecification> splitSpecs,
+        ListBase<MSBuildSpecificationResult>? errorResults)
+    {
         // MSBuild normally validates specifications after it splits each one into fixed, wildcard, and file parts.
-        // None of the validation is strictly necessary, but would be done here if we wanted to roughly match.
-        // Things that are considered "invalid: should be put in the literalSpecs even if they contain wildcards.
+        // Most of that validation isn't strictly necessary for correctness here, but specs that MSBuild treats as
+        // "errors" (and surfaces as literal strings) are tracked when an error sink is provided.
         //
         // What MSBuild considers invalid:
         //
@@ -438,6 +517,7 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
         //  - A colon after the second character - not a real risk unless you create a `Uri` and breaks Unix paths.
         //  - `...` - this isn't needed either, there is no risk with this.
         //  - `**` not between separators - a lot of pain for not much gain, so we don't do this.
+        //  - Spec that normalizes to empty - currently captured below when an error sink is provided.
 
         StringSegment right = specs;
 
@@ -445,7 +525,7 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
         {
             if (left.IsEmpty)
             {
-                // Skip empty segments.
+                // Skip empty segments (semicolon delimiters with nothing between them).
                 continue;
             }
 
@@ -455,6 +535,14 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
             // improve performance further downstream as we can be more efficient with additional comparisons.
 
             StringSegment normalized = Normalize(left);
+
+            if (normalized.IsEmpty)
+            {
+                // E.g. whitespace-only segment. Constructor would throw; surface as an error spec when caller asked.
+                errorResults?.Add(MSBuildSpecificationResult.FromError(left, "Specification normalizes to empty."));
+                continue;
+            }
+
             bool found = false;
 
             for (int i = 0; i < splitSpecs.Count; i++)
@@ -514,8 +602,6 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
                 splitSpecs.Add(newSpec);
             }
         }
-
-        return splitSpecs;
     }
 
     /// <summary>

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -113,19 +113,46 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
 
         if (lastSeparator < 1)
         {
-            // No separator, only special case is "**"
-            FixedPath = default;
+            if (lastSeparator < 0)
+            {
+                // No separator at all. Only special case is "**".
+                FixedPath = default;
 
-            if (Normalized == "**")
+                if (Normalized == "**")
+                {
+                    goto SimpleRecursiveMatch;
+                }
+                else
+                {
+                    WildPath = default;
+                    FileName = Normalized;
+                }
+
+                return;
+            }
+
+            // lastSeparator == 0: rooted with the only separator at the start (e.g. "/**" or
+            // "/foo.txt" on Unix; "\foo" drive-relative on Windows). FixedPath is the root
+            // separator; the suffix has no further separators so it's either empty, the recursive
+            // wildcard "**", or a filename.
+            FixedPath = Normalized[..1];
+            StringSegment suffix = Normalized[1..];
+
+            if (suffix.IsEmpty)
+            {
+                // Just the root itself.
+                WildPath = default;
+                FileName = default;
+                return;
+            }
+
+            if (suffix == "**")
             {
                 goto SimpleRecursiveMatch;
             }
-            else
-            {
-                WildPath = default;
-                FileName = Normalized;
-            }
 
+            WildPath = default;
+            FileName = suffix;
             return;
         }
 
@@ -185,12 +212,16 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
         }
         else
         {
-            // We have a fixed part and a wildcard part
-            FixedPath = Normalized[..lastSeparatorBeforeWildCard];
+            // We have a fixed part and a wildcard part. When the only separator before the
+            // wildcard is the leading root separator (e.g. "/**/*.cs"), FixedPath IS the root
+            // separator rather than an empty slice.
+            FixedPath = lastSeparatorBeforeWildCard == 0
+                ? Normalized[..1]
+                : Normalized[..lastSeparatorBeforeWildCard];
 
             if (trailingWildDirectory)
             {
-                // Trailing wild directory (e.g. "foo/bar*/**").
+                // Trailing wild directory (e.g. "foo/bar*/**" or "/**/foo/**").
                 WildPath = Normalized[(lastSeparatorBeforeWildCard + 1)..];
                 FileName = "*";
                 IsSimpleRecursiveMatch = WildPath == "**";
@@ -198,8 +229,10 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
             }
             else
             {
-                // Normal case with wildcards in the path (e.g. "foo/bar*/baz/*.txt").
-                WildPath = Normalized.Slice(FixedPath.Length + 1, Normalized.Length - FileName.Length - FixedPath.Length - 2);
+                // Normal case with wildcards in the path (e.g. "foo/bar*/baz/*.txt" or
+                // "/**/foo/*.txt"). Use the position-based slice so the root case (where
+                // FixedPath IS the separator) and the non-root case share the same formula.
+                WildPath = Normalized[(lastSeparatorBeforeWildCard + 1)..lastSeparator];
             }
         }
 
@@ -272,24 +305,9 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     {
         get
         {
-            if (!IsFullyQualified || !HasAnyWildCards)
+            if (!IsFullyQualified || !HasAnyWildCards || FixedPath.IsEmpty)
             {
                 return false;
-            }
-
-            // Edge case: the parser currently leaves FixedPath empty for rooted specs whose only
-            // fixed prefix IS the root separator (e.g. "/**" or "/**/*.cs" on Unix). Detect those
-            // by looking at Normalized directly so the gate still catches them. The deeper parser
-            // fix (also populating WildPath/FileName correctly for those specs) is tracked as a
-            // follow-up.
-            if (FixedPath.IsEmpty)
-            {
-                ReadOnlySpan<char> normalized = Normalized.AsSpan();
-                return normalized.Length >= 3
-                    && normalized[0] == Path.DirectorySeparatorChar
-                    && normalized[1] == '*'
-                    && normalized[2] == '*'
-                    && (normalized.Length == 3 || normalized[3] == Path.DirectorySeparatorChar);
             }
 
             if (!IsSimpleRecursiveMatch

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -296,7 +296,7 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     ///  <para>
     ///   MSBuild's <c>FileMatcher</c> treats this as a forbidden pattern by default
     ///   (<c>SearchAction.FailBecauseDriveEnumerationIsForbidden</c>) because it would walk an entire
-    ///   drive or share. <see cref="MSBuildEnumerator.CreateResult(string, string?, string?, MSBuildEnumerationOptions?)"/>
+    ///   drive or share. <see cref="MSBuildEnumerator.CreateResult"/>
     ///   surfaces it as <see cref="MSBuildSearchAction.FailBecauseDriveEnumerationIsForbidden"/> unless
     ///   the caller opts in via <see cref="MSBuildEnumerationOptions.AllowDriveEnumeration"/>.
     ///  </para>
@@ -321,7 +321,20 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
 
             ReadOnlySpan<char> fixedSpan = FixedPath.AsSpan();
             ReadOnlySpan<char> rootSpan = Path.GetPathRoot(fixedSpan);
+
+            // Path.GetPathRoot may or may not include a trailing separator depending on the input
+            // and runtime (notably for UNC roots like "\\server\share" vs "\\server\share\").
+            // Trim a single trailing separator from both spans so the comparison is
+            // normalization-insensitive. The length > 1 guard preserves the "FixedPath is itself
+            // just the separator" case (Unix "/").
+            fixedSpan = TrimTrailingSeparator(fixedSpan);
+            rootSpan = TrimTrailingSeparator(rootSpan);
             return rootSpan.Length > 0 && rootSpan.Length == fixedSpan.Length;
+
+            static ReadOnlySpan<char> TrimTrailingSeparator(ReadOnlySpan<char> span)
+                => span.Length > 1 && span[^1] == Path.DirectorySeparatorChar
+                    ? span[..^1]
+                    : span;
         }
     }
 

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -272,9 +272,24 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     {
         get
         {
-            if (!IsFullyQualified || !HasAnyWildCards || FixedPath.IsEmpty)
+            if (!IsFullyQualified || !HasAnyWildCards)
             {
                 return false;
+            }
+
+            // Edge case: the parser currently leaves FixedPath empty for rooted specs whose only
+            // fixed prefix IS the root separator (e.g. "/**" or "/**/*.cs" on Unix). Detect those
+            // by looking at Normalized directly so the gate still catches them. The deeper parser
+            // fix (also populating WildPath/FileName correctly for those specs) is tracked as a
+            // follow-up.
+            if (FixedPath.IsEmpty)
+            {
+                ReadOnlySpan<char> normalized = Normalized.AsSpan();
+                return normalized.Length >= 3
+                    && normalized[0] == Path.DirectorySeparatorChar
+                    && normalized[1] == '*'
+                    && normalized[2] == '*'
+                    && (normalized.Length == 3 || normalized[3] == Path.DirectorySeparatorChar);
             }
 
             if (!IsSimpleRecursiveMatch

--- a/touki/Touki/Io/MSBuildSpecificationResult.cs
+++ b/touki/Touki/Io/MSBuildSpecificationResult.cs
@@ -38,8 +38,15 @@ public readonly struct MSBuildSpecificationResult
     ///  <see langword="true"/> when this result represents an error spec that should be surfaced as a literal
     ///  string rather than evaluated as a glob.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Only <see cref="Specification"/> is null-tracked when <see cref="IsError"/> is <see langword="false"/>;
+    ///   <see cref="ErrorReason"/> intentionally lacks a symmetric annotation because <c>default(MSBuildSpecificationResult)</c>
+    ///   has a null <see cref="ErrorReason"/> with <see cref="IsError"/> returning <see langword="true"/>. Callers that
+    ///   inspect <see cref="ErrorReason"/> should null-check explicitly.
+    ///  </para>
+    /// </remarks>
     [MemberNotNullWhen(false, nameof(Specification))]
-    [MemberNotNullWhen(true, nameof(ErrorReason))]
     public bool IsError => Specification is null;
 
     private MSBuildSpecificationResult(StringSegment original, MSBuildSpecification? specification, string? errorReason)

--- a/touki/Touki/Io/MSBuildSpecificationResult.cs
+++ b/touki/Touki/Io/MSBuildSpecificationResult.cs
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Result of classifying a single MSBuild specification produced by
+///  <see cref="MSBuildSpecification.SplitWithErrors(StringSegment, bool)"/>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   A result is either a successfully parsed <see cref="MSBuildSpecification"/> or an "error" spec
+///   that MSBuild's <c>FileMatcher</c> would surface as a literal string rather than evaluating as a
+///   glob. Use <see cref="IsError"/> to discriminate; on success read <see cref="Specification"/>,
+///   on failure read <see cref="Original"/> and <see cref="ErrorReason"/>.
+///  </para>
+/// </remarks>
+public readonly struct MSBuildSpecificationResult
+{
+    /// <summary>
+    ///  The raw specification as it appeared in the input, before normalization.
+    /// </summary>
+    public StringSegment Original { get; }
+
+    /// <summary>
+    ///  The parsed specification when <see cref="IsError"/> is <see langword="false"/>; otherwise <see langword="null"/>.
+    /// </summary>
+    public MSBuildSpecification? Specification { get; }
+
+    /// <summary>
+    ///  A short human-readable reason describing why the spec was classified as an error, or
+    ///  <see langword="null"/> when <see cref="IsError"/> is <see langword="false"/>.
+    /// </summary>
+    public string? ErrorReason { get; }
+
+    /// <summary>
+    ///  <see langword="true"/> when this result represents an error spec that should be surfaced as a literal
+    ///  string rather than evaluated as a glob.
+    /// </summary>
+    [MemberNotNullWhen(false, nameof(Specification))]
+    [MemberNotNullWhen(true, nameof(ErrorReason))]
+    public bool IsError => Specification is null;
+
+    private MSBuildSpecificationResult(StringSegment original, MSBuildSpecification? specification, string? errorReason)
+    {
+        Original = original;
+        Specification = specification;
+        ErrorReason = errorReason;
+    }
+
+    /// <summary>
+    ///  Creates a successful result wrapping the given <paramref name="specification"/>.
+    /// </summary>
+    public static MSBuildSpecificationResult FromSpecification(MSBuildSpecification specification)
+    {
+        ArgumentNullException.ThrowIfNull(specification);
+        return new MSBuildSpecificationResult(specification.Original, specification, errorReason: null);
+    }
+
+    /// <summary>
+    ///  Creates an error result for the given raw <paramref name="original"/> spec.
+    /// </summary>
+    /// <param name="original">The raw specification as it appeared in the input.</param>
+    /// <param name="errorReason">A short human-readable reason describing the failure.</param>
+    public static MSBuildSpecificationResult FromError(StringSegment original, string errorReason)
+    {
+        ArgumentNullException.ThrowIfNull(errorReason);
+        return new MSBuildSpecificationResult(original, specification: null, errorReason);
+    }
+}


### PR DESCRIPTION
Tracks part of #85.

Lays out the API foundation for matching MSBuild `FileMatcher`'s "error spec" and "stop searching" behaviors when enumerating files, and gates drive-root recursion (`C:\**`, `/**`, `\\server\share\**`) by default to match MSBuild's `MSBUILDDISABLEDRIVEENUMERATIONONWILDCARDS` behavior shipped since MSBuild 17.x.

## New public types under `Touki.Io`

- **`MSBuildSpecificationResult`** — either a parsed `MSBuildSpecification` or `(Original, ErrorReason)` for specs `FileMatcher` would surface as literal strings.
- **`MSBuildSearchAction`** — enum mirroring `FileMatcher.SearchAction`'s seven values with matching numeric layout (`RunSearch=0`, `ReturnFileSpec=1`, `ReturnEmptyList=2`, `FailBecauseFileTooLong=3`, `FailBecauseSubdirectoryTooLong=4`, `FailBecauseDriveEnumerationIsForbidden=5`, `LogDriveEnumerationWildcard=6`).
- **`MSBuildEnumerationOptions`** — composes `EnumerationOptions` with `AllowDriveEnumeration` (default `false`). Each instance gets a fresh `EnumerationOptions` so mutating it never bleeds into unrelated callers.
- **`MSBuildEnumerationResult`** — `readonly struct` (`Enumerator`, `Action`, `FailedExcludeSpec`, `GlobFailure`) mirroring `FileMatcher.GetFiles`'s 4-tuple return.

## New behavior

- **`MSBuildSpecification.SplitWithErrors`** — overload that preserves error specs in the returned list. Existing `Split` is factored through a shared `SplitCore` and keeps today's silent-drop semantics for back-compat. First classified error class: spec normalizes to empty (whitespace-only segments in a semicolon list), which previously crashed inside the constructor.
- **`MSBuildSpecification.IsDriveRootRecursion`** — `true` when the spec is fully qualified, `FixedPath` equals the filesystem root, and `WildPath` begins with `**`.
- **`MSBuildEnumerator.CreateResult`** — new entry point alongside `Create` that returns an `MSBuildEnumerationResult`. Parses the include spec once and drives `MSBuildMatchBuilder` directly, avoiding the triple-parse path a naive delegation to `Create` would have caused. Refuses drive-root recursion with `FailBecauseDriveEnumerationIsForbidden` unless the caller opts in via `MSBuildEnumerationOptions.AllowDriveEnumeration`.

Tests use the existing `FileMatcherWrapper` as the MSBuild oracle to confirm both implementations refuse drive-root recursion by default.

## Performance validation

Four BenchmarkDotNet classes (two existing, extended; two new) cover setup-dominated and at-scale enumeration on both .NET 10 (modern RyuJIT) and .NET Framework 4.8.1 (RyuJIT).

| Class | Spec | Excludes | Root |
|---|---|---|---|
| `MsBuildSetupPerf` | `**/*.cs` | none | small tmp tree, 5 files |
| `MsBuildSetupExcludesPerf` | `**/*.cs` | default item excludes | small tmp tree, 6 files |
| `MsBuildEnumeratePerf2` | `**/*.cs` | default item excludes | touki repo root (now anchors on the repo root via walk-up from `AppContext.BaseDirectory` looking for `touki.slnx`; no hardcoded path) |
| `MsBuildEnumeratePerf` | `**/src/**/*.cs` | none | `n:\repos\runtime` (heaviest scale) |

Each class baselines against MSBuild via `FileMatcherWrapper.GetFiles`. All four exercise both `Create` (existing) and `CreateResult` (new).

### Throughput (mean, ratio vs MSBuild = 1.00)

| Scenario | net10 (modern .NET RyuJIT) | net481 (.NET Framework 4.8.1 RyuJIT) |
|---|---|---|
| Setup, no excl. (5 files) | 0.29 / 0.29 | 0.40 / 0.39 |
| Setup, default excl. | 0.23 / 0.23 | 0.38 / 0.38 |
| touki repo, default excl. | 0.38 / 0.38 | 0.41 / 0.41 |
| runtime/src, no excl. | 0.84 / 0.84 | 1.04 / 1.03 |

Numbers are `Enumerator` / `EnumeratorResult`.

### Allocations (Allocated, ratio vs MSBuild = 1.00)

| Scenario | net10 | net481 |
|---|---:|---:|
| Setup, no excl. | 0.14 | 0.17 |
| Setup, default excl. | 0.25 | 0.27 |
| touki repo, default excl. | 0.27 | 0.30 |
| runtime/src, no excl. | 0.27 | 0.33 |

### Key findings

- **`CreateResult` is statistically identical to `Create` across every scale on both TFMs** (delta < 1%, well inside StdDev). Allocations are byte-for-byte equal. The single-parse refactor in `CreateResult` holds.
- **Memory savings are scale-invariant**: touki allocates 14-33% of what `FileMatcher` allocates per call. At the runtime/src scale that is 33.5 MB → 9.1 MB on net10 (24 MB saved per call) and 35 MB → 11 MB on net481.
- **GC pressure on net481 differs sharply at scale**: `FileMatcher` triggers 1000 Gen1 collections per 1000 ops on runtime/src; touki triggers zero Gen1 collections on either TFM.
- **Setup overhead shrinks as I/O dominates**. At runtime/src scale the per-call setup is ~0.02% of total time.
- **At the very largest scale on net481** (runtime/src, no excludes), touki is ~3% slower than `FileMatcher` (within typical measurement noise). This pre-existed in `Create` and is **not** introduced by this PR; `CreateResult` matches `Create`. Likely cause is a more aggressive net481 inner-loop in `FileMatcher` for the wildcard-in-middle no-excludes case. Worth a follow-up profile but out of scope here.

Reports written under `BenchmarkDotNet.Artifacts/results/`. Not pinned to the repository.

> **Note:** the touki-repo row was refreshed after fixing a pre-existing bug in `MsBuildEnumeratePerf2`'s `s_excludes` (trailing `;` on each entry made the FileMatcher-side excludes no-ops). Ratios moved by < 1 percentage point, within noise; memory unchanged. Touki side was always correct (consumes the unsplit semicolon string directly).

## Review feedback addressed

- `MSBuildSpecificationResult`: dropped the unsound `[MemberNotNullWhen(true, nameof(ErrorReason))]` (default value violated it).
- `MSBuildEnumerationOptions`: removed the static `Default` singleton and the shared internal `DefaultEnumerationOptions` field; each instance now gets its own fresh `EnumerationOptions`.
- `MSBuildEnumerator.CreateResult` XML doc for `projectDirectory: null` now matches actual behavior (absolute paths returned).
- `MsBuildEnumeratePerf2.s_excludes`: trailing `;` removed; numbers above are post-fix.

## Scope deferred to follow-up commits (#85)

- Containment-root traversal safety.
- Trailing-separator semantics in `MSBuildSpecification`.
- Broader edge-case test sweep with oracle parity.
- Wiring `MSBuildEnumerator` / `MSBuildMatchBuilder` to surface additional error classes (illegal chars, malformed `**`, etc.) through `MSBuildEnumerationResult`.
