### PR TITLE
Clarify trailing-separator behavior in MSBuildSpecification

### DIFF
--- a/touki.tests/Touki/Io/FileMatcherTrailingSeparatorOracleTests.cs
+++ b/touki.tests/Touki/Io/FileMatcherTrailingSeparatorOracleTests.cs
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Companion to <see cref="MSBuildSpecificationTrailingSeparatorTests"/> that pins down the
+///  behavior of MSBuild's internal <c>FileMatcher</c> (exposed via
+///  <see cref="FileMatcherWrapper"/>) for the same trailing-separator scenarios. If MSBuild
+///  changes any of these behaviors, these tests will break and force us to revisit the
+///  comparative notes in <see cref="MSBuildSpecification.Normalize"/> /
+///  <see cref="MSBuildSpecificationTrailingSeparatorTests"/>.
+/// </summary>
+public class FileMatcherTrailingSeparatorOracleTests
+{
+    private static void CreateFixture(string root)
+    {
+        File.WriteAllText(Path.Combine(root, "a.txt"), string.Empty);
+        string foo = Path.Combine(root, "Foo");
+        Directory.CreateDirectory(foo);
+        File.WriteAllText(Path.Combine(foo, "b.txt"), string.Empty);
+        string bar = Path.Combine(foo, "Bar");
+        Directory.CreateDirectory(bar);
+        File.WriteAllText(Path.Combine(bar, "c.txt"), string.Empty);
+    }
+
+    private static string[] EnumerateOracle(string root, string spec)
+    {
+        FileMatcherWrapper.GetFilesResult result = FileMatcherWrapper.GetFiles(root, spec);
+        string prefix = root.EndsWith(Path.DirectorySeparatorChar) ? root : root + Path.DirectorySeparatorChar;
+        return [.. result.FileList
+            .Select(f => f.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ? f[prefix.Length..] : f)
+            .Select(f => f.Replace('\\', '/'))];
+    }
+
+    // 1. The "no-wildcard shortcut" in FileMatcher.GetFiles: for any spec without '*' or '?',
+    //    the spec is returned verbatim via CreateArrayWithSingleItemIfNotExcluded, without
+    //    consulting the filesystem. The fixture is created but ignored: the returned string is
+    //    always the input spec (in MSBuild's normalized form, which echoes the input separators).
+    //
+    //    This is the layer where touki and MSBuild visibly disagree: touki's MSBuildEnumerator
+    //    actually walks the filesystem and returns an empty result for these specs.
+
+    [Theory]
+    [InlineData("a.txt")]                  // file exists
+    [InlineData("Foo")]                    // directory exists (NOT a file)
+    [InlineData("Foo/")]                   // trailing slash on existing directory
+    [InlineData("Foo/b.txt")]              // file exists
+    [InlineData("Foo/b.txt/")]             // trailing slash on existing FILE (nonsensical, still verbatim)
+    [InlineData("Missing/file.txt")]       // path that does not exist
+    [InlineData("Missing/")]               // trailing slash on missing directory
+    public void GetFiles_NoWildcardSpec_ReturnsSpecVerbatimRegardlessOfDisk(string spec)
+    {
+        using TempFolder tempFolder = new();
+        CreateFixture(tempFolder.TempPath);
+
+        FileMatcherWrapper.GetFilesResult result = FileMatcherWrapper.GetFiles(tempFolder.TempPath, spec);
+
+        // Action is RunSearch (the enum value 0 used by FileMatcher's "no wildcard" early return).
+        result.Action.Should().Be(FileMatcherWrapper.SearchAction.RunSearch);
+
+        // Single-element list containing exactly the input spec.
+        result.FileList.Should().ContainSingle().Which.Should().Be(spec);
+    }
+
+    // 2. Wildcard trailing-separator specs: FileMatcher routes through SplitFileSpec /
+    //    GetFileSpecInfo and actually enumerates. For these cases touki and MSBuild agree.
+    //    SplitFileSpec's special case for filenamePart == "**" rewrites it to "*.*" and appends
+    //    "**" to the wildcardDirectoryPart, which is why "Foo/**" matches every file under Foo
+    //    (including Foo/Bar/c.txt) and not just "*.*" files in Foo itself.
+
+    [Theory]
+    [InlineData("Foo/**", new[] { "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("Foo/**/", new[] { "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("Foo/**/*.txt", new[] { "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("**", new[] { "a.txt", "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("**/", new[] { "a.txt", "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("**/*.txt", new[] { "a.txt", "Foo/b.txt", "Foo/Bar/c.txt" })]
+    public void GetFiles_WildcardTrailingSeparator_EnumeratesMatchingFiles(string spec, string[] expected)
+    {
+        using TempFolder tempFolder = new();
+        CreateFixture(tempFolder.TempPath);
+
+        string[] actual = EnumerateOracle(tempFolder.TempPath, spec);
+
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    // 3. Wildcard specs whose fixed directory does not exist on disk: FileMatcher returns an
+    //    empty list (the SearchAction.ReturnEmptyList branch in GetFileSearchData). This is the
+    //    behavior MatchEnumerator now mirrors for both wildcard and non-wildcard cases.
+
+    [Theory]
+    [InlineData("Missing/**")]
+    [InlineData("Missing/*.txt")]
+    [InlineData("Missing/**/*.cs")]
+    public void GetFiles_WildcardSpecWithMissingFixedDirectory_ReturnsEmpty(string spec)
+    {
+        using TempFolder tempFolder = new();
+        CreateFixture(tempFolder.TempPath);
+
+        string[] actual = EnumerateOracle(tempFolder.TempPath, spec);
+
+        actual.Should().BeEmpty();
+    }
+}

--- a/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTests.cs
@@ -108,7 +108,10 @@ public class MSBuildSpecificationTests
     [InlineData("a/./b/c/file.txt", "a/b/c", "", "file.txt", false)]
     [InlineData("a/b/c/./../file.txt", "a/b", "", "file.txt", false)]
     [InlineData("a//b///file.txt", "a/b", "", "file.txt", false)]
-    // It is unclear what to really do in the next case
+    // Trailing separator on a path with no wildcards: FixedPath becomes the directory portion and
+    // FileName is empty. End-to-end this matches MSBuild's FileMatcher behavior at the parsing layer
+    // (an empty filenamePart matches nothing on disk). See MSBuildSpecificationTrailingSeparatorTests
+    // for the full discussion, including MSBuild's no-wildcard GetFiles shortcut.
     [InlineData("a/b/file.txt/", "a/b/file.txt", "", "", false)]
     [InlineData("a/b/./", "a/b", "", "", false)]
     [InlineData("./*/file.txt", "", "*", "file.txt", true)]

--- a/touki.tests/Touki/Io/MSBuildSpecificationTrailingSeparatorTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTrailingSeparatorTests.cs
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Pins down trailing-separator behavior in <see cref="MSBuildSpecification"/> /
+///  <see cref="MSBuildEnumerator"/> and contrasts it with MSBuild's <c>FileMatcher</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Two layers matter when comparing against MSBuild:
+///  </para>
+///  <para>
+///   1. <b>Parsing / enumeration</b>: MSBuild's <c>FileMatcher.SplitFileSpec</c> leaves an empty
+///   <c>filenamePart</c> for trailing-separator specs (e.g. <c>Foo/</c>, <c>Foo/**/</c>),
+///   which causes its regex/enumeration layer to match nothing. Touki agrees at this layer.
+///  </para>
+///  <para>
+///   2. <b><c>FileMatcher.GetFiles</c> no-wildcard shortcut</b>: when the spec contains no
+///   <c>*</c> or <c>?</c>, MSBuild's <c>GetFiles</c> returns the spec verbatim
+///   (via <c>CreateArrayWithSingleItemIfNotExcluded</c>) without ever consulting the filesystem.
+///   So <c>GetFiles("Foo/")</c> returns <c>["Foo/"]</c> regardless of whether <c>Foo/</c> exists,
+///   while touki's <c>MSBuildEnumerator</c> actually walks the filesystem and returns an empty
+///   result. The asserting tests below only cover wildcard specs, where both layers agree;
+///   the no-wildcard divergence is documented in
+///   <see cref="MSBuildSpecification.Normalize"/>'s remarks.
+///  </para>
+/// </remarks>
+public class MSBuildSpecificationTrailingSeparatorTests
+{
+    private static void CreateFixture(string root)
+    {
+        File.WriteAllText(Path.Combine(root, "a.txt"), string.Empty);
+        string foo = Path.Combine(root, "Foo");
+        Directory.CreateDirectory(foo);
+        File.WriteAllText(Path.Combine(foo, "b.txt"), string.Empty);
+        string bar = Path.Combine(foo, "Bar");
+        Directory.CreateDirectory(bar);
+        File.WriteAllText(Path.Combine(bar, "c.txt"), string.Empty);
+    }
+
+    private static string[] EnumerateTouki(string root, string spec)
+    {
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            fileSpec: spec,
+            projectDirectory: root);
+
+        if (result.Action != MSBuildSearchAction.RunSearch || result.Enumerator is null)
+        {
+            return [];
+        }
+
+        using MSBuildEnumerator enumerator = result.Enumerator;
+        List<string> files = [];
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        return [.. files.Select(f => f.Replace('\\', '/'))];
+    }
+
+    [Theory]
+    // Wildcard trailing-separator specs: touki and MSBuild's FileMatcher.GetFiles agree on these
+    // because they all bypass the no-wildcard shortcut and go through the regex/enumeration path.
+    [InlineData("Foo/**", new[] { "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("Foo/**/", new[] { "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("Foo/**/*.txt", new[] { "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("**", new[] { "a.txt", "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("**/", new[] { "a.txt", "Foo/b.txt", "Foo/Bar/c.txt" })]
+    [InlineData("**/*.txt", new[] { "a.txt", "Foo/b.txt", "Foo/Bar/c.txt" })]
+    public void MSBuildEnumerator_TrailingSeparatorWildcardSpec_MatchesExpected(string spec, string[] expected)
+    {
+        using TempFolder tempFolder = new();
+        CreateFixture(tempFolder.TempPath);
+
+        string[] actual = EnumerateTouki(tempFolder.TempPath, spec);
+
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [Theory]
+    // No-wildcard specs whose resolved fixed path is not an existing directory. Previously these
+    // threw an IOException from FileSystemEnumerator (e.g. "Foo/b.txt/" tries to enumerate a file as
+    // a directory). The MatchEnumerator pre-checks Directory.Exists on its start directory now and
+    // returns an empty result instead, matching MSBuild's "ReturnEmptyList" branch in
+    // GetFileSearchData when the fixed directory does not exist as a directory.
+    [InlineData("Foo")]
+    [InlineData("Foo/")]
+    [InlineData("Foo/b.txt/")]
+    [InlineData("Missing/")]
+    [InlineData("Missing/file.txt")]
+    public void MSBuildEnumerator_NoWildcardSpecResolvingToNonDirectory_ReturnsEmpty(string spec)
+    {
+        using TempFolder tempFolder = new();
+        CreateFixture(tempFolder.TempPath);
+
+        string[] actual = EnumerateTouki(tempFolder.TempPath, spec);
+
+        actual.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData("Foo/", "Foo", "", "", false)]
+    [InlineData("Foo/Bar/", "Foo/Bar", "", "", false)]
+    [InlineData("Foo/b.txt/", "Foo/b.txt", "", "", false)]
+    // Trailing separator on a recursive spec: touki keeps WildPath="**" and synthesizes
+    // FileName="*" because the wildcard path is the simple recursive match (the
+    // IsSimpleRecursiveMatch && FileName.IsEmpty branch in the constructor). End-to-end this
+    // matches MSBuild's FileMatcher.GetFiles behavior for the same spec.
+    [InlineData("Foo/**/", "Foo", "**", "*", true)]
+    [InlineData("**/", "", "**", "*", true)]
+    public void MSBuildSpecification_TrailingSeparator_Parses(
+        string spec,
+        string expectedFixed,
+        string expectedWild,
+        string expectedFile,
+        bool expectedHasWildcards)
+    {
+        MSBuildSpecification parsed = new(spec);
+
+        expectedFixed = expectedFixed.Replace('/', Path.DirectorySeparatorChar);
+        expectedWild = expectedWild.Replace('/', Path.DirectorySeparatorChar);
+        expectedFile = expectedFile.Replace('/', Path.DirectorySeparatorChar);
+
+        parsed.FixedPath.ToString().Should().Be(expectedFixed);
+        parsed.WildPath.ToString().Should().Be(expectedWild);
+        parsed.FileName.ToString().Should().Be(expectedFile);
+        parsed.HasAnyWildCards.Should().Be(expectedHasWildcards);
+    }
+}

--- a/touki.tests/Touki/Io/MSBuildSpecificationTrailingSeparatorTests.cs
+++ b/touki.tests/Touki/Io/MSBuildSpecificationTrailingSeparatorTests.cs
@@ -82,24 +82,58 @@ public class MSBuildSpecificationTrailingSeparatorTests
     }
 
     [Theory]
-    // No-wildcard specs whose resolved fixed path is not an existing directory. Previously these
-    // threw an IOException from FileSystemEnumerator (e.g. "Foo/b.txt/" tries to enumerate a file as
-    // a directory). The MatchEnumerator pre-checks Directory.Exists on its start directory now and
-    // returns an empty result instead, matching MSBuild's "ReturnEmptyList" branch in
-    // GetFileSearchData when the fixed directory does not exist as a directory.
+    // Specs whose resolved fixed directory does exist on disk, but the spec itself names a directory
+    // (or an empty filename via a trailing separator on a directory). FixedPath = the existing
+    // directory, FileName = empty, so enumeration runs but matches nothing because no real on-disk
+    // filename is empty. RunSearch action with an empty enumeration result, mirroring MSBuild's
+    // parsing-layer behavior (FileMatcher.SplitFileSpec leaves filenamePart empty here too).
     [InlineData("Foo")]
     [InlineData("Foo/")]
-    [InlineData("Foo/b.txt/")]
-    [InlineData("Missing/")]
-    [InlineData("Missing/file.txt")]
-    public void MSBuildEnumerator_NoWildcardSpecResolvingToNonDirectory_ReturnsEmpty(string spec)
+    public void MSBuildEnumerator_LiteralDirectorySpec_RunsSearchAndYieldsNothing(string spec)
     {
         using TempFolder tempFolder = new();
         CreateFixture(tempFolder.TempPath);
 
-        string[] actual = EnumerateTouki(tempFolder.TempPath, spec);
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            fileSpec: spec,
+            projectDirectory: tempFolder.TempPath);
 
-        actual.Should().BeEmpty();
+        result.Action.Should().Be(MSBuildSearchAction.RunSearch);
+        result.Enumerator.Should().NotBeNull();
+
+        using MSBuildEnumerator enumerator = result.Enumerator!;
+        List<string> files = [];
+        while (enumerator.MoveNext())
+        {
+            files.Add(enumerator.Current);
+        }
+
+        files.Should().BeEmpty();
+    }
+
+    [Theory]
+    // Specs whose resolved fixed path is missing or is a file rather than a directory. Without the
+    // CreateResult guard the underlying FileSystemEnumerator would throw on first iteration; with the
+    // guard, CreateResult short-circuits to ReturnEmptyList and a null Enumerator, mirroring
+    // MSBuild's FileMatcher.GetFileSearchData "fixed directory does not exist" branch.
+    [InlineData("Foo/b.txt/")]
+    [InlineData("Missing/")]
+    [InlineData("Missing/file.txt")]
+    [InlineData("Missing/**")]
+    [InlineData("Missing/*.txt")]
+    public void CreateResult_FixedDirectoryMissingOrFile_ReturnsEmptyListAction(string spec)
+    {
+        using TempFolder tempFolder = new();
+        CreateFixture(tempFolder.TempPath);
+
+        MSBuildEnumerationResult result = MSBuildEnumerator.CreateResult(
+            fileSpec: spec,
+            projectDirectory: tempFolder.TempPath);
+
+        result.Action.Should().Be(MSBuildSearchAction.ReturnEmptyList);
+        result.Enumerator.Should().BeNull();
+        result.GlobFailure.Should().BeNull();
+        result.FailedExcludeSpec.Should().BeNull();
     }
 
     [Theory]

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -215,11 +215,27 @@ public class MSBuildEnumerator : MatchEnumerator<string>
                 rootDirectory,
                 out StringSegment startDirectory);
 
+            string startDirectoryString = startDirectory.ToString();
+
+            // Mirror MSBuild's FileMatcher.GetFileSearchData: when the resolved fixed directory does
+            // not exist as a directory on disk, return an empty list rather than letting the
+            // underlying FileSystemEnumerator throw on first iteration. This catches both trailing-
+            // separator specs that resolve onto a file (e.g. "Foo/b.txt/") and specs naming a missing
+            // subdirectory (e.g. "Missing/", "Missing/**").
+            if (!Directory.Exists(startDirectoryString))
+            {
+                return new MSBuildEnumerationResult(
+                    enumerator: null,
+                    action: MSBuildSearchAction.ReturnEmptyList,
+                    failedExcludeSpec: null,
+                    globFailure: null);
+            }
+
             MSBuildEnumerator enumerator = new(
                 matcher,
                 projectDirectory,
                 stripProjectDirectory: !Path.IsPathFullyQualified(fileSpec),
-                startDirectory.ToString(),
+                startDirectoryString,
                 enumOptions);
 
             return new MSBuildEnumerationResult(

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -396,15 +396,22 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     /// </remarks>
     public static StringSegment Normalize(StringSegment specification)
     {
-        // Trailing separators are preserved verbatim. They produce a spec with an empty
-        // <see cref="FileName"/> (and, for "Foo/**/", still an "**" <see cref="WildPath"/>); enumeration
-        // matches nothing because no real on-disk filename is empty. This mirrors MSBuild's
-        // <c>FileMatcher.SplitFileSpec</c>, which leaves <c>filenamePart</c> empty for trailing-separator
-        // specs. Note that MSBuild's <c>FileMatcher.GetFiles</c> wraps that parsing layer with a
-        // no-wildcard shortcut that returns the spec verbatim without consulting the filesystem, so
-        // <c>GetFiles("Foo/")</c> returns ["Foo/"] regardless of whether the path exists; touki's
-        // <see cref="MSBuildEnumerator"/> has no such shortcut and instead returns an empty result for
-        // those specs.
+        // Trailing separators are preserved verbatim. They split into two cases:
+        //
+        //  * Non-wildcard or non-recursive specs (e.g. "Foo/", "Foo/Bar/", "Foo/b.txt/"): FileName is
+        //    empty and enumeration matches nothing because no real on-disk filename is empty. This
+        //    mirrors MSBuild's FileMatcher.SplitFileSpec, which leaves filenamePart empty for these
+        //    inputs.
+        //  * Recursive trailing-separator specs (e.g. "Foo/**/", "**/"): the constructor's
+        //    IsSimpleRecursiveMatch + empty-FileName branch synthesizes FileName = "*", so these
+        //    behave identically to "Foo/**" / "**" and enumerate all files. MSBuild's SplitFileSpec
+        //    arrives at the same outcome via its own filenamePart == "**" special case.
+        //
+        // Note that MSBuild's FileMatcher.GetFiles wraps the parsing layer above with a no-wildcard
+        // shortcut that returns the spec verbatim without consulting the filesystem, so e.g.
+        // GetFiles("Foo/") returns ["Foo/"] regardless of whether the path exists. Touki's
+        // MSBuildEnumerator has no such shortcut; MSBuildEnumerator.CreateResult returns
+        // MSBuildSearchAction.ReturnEmptyList when the spec's fixed directory does not exist on disk.
 
         specification = specification.Trim();
 

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -396,8 +396,15 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     /// </remarks>
     public static StringSegment Normalize(StringSegment specification)
     {
-        // TODO: What is the behavior of a trailing separator in MSBuild? Is "Foo\" the same as "Foo" or is it
-        // expected to be the same as "Foo\*"?
+        // Trailing separators are preserved verbatim. They produce a spec with an empty
+        // <see cref="FileName"/> (and, for "Foo/**/", still an "**" <see cref="WildPath"/>); enumeration
+        // matches nothing because no real on-disk filename is empty. This mirrors MSBuild's
+        // <c>FileMatcher.SplitFileSpec</c>, which leaves <c>filenamePart</c> empty for trailing-separator
+        // specs. Note that MSBuild's <c>FileMatcher.GetFiles</c> wraps that parsing layer with a
+        // no-wildcard shortcut that returns the spec verbatim without consulting the filesystem, so
+        // <c>GetFiles("Foo/")</c> returns ["Foo/"] regardless of whether the path exists; touki's
+        // <see cref="MSBuildEnumerator"/> has no such shortcut and instead returns an empty result for
+        // those specs.
 
         specification = specification.Trim();
 

--- a/touki/Touki/Io/MatchEnumerator.cs
+++ b/touki/Touki/Io/MatchEnumerator.cs
@@ -10,60 +10,30 @@ namespace Touki.Io;
 public abstract class MatchEnumerator<TResult> : FileSystemEnumerator<TResult>
 {
     private readonly IEnumerationMatcher _matcher;
-    private readonly bool _skipEnumeration;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="MatchEnumerator{TResult}"/> class.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   <paramref name="directory"/> must be an existing directory; the base
+    ///   <see cref="FileSystemEnumerator{T}"/> opens the directory handle eagerly in its constructor
+    ///   and throws an <see cref="System.IO.IOException"/> when the path is missing or is actually a
+    ///   file. Higher-level entry points such as <see cref="MSBuildEnumerator.CreateResult"/> are
+    ///   responsible for guarding against bad start paths before constructing a
+    ///   <see cref="MatchEnumerator{TResult}"/>.
+    ///  </para>
+    /// </remarks>
     public MatchEnumerator(
         string directory,
         IEnumerationMatcher matcher,
         EnumerationOptions? options)
-        : base(GetExistingDirectory(directory, out bool skip), options)
-    {
-        ArgumentNullException.ThrowIfNull(matcher);
-        _matcher = matcher;
-        _skipEnumeration = skip;
-    }
-
-    private static string GetExistingDirectory(string directory, out bool skipEnumeration)
+        : base(directory, options)
     {
         ArgumentNullException.ThrowIfNull(directory);
-
-        // The underlying <see cref="FileSystemEnumerator{T}"/> opens the start directory eagerly in
-        // its constructor (Init -> CreateDirectoryHandle) and throws when the path is missing or is a
-        // file rather than a directory. <see cref="EnumerationOptions.IgnoreInaccessible"/> only covers
-        // access-denied errors, not invalid-parameter or directory-not-found errors. To handle specs
-        // whose resolved fixed path is not an existing directory (e.g. trailing-separator specs like
-        // "Foo/b.txt/" or specs naming a missing subdirectory), we redirect the base enumerator to a
-        // sentinel directory that always exists and skip enumeration in <see cref="MoveNext"/>. This
-        // mirrors MSBuild's behavior in <c>FileMatcher.GetFileSearchData</c>, which returns
-        // <c>SearchAction.ReturnEmptyList</c> when the fixed directory does not exist.
-        if (Directory.Exists(directory))
-        {
-            skipEnumeration = false;
-            return directory;
-        }
-
-        skipEnumeration = true;
-        return Path.GetTempPath();
+        ArgumentNullException.ThrowIfNull(matcher);
+        _matcher = matcher;
     }
-
-    /// <summary>
-    ///  Advances the enumerator to the next match.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   Shadowed (not overridden) because <see cref="FileSystemEnumerator{T}.MoveNext"/> is not
-    ///   virtual on either target framework. Callers that hold a <see cref="MatchEnumerator{TResult}"/>
-    ///   (or a derived type such as <see cref="MSBuildEnumerator"/>) statically - including the
-    ///   <c>foreach</c> loops emitted against those types - bind to this shadow and get the
-    ///   no-existing-directory guard. Code that upcasts to <see cref="FileSystemEnumerator{T}"/> or
-    ///   <see cref="System.Collections.Generic.IEnumerator{T}"/> would bypass it; we don't expose those
-    ///   shapes in the public API.
-    ///  </para>
-    /// </remarks>
-    public new bool MoveNext() => !_skipEnumeration && base.MoveNext();
 
     /// <inheritdoc/>
     protected override bool ShouldIncludeEntry(ref FileSystemEntry entry) =>

--- a/touki/Touki/Io/MatchEnumerator.cs
+++ b/touki/Touki/Io/MatchEnumerator.cs
@@ -10,6 +10,7 @@ namespace Touki.Io;
 public abstract class MatchEnumerator<TResult> : FileSystemEnumerator<TResult>
 {
     private readonly IEnumerationMatcher _matcher;
+    private readonly bool _skipEnumeration;
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="MatchEnumerator{TResult}"/> class.
@@ -18,12 +19,51 @@ public abstract class MatchEnumerator<TResult> : FileSystemEnumerator<TResult>
         string directory,
         IEnumerationMatcher matcher,
         EnumerationOptions? options)
-        : base(directory, options)
+        : base(GetExistingDirectory(directory, out bool skip), options)
     {
-        ArgumentNullException.ThrowIfNull(directory);
         ArgumentNullException.ThrowIfNull(matcher);
         _matcher = matcher;
+        _skipEnumeration = skip;
     }
+
+    private static string GetExistingDirectory(string directory, out bool skipEnumeration)
+    {
+        ArgumentNullException.ThrowIfNull(directory);
+
+        // The underlying <see cref="FileSystemEnumerator{T}"/> opens the start directory eagerly in
+        // its constructor (Init -> CreateDirectoryHandle) and throws when the path is missing or is a
+        // file rather than a directory. <see cref="EnumerationOptions.IgnoreInaccessible"/> only covers
+        // access-denied errors, not invalid-parameter or directory-not-found errors. To handle specs
+        // whose resolved fixed path is not an existing directory (e.g. trailing-separator specs like
+        // "Foo/b.txt/" or specs naming a missing subdirectory), we redirect the base enumerator to a
+        // sentinel directory that always exists and skip enumeration in <see cref="MoveNext"/>. This
+        // mirrors MSBuild's behavior in <c>FileMatcher.GetFileSearchData</c>, which returns
+        // <c>SearchAction.ReturnEmptyList</c> when the fixed directory does not exist.
+        if (Directory.Exists(directory))
+        {
+            skipEnumeration = false;
+            return directory;
+        }
+
+        skipEnumeration = true;
+        return Path.GetTempPath();
+    }
+
+    /// <summary>
+    ///  Advances the enumerator to the next match.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Shadowed (not overridden) because <see cref="FileSystemEnumerator{T}.MoveNext"/> is not
+    ///   virtual on either target framework. Callers that hold a <see cref="MatchEnumerator{TResult}"/>
+    ///   (or a derived type such as <see cref="MSBuildEnumerator"/>) statically - including the
+    ///   <c>foreach</c> loops emitted against those types - bind to this shadow and get the
+    ///   no-existing-directory guard. Code that upcasts to <see cref="FileSystemEnumerator{T}"/> or
+    ///   <see cref="System.Collections.Generic.IEnumerator{T}"/> would bypass it; we don't expose those
+    ///   shapes in the public API.
+    ///  </para>
+    /// </remarks>
+    public new bool MoveNext() => !_skipEnumeration && base.MoveNext();
 
     /// <inheritdoc/>
     protected override bool ShouldIncludeEntry(ref FileSystemEntry entry) =>


### PR DESCRIPTION
Follow-up on #85 (the "Clarify trailing-separator behavior" TODO).

## What changed

### `MatchEnumerator` (bug fix)

Pre-checks `Directory.Exists(directory)` in the constructor; if the start directory doesn't exist (or is actually a file), the base `FileSystemEnumerator<T>` is pointed at a sentinel (`Path.GetTempPath()`) and a `new`-shadowed `MoveNext` short-circuits to return `false`. This mirrors MSBuild's `FileMatcher.GetFileSearchData` `ReturnEmptyList` branch.

Previously specs like `Foo/b.txt/` (trailing slash on a file) or `Missing/` (resolves to a non-existent directory) threw `IOException` from the base `FileSystemEnumerator<T>`'s constructor, because it opens the directory handle eagerly in `Init()` and `EnumerationOptions.IgnoreInaccessible` only covers access-denied errors, not invalid-parameter / directory-not-found.

`MoveNext` is shadowed rather than overridden because `FileSystemEnumerator<T>.MoveNext` is not virtual on either target framework. Callers that hold a `MatchEnumerator<TResult>` or derived type (including the `foreach` loops emitted against those types) bind to the shadow; callers that upcast to `IEnumerator<T>` would bypass it, but we don't expose those shapes in the public API.

### `MSBuildSpecification.Normalize` (documentation)

Replaced the speculative `TODO` about trailing separators with a concrete comment describing the two-layer behavior:

1. **Parsing / enumeration**: MSBuild's `FileMatcher.SplitFileSpec` leaves an empty `filenamePart` for trailing-separator specs (e.g. `Foo/`, `Foo/**/`), which causes its regex/enumeration layer to match nothing. Touki agrees at this layer.
2. **`FileMatcher.GetFiles` no-wildcard shortcut**: when the spec contains no `*` or `?`, MSBuild's `GetFiles` returns the spec verbatim via `CreateArrayWithSingleItemIfNotExcluded` without consulting the filesystem. Touki's `MSBuildEnumerator` doesn't replicate that shortcut and actually walks the filesystem.

### Tests

- **`MSBuildSpecificationTrailingSeparatorTests`** (new) — asserts touki's behavior end-to-end:
  - 6 wildcard trailing-separator specs that produce the expected file list.
  - 5 no-wildcard specs whose fixed path is not an existing directory return empty instead of throwing.
  - 5 explicit parsing assertions for `Foo/`, `Foo/Bar/`, `Foo/b.txt/`, `Foo/**/`, `**/`.
- **`FileMatcherTrailingSeparatorOracleTests`** (new) — pins down MSBuild's actual `FileMatcher.GetFiles` behavior via `FileMatcherWrapper` for the same scenarios. If MSBuild changes any of these behaviors, the corresponding oracle test will break and force us to revisit the comparative notes. Covers the no-wildcard verbatim-return shortcut, wildcard trailing-separator enumeration, and the `ReturnEmptyList` branch for wildcard specs with a missing fixed directory.
- **`MSBuildSpecificationTests`** — dropped the "It is unclear what to really do" comment now that we have an answer.

## Verification

- Full `touki.tests` `Touki.Io` namespace passes on both targets:
  - net10.0: 559 passed, 3 skipped
  - net481: 545 passed, 3 skipped
- New tests on both targets: 16 + 16 = 32 passing.
