### PR TITLE
Add root-recursion edge-case tests and MSBuild escape parity tests

### DIFF
--- a/touki.tests/Touki/Io/EscapingUtilitiesOracleTests.cs
+++ b/touki.tests/Touki/Io/EscapingUtilitiesOracleTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Parity tests confirming touki's <see cref="MSBuildSpecification.Unescape"/> behaves the same as
+///  MSBuild's <c>EscapingUtilities.UnescapeAll</c> for valid and malformed <c>%XX</c> escape
+///  sequences. MSBuild deliberately tolerates malformed escapes (emits the raw characters) rather
+///  than reporting an error class, so the contract here is "match MSBuild's tolerance," not
+///  "validate."
+/// </summary>
+public class EscapingUtilitiesOracleTests
+{
+    [Theory]
+    // Strings with no escape characters round-trip unchanged.
+    [InlineData("")]
+    [InlineData("file.cs")]
+    [InlineData("foo/bar/baz.txt")]
+    [InlineData("**/*.cs")]
+    // Valid %XX escapes are decoded.
+    [InlineData("foo%20bar")]                 // %20 = space
+    [InlineData("foo%2520bar")]               // %25 = '%', then "20bar"
+    [InlineData("%2A.cs")]                    // %2A = '*'
+    [InlineData("dir%2Fname")]                // %2F = '/'
+    [InlineData("100%25done")]                // %25 = '%'
+    [InlineData("%00")]                       // %00 = NUL — decoded but illegal at the spec layer
+    [InlineData("file%2Bname")]               // %2B = '+'
+    [InlineData("hex%41%42%43")]              // %41-%43 = 'A','B','C'
+    // Lowercase hex digits.
+    [InlineData("foo%2abar")]
+    [InlineData("foo%2fbar")]
+    // Mixed-case hex digits.
+    [InlineData("foo%2Abar")]
+    [InlineData("foo%2Fbar")]
+    // Malformed escapes (non-hex digits, truncated). MSBuild leaves these literal.
+    [InlineData("%XX")]
+    [InlineData("%GG")]
+    [InlineData("%2")]                        // truncated, single hex digit
+    [InlineData("%")]                         // bare %
+    [InlineData("foo%")]                      // bare % at end
+    [InlineData("foo%Z")]
+    [InlineData("foo%2Zbar")]                 // valid first hex, invalid second
+    [InlineData("100% done")]                 // % followed by non-hex
+    [InlineData("%%20")]                      // bare % followed by valid escape
+    [InlineData("a%20%XX%20b")]               // mix of valid and malformed
+    // Multiple escapes in sequence.
+    [InlineData("%20%20%20")]
+    [InlineData("%2A%2A%2F%2A%2E%63%73")]     // "**/*.cs" as escapes
+    public void Unescape_MatchesMSBuildUnescapeAll(string input)
+    {
+        string toukiResult = MSBuildSpecification.Unescape(input).ToString();
+        string oracleResult = EscapingUtilitiesWrapper.UnescapeAll(input);
+
+        toukiResult.Should().Be(oracleResult, $"input was '{input}'");
+    }
+}

--- a/touki.tests/Touki/Io/EscapingUtilitiesWrapper.cs
+++ b/touki.tests/Touki/Io/EscapingUtilitiesWrapper.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Reflection;
+using Microsoft.Build.Globbing;
+
+namespace Touki.Io;
+
+/// <summary>
+///  Reflection-based access to MSBuild's internal <c>EscapingUtilities.UnescapeAll</c>. Used by
+///  parity tests in <see cref="EscapingUtilitiesOracleTests"/> to confirm touki's
+///  <see cref="MSBuildSpecification.Unescape"/> matches MSBuild's behavior for valid and invalid
+///  <c>%XX</c> escape sequences.
+/// </summary>
+public static class EscapingUtilitiesWrapper
+{
+    private static readonly MethodInfo s_unescapeAllMethod = ResolveUnescapeAll();
+
+    private static MethodInfo ResolveUnescapeAll()
+    {
+        Type escapingUtilities = typeof(MSBuildGlob).Assembly.GetType("Microsoft.Build.Shared.EscapingUtilities")
+            ?? throw new InvalidOperationException("Could not find EscapingUtilities type.");
+
+        return escapingUtilities.GetMethod(
+            "UnescapeAll",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+            binder: null,
+            types: [typeof(string), typeof(bool)],
+            modifiers: null)
+            ?? throw new InvalidOperationException("Could not find UnescapeAll(string, bool) method.");
+    }
+
+    /// <summary>
+    ///  Calls MSBuild's <c>EscapingUtilities.UnescapeAll(escaped, trim: false)</c> and returns the
+    ///  result.
+    /// </summary>
+    public static string UnescapeAll(string escaped)
+    {
+        ArgumentNullException.ThrowIfNull(escaped);
+        try
+        {
+            return (string)s_unescapeAllMethod.Invoke(null, [escaped, false])!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException is not null)
+        {
+            throw tie.InnerException;
+        }
+    }
+}

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -135,10 +135,12 @@ public class MSBuildEnumerationResultTests
             Assert.Skip("Drive-letter roots are Windows-only.");
         }
 
-        // These specs are not fully qualified relative to a drive root; FullyQualify resolves them
-        // against the current directory, so the resulting FixedPath sits below (or different from)
-        // the drive root and the gate doesn't fire.
-        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        // Anchor against a synthetic deep base so the assertion isn't affected by what the test
+        // host's current directory happens to be. Using Environment.CurrentDirectory would make
+        // `..\**` resolve to the drive root if the host happens to run from a one-deep path
+        // like C:\repo, flipping the result.
+        const string DeepBase = @"C:\synthetic\deep\base";
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(DeepBase);
         parsed.IsDriveRootRecursion.Should().BeFalse();
     }
 

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -97,6 +97,129 @@ public class MSBuildEnumerationResultTests
         spec.IsDriveRootRecursion.Should().BeTrue();
     }
 
+    // Extra root-recursion edge cases. These all exercise specs that Normalize / FullyQualify
+    // need to massage before IsDriveRootRecursion can give a meaningful answer.
+
+    [Theory]
+    [InlineData(@"C:\**")]                       // canonical
+    [InlineData(@"c:\**")]                       // lowercase drive letter
+    [InlineData(@"C:\\**")]                      // double separator after drive
+    [InlineData(@"C:\\\\**")]                    // four separators
+    [InlineData(@"C:/**")]                       // alt separator
+    [InlineData(@"  C:\**  ")]                   // leading + trailing whitespace
+    [InlineData(@"C:\**\")]                      // trailing separator on the recursive segment
+    [InlineData(@"C:\**\**")]                    // duplicate ** (Normalize dedupes)
+    [InlineData(@"C:\.\**")]                     // current-directory segment
+    [InlineData(@"C:\foo\..\**")]                // parent segment that cancels back to root
+    [InlineData(@"\**")]                         // root-relative — Path.GetFullPath resolves to current drive root, so the gate fires
+    public void IsDriveRootRecursion_WindowsDriveRootVariants_ReturnTrue(string spec)
+    {
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("Drive-letter roots are Windows-only.");
+        }
+
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(@"C:**")]                        // drive-relative (no separator) — not fully qualified
+    [InlineData(@"C:relative\**")]               // drive-relative path
+    [InlineData(@"..\**")]                       // parent-relative
+    [InlineData(@".\**")]                        // current-relative
+    public void IsDriveRootRecursion_WindowsRelativeWildcardSpecs_ReturnFalse(string spec)
+    {
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("Drive-letter roots are Windows-only.");
+        }
+
+        // These specs are not fully qualified relative to a drive root; FullyQualify resolves them
+        // against the current directory, so the resulting FixedPath sits below (or different from)
+        // the drive root and the gate doesn't fire.
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(@"C:\foo\**")]                   // drive-rooted but not at root
+    [InlineData(@"C:\Users\**")]
+    [InlineData(@"C:\foo\bar\**\*.cs")]
+    public void IsDriveRootRecursion_WindowsDriveSubdirectoryRecursion_ReturnFalse(string spec)
+    {
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("Drive-letter roots are Windows-only.");
+        }
+
+        // Drive-rooted recursive specs that don't sit AT the drive root are safe; only specs whose
+        // FixedPath equals the drive root trip IsDriveRootRecursion.
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(@"\\server\share\**")]
+    [InlineData(@"\\server\share\**\*.cs")]
+    [InlineData(@"\\server\share\\**")]          // double separator
+    [InlineData(@"//server/share/**")]           // alt separators throughout
+    [InlineData(@"  \\server\share\**  ")]       // whitespace
+    public void IsDriveRootRecursion_UncRootVariants_ReturnTrue(string spec)
+    {
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("UNC paths are Windows-only.");
+        }
+
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(@"\\server\share\foo\**")]
+    [InlineData(@"\\server\share\foo\bar\**\*.cs")]
+    public void IsDriveRootRecursion_UncSubdirectoryRecursion_ReturnFalse(string spec)
+    {
+        if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+        {
+            Assert.Skip("UNC paths are Windows-only.");
+        }
+
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(@"/**")]
+    [InlineData(@"/**/*.cs")]
+    [InlineData(@"//**")]                        // double leading separator (Normalize collapses)
+    [InlineData(@"/.\**")]
+    public void IsDriveRootRecursion_UnixRootRecursion_ReturnTrue(string spec)
+    {
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        {
+            Assert.Skip("Unix-style absolute roots are not the canonical root on Windows.");
+        }
+
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(@"/foo/**")]
+    [InlineData(@"/usr/local/**/*.h")]
+    public void IsDriveRootRecursion_UnixSubdirectoryRecursion_ReturnFalse(string spec)
+    {
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        {
+            Assert.Skip("Unix-style absolute roots are not the canonical root on Windows.");
+        }
+
+        MSBuildSpecification parsed = new MSBuildSpecification(spec).FullyQualify(Environment.CurrentDirectory);
+        parsed.IsDriveRootRecursion.Should().BeFalse();
+    }
+
     [Fact]
     public void CreateResult_DriveRootRecursionDefault_StopsSearching()
     {


### PR DESCRIPTION
Issue #85 follow-up: complete the remaining "more unit tests" items. **Test-only change — no production code touched.**

## Root recursion edge cases — [`MSBuildEnumerationResultTests`](touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs)

Six new theories with **27 inline cases** exercising paths through `Normalize` + `FullyQualify` + `IsDriveRootRecursion` that the original test set didn't cover. Each theory uses `Assert.Skip` so it only runs on the relevant platform.

| Theory | Cases | What it pins |
|---|---|---|
| `IsDriveRootRecursion_WindowsDriveRootVariants_ReturnTrue` | 11 | canonical `C:\**`, lowercase drive letter, multiple separators (`C:\\**`, `C:\\\\**`), alt separator (`C:/**`), leading/trailing whitespace, trailing separator on `**`, duplicate `**`, `.` segment, `..` segment that cancels to root, **`\**` (root-relative)** — `Path.GetFullPath` resolves this to the current drive's root, so the gate fires |
| `IsDriveRootRecursion_WindowsRelativeWildcardSpecs_ReturnFalse` | 4 | drive-relative `C:**`/`C:relative\**`, parent-relative `..\**`, current-relative `.\**` |
| `IsDriveRootRecursion_WindowsDriveSubdirectoryRecursion_ReturnFalse` | 3 | drive-rooted but not AT the root (`C:\foo\**`, etc.) |
| `IsDriveRootRecursion_UncRootVariants_ReturnTrue` | 5 | UNC root with double separator, alt separators, whitespace |
| `IsDriveRootRecursion_UncSubdirectoryRecursion_ReturnFalse` | 2 | UNC-rooted subdirectory recursion |
| `IsDriveRootRecursion_UnixRootRecursion_ReturnTrue` + `_UnixSubdirectoryRecursion_ReturnFalse` | 4 + 2 | Unix `/`, `/**`, `/**/*.cs`, `//**`, `/foo/**`, etc. |

The **`\**` case is worth flagging**: a spec that looks "relative to current dir" actually expands to the current drive's full recursion through `Path.GetFullPath`. The existing gate handles it; this test now pins that behavior so a future change can't accidentally remove the protection.

## Escape sequence parity — new [`EscapingUtilitiesWrapper`](touki.tests/Touki/Io/EscapingUtilitiesWrapper.cs) + [`EscapingUtilitiesOracleTests`](touki.tests/Touki/Io/EscapingUtilitiesOracleTests.cs)

Reflection wrapper exposes MSBuild's internal `EscapingUtilities.UnescapeAll(string, bool)`. New theory **`Unescape_MatchesMSBuildUnescapeAll`** asserts touki's `MSBuildSpecification.Unescape` produces byte-for-byte identical output to MSBuild's `UnescapeAll` for **28 inputs**:

- Strings with no escape characters (round-trip unchanged).
- Valid `%XX` sequences with uppercase, lowercase, and mixed-case hex digits.
- Nested escapes (`%2520` → `%20`).
- `%00` — decoded to NUL (which would then be classified illegal at the spec layer by `Validate`, but `Unescape` itself just decodes).
- Malformed escapes that MSBuild deliberately tolerates as literals: `%XX`, `%GG`, bare `%`, truncated `%2`, valid-then-invalid `%2Z`, `%` followed by non-hex, and mixed valid+malformed sequences (`a%20%XX%20b`).

**All 28 cases match MSBuild exactly** — touki has no parity gap on `UnescapeAll`. The "escape sequence behavior parity" item in issue #85 can be ticked.

## Verification

- net10 `EscapingUtilitiesOracleTests`: 28/28 passed.
- net10 `MSBuildEnumerationResultTests`: 43 passed, 6 platform-skipped (Unix-only theories on Windows).
- Full `Touki.Io` namespace: all MSBuild-related tests pass. (Five unrelated pre-existing `ClipboardTests` flakes on the host machine — environment-dependent, not introduced by this PR.)
