### PR TITLE
Cleanup: typography, test namespaces, extglob tail-anchor

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -16,12 +16,12 @@ The "Disambiguation" section below records every known overlap.
 | [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | hot-path tuning for `net481` in `touki/Framework/`, generic specialization, scalar/unrolled vs BCL delegation, net481 RyuJIT regressions | `performance-testing` |
 | [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations | `framework-jit-optimization` |
 | [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review checklist before opening or pushing a PR; missing tests, unchecked length sums, empty-span foot-guns, TFM phrasing | `create-pr`, `polyfill-dotnet-api` |
-| [security-review](./security-review/SKILL.md) | "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling"; any member accepting caller-supplied data, any use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, or any BCL API whose name or doc says "unsafe" / "caller must" &mdash; abusive-input handling, length / integer overflow, allocation and algorithmic DoS, caller-validated preconditions, argument validation | `pre-pr-self-review`, `performance-testing` |
-| [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", "publish for review" &mdash; **initial** publish | `pre-pr-self-review` |
-| [address-pr-feedback](./address-pr-feedback/SKILL.md) | "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure" &mdash; **post-PR** review-cycle work | `pre-pr-self-review` |
-| [agent-files-review](./agent-files-review/SKILL.md) | reviewing/validating agent-customization files (`AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, validator, CI workflow); fixing `agent-files.yml` failures | &mdash; |
+| [security-review](./security-review/SKILL.md) | "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling"; any member accepting caller-supplied data, any use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, or any BCL API whose name or doc says "unsafe" / "caller must" - abusive-input handling, length / integer overflow, allocation and algorithmic DoS, caller-validated preconditions, argument validation | `pre-pr-self-review`, `performance-testing` |
+| [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", "publish for review" - **initial** publish | `pre-pr-self-review` |
+| [address-pr-feedback](./address-pr-feedback/SKILL.md) | "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure" - **post-PR** review-cycle work | `pre-pr-self-review` |
+| [agent-files-review](./agent-files-review/SKILL.md) | reviewing/validating agent-customization files (`AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, validator, CI workflow); fixing `agent-files.yml` failures | - |
 | [run-tests-on-wsl](./run-tests-on-wsl/SKILL.md) | "run tests on Linux", "run the Posix/PosixPath/Bash oracles", "iterate Unix tests locally"; WSL Ubuntu bootstrap, the `~/repos/touki` Linux-native mirror that sidesteps the `/mnt/` DrvFs NuGet trap, the `DOTNET_ROOT` apphost requirement, and the `iconv` UTF-16 log trick | `performance-testing`, `pre-pr-self-review` |
-| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" &mdash; choosing the right `Major.Minor.Patch`, alpha/beta/rc/stable channel, tag stream (`v*` vs `ts-v*`), and GitHub release notes | `pre-pr-self-review` |
+| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" - choosing the right `Major.Minor.Patch`, alpha/beta/rc/stable channel, tag stream (`v*` vs `ts-v*`), and GitHub release notes | `pre-pr-self-review` |
 
 ## Disambiguation
 
@@ -72,7 +72,7 @@ You will frequently use both in sequence.
 
 Freshness is tracked from git history, not from a manual column. CI warns
 (does not fail) when a skill directory has no commits in the last 90 days
-&mdash; see [.github/workflows/agent-files.yml](../../.github/workflows/agent-files.yml).
+- see [.github/workflows/agent-files.yml](../../.github/workflows/agent-files.yml).
 
 A stale warning means "re-read this skill end-to-end against the current
 codebase." Confirm:
@@ -82,7 +82,7 @@ codebase." Confirm:
 3. Every claim about the codebase is still true.
 
 The only way to clear the warning is to commit a change to the skill
-directory &mdash; ideally the result of a real review pass, but at minimum a
+directory - ideally the result of a real review pass, but at minimum a
 whitespace touch with a commit message stating "verified still current."
 
 When adding a new skill, append a row to the inventory above in the same

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: address-pr-feedback
-description: Address feedback on an existing pull request &mdash; review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
+description: Address feedback on an existing pull request - review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
 ---
 
 # Address PR feedback
@@ -10,7 +10,7 @@ Both skills share the **same** publish gate: neither `git commit` nor
 `git push` runs without an explicit publishing verb from the user. The
 difference is what each skill authorizes you to *edit*:
 
-- `create-pr` authorizes preparing a new PR from in-progress work —
+- `create-pr` authorizes preparing a new PR from in-progress work -
   branching, staging, proposing a commit message. The commit and push
   still wait on approval.
 - This skill authorizes editing files in response to review feedback or
@@ -28,11 +28,11 @@ Carefully read the most recent user message and identify whether it
 contains an explicit publishing verb before you stage, commit, or push.
 Pattern-match the words, do not infer intent.
 
-**Approval** &mdash; verbs that authorize publishing the current change:
+**Approval** - verbs that authorize publishing the current change:
 `commit`, `push`, `update the PR`, `ship it`, `send it`, `yes push`, or
 direct synonyms when paired with a publishing intent.
 
-**Not approval** &mdash; everything else, including these phrasings that
+**Not approval** - everything else, including these phrasings that
 have caused violations on this repo:
 
 - "Address the review comments." / "Reply to the comments on the PR." /
@@ -59,7 +59,7 @@ Stop and ask one short yes/no question.
    disagree with, plan a written response rather than silently overriding.
 3. **Edit files.** Make the code changes. Run the build and any relevant
    tests. The applicable validation rules are still
-   [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; a follow-up
+   [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - a follow-up
    round needs the same checks as the initial PR.
 4. **Stop. Describe.** Summarize what you changed, why, and what (if
    anything) you chose not to act on. Do **not** run `git add`, `git
@@ -68,19 +68,19 @@ Stop and ask one short yes/no question.
    above).
 6. **Only then** stage by path, commit with a message that summarizes the
    round of changes, and push. The staging/commit/push mechanics are the
-   same as in [`create-pr`](../create-pr/SKILL.md) §3&ndash;§4.
+   same as in [`create-pr`](../create-pr/SKILL.md) §3-§4.
 
 ## When you've already violated the rule
 
 Acknowledge the violation directly without minimizing. Do **not** push a
-follow-up commit to "fix" the situation without explicit approval &mdash;
+follow-up commit to "fix" the situation without explicit approval -
 that compounds the failure. The user decides whether to revert,
 force-push, or leave the commit in place.
 
 ## Related
 
-- [AGENTS.md](../../../AGENTS.md) &mdash; the rule itself.
-- [`create-pr`](../create-pr/SKILL.md) &mdash; opening the initial PR
+- [AGENTS.md](../../../AGENTS.md) - the rule itself.
+- [`create-pr`](../create-pr/SKILL.md) - opening the initial PR
   (different approval semantics).
-- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; validation
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - validation
   checklist that applies to both initial and follow-up rounds.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -3,7 +3,7 @@ name: agent-files-review
 description: Review changes to AI-agent customization files in this repo (AGENTS.md, .github/copilot-instructions.md, *.instructions.md, *.prompt.md, *.agent.md, SKILL.md, validator, CI workflow). Use when asked to review or validate agent-file changes, fix CI failures from agent-files.yml, or audit a draft of any of these files.
 ---
 
-# Agent customization files — review checklist
+# Agent customization files - review checklist
 
 Run through every applicable item below before approving a change to an agent
 customization file. The PR review history showed each of these caught a real bug.
@@ -22,7 +22,7 @@ customization file. The PR review history showed each of these caught a real bug
   filesystem paths or `./` prefixes that would defeat the regex.
 - Don't use end-of-line comments in AGENTS.md examples or anywhere else; the
   file itself bans the pattern. Same applies to YAML examples in the README
-  files for `.github/agents/`, `.github/prompts/`, etc. — put `# comment`
+  files for `.github/agents/`, `.github/prompts/`, etc. - put `# comment`
   lines above the field, not after it.
 - Watch for placeholder syntax in code examples (e.g.
   `<see langword=".."/>`). Use a recognizable ellipsis (`"..."`) or a real
@@ -84,14 +84,14 @@ customization file. The PR review history showed each of these caught a real bug
 - [.markdownlint.jsonc](../../../.markdownlint.jsonc) intentionally disables
   MD013 (line-length), MD022/MD032 (blanks-around), MD033 (inline HTML),
   MD041 (first-line heading). It keeps MD040 (fenced-code-language),
-  no-trailing-spaces, no-hard-tabs. Don't disable MD040 — adding a `text`
+  no-trailing-spaces, no-hard-tabs. Don't disable MD040 - adding a `text`
   language tag is trivial and prevents drift.
 - The CI job runs on `ubuntu-latest`. PowerShell is preinstalled; no `pip`
   step is needed.
 
 ## 7. Relative Markdown links must resolve in this branch
 
-The CI link check is **offline lychee** &mdash; it only follows links that
+The CI link check is **offline lychee** - it only follows links that
 resolve to files in the current working tree. A link to a file that exists
 on the canonical repo's `main` but not in your branch will fail.
 
@@ -152,7 +152,7 @@ on the canonical repo's `main` but not in your branch will fail.
 **Always run the validator before declaring a review complete or pushing
 agent-file changes.** It catches mirror drift, missing/invalid frontmatter,
 SKILL.md naming mistakes, missing trailing newlines, and trailing/empty-line
-whitespace &mdash; the same rules CI enforces.
+whitespace - the same rules CI enforces.
 
 ```pwsh
 # Validate everything (frontmatter, mirror sync, dir-name match, whitespace,
@@ -173,5 +173,5 @@ passes, sanity-check that your Markdown:
 
 If CI fails after a local validator pass, the failure is almost always
 markdownlint (open the failing job's annotations) or the lychee link check
-(broken relative link &mdash; remember the mirror rewrites links, so test
+(broken relative link - remember the mirror rewrites links, so test
 the form in AGENTS.md, not the rewritten copy).

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -13,12 +13,12 @@ confirmation.
 *work* of preparing one. It does **not** authorize the commit or the push.
 The **Approval checkpoint** inside step 3 (Commit changes) is the gate:
 staging happens before it, `git commit` and everything after happen only
-once the user supplies an explicit publishing verb &mdash; `commit`, `push`,
+once the user supplies an explicit publishing verb - `commit`, `push`,
 `ship it`, or equivalent. See AGENTS.md § "Working with the user on
 changes" for the canonical rule and the recurring not-approval phrasings.
 
 Before running this workflow, walk through the
-[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist &mdash; it
+[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist - it
 catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
 that have repeatedly cost a review round-trip on this repo. If the change
 polyfills a .NET API for .NET Framework, the
@@ -29,10 +29,10 @@ design rules the self-review then validates against.
 
 Run these (read-only) checks first:
 
-- `git remote -v` — determine whether an `upstream` remote exists.
-- `git rev-parse --abbrev-ref HEAD` — current branch name.
-- `git status --porcelain` — uncommitted changes.
-- `git log --oneline @{u}.. 2>$null` (if upstream is set) — unpushed commits.
+- `git remote -v` - determine whether an `upstream` remote exists.
+- `git rev-parse --abbrev-ref HEAD` - current branch name.
+- `git status --porcelain` - uncommitted changes.
+- `git log --oneline @{u}.. 2>$null` (if upstream is set) - unpushed commits.
 
 Decide the PR base:
 
@@ -93,14 +93,14 @@ original "open a PR" request.
 
 **Prefer the VS Code GitHub Pull Requests tool**
 (`github-pull-request_create_pull_request`) when it is available in the
-current tool set — it works without requiring `gh` to be installed and
+current tool set - it works without requiring `gh` to be installed and
 returns the PR number/URL directly. Fall back to the GitHub CLI (`gh`) if
 the VS Code tool is not available, and only fall back to a browser compare
 URL if neither is available.
 
 Determine the target with the rule from step 1.
 
-### Option A — VS Code GitHub Pull Requests tool (preferred)
+### Option A - VS Code GitHub Pull Requests tool (preferred)
 
 Call `github-pull-request_create_pull_request` with:
 
@@ -110,7 +110,7 @@ Call `github-pull-request_create_pull_request` with:
 - For an upstream-targeted PR, set `repo` to `{ owner: <upstreamOwner>, name: <repo> }` and `headOwner` to the fork owner.
 - For an origin-only PR, omit `repo` and `headOwner` (they default correctly).
 
-### Option B — GitHub CLI fallback
+### Option B - GitHub CLI fallback
 
 - **Upstream exists**:
 
@@ -133,7 +133,7 @@ Call `github-pull-request_create_pull_request` with:
 - If the user has not supplied a title/body, propose one and confirm before
   creating.
 
-### Option C — Browser fallback
+### Option C - Browser fallback
 
 If neither the VS Code tool nor `gh` is available, print the compare URL:
 
@@ -155,7 +155,7 @@ has different commit/push approval semantics.
 
 ## Guardrails
 
-- Never commit directly to `main`, even if the user is currently on it —
+- Never commit directly to `main`, even if the user is currently on it -
   always branch first.
 - Never delete branches, force-push, or rewrite history as part of this
   workflow.

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -14,7 +14,7 @@ This skill captures decisions distilled from real benchmarks under
 [performance-testing](../performance-testing/SKILL.md) skill workflow before
 committing a change. Run the
 [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist before
-opening a PR &mdash; in particular &sect;5 (allocation-free over raw speed)
+opening a PR - in particular &sect;5 (allocation-free over raw speed)
 and &sect;7 (perf claims must name the JIT and be measured) apply directly
 to changes guided by this skill.
 
@@ -27,7 +27,7 @@ lives in `touki/Framework/`.
 ## What is and isn't available on `net481`
 
 - **No auto-vectorization.** The BCL `MemoryExtensions` methods on net481 ship with
-  System.Memory. They are hand-tuned scalar / integer-stride implementations &mdash;
+  System.Memory. They are hand-tuned scalar / integer-stride implementations -
   they do **not** use SIMD.
 - **No `System.Runtime.Intrinsics`.** `Vector128`/`Vector256`/`Vector512`,
   `Sse2.CompareEqual`, `Avx2.MoveMask` are .NET 5+. Not available here.
@@ -40,12 +40,12 @@ lives in `touki/Framework/`.
 "Integer-stride" means routines like `IndexOf` and `SequenceEqual` internally
 process multiple elements per loop step (e.g. compare a `ulong` chunk that spans
 4 chars or 8 bytes) rather than one element at a time. This is **not**
-vectorization &mdash; just careful scalar code &mdash; but it still substantially
+vectorization - just careful scalar code - but it still substantially
 beats a naive per-element loop for whole-buffer primitives.
 
 **Practical consequence:** do not assume "the BCL is vectorized so my generic code
 is fine." On `net481` a hand-written specialized loop frequently beats the BCL by
-2&ndash;3&times; for full-scan workloads.
+2-3&times; for full-scan workloads.
 
 ## Decision flow for a new framework-only fast path
 
@@ -61,7 +61,7 @@ is fine." On `net481` a hand-written specialized loop frequently beats the BCL b
    increment. See [unrolling.md](unrolling.md) for the right form (and the wrong
    ones).
 6. **Stop there.** Do not pursue SIMD, SWAR, or branchless tricks without data
-   showing they win &mdash; in practice they regress more often than they help.
+   showing they win - in practice they regress more often than they help.
    See [antipatterns.md](antipatterns.md).
 7. Run the same benchmark on `net10.0` to confirm you have not regressed the
    modern path. If a specialization is harmful on net10 (because the BCL is
@@ -71,7 +71,7 @@ is fine." On `net481` a hand-written specialized loop frequently beats the BCL b
 ## Quick reference: ratios from real benchmarks
 
 All numbers are from the smoke benchmarks in `touki.perf/`. Treat as
-order-of-magnitude, not exact &mdash; rerun before claiming a specific number in
+order-of-magnitude, not exact - rerun before claiming a specific number in
 a PR.
 
 | Decision | Net481 effect (length 4096, full scan) |
@@ -82,10 +82,10 @@ a PR.
 | Unroll-8 same form | **1.6&times; slower** than scalar at 256+ |
 | Per-iteration `*ptr; ptr++` instead of indexed reads | ~1.4&times; slower than indexed |
 | Integer-indexed unroll (`ptr[i+0..3]; i += 4`) | **Worse than the scalar baseline** |
-| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5&ndash;3&times; slower** than branchful conditional store |
+| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5-3&times; slower** than branchful conditional store |
 | SWAR haszero for char `Replace` (dense matches) | **3&times; slower** than scalar |
-| BCL `IndexOf` for `Replace` (full-scan) | 2.18&ndash;3.08&times; slower than specialized scalar |
-| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2&ndash;3&times; **faster** than full-scan specialization |
+| BCL `IndexOf` for `Replace` (full-scan) | 2.18-3.08&times; slower than specialized scalar |
+| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2-3&times; **faster** than full-scan specialization |
 | Exponential `SequenceEqual` probe for `CommonPrefixLength` (4096, full match) | 3.3&times; faster than per-element scalar |
 | Tuple swap `(a, b) = (b, a)` for plain locals | **~23% slower** than `T t = a; a = b; b = t;` |
 | Tuple swap on paired `Span<T>` indexed swap (sort hot path) | **~9% slower** than explicit temps |
@@ -96,11 +96,11 @@ The two BCL rows look contradictory. They aren't. See
 
 ## Sub-pages
 
-- [specialization.md](specialization.md) &mdash; `typeof(T)` pattern, `Unsafe.As`,
+- [specialization.md](specialization.md) - `typeof(T)` pattern, `Unsafe.As`,
   primitive bit-equality classes, when generic methods get inlined.
-- [unrolling.md](unrolling.md) &mdash; the only unroll form that wins on `net481`,
+- [unrolling.md](unrolling.md) - the only unroll form that wins on `net481`,
   and three that don't.
-- [bcl-tradeoffs.md](bcl-tradeoffs.md) &mdash; when to defer to BCL `IndexOf` /
+- [bcl-tradeoffs.md](bcl-tradeoffs.md) - when to defer to BCL `IndexOf` /
   `SequenceEqual` on `net481` despite no vectorization.
-- [antipatterns.md](antipatterns.md) &mdash; specific tricks that look clever but
+- [antipatterns.md](antipatterns.md) - specific tricks that look clever but
   regress on the older JIT.

--- a/.agents/skills/framework-jit-optimization/antipatterns.md
+++ b/.agents/skills/framework-jit-optimization/antipatterns.md
@@ -14,7 +14,7 @@ your specific call pattern.
 The `net481` JIT does not lower the ternary into a `cmov` for `ushort` / `byte`
 stores. You get a guaranteed store every iteration regardless of whether the
 value changed. For a sparse-match `Replace` workload (the realistic case), the
-extra writes cost 1.5&ndash;3&times; vs the branchful form below.
+extra writes cost 1.5-3&times; vs the branchful form below.
 
 ```c#
 // GOOD on net481.
@@ -75,7 +75,7 @@ while (ptr < unrollEnd)
 
 The bit-trick (`(x - Lo16) & ~x & Hi16`) adds a dependent-chain of 3 arithmetic
 ops per chunk, plus a load and an XOR, plus the broadcast computation. **Whenever
-any lane matches, the code falls through to the four scalar checks** &mdash; you
+any lane matches, the code falls through to the four scalar checks** - you
 pay the SWAR overhead **on top of** the mutation cost. On dense matches this
 regresses by 3&times;.
 
@@ -86,7 +86,7 @@ parallelizing the arithmetic with the scalar reads.
 
 ## Replacing BCL `IndexOf` with a scalar specialization for sparse search
 
-See [bcl-tradeoffs.md](bcl-tradeoffs.md). The rule cuts both ways &mdash; full
+See [bcl-tradeoffs.md](bcl-tradeoffs.md). The rule cuts both ways - full
 scan favors specialization, sparse search favors the BCL. Don't apply one half
 without the other.
 
@@ -107,13 +107,13 @@ a tight scalar loop at length 16 just from adding the attribute back.
 
 If you really must remove it (e.g. method body becomes too large), measure
 before and after. Don't strip it because "the method is short anyway, the JIT
-will inline it" &mdash; on `net481` the JIT often won't.
+will inline it" - on `net481` the JIT often won't.
 
 ## `Vector<T>` from `System.Numerics.Vectors` "for portable SIMD"
 
 It exists on `net481`. It does not auto-vectorize equality-replace loops on
 the older JIT, and per-load/store overhead loses to a plain unrolled scalar
-loop at typical sizes (16&ndash;4096). Don't reach for it unless you've
+loop at typical sizes (16-4096). Don't reach for it unless you've
 benchmarked it for your specific shape and seen a win.
 
 True SIMD on `net481` requires `System.Runtime.Intrinsics`, which is .NET 5+

--- a/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
+++ b/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
@@ -2,7 +2,7 @@
 
 The System.Memory primitives `IndexOf` and `SequenceEqual` are not vectorized on
 `net481`, but they're not naive per-element loops either. They use
-**integer-stride scalar tricks** &mdash; comparing `ulong`-sized chunks (4 chars
+**integer-stride scalar tricks** - comparing `ulong`-sized chunks (4 chars
 or 8 bytes at a time) with bit operations. This makes the choice between
 "specialize my own loop" and "lean on the BCL" non-obvious.
 
@@ -23,7 +23,7 @@ slightly less aggressive unrolling lose to a hand-written `ushort*` /
 
 | Method | Realistic input | Win factor (length 4096) |
 | --- | --- | --- |
-| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18&ndash;3.08&times; faster than `IndexOf`-walking |
+| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18-3.08&times; faster than `IndexOf`-walking |
 | `IndexOfAnyExcept(T)` | typically scans most of the buffer (e.g. trim, parse) | 0.34&times; vs scalar = 3&times; faster |
 
 These are the methods that already have `typeof(T)` specialization in
@@ -31,7 +31,7 @@ These are the methods that already have `typeof(T)` specialization in
 
 ## Cases where deferring to the BCL wins (skip-run / log-probe workloads)
 
-The hot loop **doesn't** visit every element &mdash; the BCL's stride trick
+The hot loop **doesn't** visit every element - the BCL's stride trick
 skips long non-match runs faster than per-element compares can advance.
 
 ### `Count(T)` via repeated `IndexOf` slicing
@@ -87,7 +87,7 @@ return length;
 full match this beats any scalar loop by **3.3&times;** even on `net481`.
 
 The early-divergence case (mismatch at index 8) is roughly tied with a scalar
-specialization &mdash; absolute saving is ~8 ns &mdash; not worth a 3.3&times;
+specialization - absolute saving is ~8 ns - not worth a 3.3&times;
 regression on the long-prefix case (path normalization, string interning,
 sorted-key compression are the realistic callers).
 
@@ -115,7 +115,7 @@ either-or; we have no benchmark showing a hybrid wins.
 ## Reference benchmarks
 
 - [touki.perf/SpanCountAndPrefixPerf.cs](../../../touki.perf/SpanCountAndPrefixPerf.cs)
-  &mdash; `Count` over `MatchEvery = 1, 7, 64` and `CommonPrefixLength` over
+  - `Count` over `MatchEvery = 1, 7, 64` and `CommonPrefixLength` over
   `Diverge = 0, 8, full`.
-- [touki.perf/SpanReplace.cs](../../../touki.perf/SpanReplace.cs) &mdash;
+- [touki.perf/SpanReplace.cs](../../../touki.perf/SpanReplace.cs) -
   full-scan workload where specialization wins.

--- a/.agents/skills/framework-jit-optimization/specialization.md
+++ b/.agents/skills/framework-jit-optimization/specialization.md
@@ -18,7 +18,7 @@ public unsafe void Replace(T oldValue, T newValue)
 
     if (typeof(T) == typeof(char) || typeof(T) == typeof(short) || typeof(T) == typeof(ushort))
     {
-        // The `& 0xFFFF` is load-bearing on net481 RyuJIT &mdash; see
+        // The `& 0xFFFF` is load-bearing on net481 RyuJIT - see
         // "Signed-primitive constant-propagation pitfall" below.
         ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
         ushort newShort = (ushort)(Unsafe.As<T, ushort>(ref newValue) & 0xFFFF);
@@ -43,7 +43,7 @@ public unsafe void Replace(T oldValue, T newValue)
 ## Why `Unsafe.As<T, TPrimitive>(ref value)`
 
 A regular cast `(ushort)(object)oldValue` boxes. `Unsafe.As<T, ushort>(ref oldValue)`
-is a no-op reinterpret &mdash; the JIT sees the constant `typeof(T) == typeof(ushort)`
+is a no-op reinterpret - the JIT sees the constant `typeof(T) == typeof(ushort)`
 test before it, knows the cast is valid, and emits a direct load.
 
 ## Bit-equality equivalence classes
@@ -58,7 +58,7 @@ single typed pointer loop covers a whole class:
 | `int` / `uint` | 32 bits | `uint*` |
 | `long` / `ulong` / `IntPtr` (on 64-bit) | 64 bits | `ulong*` |
 
-`float` / `double` / `decimal` are **not** members of these classes &mdash; their
+`float` / `double` / `decimal` are **not** members of these classes - their
 `IEquatable` semantics differ from bit equality (NaN, negative zero,
 denormalized flags). Don't fold them in.
 
@@ -78,19 +78,19 @@ Always put this on the generic entry method when you specialize:
   attribute is doing real work, not just hinting.
 
 The inlining attribute is also why we don't need separate `extension(Span<char>)`
-overloads &mdash; the generic version with the `typeof` ladder, when inlined,
+overloads - the generic version with the `typeof` ladder, when inlined,
 generates code identical to a hand-written `Span<char>` overload.
 
 ## Verifying the JIT actually elides the dead branches
 
 For `T = int`, the `typeof(T) == typeof(char)` branch should become unreachable.
-You can confirm with a debugger by setting a breakpoint inside it &mdash; on a
+You can confirm with a debugger by setting a breakpoint inside it - on a
 Release build with the attribute applied, the JIT will refuse to set the
 breakpoint because the code was eliminated.
 
 If the elision is failing (e.g. you forget `[AggressiveInlining]`, or `T` is
 itself a generic in some outer context where `typeof(T)` isn't a JIT-time
-constant), you'll see all branches in the disassembly &mdash; and your benchmark
+constant), you'll see all branches in the disassembly - and your benchmark
 ratio will reflect it. Add the attribute, or hoist the call site so `T` is
 concrete.
 
@@ -110,7 +110,7 @@ Without the mask, `[AggressiveInlining]` plus a literal signed argument
 **Release** (Debug passes). The caller's int-promoted constant
 (`-1` &rarr; `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
 loop's `cmp` immediate as a 32-bit value. The `movzx`-loaded byte is in
-`[0, 0xFF]`, so `cmp ecx, 0FFFFFFFF` is unconditionally false &mdash; the loop
+`[0, 0xFF]`, so `cmp ecx, 0FFFFFFFF` is unconditionally false - the loop
 runs, finds nothing, returns silently.
 
 The cast alone (`(byte)Unsafe.As<...>`) does not fix it; RyuJIT's constant
@@ -127,7 +127,7 @@ int-promoted form already has zero upper bits). Always include `sbyte` and
 
 ## See also
 
-- [unrolling.md](unrolling.md) &mdash; what to put inside the per-primitive
+- [unrolling.md](unrolling.md) - what to put inside the per-primitive
   block.
-- [bcl-tradeoffs.md](bcl-tradeoffs.md) &mdash; whether to specialize at all,
+- [bcl-tradeoffs.md](bcl-tradeoffs.md) - whether to specialize at all,
   vs delegate to a BCL primitive.

--- a/.agents/skills/framework-jit-optimization/unrolling.md
+++ b/.agents/skills/framework-jit-optimization/unrolling.md
@@ -40,7 +40,7 @@ Two key choices:
 2. **Single `ptr += 4` per iteration.** One arithmetic op at the end of the
    chunk instead of one per element.
 
-Measured: 14&ndash;36% faster than the scalar baseline at every size on both
+Measured: 14-36% faster than the scalar baseline at every size on both
 runtimes.
 
 ## Don't use these
@@ -57,7 +57,7 @@ if (*ptr == oldShort) *ptr = newShort; ptr++;
 
 Every load now depends on the previous `ptr++`. The JIT does not recover the
 parallelism by recognizing the pattern. Measured: 0.84&times; vs 1.12&times;
-ratio at length 256 on `net481` &mdash; the `ptr++` form is actually slower
+ratio at length 256 on `net481` - the `ptr++` form is actually slower
 than the un-unrolled scalar baseline.
 
 ### Integer-indexed body
@@ -89,7 +89,7 @@ while (ptr < unrollEnd)
 }
 ```
 
-Wins at length 16 (small loop, fewer iterations). **Regresses 1.3&ndash;1.6&times;
+Wins at length 16 (small loop, fewer iterations). **Regresses 1.3-1.6&times;
 at length 256+** on `net481`. Most likely the larger method body trips a
 register-allocation or loop-alignment threshold. The .NET 10 JIT recovers but
 `net481` does not.
@@ -127,6 +127,6 @@ preserve the "last occurrence" semantics).
 
 ## Tail loop
 
-Always pair the unrolled body with a scalar tail that handles 0&ndash;3
+Always pair the unrolled body with a scalar tail that handles 0-3
 elements. `length & ~3` rounds the unroll boundary down to a multiple of 4;
 the remainder is `length & 3` elements walked one at a time.

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -18,12 +18,12 @@ References to those types from a benchmark must be guarded with `#if NETFRAMEWOR
 
 **Related skills:**
 
-- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) &mdash; reasons
+- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - reasons
   to add a polyfill (and therefore a benchmark) in the first place.
-- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) &mdash;
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) -
   decisions about specialization, unrolling, and BCL-delegation on net481 that the
   benchmarks here exist to validate.
-- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; requires a benchmark
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - requires a benchmark
   in `touki.perf/` (or an explicit "not measured" note) for any perf claim that
   drives a code change in `touki/Framework/`.
 
@@ -45,10 +45,10 @@ References to those types from a benchmark must be guarded with `#if NETFRAMEWOR
 
 [GlobalUsings.cs](../../../touki.perf/GlobalUsings.cs) already provides:
 
-- `BenchmarkDotNet.Attributes` &mdash; `[Benchmark]`, `[MemoryDiagnoser]`, `[Params]`,
+- `BenchmarkDotNet.Attributes` - `[Benchmark]`, `[MemoryDiagnoser]`, `[Params]`,
   `[GlobalSetup]`, etc.
-- `BenchmarkDotNet.Jobs` &mdash; `RuntimeMoniker`, `[SimpleJob]`.
-- `Touki` &mdash; the library root namespace.
+- `BenchmarkDotNet.Jobs` - `RuntimeMoniker`, `[SimpleJob]`.
+- `Touki` - the library root namespace.
 - `Microsoft.IO` (on NETFRAMEWORK) or `System.IO` otherwise.
 
 Do not re-import these.
@@ -73,13 +73,13 @@ public class StringFormatting
 ```
 
 Mark one method `[Benchmark(Baseline = true)]` whenever you are comparing
-alternative implementations &mdash; the report adds a **Ratio** and
+alternative implementations - the report adds a **Ratio** and
 **RatioSD** column relative to that baseline.
 
 ### Optional attributes
 
 - `[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]`
-  &mdash; cuts run time when iterating on a benchmark. Use only while developing; remove
+  - cuts run time when iterating on a benchmark. Use only while developing; remove
   (or revert to defaults) before checking in stable measurements. See
   [StoreInteger.cs](../../../touki.perf/StoreInteger.cs) for an example.
 - `[Params(...)]` on a public field/property to run the benchmark for each value.
@@ -95,15 +95,15 @@ alternative implementations &mdash; the report adds a **Ratio** and
   consumes the return value to prevent that. For buffer-mutating APIs
   (`Span<T>.Replace`, `Random.NextBytes`, `Encoding.GetBytes`) return
   `buffer[0]`, the last element, or an XOR/sum digest of the buffer
-  &mdash; not `buffer.Length` or any other value invariant of execution.
+  - not `buffer.Length` or any other value invariant of execution.
   Symptoms of forgetting: "optimized" variants slower than the baseline
   (because the baseline got eliminated), >50% StdDev between runs,
   near-zero timings for non-trivial work. See
   [BenchmarkDotNet good practices](https://benchmarkdotnet.org/articles/guides/good-practices.html).
-- Be cheap to call repeatedly &mdash; BenchmarkDotNet invokes it millions of times.
+- Be cheap to call repeatedly - BenchmarkDotNet invokes it millions of times.
 - Avoid per-call setup; move setup into `[GlobalSetup]` or readonly fields.
 - Avoid wrapping the system-under-test in a helper method just to satisfy
-  overload resolution &mdash; the helper's call frame, type check, and
+  overload resolution - the helper's call frame, type check, and
   generic instantiation show up in the measurement. Either rename one
   overload temporarily while measuring, or split into two benchmark classes.
 - Ref structs cannot be returned from `[Benchmark]` methods; consume them
@@ -116,7 +116,7 @@ arguments are forwarded to BenchmarkDotNet. Run from the repo root in PowerShell
 
 ### Specifying the target framework is required
 
-Because `touki.perf` is multi-targeted, **`dotnet run` requires `-f <tfm>`** &mdash;
+Because `touki.perf` is multi-targeted, **`dotnet run` requires `-f <tfm>`** -
 the SDK will not pick one for you and the run fails with NETSDK1005 or an ambiguous
 target error if you omit it. Always pass `-f net10.0` or `-f net481` (or whatever
 `$(DotNetCoreVersion)` currently resolves to).
@@ -133,7 +133,7 @@ dotnet run -c Release -f net481 --project touki.perf -- --filter *StoreInteger*
 will warn loudly.
 
 When a change touches code that compiles for both targets, **run both TFMs**. The
-results often differ dramatically &mdash; the modern runtime has vectorized BCL APIs
+results often differ dramatically - the modern runtime has vectorized BCL APIs
 that .NET Framework lacks, so a hand-tuned net481 fast path may look identical to the
 generic path on net10.
 
@@ -157,11 +157,11 @@ With no `--filter`, BenchmarkSwitcher prints a numbered menu. Useful when explor
 
 ### Useful extra switches
 
-- `--job short` &mdash; very fast, low-confidence run; good for smoke-testing a new
+- `--job short` - very fast, low-confidence run; good for smoke-testing a new
   benchmark before committing to a full run.
-- `--memory` &mdash; enables the memory diagnoser for this run even if the class is not
+- `--memory` - enables the memory diagnoser for this run even if the class is not
   decorated. Prefer the attribute.
-- `--exporters github` &mdash; emits a GitHub-flavored Markdown report alongside the
+- `--exporters github` - emits a GitHub-flavored Markdown report alongside the
   default outputs.
 
 ## 3. Evaluating memory usage
@@ -183,9 +183,9 @@ With `[MemoryDiagnoser]` (or `--memory`), each row of the results table includes
   `Allocated` to confirm a perf change is not just trading CPU for allocations (or
   vice versa).
 - `Gen0` ticking up while `Allocated` stays flat usually means you allocated a lot of
-  short-lived objects on previous iterations &mdash; recheck `[GlobalSetup]`.
+  short-lived objects on previous iterations - recheck `[GlobalSetup]`.
 - Stack-only types (`Span<T>`, `ref struct`s, `stackalloc`) do not contribute to
-  `Allocated`. Boxing of value types does &mdash; watch for accidental boxing through
+  `Allocated`. Boxing of value types does - watch for accidental boxing through
   `object`, non-generic interfaces, or `string.Format`.
 - On `net481` the JIT and BCL allocate differently than on the modern .NET target
   (`net10.0`). Always run both before declaring a win.
@@ -195,9 +195,9 @@ With `[MemoryDiagnoser]` (or `--memory`), each row of the results table includes
 After each run BenchmarkDotNet writes artifacts under
 `BenchmarkDotNet.Artifacts/results/` next to the executable, including:
 
-- `*.md` &mdash; GitHub-friendly Markdown table (paste this into PR descriptions).
-- `*.csv` and `*.html` &mdash; for spreadsheets / browser viewing.
-- `*-report-full.json` &mdash; raw measurements; useful for diffing two runs
+- `*.md` - GitHub-friendly Markdown table (paste this into PR descriptions).
+- `*.csv` and `*.html` - for spreadsheets / browser viewing.
+- `*-report-full.json` - raw measurements; useful for diffing two runs
   programmatically.
 
 The same table is also printed to the console at the end of the run.
@@ -220,10 +220,10 @@ The same table is also printed to the console at the end of the run.
 
 ## 5. Codegen-level optimization rules
 
-For decisions about *how to write* a hot path &mdash; whether to specialize a
+For decisions about *how to write* a hot path - whether to specialize a
 generic for primitives, choose between scalar/unrolled forms, defer to BCL
 primitives like `IndexOf` / `SequenceEqual`, or interpret a `net481`-vs-`net10`
-divergence &mdash; see the
+divergence - see the
 [framework-jit-optimization](../framework-jit-optimization/SKILL.md) skill.
 That skill is the right entry point for "this loop is slow on `net481`, what
 should I try?" questions, while this one is about authoring and running the
@@ -233,7 +233,7 @@ benchmarks themselves.
 
 `IDE0180` ("use tuple to swap values") is disabled globally in
 [.editorconfig](../../../.editorconfig) because the auto-fix is unsafe on
-`net481` &mdash; see [SpanSwapPerf.cs](../../../touki.perf/SpanSwapPerf.cs)
+`net481` - see [SpanSwapPerf.cs](../../../touki.perf/SpanSwapPerf.cs)
 for the measurements. The summary is:
 
 | Form | net481 RyuJIT | .NET 10 RyuJIT |
@@ -261,4 +261,4 @@ with a localized pragma rather than re-enabling the rule globally:
 
 Do **not** apply this to code under `touki/Framework/` (compiled only for
 .NET Framework) or to code shared across both targets without a
-`#if NET` / `#else` split &mdash; the .NET Framework branch will regress.
+`#if NET` / `#else` split - the .NET Framework branch will regress.

--- a/.agents/skills/polyfill-dotnet-api/SKILL.md
+++ b/.agents/skills/polyfill-dotnet-api/SKILL.md
@@ -45,7 +45,7 @@ delete the probe.
 
 When adding a new package, place the `<PackageReference>` inside the
 `Condition="'$(TargetFramework)' == '$(DotNetFrameworkVersion)'"`
-ItemGroup &mdash; never unconditional.
+ItemGroup - never unconditional.
 
 ### 2. PolySharp source-generated polyfills
 
@@ -86,7 +86,7 @@ when there's a real caller; "completeness" polyfills bloat the surface.
   rather than static-class extension methods. Lookup picks the BCL
   member on modern .NET and the polyfill on net472. See
   [ConvertExtensions.cs](../../../touki/Framework/Polyfills/System/ConvertExtensions.cs).
-- **Don't `#if NETFRAMEWORK` inside `touki/Framework/`** &mdash; the
+- **Don't `#if NETFRAMEWORK` inside `touki/Framework/`** - the
   whole folder is already framework-only.
 - **Touki-specific helpers (not polyfills)** live in
   `touki/Framework/Touki/...` with `Touki.*` namespaces. If your file
@@ -113,7 +113,7 @@ when there's a real caller; "completeness" polyfills bloat the surface.
 
 The point of a span overload is to skip the array overload's
 allocation. Allocating a temp `T[]` to delegate to the BCL throws that
-benefit away. **Default allocation-free even at 5&ndash;15% throughput
+benefit away. **Default allocation-free even at 5-15% throughput
 cost**; document the trade-off in `<remarks>`. Use existing helpers
 before inventing new ones:
 
@@ -151,7 +151,7 @@ and comment which BCL surface is targeted and why.
 
 ### Argument validation
 
-- `ArgumentNullException.ThrowIfNull(arg)` &mdash; the polyfill at
+- `ArgumentNullException.ThrowIfNull(arg)` - the polyfill at
   [`ArgumentNullExtensions`](../../../touki/Framework/Polyfills/System/ArgumentNullExtensions.cs)
   covers net472.
 - `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when available;
@@ -211,13 +211,13 @@ enforces these; this section explains *why*.
    with `movzx`, RyuJIT propagates the *int-promoted* constant into
    the compare immediate (`cmp ecx, 0xFFFFFFFF`) instead of the
    requested byte (`0xFF`). The `movzx`-loaded byte is in `[0, 0xFF]`
-   so the compare is *unconditionally false* &mdash; the loop runs
+   so the compare is *unconditionally false* - the loop runs
    silently doing nothing in Release. Debug passes (no inlining).
    Confirmed by disassembly in
    [ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs).
 
    **Fix:** explicitly mask in the int domain so RyuJIT must fold the
-   high bits to zero. The cast alone is not enough &mdash; the JIT's
+   high bits to zero. The cast alone is not enough - the JIT's
    constant tracker doesn't model the `conv.u1` IL op as truncating
    to `[0, 0xFF]` here. Use:
 
@@ -232,7 +232,7 @@ enforces these; this section explains *why*.
    benchmark for the disassembly proof. The unsigned cases (`byte`,
    `ushort`, `char`) are unaffected because their int-promoted form
    already has the upper bits zero. Tests on signed inputs are
-   essential &mdash; symmetric tests that only use `byte`/`char` will
+   essential - symmetric tests that only use `byte`/`char` will
    not catch this.
 
 3. **`Random.NextBytes(byte[])` is native on net481; the obvious
@@ -269,9 +269,9 @@ enforces these; this section explains *why*.
 
 | API | Source | File |
 | --- | --- | --- |
-| `Span<T>.IndexOf` / `Contains` | `System.Memory` | &mdash; |
-| `HashCode` | `Microsoft.Bcl.HashCode` | &mdash; |
-| `IsExternalInit`, `CallerArgumentExpression` | PolySharp | &mdash; |
+| `Span<T>.IndexOf` / `Contains` | `System.Memory` | - |
+| `HashCode` | `Microsoft.Bcl.HashCode` | - |
+| `IsExternalInit`, `CallerArgumentExpression` | PolySharp | - |
 | `ROS<T>.StartsWith(T)` (single element) | hand | [SpanExtensions.StartsEndsWith.cs](../../../touki/Framework/Polyfills/System/SpanExtensions.StartsEndsWith.cs) |
 | `Convert.ToHexString` / `FromHexString` | hand | [ConvertExtensions.cs](../../../touki/Framework/Polyfills/System/ConvertExtensions.cs) |
 | `Random.NextBytes(Span<byte>)` | hand | [RandomExtensions.cs](../../../touki/Framework/Polyfills/System/RandomExtensions.cs) |

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -11,27 +11,27 @@ the skill whenever a reviewer flags something not yet listed.
 
 **Related skills:**
 
-- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) &mdash; the
+- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - the
   source-preference and design rules for adding a new polyfill that
   this checklist then validates.
-- [`create-pr`](../create-pr/SKILL.md) &mdash; the workflow this checklist
+- [`create-pr`](../create-pr/SKILL.md) - the workflow this checklist
   precedes.
-- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) &mdash; the
+- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - the
   follow-up workflow that re-runs this checklist after review comments.
-- [`performance-testing`](../performance-testing/SKILL.md) &mdash; benchmark
+- [`performance-testing`](../performance-testing/SKILL.md) - benchmark
   authoring required by &sect;7 when a perf claim drives a code change.
 - [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
-  &mdash; net481 RyuJIT tradeoffs cited in &sect;5 and &sect;7.
-- [`agent-files-review`](../agent-files-review/SKILL.md) &mdash; for any
+  - net481 RyuJIT tradeoffs cited in &sect;5 and &sect;7.
+- [`agent-files-review`](../agent-files-review/SKILL.md) - for any
   changes under `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`.
-- [`security-review`](../security-review/SKILL.md) &mdash; the
+- [`security-review`](../security-review/SKILL.md) - the
   security-specific subset (abusive-input handling, length / integer
   overflow, allocation and algorithmic DoS, argument validation, and
   every use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` /
   `Marshal.*` or any BCL API whose docs say "unsafe" or "caller
   must"). Invoke alongside this checklist for any change that adds
   or modifies a member accepting caller-supplied data, or any change
-  that touches one of those caller-validated constructs &mdash; the
+  that touches one of those caller-validated constructs - the
   common case, not a niche.
 
 ## 1. Tests cover every new branch
@@ -46,7 +46,7 @@ For each new `public` (or `InternalsVisibleTo`-internal) member:
   the fast path *and* a subclass override.
 - Generic primitive specializations: every specialized branch needs a
   test. Don't rely on `byte`/`int` covering `bool`/`sbyte`/`short`/
-  `ushort`/`uint`/`long`/`ulong` &mdash; each has independent ref
+  `ushort`/`uint`/`long`/`ulong` - each has independent ref
   reinterpretation.
 - Security-sensitive APIs (`FixedTimeEquals`, hex decode): cover equal,
   differing-content, length mismatch, both empty, one empty, and a long
@@ -54,7 +54,7 @@ For each new `public` (or `InternalsVisibleTo`-internal) member:
 - Allocating APIs (`Concat`, `ToHexString`): include an
   `OverflowException` test on the length sum (see &sect;3).
 
-Test hygiene for the tests themselves &mdash; the recurring miss list
+Test hygiene for the tests themselves - the recurring miss list
 that costs the most review rounds on coverage-only PRs:
 
 - **Test method names start with the method under test.**
@@ -64,7 +64,7 @@ that costs the most review rounds on coverage-only PRs:
   `SliceAtNull_ReadOnlySpan_Empty_ReturnsEmpty` is right.
 - **Every `IDisposable` test local uses `using` or `try`/`finally`.**
   `TempFolder`, `IEnumerationMatcher`, anything returned by
-  `MSBuildMatchBuilder.FromSpecification`, `ArrayPoolList<T>` &mdash;
+  `MSBuildMatchBuilder.FromSpecification`, `ArrayPoolList<T>` -
   a bare local leaks the resource when an assertion fails. See
   the "Disposables in test bodies" section in `tests.instructions.md`
   for the pattern when the test itself exercises explicit `Dispose()`.
@@ -103,7 +103,7 @@ for the canonical `OverflowException` test pattern.
 
 ## 4. Throw helpers
 
-- Null guards use `ArgumentNullException.ThrowIfNull(arg)` &mdash; the
+- Null guards use `ArgumentNullException.ThrowIfNull(arg)` - the
   polyfill at
   [touki/Framework/Polyfills/System/ArgumentNullExtensions.cs](../../../touki/Framework/Polyfills/System/ArgumentNullExtensions.cs)
   covers net472.
@@ -118,7 +118,7 @@ The whole reason callers reach for a span overload is to avoid the
 allocation the array overload makes. A polyfill that allocates a temp
 `T[]` to delegate to the BCL has thrown that benefit away.
 
-**Default to allocation-free, even if 5&ndash;15% slower.** Document
+**Default to allocation-free, even if 5-15% slower.** Document
 the trade-off in `<remarks>` so callers understand the choice.
 
 Strategies used elsewhere in this repo (look here before inventing a
@@ -148,7 +148,7 @@ new one):
   internal helpers directly without exposing them in the public API.
 
 If the only way to be allocation-free is to call an `internal` BCL API,
-allocate &mdash; do not reflect into the BCL.
+allocate - do not reflect into the BCL.
 
 ## 6. Behavior parity with the modern BCL
 
@@ -156,7 +156,7 @@ allocate &mdash; do not reflect into the BCL.
   inputs, length-zero destination, exception types and message family).
 - Mirror the BCL exception type and message family for observable cases.
 - For stateful types (`HashCode`, `Random`), document any deviation in
-  `<remarks>`. `HashCode` is process-local in the BCL too &mdash;
+  `<remarks>`. `HashCode` is process-local in the BCL too -
   within-process determinism is the only contract.
 - For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
   the polyfill's fast path applies only when
@@ -165,7 +165,7 @@ allocate &mdash; do not reflect into the BCL.
 
 ## 7. Performance claims name the JIT and are measured
 
-State which JIT &mdash; **net481 RyuJIT** (no tiered JIT, no PGO, no
+State which JIT - **net481 RyuJIT** (no tiered JIT, no PGO, no
 `EqualityComparer<T>.Default` intrinsic, weaker inlining) vs **modern
 .NET RyuJIT** (.NET 6+, tiered, PGO, devirtualizes
 `EqualityComparer<T>.Default`). Unqualified "RyuJIT does X" claims are
@@ -203,9 +203,9 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
 
 ## 9. Final audit before staging
 
-- `git status --short` &mdash; delete leftover probe / scratch files;
+- `git status --short` - delete leftover probe / scratch files;
   confirm every listed file belongs in the change set.
-- `git diff --check` &mdash; whitespace.
+- `git diff --check` - whitespace.
 - **Rebase onto the canonical `main` if the branch trails it.** Use
   `upstream/main` when working from a fork (the canonical repo lives at
   `upstream`), `origin/main` when cloning the canonical repo directly.
@@ -220,7 +220,7 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
   options including `-ChangedOnly` and `-Base`).
 - Build both TFMs.
 - Run `dotnet test` in **both Debug and Release**. Release-mode RyuJIT
-  inlining surfaces bugs Debug doesn't &mdash; e.g.
+  inlining surfaces bugs Debug doesn't - e.g.
   `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates
   the caller's int-promoted argument into the comparison immediate
   (`cmp ecx, 0xFFFFFFFF` instead of `cmp ecx, 0xFF`) for negative

--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -32,20 +32,20 @@ release notes. It does **not** authorize the tag push. The
 
 Read-only checks:
 
-- `git remote -v` — confirm `origin` points at `JeremyKuhne/touki` (push
+- `git remote -v` - confirm `origin` points at `JeremyKuhne/touki` (push
   target).
-- `git rev-parse --abbrev-ref HEAD` — must be `main` or a release branch.
+- `git rev-parse --abbrev-ref HEAD` - must be `main` or a release branch.
   Refuse to tag from an arbitrary feature branch unless the user explicitly
   says so.
-- `git status --porcelain` — must be clean. If dirty, stop and ask.
-- `git log origin/main..HEAD` and `git log HEAD..origin/main` — must both be
+- `git status --porcelain` - must be clean. If dirty, stop and ask.
+- `git log origin/main..HEAD` and `git log HEAD..origin/main` - must both be
   empty. Tag must point at the published `origin/main` tip (or whatever the
   user confirmed in the previous bullet).
 
 Ask the user **which package** if not already obvious from the request:
 
-- `KlutzyNinja.Touki` — the main library.
-- `KlutzyNinja.Touki.TestSupport` — test helpers (rarely shipped; see
+- `KlutzyNinja.Touki` - the main library.
+- `KlutzyNinja.Touki.TestSupport` - test helpers (rarely shipped; see
   [docs/release-strategy](../../../touki.testsupport/README.md)).
 
 Use `vscode_askQuestions` only if ambiguous; if the user said "publish
@@ -89,12 +89,12 @@ prompt** the user with the current state explicit:
 Use `vscode_askQuestions` with these options (mark the matching-prior option
 as `recommended: true`):
 
-- `Stay in alpha` — bug fixes / additive work during early development.
-- `Promote to beta` — feature-complete for the upcoming Minor; only
+- `Stay in alpha` - bug fixes / additive work during early development.
+- `Promote to beta` - feature-complete for the upcoming Minor; only
   stabilization work expected.
-- `Promote to rc` — release candidate; only blocker bug fixes.
-- `Promote to stable` — drop the prerelease label entirely.
-- `Use a different label` — free-form.
+- `Promote to rc` - release candidate; only blocker bug fixes.
+- `Promote to stable` - drop the prerelease label entirely.
+- `Use a different label` - free-form.
 
 Channel rules of thumb:
 
@@ -125,10 +125,10 @@ underlying `Major.Minor.Patch` portion.
 For pre-1.0, the user may treat **Major** and **Minor** as both "Minor"
 during alpha/beta. That is fine; just confirm the call out loud:
 
-> "This change adds a public type but you're still in 0.1.x alpha — bump
+> "This change adds a public type but you're still in 0.1.x alpha - bump
 > to 0.2.0-alpha.1 (treating it as Minor) or stay at 0.1.0-alpha.13?"
 
-### When `AssemblyVersion` changes — and why it matters
+### When `AssemblyVersion` changes - and why it matters
 
 MinVer's defaults (used as-is in this repo, no overrides) produce:
 
@@ -144,11 +144,11 @@ Only a **Major** bump changes `AssemblyVersion`. That has real consequences:
   binding redirects (on .NET Framework). Strong-named assemblies make this
   stricter, and `touki.dll` is strong-named.
 - A change in `Version`/`FileVersion` *without* `AssemblyVersion` changing
-  is binary-compatible — consumers can drop the new DLL into an existing
+  is binary-compatible - consumers can drop the new DLL into an existing
   bin folder and it just works.
 
 **Therefore:** any binary breaking change *must* bump `Major`, even during
-0.x. Refusing to bump `Major` on a binary break — to "stay at 0.1.x" —
+0.x. Refusing to bump `Major` on a binary break - to "stay at 0.1.x" -
 silently keeps `AssemblyVersion = 0.0.0.0` across an incompatible
 boundary, which is a real foot-gun for downstream binders.
 
@@ -179,12 +179,12 @@ Examples (good):
 
 Examples (rejected by guard):
 
-- `v.0.1.0-alpha.11` — stray `.` after `v`. The historical 9/10/11 tags
+- `v.0.1.0-alpha.11` - stray `.` after `v`. The historical 9/10/11 tags
   hit this; do not recreate it.
-- `0.1.0-alpha.13` — missing `v` prefix.
-- `v0.1.0.alpha.13` — `.` instead of `-` before prerelease.
-- `v0.1` — missing patch component.
-- `v01.02.03` — leading zeros in numeric identifiers.
+- `0.1.0-alpha.13` - missing `v` prefix.
+- `v0.1.0.alpha.13` - `.` instead of `-` before prerelease.
+- `v0.1` - missing patch component.
+- `v01.02.03` - leading zeros in numeric identifiers.
 
 The regex used by the workflow guards (must match):
 
@@ -207,7 +207,7 @@ The regex used by the workflow guards (must match):
 
 Wait for an explicit publishing verb (`tag`, `push the tag`, `ship it`,
 `publish`). Do **not** infer approval from the original "publish a release"
-request — that authorized the *preparation*, not the push. See AGENTS.md.
+request - that authorized the *preparation*, not the push. See AGENTS.md.
 
 ## 7. Create and push the tag
 
@@ -218,7 +218,7 @@ git tag -a v0.1.0-alpha.13 -m "v0.1.0-alpha.13"
 git push origin v0.1.0-alpha.13
 ```
 
-Do **not** use lightweight tags — annotated tags carry the tagger and date
+Do **not** use lightweight tags - annotated tags carry the tagger and date
 that show up in GitHub releases.
 
 Pushing the tag triggers the publish workflow. Watch the run:
@@ -229,10 +229,10 @@ Pushing the tag triggers the publish workflow. Watch the run:
 The workflow validates the tag format, packs, OIDC-logs into NuGet, and
 pushes with `--skip-duplicate`. The main publish workflow filters out
 `KlutzyNinja.Touki.TestSupport.*` from its glob, and TestSupport's workflow
-fires only on `ts-v*` — they will not stomp each other.
+fires only on `ts-v*` - they will not stomp each other.
 
 If the workflow fails, treat it like any CI failure: do **not** delete and
-re-push the tag without explicit user approval — that's destructive and the
+re-push the tag without explicit user approval - that's destructive and the
 nuget.org publish is irreversible. Fix forward with the next tag in the
 stream.
 
@@ -243,7 +243,7 @@ not published, both workflows accept a `workflow_dispatch` with a
 required `tag` input. Provide the **exact existing tag name** (e.g.
 `v0.1.0-alpha.13` or `ts-v0.1.0-alpha.9`); the workflow checks out that
 ref, runs the same tag-format guard, and publishes. Do **not** dispatch
-without a tag input — the workflow will fail validation rather than
+without a tag input - the workflow will fail validation rather than
 publish a `0.0.0-alpha.0.<height>` MinVer fallback.
 
 ## 8. Create the GitHub release
@@ -316,7 +316,7 @@ Notes on the template:
 - If you bumped `KlutzyNinja.Touki`, consider whether the sample's pinned
   version in [Directory.Packages.props](../../../Directory.Packages.props)
   should advance. The sample dog-foods the released package; leaving it
-  stale defeats the purpose. (Open as a follow-up PR — not part of the
+  stale defeats the purpose. (Open as a follow-up PR - not part of the
   release commit/tag.)
 - If you bumped `Major` (binary break), also bump `Major` of TestSupport
   on its next release. They don't have to march in lockstep but TestSupport
@@ -326,14 +326,14 @@ Notes on the template:
 
 ## Cross-references
 
-- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) — run before
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - run before
   shipping any change that lands in a release.
-- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) — used to land
+- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - used to land
   the changes that this skill then ships.
-- AGENTS.md § "Working with the user on changes" — publish-boundary rule
+- AGENTS.md § "Working with the user on changes" - publish-boundary rule
   governing the approval checkpoint in step 6.
-- [Directory.Build.targets](../../../Directory.Build.targets) — central
+- [Directory.Build.targets](../../../Directory.Build.targets) - central
   MinVer wiring.
 - [.github/workflows/publish.yml](../../../.github/workflows/publish.yml),
   [.github/workflows/publishtestsupport.yml](../../../.github/workflows/publishtestsupport.yml)
-  — the publish pipelines themselves.
+  - the publish pipelines themselves.

--- a/.agents/skills/run-tests-on-wsl/SKILL.md
+++ b/.agents/skills/run-tests-on-wsl/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: run-tests-on-wsl
-description: Run touki tests &mdash; especially the Unix-only oracle suites under `touki.tests/Touki/Io/Globbing/` &mdash; inside WSL Ubuntu on Windows. Use when the user asks to "run tests on Linux", "run the Posix/PosixPath/Bash oracles", or "iterate Unix tests locally", and for any fix that needs Linux verification before pushing.
+description: Run touki tests - especially the Unix-only oracle suites under `touki.tests/Touki/Io/Globbing/` - inside WSL Ubuntu on Windows. Use when the user asks to "run tests on Linux", "run the Posix/PosixPath/Bash oracles", or "iterate Unix tests locally", and for any fix that needs Linux verification before pushing.
 ---
 
 # Running tests inside WSL Ubuntu
 
 **Headline rule:** keep a Linux-native checkout (e.g. `~/repos/touki`) and
 sync from the Windows-mounted checkout before each run. Building directly
-from the `/mnt/<drive>/...` mount **does not work** &mdash; see the trap
+from the `/mnt/<drive>/...` mount **does not work** - see the trap
 below.
 
 The agent drives WSL from the existing PowerShell terminal via `wsl --`;
@@ -22,7 +22,7 @@ paths for `<WIN_CHECKOUT>` (e.g. `/mnt/d/src/touki`) and `<LINUX_CHECKOUT>`
 `/mnt/c/Users/<user>/AppData/Roaming/NuGet/NuGet.Config` and
 `/mnt/c/Program Files (x86)/NuGet/Config/Microsoft.VisualStudio.*.config`,
 which reference
-`C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages` &mdash;
+`C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages` -
 unreachable as a Linux path. NuGet writes the Windows fallback verbatim into
 `project.assets.json` / `*.nuget.dgspec.json`, and the next build fails with:
 
@@ -40,11 +40,11 @@ moving the checkout off the DrvFs mount does.
 
 - WSL2 with a default Ubuntu distro. If `wsl -l -v` reports "Windows
   Subsystem for Linux is not installed", the user must run `wsl --install`
-  from an elevated PowerShell and reboot &mdash; the agent cannot drive the
+  from an elevated PowerShell and reboot - the agent cannot drive the
   elevation prompt.
 - `libicu-dev` installed (`sudo apt-get install -y libicu-dev`). Without
   it, `dotnet --version` throws on `Console.OutputEncoding`. Tell the user
-  to run `sudo` &mdash; do not collect the password via chat.
+  to run `sudo` - do not collect the password via chat.
 - .NET SDK 10 under `$HOME/.dotnet` (the repo's
   [setup.sh](../../../setup.sh) installs latest 10.x). If
   [global.json](../../../global.json) pins a specific feature-band patch
@@ -80,7 +80,7 @@ wsl --cd <LINUX_CHECKOUT> -- bash -ic `
     'dotnet build touki.tests -c Release -f net10.0 --nologo'
 
 # 3. Run a filtered subset. `--filter-method` only allows wildcards at the
-#    start and/or end of the pattern and does not support `|` OR &mdash;
+#    start and/or end of the pattern and does not support `|` OR -
 #    run each suite separately.
 wsl --cd <LINUX_CHECKOUT> -- bash -ic `
     'dotnet test touki.tests -c Release -f net10.0 --no-build --nologo -- --filter-method "*Posix*"'
@@ -105,14 +105,14 @@ findings in [docs/globbing-feature-plan.md](../../../docs/globbing-feature-plan.
 The one OS-conditional row to expect is
 `SequentialSeparatorMSBuildOracleTests` `//a` vs `/a`: `MSBuildGlob` on
 Linux treats `//a` &equiv; `/a`; on Windows it treats `//a` as a UNC root.
-Touki is OS-stable, matching the Windows verdict &mdash; this is a
+Touki is OS-stable, matching the Windows verdict - this is a
 documented platform divergence in the oracle, not in touki.
 
 ## Related skills
 
-- [`performance-testing`](../performance-testing/SKILL.md) &mdash; same
+- [`performance-testing`](../performance-testing/SKILL.md) - same
   recipe runs `touki.perf` benchmarks on Linux; swap `touki.tests` for
   `touki.perf`.
-- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; for
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - for
   changes touching `touki/Touki/Io/Globbing/`, run the Linux oracle suites
   before pushing so Unix-only regressions are caught locally instead of in CI.

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-review
-description: Security-focused review of pending changes. Audit any change that could affect safety or correctness under abusive input or unchecked preconditions &mdash; oversized values, malformed structures, integer/length overflow, catastrophic backtracking, allocation pressure, other denial-of-service shapes, and any use of `unsafe` code or the `Unsafe` / `MemoryMarshal` / `Marshal` static helpers (which trade compiler safety guarantees for speed and need extra scrutiny). Add regression tests that pin safe behavior even when the current implementation already handles the input correctly. Use when asked to "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling", or before publishing any change that adds or modifies code that parses, decodes, encodes, compiles, marshals, or reinterprets memory.
+description: Security-focused review of pending changes. Audit any change that could affect safety or correctness under abusive input or unchecked preconditions - oversized values, malformed structures, integer/length overflow, catastrophic backtracking, allocation pressure, other denial-of-service shapes, and any use of `unsafe` code or the `Unsafe` / `MemoryMarshal` / `Marshal` static helpers (which trade compiler safety guarantees for speed and need extra scrutiny). Add regression tests that pin safe behavior even when the current implementation already handles the input correctly. Use when asked to "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling", or before publishing any change that adds or modifies code that parses, decodes, encodes, compiles, marshals, or reinterprets memory.
 ---
 
 # Security review
@@ -10,9 +10,9 @@ APIs** (everything the C# compiler doesn't check for you).
 
 **Related skills:**
 
-- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) &mdash; broader
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - broader
   self-review; run this skill alongside it before any publish.
-- [`performance-testing`](../performance-testing/SKILL.md) &mdash; use
+- [`performance-testing`](../performance-testing/SKILL.md) - use
   when you need to *measure* a worst-case input rather than just bound
   it with a `Stopwatch`.
 
@@ -25,7 +25,7 @@ APIs** (everything the C# compiler doesn't check for you).
 - A change introduces or modifies `unsafe` code, calls into
   `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, `fixed`, raw pointers,
   unbounded `stackalloc`, or any BCL API whose XML doc says "unsafe"
-  or "caller must". Applies even when inputs are fully internal &mdash;
+  or "caller must". Applies even when inputs are fully internal -
   preconditions drift across refactors.
 - A CVE in a comparable library prompts "do we have the same shape?".
 
@@ -58,14 +58,14 @@ APIs** (everything the C# compiler doesn't check for you).
 
 Label every finding before the report.
 
-- **High** &mdash; memory corruption, OOB read/write, type confusion,
+- **High** - memory corruption, OOB read/write, type confusion,
   lifetime escape, RCE, disclosure of secrets/addresses, auth bypass.
   Fix on the same PR.
-- **Medium** &mdash; DoS (CPU, memory, stack, FDs), crashing unhandled
+- **Medium** - DoS (CPU, memory, stack, FDs), crashing unhandled
   exception, parser accepting malformed input as valid, ambiguous
   parsing that smuggles a different shape past validation. Usually
   fix on the same PR; deferral needs a documented mitigation.
-- **Low** &mdash; silent truncation still bounded by a downstream BCL
+- **Low** - silent truncation still bounded by a downstream BCL
   slice check, documented contract violations on edge cases,
   non-sensitive error-message leakage. Safe to defer; still pin the
   *corrected* behavior with a regression test once the fix lands.
@@ -110,7 +110,7 @@ error, opt-out (e.g. `-1`) disables the check.
 
 **Tests:** boundary inside the representable range plus boundary
 outside. Specialized fast paths often bypass the affected code
-&mdash; pick an input shape that **forces the general path**.
+- pick an input shape that **forces the general path**.
 
 ### 3. Allocation pressure / memory DoS
 
@@ -211,7 +211,7 @@ Walk every use site against this table; rows are independent.
 
 ### 8. Path traversal / sandbox escape
 
-- API takes a root + relative input and returns paths &mdash; results
+- API takes a root + relative input and returns paths - results
   stay inside the root? Symlink behavior is the caller's documented
   choice, not silently re-enabled?
 - Caller-supplied fragments concatenated without normalization?
@@ -231,7 +231,7 @@ configured root.
   documented to accept any underlying value with explicit defaulting.
 
 **Test:** one per parameter for each forbidden violation mode. Don't
-trust the downstream BCL primitive to throw &mdash; the contract is
+trust the downstream BCL primitive to throw - the contract is
 yours.
 
 ## Review procedure

--- a/.github/agents/touki-reviewer.agent.md
+++ b/.github/agents/touki-reviewer.agent.md
@@ -1,5 +1,5 @@
 ---
-description: Read-only reviewer for touki PRs. Checks cross-TFM correctness, the JIT-naming rule, polyfill conventions, and missing tests/docs. Findings only — never offers fixes.
+description: Read-only reviewer for touki PRs. Checks cross-TFM correctness, the JIT-naming rule, polyfill conventions, and missing tests/docs. Findings only - never offers fixes.
 tools: ['search', 'usages', 'problems', 'changes', 'fetch']
 ---
 
@@ -21,7 +21,7 @@ checked. Do not pad.
    and .NET Framework 4.7.2. Flag any modern C# / BCL usage not gated for the
    older target. Flag missing `#if NET` where required. Note: code under
    `touki/Framework/` already targets only the framework, so `#if NETFRAMEWORK`
-   inside that tree is dead &mdash; see
+   inside that tree is dead - see
    [.github/instructions/polyfills.instructions.md](../instructions/polyfills.instructions.md).
 
 2. **Polyfill conventions.** For files under `touki/Framework/Polyfills/`:
@@ -38,7 +38,7 @@ checked. Do not pad.
    "modern .NET RyuJIT". Unqualified "RyuJIT" claims are a finding. Flag
    `[MethodImpl(MethodImplOptions.AggressiveInlining)]` methods that take a
    generic `T` and call `Unsafe.As<T, byte/sbyte/short/ushort>(ref param)`
-   without masking &mdash; this is the documented net481 codegen bug. See
+   without masking - this is the documented net481 codegen bug. See
    [touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs](../../touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs).
 
 4. **Public API additions.**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,12 +21,12 @@ All code must compile and behave correctly on both targets.
 
 Top-level layout:
 
-- `touki/` &mdash; main library
-- `touki.tests/` &mdash; xUnit tests (uses FluentAssertions; access to internals via `InternalsVisibleTo`)
-- `touki.testsupport/` &mdash; shared test helpers (`TestAccessor`, etc.)
-- `touki.perf/` &mdash; BenchmarkDotNet performance projects
-- `sample/` &mdash; usage samples
-- `docs/` &mdash; contributor and design documentation
+- `touki/` - main library
+- `touki.tests/` - xUnit tests (uses FluentAssertions; access to internals via `InternalsVisibleTo`)
+- `touki.testsupport/` - shared test helpers (`TestAccessor`, etc.)
+- `touki.perf/` - BenchmarkDotNet performance projects
+- `sample/` - usage samples
+- `docs/` - contributor and design documentation
 
 ## Environment setup
 
@@ -41,7 +41,7 @@ Top-level layout:
 - Always use C# keywords for types (`int`, `string`, `bool`) instead of their aliases
   (`Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
-- Avoid `var` &mdash; use explicit type declarations, target-typed `new`, and
+- Avoid `var` - use explicit type declarations, target-typed `new`, and
   [collection expressions](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/collection-expressions)
   together: `List<string> list = new();`, `int[] values = [1, 2, 3];`,
   `Point[] points = [new(1, 2), new(5, 6)];`. The variable's type is always
@@ -82,6 +82,13 @@ Top-level layout:
   from the method with the most arguments, overriding tags where they differ.
 - Use `<see langword="..."/>` tags for language keywords in comments
   (e.g. `<see langword="true"/>` instead of `true`).
+- Prefer plain ASCII characters that don't need escaping (`-`, `"`, `...`,
+  `->`) over typographic Unicode (`—`, `–`, `"`, `"`, `…`, `→`) or HTML
+  entities (`&mdash;`, `&ndash;`, `&hellip;`, `&rarr;`, `&nbsp;`). Use a
+  plain `-` (with surrounding spaces when separating clauses) instead of
+  em/en-dashes. Only escape when the raw character would actually be
+  parsed as markup (e.g. `<` inside an XML doc comment); do not escape
+  defensively when it isn't needed.
 
 ## Line breaks and whitespace
 
@@ -100,7 +107,7 @@ Top-level layout:
 - When breaking lines in a method call, all parameters should be indented on their own
   lines.
 - After multiple edits to a file, verify that blank lines and whitespace remain correct.
-- When using search-and-replace tools, include 3&ndash;5 lines of context before and
+- When using search-and-replace tools, include 3-5 lines of context before and
   after the target text.
 
 ## Testing
@@ -110,7 +117,7 @@ Detailed test conventions live in
 (applies to `touki.tests/**/*.cs`). Headline rules: place tests in `touki.tests`;
 name them `MethodName_StateUnderTest_ExpectedBehavior`; use FluentAssertions (global
 using); access internals directly via `InternalsVisibleTo` and private members via
-`TestAccessor`; ref structs can't be used in lambdas &mdash; use `try`/`finally`.
+`TestAccessor`; ref structs can't be used in lambdas - use `try`/`finally`.
 
 Performance-test conventions for `touki.perf/` (BenchmarkDotNet, Release-only,
 JIT-naming rule, regression thresholds) live in
@@ -158,12 +165,12 @@ None of these authorize a push or a PR. They have all been
 mistaken for it on this repo:
 
 - "address the review comments" / "fix the comments" / "look at the
-  comments" &mdash; edit-only.
+  comments" - edit-only.
 - "do the next step" / "let's do X next" / a bare "go ahead" attached
-  to a task description &mdash; selects which task, not whether to publish.
-- "fix the CI failure" / "the PR is failing" &mdash; diagnosis or local
+  to a task description - selects which task, not whether to publish.
+- "fix the CI failure" / "the PR is failing" - diagnosis or local
   fix, not a push.
-- "pull main and work on X" &mdash; authorizes the work only.
+- "pull main and work on X" - authorizes the work only.
 
 When in doubt, ask one short yes/no question.
 
@@ -185,7 +192,7 @@ When in doubt, ask one short yes/no question.
 ### After a violation
 
 Acknowledge directly without minimizing. **Do not push a follow-up
-"fix" commit without explicit approval** &mdash; that compounds the
+"fix" commit without explicit approval** - that compounds the
 failure. The user decides whether to revert, force-push, or leave it.
 
 ### Other rules
@@ -194,7 +201,7 @@ failure. The user decides whether to revert, force-push, or leave it.
   tree spans more than one logical change. Run `git status --short`
   first; if topics are intermingled, ask how to split.
 - **Run `dotnet test -c Release` before declaring a fix done.**
-  Release-mode inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As`
+  Release-mode inlining surfaces bugs Debug doesn't - `Unsafe.As`
   on a method parameter is a known foot-gun on net481 RyuJIT.
 
 ### Enforcement
@@ -214,7 +221,7 @@ only guard that works in every configuration.
   `gh pr create|merge|close|edit`. In Default Approvals mode each
   denied command requires an in-chat **Allow** click; that click is
   the approval. **In Bypass Approvals or Autopilot, this denylist is
-  ignored at runtime** &mdash; the entries remain as documentation of
+  ignored at runtime** - the entries remain as documentation of
   which commands cross the publish boundary, and as a defense-in-depth
   tripwire for contributors and agents who *are* in Default Approvals
   mode. Do not rely on the denylist to stop you.
@@ -235,7 +242,7 @@ only guard that works in every configuration.
   force pushes and branch deletion blocked) is the only server-side
   guard that survives every approval mode. It does not stop
   `gh pr create|merge|close|edit`, MCP `create_pull_request`,
-  `merge_pull_request`, or pushes to feature branches &mdash; only
+  `merge_pull_request`, or pushes to feature branches - only
   direct writes to `main` itself.
 
 The agent's pre-flight check (re-read the user's most recent message
@@ -259,7 +266,7 @@ catch a mistake.
   first.** On net472/net481 the `ReadOnlySpan<T>` indexer costs ~8 µops
   per element (slow-span layout) versus ~1 µop on net10. Hoist
   `ref T = MemoryMarshal.GetReference(span)` outside the loop and walk
-  with `Unsafe.Add<T>(ref, i)` for a 19&ndash;44% Framework win at no
+  with `Unsafe.Add<T>(ref, i)` for a 19-44% Framework win at no
   `unsafe`-keyword cost. Prefer a single simple implementation when it
   measures within ~5% of any Framework-tuned variant on net10 so the
   simple source keeps accruing future RyuJIT improvements; split with
@@ -274,7 +281,7 @@ catch a mistake.
     standard size); it rents from `ArrayPool<byte>` automatically if the
     content outgrows the buffer, and `ToStringAndDispose()` returns the
     final string while releasing the rental. Verified savings of
-    58&ndash;63&nbsp;% allocated bytes when replacing `StringBuilder` in the
+    58-63&nbsp;% allocated bytes when replacing `StringBuilder` in the
     `GlobMatcherFactory` bytecode encoder, with no measurable throughput
     cost.
   - `Touki.Text.StringSegment` / `Touki.Text.StringSpan` instead of
@@ -306,7 +313,7 @@ automatically based on each file's `applyTo` glob.
 
 Currently:
 
-- [.github/instructions/msbuild.instructions.md](instructions/msbuild.instructions.md) &mdash; rules for `*.csproj`, `*.props`, `*.targets`.
-- [.github/instructions/tests.instructions.md](instructions/tests.instructions.md) &mdash; conventions for `touki.tests/**/*.cs`.
-- [.github/instructions/perf.instructions.md](instructions/perf.instructions.md) &mdash; BenchmarkDotNet conventions and the JIT-naming rule for `touki.perf/**/*.cs`.
-- [.github/instructions/polyfills.instructions.md](instructions/polyfills.instructions.md) &mdash; the two non-negotiable rules for `touki/Framework/Polyfills/**/*.cs`.
+- [.github/instructions/msbuild.instructions.md](instructions/msbuild.instructions.md) - rules for `*.csproj`, `*.props`, `*.targets`.
+- [.github/instructions/tests.instructions.md](instructions/tests.instructions.md) - conventions for `touki.tests/**/*.cs`.
+- [.github/instructions/perf.instructions.md](instructions/perf.instructions.md) - BenchmarkDotNet conventions and the JIT-naming rule for `touki.perf/**/*.cs`.
+- [.github/instructions/polyfills.instructions.md](instructions/polyfills.instructions.md) - the two non-negotiable rules for `touki/Framework/Polyfills/**/*.cs`.

--- a/.github/instructions/perf.instructions.md
+++ b/.github/instructions/perf.instructions.md
@@ -15,17 +15,17 @@ skills for the workflow and net481-specific JIT details.
   meaningless and will mislead any performance claim built on them.
 - Benchmarks must run cleanly on **both** target frameworks (.NET 10 and
   .NET Framework 4.8.1). A regression on one TFM and not the other is a real
-  signal, not noise &mdash; see the JIT-naming rule below.
+  signal, not noise - see the JIT-naming rule below.
 
 ## JIT-naming rule (non-negotiable)
 
 When making any performance claim in code comments, PR descriptions, or
 benchmark commentary, name the JIT explicitly:
 
-- **".NET Framework 4.8.1 RyuJIT"** &mdash; older, no
+- **".NET Framework 4.8.1 RyuJIT"** - older, no
   `EqualityComparer<T>.Default` intrinsic, no tiered JIT, weaker inlining,
   no dynamic PGO.
-- **"modern .NET RyuJIT"** (.NET 6+) &mdash; devirtualization, tiered JIT,
+- **"modern .NET RyuJIT"** (.NET 6+) - devirtualization, tiered JIT,
   dynamic PGO, much more aggressive inlining.
 
 Unqualified "RyuJIT" claims are wrong about half the time. Code changes in
@@ -35,7 +35,7 @@ Unqualified "RyuJIT" claims are wrong about half the time. Code changes in
 ## Reading BenchmarkDotNet output
 
 - **Mean** is what you compare; **Median** is a sanity check (large
-  Mean&ndash;Median spread = unstable benchmark, fix before drawing
+  Mean-Median spread = unstable benchmark, fix before drawing
   conclusions).
 - **Allocated** is per-operation managed allocation. **Any new allocation
   in a documented hot path is a regression**, regardless of throughput.

--- a/.github/instructions/polyfills.instructions.md
+++ b/.github/instructions/polyfills.instructions.md
@@ -38,7 +38,7 @@ skill. Headline:
 1. Microsoft-shipped package (`System.Memory`, `Microsoft.Bcl.*`,
    `Microsoft.IO.Redist`).
 2. PolySharp source-gen for compiler attributes.
-3. Hand-rolled polyfill in this directory &mdash; **last resort**, only with
+3. Hand-rolled polyfill in this directory - **last resort**, only with
    a real caller. Don't polyfill for completeness.
 
 See [docs/polyfill-layout.md](../../docs/polyfill-layout.md) for the

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -5,15 +5,19 @@ applyTo: 'touki.tests/**/*.cs'
 # Test conventions for `touki.tests`
 
 [AGENTS.md](../../AGENTS.md) is canonical. This file is a path-scoped
-elaboration of the same rules for `touki.tests/**/*.cs` &mdash; it adds detail
+elaboration of the same rules for `touki.tests/**/*.cs` - it adds detail
 that would bloat the canonical file but must not contradict it. If the two
 ever drift, AGENTS.md wins; update this file to match.
 
 ## Placement and naming
 
 - Place tests in the `touki.tests` project.
-- Test classes live in the same namespace as the class under test, with `Tests`
-  appended (e.g. `ListBaseTests` for `ListBase`).
+- Test classes live in the **exact same namespace** as the class under test
+  (e.g. `ListBase` is in `Touki.Collections`, so `ListBaseTests` is also in
+  `Touki.Collections`). Do **not** append `Tests` to the namespace or insert
+  a `Tests` segment (no `Touki.CollectionsTests`, no `Touki.Tests.Collections`,
+  no `System.Tests`). The class name carries the `Tests` suffix; the namespace
+  matches production. This aids discovery and keeps `using` directives minimal.
 - Test methods are named `MethodName_StateUnderTest_ExpectedBehavior`
   (e.g. `MoveNext_AtStart_ReturnsTrue`).
 - Order test methods by the method they are testing.
@@ -23,9 +27,10 @@ ever drift, AGENTS.md wins; update this file to match.
 
 - Do **not** add "Arrange, Act, Assert" comments in tests.
 - Use FluentAssertions for assertions. `FluentAssertions` and `Xunit` are
-  already global usings &mdash; do not add new usings for these to test files.
-- Prefer `[Theory]` with `[InlineData]` only when there are 3+ inputs;
-  otherwise `[Fact]`.
+  already global usings - do not add new usings for these to test files.
+- Prefer `[Theory]` with `[InlineData]` only when there are 3 or more
+  distinct test cases (rows of `[InlineData]`); for 1-2 cases use
+  separate `[Fact]` methods.
 
 ## Internals and private access
 
@@ -42,9 +47,9 @@ ever drift, AGENTS.md wins; update this file to match.
 
 ## Disposables in test bodies
 
-Anything that allocates a real resource &mdash; `TempFolder`,
+Anything that allocates a real resource - `TempFolder`,
 `IEnumerationMatcher`, `MSBuildMatchBuilder.FromSpecification`,
-`ArrayPoolList<T>`, etc. &mdash; must be cleaned up even when assertions
+`ArrayPoolList<T>`, etc. - must be cleaned up even when assertions
 fail. Default to `using` declarations.
 
 - For "happy path" tests, write `using TempFolder folder = new();` and
@@ -54,7 +59,7 @@ fail. Default to `using` declarations.
   double-dispose, dispose-after-external-deletion), `using` would call
   `Dispose()` before the test body runs the assertion. Use
   `try`/`finally` instead and call `Dispose()` defensively in the
-  `finally` &mdash; `DisposableBase` guards against double disposal:
+  `finally` - `DisposableBase` guards against double disposal:
 
   ```c#
   TempFolder folder = new();
@@ -83,7 +88,7 @@ makes the test locale-dependent and flaky on non-en-US machines.
 
 - For formats that include culture-sensitive separators or symbols (`N`,
   `C`, `P`, `D` for dates, etc.), derive the expected string from
-  `CultureInfo.CurrentCulture` &mdash; or, when the test is meant to
+  `CultureInfo.CurrentCulture` - or, when the test is meant to
   pin behavior under a specific culture, set
   `Thread.CurrentThread.CurrentCulture` (and restore in `finally`).
 - Culture-insensitive formats (`X`, `B`, default `G` on integers,
@@ -92,7 +97,7 @@ makes the test locale-dependent and flaky on non-en-US machines.
 ## Release-mode rule
 
 - Run `dotnet test -c Release` before declaring a fix done. Release-mode
-  inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As` on a method
+  inlining surfaces bugs Debug doesn't - `Unsafe.As` on a method
   parameter is a known foot-gun on net481 RyuJIT.
 
 ## Allocation assertions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,12 @@ All code must compile and behave correctly on both targets.
 
 Top-level layout:
 
-- `touki/` &mdash; main library
-- `touki.tests/` &mdash; xUnit tests (uses FluentAssertions; access to internals via `InternalsVisibleTo`)
-- `touki.testsupport/` &mdash; shared test helpers (`TestAccessor`, etc.)
-- `touki.perf/` &mdash; BenchmarkDotNet performance projects
-- `sample/` &mdash; usage samples
-- `docs/` &mdash; contributor and design documentation
+- `touki/` - main library
+- `touki.tests/` - xUnit tests (uses FluentAssertions; access to internals via `InternalsVisibleTo`)
+- `touki.testsupport/` - shared test helpers (`TestAccessor`, etc.)
+- `touki.perf/` - BenchmarkDotNet performance projects
+- `sample/` - usage samples
+- `docs/` - contributor and design documentation
 
 ## Environment setup
 
@@ -40,7 +40,7 @@ Top-level layout:
 - Always use C# keywords for types (`int`, `string`, `bool`) instead of their aliases
   (`Int32`, `String`, `Boolean`).
 - Always use `nint` and `nuint` for native integer types (not `IntPtr` and `UIntPtr`).
-- Avoid `var` &mdash; use explicit type declarations, target-typed `new`, and
+- Avoid `var` - use explicit type declarations, target-typed `new`, and
   [collection expressions](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/collection-expressions)
   together: `List<string> list = new();`, `int[] values = [1, 2, 3];`,
   `Point[] points = [new(1, 2), new(5, 6)];`. The variable's type is always
@@ -81,6 +81,13 @@ Top-level layout:
   from the method with the most arguments, overriding tags where they differ.
 - Use `<see langword="..."/>` tags for language keywords in comments
   (e.g. `<see langword="true"/>` instead of `true`).
+- Prefer plain ASCII characters that don't need escaping (`-`, `"`, `...`,
+  `->`) over typographic Unicode (`—`, `–`, `"`, `"`, `…`, `→`) or HTML
+  entities (`&mdash;`, `&ndash;`, `&hellip;`, `&rarr;`, `&nbsp;`). Use a
+  plain `-` (with surrounding spaces when separating clauses) instead of
+  em/en-dashes. Only escape when the raw character would actually be
+  parsed as markup (e.g. `<` inside an XML doc comment); do not escape
+  defensively when it isn't needed.
 
 ## Line breaks and whitespace
 
@@ -99,7 +106,7 @@ Top-level layout:
 - When breaking lines in a method call, all parameters should be indented on their own
   lines.
 - After multiple edits to a file, verify that blank lines and whitespace remain correct.
-- When using search-and-replace tools, include 3&ndash;5 lines of context before and
+- When using search-and-replace tools, include 3-5 lines of context before and
   after the target text.
 
 ## Testing
@@ -109,7 +116,7 @@ Detailed test conventions live in
 (applies to `touki.tests/**/*.cs`). Headline rules: place tests in `touki.tests`;
 name them `MethodName_StateUnderTest_ExpectedBehavior`; use FluentAssertions (global
 using); access internals directly via `InternalsVisibleTo` and private members via
-`TestAccessor`; ref structs can't be used in lambdas &mdash; use `try`/`finally`.
+`TestAccessor`; ref structs can't be used in lambdas - use `try`/`finally`.
 
 Performance-test conventions for `touki.perf/` (BenchmarkDotNet, Release-only,
 JIT-naming rule, regression thresholds) live in
@@ -157,12 +164,12 @@ None of these authorize a push or a PR. They have all been
 mistaken for it on this repo:
 
 - "address the review comments" / "fix the comments" / "look at the
-  comments" &mdash; edit-only.
+  comments" - edit-only.
 - "do the next step" / "let's do X next" / a bare "go ahead" attached
-  to a task description &mdash; selects which task, not whether to publish.
-- "fix the CI failure" / "the PR is failing" &mdash; diagnosis or local
+  to a task description - selects which task, not whether to publish.
+- "fix the CI failure" / "the PR is failing" - diagnosis or local
   fix, not a push.
-- "pull main and work on X" &mdash; authorizes the work only.
+- "pull main and work on X" - authorizes the work only.
 
 When in doubt, ask one short yes/no question.
 
@@ -184,7 +191,7 @@ When in doubt, ask one short yes/no question.
 ### After a violation
 
 Acknowledge directly without minimizing. **Do not push a follow-up
-"fix" commit without explicit approval** &mdash; that compounds the
+"fix" commit without explicit approval** - that compounds the
 failure. The user decides whether to revert, force-push, or leave it.
 
 ### Other rules
@@ -193,7 +200,7 @@ failure. The user decides whether to revert, force-push, or leave it.
   tree spans more than one logical change. Run `git status --short`
   first; if topics are intermingled, ask how to split.
 - **Run `dotnet test -c Release` before declaring a fix done.**
-  Release-mode inlining surfaces bugs Debug doesn't &mdash; `Unsafe.As`
+  Release-mode inlining surfaces bugs Debug doesn't - `Unsafe.As`
   on a method parameter is a known foot-gun on net481 RyuJIT.
 
 ### Enforcement
@@ -213,7 +220,7 @@ only guard that works in every configuration.
   `gh pr create|merge|close|edit`. In Default Approvals mode each
   denied command requires an in-chat **Allow** click; that click is
   the approval. **In Bypass Approvals or Autopilot, this denylist is
-  ignored at runtime** &mdash; the entries remain as documentation of
+  ignored at runtime** - the entries remain as documentation of
   which commands cross the publish boundary, and as a defense-in-depth
   tripwire for contributors and agents who *are* in Default Approvals
   mode. Do not rely on the denylist to stop you.
@@ -234,7 +241,7 @@ only guard that works in every configuration.
   force pushes and branch deletion blocked) is the only server-side
   guard that survives every approval mode. It does not stop
   `gh pr create|merge|close|edit`, MCP `create_pull_request`,
-  `merge_pull_request`, or pushes to feature branches &mdash; only
+  `merge_pull_request`, or pushes to feature branches - only
   direct writes to `main` itself.
 
 The agent's pre-flight check (re-read the user's most recent message
@@ -258,7 +265,7 @@ catch a mistake.
   first.** On net472/net481 the `ReadOnlySpan<T>` indexer costs ~8 µops
   per element (slow-span layout) versus ~1 µop on net10. Hoist
   `ref T = MemoryMarshal.GetReference(span)` outside the loop and walk
-  with `Unsafe.Add<T>(ref, i)` for a 19&ndash;44% Framework win at no
+  with `Unsafe.Add<T>(ref, i)` for a 19-44% Framework win at no
   `unsafe`-keyword cost. Prefer a single simple implementation when it
   measures within ~5% of any Framework-tuned variant on net10 so the
   simple source keeps accruing future RyuJIT improvements; split with
@@ -273,7 +280,7 @@ catch a mistake.
     standard size); it rents from `ArrayPool<byte>` automatically if the
     content outgrows the buffer, and `ToStringAndDispose()` returns the
     final string while releasing the rental. Verified savings of
-    58&ndash;63&nbsp;% allocated bytes when replacing `StringBuilder` in the
+    58-63&nbsp;% allocated bytes when replacing `StringBuilder` in the
     `GlobMatcherFactory` bytecode encoder, with no measurable throughput
     cost.
   - `Touki.Text.StringSegment` / `Touki.Text.StringSpan` instead of
@@ -305,7 +312,7 @@ automatically based on each file's `applyTo` glob.
 
 Currently:
 
-- [.github/instructions/msbuild.instructions.md](.github/instructions/msbuild.instructions.md) &mdash; rules for `*.csproj`, `*.props`, `*.targets`.
-- [.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md) &mdash; conventions for `touki.tests/**/*.cs`.
-- [.github/instructions/perf.instructions.md](.github/instructions/perf.instructions.md) &mdash; BenchmarkDotNet conventions and the JIT-naming rule for `touki.perf/**/*.cs`.
-- [.github/instructions/polyfills.instructions.md](.github/instructions/polyfills.instructions.md) &mdash; the two non-negotiable rules for `touki/Framework/Polyfills/**/*.cs`.
+- [.github/instructions/msbuild.instructions.md](.github/instructions/msbuild.instructions.md) - rules for `*.csproj`, `*.props`, `*.targets`.
+- [.github/instructions/tests.instructions.md](.github/instructions/tests.instructions.md) - conventions for `touki.tests/**/*.cs`.
+- [.github/instructions/perf.instructions.md](.github/instructions/perf.instructions.md) - BenchmarkDotNet conventions and the JIT-naming rule for `touki.perf/**/*.cs`.
+- [.github/instructions/polyfills.instructions.md](.github/instructions/polyfills.instructions.md) - the two non-negotiable rules for `touki/Framework/Polyfills/**/*.cs`.

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -31,7 +31,7 @@ features (path scoping, tool restrictions, slash-command UX, packaged scripts).
 ## MCP servers
 
 Workspace-scoped MCP server config lives in [.vscode/mcp.json](../.vscode/mcp.json).
-Add a server here only when the agent genuinely cannot reach the data otherwise &mdash;
+Add a server here only when the agent genuinely cannot reach the data otherwise -
 prefer instructions and skills first (see the practitioner guide rule "instructions
 &rarr; skills &rarr; MCP").
 
@@ -138,7 +138,7 @@ Roughly monthly:
 
 ## Verifying instructions are loaded
 
-- **VS Code**: right-click in the Chat view, choose **Diagnostics** &mdash; lists all
+- **VS Code**: right-click in the Chat view, choose **Diagnostics** - lists all
   loaded instruction/skill/agent files and any errors.
 - **github.com**: open a PR; the Copilot code review check lists the instruction files
   it consulted.

--- a/docs/bcl-ignorecase-valley-rca.md
+++ b/docs/bcl-ignorecase-valley-rca.md
@@ -1,8 +1,8 @@
-# BCL `OrdinalIgnoreCase` valley — root cause analysis
+# BCL `OrdinalIgnoreCase` valley - root cause analysis
 
 Detailed analysis of why
 `MemoryExtensions.Equals(span, span, StringComparison.OrdinalIgnoreCase)`
-exhibits a perf valley at 8–15 chars on .NET 10 RyuJIT. Sourced from
+exhibits a perf valley at 8-15 chars on .NET 10 RyuJIT. Sourced from
 `BenchmarkDotNet.Artifacts/results/touki.perf.AsciiIgnoreCasePerf-asm.md`
 (generated with `[DisassemblyDiagnoser(maxDepth: 3)]`). The takeaway
 sidesteps the "span efficiency" hypothesis: **the valley is a JIT codegen
@@ -12,9 +12,9 @@ not a span performance problem.**
 Hardware: Intel Core i9-14900K, .NET 10.0.7, x64 RyuJIT x86-64-v3, AVX2.
 
 This document is a worked case study. The general field manual for
-span-walking code on .NET Framework — slow-span layout, the Strategy
+span-walking code on .NET Framework - slow-span layout, the Strategy
 A-through-E hierarchy, the within-noise rule for TFM-split
-implementations — lives in
+implementations - lives in
 [framework-span-performance.md](framework-span-performance.md).
 
 ---
@@ -90,11 +90,11 @@ M01_L01:
 ```
 
 This is well-written SIMD code. Length 20 measures **2.6 ns**, length 64
-measures **6.3 ns** — within reach of memcpy throughput.
+measures **6.3 ns** - within reach of memcpy throughput.
 
 ---
 
-## 3. The Vector128 path (length 8–15) is *not* vectorized in the inner compare
+## 3. The Vector128 path (length 8-15) is *not* vectorized in the inner compare
 
 `Ordinal.EqualsIgnoreCase_Vector<Vector128<UInt16>>`:
 
@@ -211,7 +211,7 @@ The helper is 30% faster than the BCL at length 10 because:
 
 ## 5. "How much is span inefficiency?"
 
-**Roughly 10–20% of the helper's code size, none of the BCL's slowness.**
+**Roughly 10-20% of the helper's code size, none of the BCL's slowness.**
 
 ### On the helper side
 
@@ -229,7 +229,7 @@ This costs:
 
 For a 10-char input, the staging cost dilutes the win the helper would
 otherwise have. The hot loop reads `[rsp+50]` and `[rsp+40]` every
-iteration — these become L1-cache loads (~5 cycle latency) instead of
+iteration - these become L1-cache loads (~5 cycle latency) instead of
 register accesses (~0).
 
 **This is real span efficiency cost**, but it's bounded. Estimated impact:
@@ -245,7 +245,7 @@ reload sequences rather than to vector instructions.
 
 The Vector256 specialization of the *same generic method* has a 56-byte
 frame and keeps everything in `ymm` registers. The codegen difference is
-entirely in the JIT's handling of the generic vector type parameter —
+entirely in the JIT's handling of the generic vector type parameter -
 not in spans.
 
 ---
@@ -258,7 +258,7 @@ not in spans.
 |---|---|
 | `SpanExtensions.EqualsOrdinalIgnoreCase` for span lengths < 16 | Sidesteps the Vector128 valley. 10-char compare 10.04 → 4.79 ns. |
 | `[AggressiveInlining]` on the dispatch wrapper, separate non-inlined fold loop | On net481 saves ~7 ns by allowing the inliner to fold the length-check into the call site. On net10 zero-effect. |
-| Crossover threshold at 16 chars | Matches `Vector128<short>.Count × 2` — the BCL's own dispatch point. |
+| Crossover threshold at 16 chars | Matches `Vector128<short>.Count × 2` - the BCL's own dispatch point. |
 
 ### 6.2 Potential incremental wins
 
@@ -266,7 +266,7 @@ not in spans.
 shared ASCII fold core.**
 Drops the 64-byte stack zero-init. Likely ~0.3 ns measurable on the
 length-5/10 case where the prologue is a significant fraction of total time.
-**Risk: zero** — the fold loop never reads uninitialized memory.
+**Risk: zero** - the fold loop never reads uninitialized memory.
 **Status: candidate.**
 
 **(b) Hoist the BCL-fallback span construction out of the hot path.**
@@ -320,7 +320,7 @@ disappears on net10.
 ### 6.3 Not worth doing
 
 - **A Vector128 hand-roll in `SpanExtensions.CompareOrdinalIgnoreCase`
-  for length 8–15.** This
+  for length 8-15.** This
   would require re-implementing the BCL's logic correctly. The helper's
   scalar fold loop already beats the BCL Vector128 path; building a
   correct Vector128 path means matching the Vector256 path's quality,
@@ -339,9 +339,9 @@ Order revised after experimental validation on net481 (see §B.5):
 | Slice | What | Expected impact | Status |
 |---|---|---|---|
 | 7b | Move non-ASCII BCL fallback into a `[NoInlining]` helper taking `ref char` | net10: −0.5 to −1 ns on length-10 hit. net481: ~−1 ns on length-5 hit (eliminates the per-iter stack load). | **Recommended.** |
-| 7c | File runtime issue for `Ordinal.EqualsIgnoreCase_Vector<Vector128<UInt16>>` codegen on net10 | Eventually removes the need for the helper on net10 at length 8–15. No effect on net481. | Filing recommended; not blocking. |
-| 7a | `[SkipLocalsInit]` on the `SpanExtensions` ASCII-fold methods | net10: ≈ 0 (below noise). **net481: 0 — attribute not honored by net481 RyuJIT, see §B.5.** | **Already applied for hygiene** but produces no measurable benefit on either TFM. Keep for code-style consistency; do not cite it as a perf mitigation. |
-| 7d (new) | Force-inline the scalar ASCII fold into `SpanExtensions.EqualsOrdinalIgnoreCase` so net481 sees only one function call instead of two | net481 length-5: ~−6 ns predicted (one full call frame). Risk: code bloat at every call site. Worth a focused experiment with rollback if call sites grow. | **Candidate — biggest remaining net481 win**. |
+| 7c | File runtime issue for `Ordinal.EqualsIgnoreCase_Vector<Vector128<UInt16>>` codegen on net10 | Eventually removes the need for the helper on net10 at length 8-15. No effect on net481. | Filing recommended; not blocking. |
+| 7a | `[SkipLocalsInit]` on the `SpanExtensions` ASCII-fold methods | net10: ≈ 0 (below noise). **net481: 0 - attribute not honored by net481 RyuJIT, see §B.5.** | **Already applied for hygiene** but produces no measurable benefit on either TFM. Keep for code-style consistency; do not cite it as a perf mitigation. |
+| 7d (new) | Force-inline the scalar ASCII fold into `SpanExtensions.EqualsOrdinalIgnoreCase` so net481 sees only one function call instead of two | net481 length-5: ~−6 ns predicted (one full call frame). Risk: code bloat at every call site. Worth a focused experiment with rollback if call sites grow. | **Candidate - biggest remaining net481 win**. |
 
 ---
 
@@ -355,7 +355,7 @@ Length 10, helper, 6.6 ns measured:
 - 10 iterations × 12 ops each = 120 ops at ~4 IPC: ~30 cycles
 - Epilogue: ~3 cycles
 - Total: ~40 cycles ≈ 10 ns. Measured 6.6 ns suggests heavy out-of-order
-  overlap — typical for hot, predictable straight-line code.
+  overlap - typical for hot, predictable straight-line code.
 
 Length 10, BCL Vector128, 9.4 ns measured:
 
@@ -373,7 +373,7 @@ Length 10, BCL Vector128, 9.4 ns measured:
   The gap between predicted and measured is consistent with the BCL hot
   path being predictable; the cost is real, just well-overlapped.
 
-The point of the math is not to predict to the nanosecond — it's to show
+The point of the math is not to predict to the nanosecond - it's to show
 the work the JIT chose to emit, and that the BCL is doing roughly 3× more
 work than the helper at this length.
 
@@ -381,7 +381,7 @@ work than the helper at this length.
 
 ## Appendix B: .NET Framework 4.8.1 disassembly
 
-`[DisassemblyDiagnoser]` **does** work on .NET Framework — that note in an
+`[DisassemblyDiagnoser]` **does** work on .NET Framework - that note in an
 earlier draft of this doc was wrong. The full net481 disasm is captured in
 `BenchmarkDotNet.Artifacts/results/touki.perf.AsciiIgnoreCasePerf-asm.md`
 (regenerate with the diagnoser attribute on `AsciiIgnoreCasePerf`). The
@@ -401,7 +401,7 @@ reference and a byte offset, not a raw pointer.
 | 20 | 41.5 ns | 41.9 ns | ≈ tie (helper delegates to BCL) |
 | 64 | 72.2 ns | 69.7 ns | +2.5 ns (helper has small delegation tax) |
 
-The largest delta is at length 5 — exactly the opposite of net10, where
+The largest delta is at length 5 - exactly the opposite of net10, where
 length 10 was the valley. On net481 there is **no valley**, because there
 is no vectorized path that suddenly cuts in at length 16. The cost grows
 roughly linearly with length on both helper and BCL.
@@ -538,14 +538,14 @@ M02_L02:
 
 **This is the "slow span" tax on net481, per character:**
 
-- `cmp qword ptr [rcx], 0` — check if span is backed by a managed object
-- `mov r11, [rcx]` — load the object pointer
-- `cmp [r11], r11d` — touch the object (GC liveness / null check fold)
-- `lea r10, [r11+8]` — skip the array header
-- `mov rax, [rcx+8]` — load the offset field
-- `add r10, rax` — apply offset
-- `movsxd r11, r8d`, `shl rax, 1`, `add r10, rax` — index by 2 (char size)
-- `movzx eax, word ptr [rax]` — load the character
+- `cmp qword ptr [rcx], 0` - check if span is backed by a managed object
+- `mov r11, [rcx]` - load the object pointer
+- `cmp [r11], r11d` - touch the object (GC liveness / null check fold)
+- `lea r10, [r11+8]` - skip the array header
+- `mov rax, [rcx+8]` - load the offset field
+- `add r10, rax` - apply offset
+- `movsxd r11, r8d`, `shl rax, 1`, `add r10, rax` - index by 2 (char size)
+- `movzx eax, word ptr [rax]` - load the character
 
 **Roughly 8 µops to load one character** on net481 vs **1 µop** on net10
 (where spans store a raw `ref char` that compiles to a register move).
@@ -560,15 +560,15 @@ overhead.
 ### B.4 Where the net481 helper's win comes from at length 5
 
 Helper at length 5: 19.9 ns. BCL at length 5: 26.6 ns. The 6.7 ns gap is
-**not** the per-character work — it's the call-chain overhead the BCL pays
+**not** the per-character work - it's the call-chain overhead the BCL pays
 that the helper avoids:
 
 | Cost | Helper | BCL |
 |---|---:|---:|
 | Bench wrapper (88 B stack + 48 B zero-init) | yes (~6 ns) | yes (~6 ns) |
-| `MemoryExtensions.Equals` (80 B + 48 B zero-init + 5 callee-saved) | — | yes (~6 ns) |
-| `MemoryMarshal.GetReference<char>` × 2 | — | yes (~2 ns) |
-| `EqualsAsciiFold` (88 B + 48 B zero-init) | yes (~6 ns) | — |
+| `MemoryExtensions.Equals` (80 B + 48 B zero-init + 5 callee-saved) | - | yes (~6 ns) |
+| `MemoryMarshal.GetReference<char>` × 2 | - | yes (~2 ns) |
+| `EqualsAsciiFold` (88 B + 48 B zero-init) | yes (~6 ns) | - |
 | Underlying compare (5 chars × 16 µops/char) | yes (~4 ns) | yes (~4 ns) |
 
 The BCL has **two more function calls** in the chain. Each adds a stack
@@ -576,7 +576,7 @@ frame, a `rep stosd` zero-init, and (in `MemoryExtensions.Equals`'s
 case) 5 callee-saved register saves. At length 5 these constant costs
 dominate.
 
-### B.5 Net481-specific mitigations — what actually works
+### B.5 Net481-specific mitigations - what actually works
 
 The recurring overhead in the helper path is the **48-byte `rep stosd`
 zero-init** at every function entry, performed because the C# compiler
@@ -625,9 +625,9 @@ This means:
 The mitigations that *do* still help on net481:
 
 1. **Reduce the number of function calls in the chain.** Currently:
-   - bench wrapper (out of our control — BDN-generated)
+   - bench wrapper (out of our control - BDN-generated)
    - → `SpanExtensions.EqualsOrdinalIgnoreCase` (inlined into the wrapper by AggressiveInlining)
-   - → `CompareOrdinalIgnoreCaseAsciiFold` (not inlined — separate call)
+   - → `CompareOrdinalIgnoreCaseAsciiFold` (not inlined - separate call)
 
    Forcing inlining of `CompareOrdinalIgnoreCaseAsciiFold` into the wrapper
    would eliminate one call frame on net481 (~6 ns at length 5). The risk
@@ -666,7 +666,7 @@ reasons. On net10 the BCL switches from a buggy Vector128 codegen to a
 clean Vector256 codegen. On net481 the BCL has no vectorization either
 side of the threshold, but at length ≥ 16 its scalar inner loop is
 slightly tighter than ours because it doesn't pay the per-char ASCII
-range-check overhead — the input is precompared scalar-wise without the
+range-check overhead - the input is precompared scalar-wise without the
 fold-letter-range check. We do extra work per char to support the fold;
 that work pays off at short lengths (where it's still very few
 iterations) but not at long lengths.
@@ -678,17 +678,17 @@ the original prediction.
 
 1. **Slice 7d (force-inline the scalar ASCII fold into
    `SpanExtensions.EqualsOrdinalIgnoreCase`)**
-   — predicted ~−6 ns on net481 length 5 by eliminating one function-call
+   - predicted ~−6 ns on net481 length 5 by eliminating one function-call
    frame (the chain becomes bench → fused helper, instead of
    bench → wrapper → fold). Risk: code bloat at every call site if too
    aggressive. Worth a focused, measured experiment.
 2. **Slice 7b (move non-ASCII fallback into a `[NoInlining]` helper
-   taking `ref char`)** — predicted −0.5 to −1 ns on both TFMs at the
+   taking `ref char`)** - predicted −0.5 to −1 ns on both TFMs at the
    typical glob length. Modest but real.
 3. **Slice 7c (file runtime issue for the Vector128 codegen on net10)**
-   — only relevant to net10; out of touki's scope to fix but worth
+   - only relevant to net10; out of touki's scope to fix but worth
    reporting.
-4. **Slice 7a (`[SkipLocalsInit]`)** — verified no-op on net481 (the
+4. **Slice 7a (`[SkipLocalsInit]`)** - verified no-op on net481 (the
    attribute is ignored by RyuJIT 4.8.1) and below-noise on net10.
    Keep applied for code-style consistency; **do not credit it as a
    perf mitigation**.

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -55,7 +55,7 @@ if (reader.TryRead(out byte tag) && reader.TryRead<int>(out int length))
 Highlights:
 
 * `TryRead`, `TryReadCount`, `TryReadTo`, `TryPeek`, `Advance`,
-  `AdvancePast` — the standard reader surface.
+  `AdvancePast` - the standard reader surface.
 * `Position`, `Length`, `Unread`, `End` for inspection.
 * `TryRead<TValue>(out TValue)` reads any other unmanaged value type
   out of a `byte` reader via a checked reinterpret.

--- a/docs/code_comprehension.md
+++ b/docs/code_comprehension.md
@@ -6,7 +6,7 @@ Note: This was generated with the help of a few AI research models. Still iterat
 
 ---
 
-## TL;DR table — where comprehension costs start to spike
+## TL;DR table - where comprehension costs start to spike
 
 The table below maps each factor to approximate ranges and **qualitative impact on comprehension**. Ranges are aggregated from research and widely used industry thresholds; use them as **screening heuristics**, not hard rules.
 
@@ -14,21 +14,21 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 
 | Factor | **Low** | **Moderate** | **High** | **Very High** | Metric | Notes |
 |---|---|---|---|---|---|---|
-| **Nesting depth** (control-flow) | 1–2 levels | 3 levels | 4–5 levels | ≥6 levels | Maximum nested blocks in a function | Deeper nesting increases effort; novices especially affected. Sonar's *Cognitive Complexity* adds cost per nesting step; controlled studies show indentation/nesting influences reading time and errors. [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf), [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf), [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y), [Hao et al., 2023](http://www.jetwi.us/uploadfile/2023/0822/20230822020204926.pdf). |
-| **Cyclomatic complexity (per method)** | ≤5 | 6–10 | 11–20 | ≥21 | McCabe's cyclomatic complexity | Classic testability metric; widely used threshold 10. But direct correlation with cognitive load is weak vs newer metrics. 2023 neuroscience study shows poor correlation with actual cognitive load. [McCabe 1976](https://www.literateprogramming.com/mccabe.pdf), fMRI study discussion in [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf), [Frontiers 2023](https://www.frontiersin.org/journals/neuroscience/articles/10.3389/fnins.2022.1065366/full). |
-| **Cognitive Complexity (per method)** | ≤5 | 6–10 | 11–15 | ≥16 | Sonar's rule-based understandability metric | Penalizes nesting and flow breaks; validated to correlate with comprehension time & perceived difficulty. [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf), meta-analysis in [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520). |
-| **Method length** (SLOC) | ≤20 | 21–50 | 51–100 | >100 | Source lines of code, excluding blanks/comments | Shorter methods tend to be easier to read; empirical proposals suggest "maintainable" sizes around a few tens of SLOC. Industry tools converge on 25 lines. [Giordano & Roveda, 2022](https://arxiv.org/pdf/2204.12553), corroborating readability models: [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf). |
-| **Parameter count** | ≤3 | 4–5 | 6–8 | ≥9 | Number of parameters per method/function | "Long Parameter List" smell typically triggered at 5+; brain-activation work shows parameter count relates to cognitive load. Industry standard: 4. [Giordano et al., 2021](https://dl.acm.org/doi/10.1145/3453483.3454069), fMRI evidence in [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf). |
-| **Line length** (columns) | ≤80 | 81–100 | 101–120 | ≥121 | Max characters per line | Longer lines reduce scan-ability; many guides cap at 80–100. Readability models count characters-per-line as predictive. [PEP 8](https://peps.python.org/pep-0008/), [Google Java style](https://google.github.io/styleguide/javaguide.html), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf). |
+| **Nesting depth** (control-flow) | 1-2 levels | 3 levels | 4-5 levels | ≥6 levels | Maximum nested blocks in a function | Deeper nesting increases effort; novices especially affected. Sonar's *Cognitive Complexity* adds cost per nesting step; controlled studies show indentation/nesting influences reading time and errors. [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf), [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf), [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y), [Hao et al., 2023](http://www.jetwi.us/uploadfile/2023/0822/20230822020204926.pdf). |
+| **Cyclomatic complexity (per method)** | ≤5 | 6-10 | 11-20 | ≥21 | McCabe's cyclomatic complexity | Classic testability metric; widely used threshold 10. But direct correlation with cognitive load is weak vs newer metrics. 2023 neuroscience study shows poor correlation with actual cognitive load. [McCabe 1976](https://www.literateprogramming.com/mccabe.pdf), fMRI study discussion in [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf), [Frontiers 2023](https://www.frontiersin.org/journals/neuroscience/articles/10.3389/fnins.2022.1065366/full). |
+| **Cognitive Complexity (per method)** | ≤5 | 6-10 | 11-15 | ≥16 | Sonar's rule-based understandability metric | Penalizes nesting and flow breaks; validated to correlate with comprehension time & perceived difficulty. [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf), meta-analysis in [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520). |
+| **Method length** (SLOC) | ≤20 | 21-50 | 51-100 | >100 | Source lines of code, excluding blanks/comments | Shorter methods tend to be easier to read; empirical proposals suggest "maintainable" sizes around a few tens of SLOC. Industry tools converge on 25 lines. [Giordano & Roveda, 2022](https://arxiv.org/pdf/2204.12553), corroborating readability models: [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf). |
+| **Parameter count** | ≤3 | 4-5 | 6-8 | ≥9 | Number of parameters per method/function | "Long Parameter List" smell typically triggered at 5+; brain-activation work shows parameter count relates to cognitive load. Industry standard: 4. [Giordano et al., 2021](https://dl.acm.org/doi/10.1145/3453483.3454069), fMRI evidence in [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf). |
+| **Line length** (columns) | ≤80 | 81-100 | 101-120 | ≥121 | Max characters per line | Longer lines reduce scan-ability; many guides cap at 80-100. Readability models count characters-per-line as predictive. [PEP 8](https://peps.python.org/pep-0008/), [Google Java style](https://google.github.io/styleguide/javaguide.html), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf). |
 | **Identifier naming** (quality) | Descriptive words, consistent | Short words or domain abbreviations | Single letters in local scopes | Misleading / inconsistent names | Qualitative: semantics, length, consistency | Full words improve speed; short/cryptic slows pros; misleading worse than meaningless. Top factor in 40-year meta-analysis. [Hofmeister et al., 2017](https://www.se.cs.uni-saarland.de/publications/docs/HoSeHo17.pdf), [Lawrie et al., 2007](https://cs.uwlax.edu/~dmathias/cs419-s2013/lawrie.pdf), [Avidan & Feitelson, 2017](https://www.cs.huji.ac.il/w~feit/papers/Mislead17ICPC.pdf), summary in [Feitelson, 2021](https://arxiv.org/pdf/2102.08314), [40-year review, 2022](https://arxiv.org/abs/2206.11102). |
-| **Boolean / expression complexity** | ≤2 terms | 3–4 terms | 5–6 terms or nested calls | ≥7 terms or deep nesting | Count of boolean operands / sub-expressions | Flat vs nested often similar for pros; meaningful intermediate variables help when expressions are "hard". [Ajami et al., 2017](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf), [Cates et al., 2021](https://www.cs.huji.ac.il/~feit/papers/TempVar21ICPC.pdf). |
+| **Boolean / expression complexity** | ≤2 terms | 3-4 terms | 5-6 terms or nested calls | ≥7 terms or deep nesting | Count of boolean operands / sub-expressions | Flat vs nested often similar for pros; meaningful intermediate variables help when expressions are "hard". [Ajami et al., 2017](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf), [Cates et al., 2021](https://www.cs.huji.ac.il/~feit/papers/TempVar21ICPC.pdf). |
 | **Recursion usage** | Tail/simple, well-named | Single recursion + base case obvious | Mutual / non-obvious termination | Deep, intertwined recursion | Presence & depth of recursion | Novices struggle substantially; even pros cite difficulty when base cases/state are implicit. [Hazzan & Lapidot, 2004](https://dl.acm.org/doi/10.1145/971300.971359), [Sahami et al., 2009](https://dl.acm.org/doi/10.1145/1539024.1508877), recent synthesis: [Stöckert et al., 2024](https://dl.acm.org/doi/10.1145/3649217.3653634). |
 | **Data-flow dependencies** | Few def-use links | Moderate def-use links | Many interdependent vars | Dense, long-range deps | DepDegree (def-use edges), PDG-based counts | Data-flow complexity shows stronger ties to brain-measured load than McCabe. [Beyer et al., 2014](https://www.sosy-lab.org/research/pub/2014-ICPC.A_Formal_Evaluation_of_DepDegree_Based_on_Weyukers_Properties.pdf), [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf). |
 | **Layout & whitespace** | Consistent indent, blank lines | Minor inconsistencies | Irregular indent, dense blocks | No indent / hard wraps | Indent consistency; blank-line frequency | Indentation strongly affects performance (~2× time difference); blank lines and visual "breathing room" help. [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf), [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf). |
-| **Regularity / repetition** | Repeated patterns | – | – | High irregularity | Presence of regular, repeated code structures | Readers invest heavily in the first occurrence; later repeats cost less—regularity reduces total effort. [Jbara & Feitelson, 2017](https://www.cs.huji.ac.il/~feit/papers/RegEye17EmpSE.pdf). |
-| **Coupling (CBO)** | ≤5 | 6–9 | 10–14 | ≥15 | Coupling Between Objects | Number of classes a class is coupled to; affects understanding system dependencies. [TechTarget overview](https://www.techtarget.com/searchapparchitecture/tip/The-basics-of-software-coupling-metrics-and-concepts) |
-| **Cohesion (LCOM4)** | 1 | 2 | 3–4 | ≥5 | Lack of Cohesion of Methods v4 | 1 = perfect single responsibility; higher = multiple concerns needing refactoring. [Aivosto metrics](https://www.aivosto.com/project/help/pm-oo-cohesion.html) |
-| **Inheritance depth** | ≤2 | 3–4 | 5–6 | ≥7 | Depth of Inheritance Tree (DIT) | Deeper trees increase complexity through inherited behaviors and overrides. |
+| **Regularity / repetition** | Repeated patterns | - | - | High irregularity | Presence of regular, repeated code structures | Readers invest heavily in the first occurrence; later repeats cost less-regularity reduces total effort. [Jbara & Feitelson, 2017](https://www.cs.huji.ac.il/~feit/papers/RegEye17EmpSE.pdf). |
+| **Coupling (CBO)** | ≤5 | 6-9 | 10-14 | ≥15 | Coupling Between Objects | Number of classes a class is coupled to; affects understanding system dependencies. [TechTarget overview](https://www.techtarget.com/searchapparchitecture/tip/The-basics-of-software-coupling-metrics-and-concepts) |
+| **Cohesion (LCOM4)** | 1 | 2 | 3-4 | ≥5 | Lack of Cohesion of Methods v4 | 1 = perfect single responsibility; higher = multiple concerns needing refactoring. [Aivosto metrics](https://www.aivosto.com/project/help/pm-oo-cohesion.html) |
+| **Inheritance depth** | ≤2 | 3-4 | 5-6 | ≥7 | Depth of Inheritance Tree (DIT) | Deeper trees increase complexity through inherited behaviors and overrides. |
 
 > **Why some ranges are qualitative.** Several phenomena (naming, expression clarity, recursion style) are categorical. For those, the "range" cells describe typical *states* rather than numeric cut-offs.
 
@@ -57,30 +57,30 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 ### Core findings from traditional research (validated through 2025)
 
 1. **Structure matters most when it increases working memory demands.** Deep **nesting**, **long parameter lists**, and **dense data-flow** all load working memory; fMRI/EEG studies show vocabulary/size and data-flow relate more to brain-measured effort than raw McCabe.
-   — Evidence: [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf), [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520), [EEG validation 2021](https://www.mdpi.com/1424-8220/21/7/2338).
+   - Evidence: [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf), [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520), [EEG validation 2021](https://www.mdpi.com/1424-8220/21/7/2338).
 
 2. **Lexicon (names, words per line) is pivotal.** Full-word identifiers speed up pros (~19% in one study); cryptic or **misleading** names are worse than meaningless ones; more identifiers/characters per line reduce readability. **2022 meta-analysis finds naming as #1 factor across 40 years of studies.**
-   — Evidence: [Hofmeister et al., 2017](https://www.se.cs.uni-saarland.de/publications/docs/HoSeHo17.pdf), [Avidan & Feitelson, 2017](https://www.cs.huji.ac.il/w~feit/papers/Mislead17ICPC.pdf), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf), [40-year review](https://arxiv.org/abs/2206.11102).
+   - Evidence: [Hofmeister et al., 2017](https://www.se.cs.uni-saarland.de/publications/docs/HoSeHo17.pdf), [Avidan & Feitelson, 2017](https://www.cs.huji.ac.il/w~feit/papers/Mislead17ICPC.pdf), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf), [40-year review](https://arxiv.org/abs/2206.11102).
 
 3. **Layout amplifies or blunts the load.** **Indentation** yields large performance gains (recent RCTs find ~2× reading-time differences for non-indented vs indented control-flow code). **Blank lines** and moderate line lengths improve readability signals.
-   — Evidence: [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y), [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf).
+   - Evidence: [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y), [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf).
 
 4. **Not all "complexity" metrics reflect human comprehension.** McCabe is still useful (e.g., for testing), but it's a weak proxy for cognitive effort. **Cognitive Complexity** and **data-flow** measures better match what strains readers. **2023 neuroscience study with 222 developers confirms McCabe's poor correlation with actual cognitive load.**
-   — Evidence: [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf), [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520), [Neuroscience validation 2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC9942489/).
+   - Evidence: [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf), [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520), [Neuroscience validation 2023](https://pmc.ncbi.nlm.nih.gov/articles/PMC9942489/).
 
 5. **Novice vs. professional patterns differ.** Novices particularly struggle with **recursion** and benefit strongly from **consistent indentation** and **clear names**; professionals also benefit, but are less sensitive to certain structure choices (e.g., flat vs. nested boolean forms show minor differences). **Syntax highlighting surprisingly shows no benefit for novice correctness (2018 study, 390 students).**
-   — Evidence: [Stöckert et al., 2024](https://dl.acm.org/doi/10.1145/3649217.3653634), [Ajami et al., 2017](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf), [Hao et al., 2023](http://www.jetwi.us/uploadfile/2023/0822/20230822020204926.pdf), [Syntax highlighting study](https://dl.acm.org/doi/10.1007/s10664-017-9579-0).
+   - Evidence: [Stöckert et al., 2024](https://dl.acm.org/doi/10.1145/3649217.3653634), [Ajami et al., 2017](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf), [Hao et al., 2023](http://www.jetwi.us/uploadfile/2023/0822/20230822020204926.pdf), [Syntax highlighting study](https://dl.acm.org/doi/10.1007/s10664-017-9579-0).
 
 ### Revolutionary insights from modern research (2021-2025)
 
 6. **Physiological measurements reveal cognitive reality.** Eye-tracking shows non-linear reading patterns; EEG theta (4-8 Hz) increases with complexity while alpha (8-13 Hz) decreases; fNIRS detects prefrontal cortex activation with 89% accuracy. **2024 deep learning model aligns gaze with code tokens for comprehension prediction.**
-   — Evidence: [FSE 2024 gaze alignment](https://2024.esec-fse.org/details/fse-2024-research-papers/58/Predicting-Code-Comprehension-A-Novel-Approach-to-Align-Human-Gaze-with-Code-Using-D), [EEG meta-analysis](https://onlinelibrary.wiley.com/doi/10.1111/psyp.14009), [fNIRS cognitive load](https://www.sciencedirect.com/science/article/abs/pii/S0010945222001551).
+   - Evidence: [FSE 2024 gaze alignment](https://2024.esec-fse.org/details/fse-2024-research-papers/58/Predicting-Code-Comprehension-A-Novel-Approach-to-Align-Human-Gaze-with-Code-Using-D), [EEG meta-analysis](https://onlinelibrary.wiley.com/doi/10.1111/psyp.14009), [fNIRS cognitive load](https://www.sciencedirect.com/science/article/abs/pii/S0010945222001551).
 
 7. **Modern paradigms reshape comprehension.** Reactive programming improves comprehension 15-25% over OOP (IEEE study, 127 participants); async/await reduces debugging time 30%; domain-specific languages show superior comprehension for domain experts. **Static typing helps maintainability but dynamic typing enables 30-40% faster initial development.**
-   — Evidence: [Reactive programming study](https://ieeexplore.ieee.org/document/7827078/), [DSL comprehension](https://www.researchgate.net/publication/225150322_Program_comprehension_of_domain-specific_and_general-purpose_languages_Comparison_using_a_family_of_experiments), [Type system experiments](https://www.researchgate.net/publication/221321863_An_Experiment_About_Static_and_Dynamic_Type_Systems_Doubts_About_the_Positive_Impact_of_Static_Type_Systems_on_Development_Time).
+   - Evidence: [Reactive programming study](https://ieeexplore.ieee.org/document/7827078/), [DSL comprehension](https://www.researchgate.net/publication/225150322_Program_comprehension_of_domain-specific_and_general-purpose_languages_Comparison_using_a_family_of_experiments), [Type system experiments](https://www.researchgate.net/publication/221321863_An_Experiment_About_Static_and_Dynamic_Type_Systems_Doubts_About_the_Positive_Impact_of_Static_Type_Systems_on_Development_Time).
 
 8. **Collaborative factors multiply benefits.** Code review effectiveness decreases faster than linearly with changeset size; pair programming shows 15% individual slowdown but dramatic quality improvement; tool-assisted reviews produce 2× accepted comments vs over-the-shoulder. **Small changes (<200 lines) enable effective linear reading strategies.**
-   — Evidence: [ICPC 2025 review strategies](https://conf.researchr.org/details/icpc-2025/icpc-2025-research/5/Code-Review-Comprehension-Reviewing-Strategies-Seen-Through-Code-Comprehension-Theor), [IET review effectiveness](https://digital-library.theiet.org/content/journals/10.1049/iet-sen.2020.0134).
+   - Evidence: [ICPC 2025 review strategies](https://conf.researchr.org/details/icpc-2025/icpc-2025-research/5/Code-Review-Comprehension-Reviewing-Strategies-Seen-Through-Code-Comprehension-Theor), [IET review effectiveness](https://digital-library.theiet.org/content/journals/10.1049/iet-sen.2020.0134).
 
 ---
 
@@ -94,29 +94,29 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 - **Why it matters.** Each level increases the number of simultaneously active conditions; **indentation** acts as a visual scaffold.
 - **What research shows.**
   - RCTs and classic studies: **indented** code is read faster and with fewer errors; non-indented code roughly **doubles** reading time in controlled tasks.
-    — [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y); [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf).
+    - [Hanenberg et al., 2024](https://link.springer.com/article/10.1007/s10664-024-10531-y); [Miara et al., 1983](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf).
   - Novices: deeper nesting and missing indent **increase cognitive load**; short, consistent indent helps.
-    — [Hao et al., 2023](http://www.jetwi.us/uploadfile/2023/0822/20230822020204926.pdf).
+    - [Hao et al., 2023](http://www.jetwi.us/uploadfile/2023/0822/20230822020204926.pdf).
   - Metrics: Sonar **Cognitive Complexity** explicitly penalizes nesting; widely used limits flag methods around **≥15**.
-    — [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf).
+    - [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf).
   - **Industry consensus:** Max nesting depth = 4 across major tools (SonarQube, CodeClimate, ESLint).
-- **Use these guardrails.** Prefer ≤2–3 levels; refactor ≥4 by extracting methods or flattening logic.
+- **Use these guardrails.** Prefer ≤2-3 levels; refactor ≥4 by extracting methods or flattening logic.
 
 #### 2) Cyclomatic vs. Cognitive Complexity
 
 - **Cyclomatic (McCabe)** counts paths and is valuable for **testing** but correlates poorly with measured **cognitive load**.
-  — [McCabe, 1976](https://www.literateprogramming.com/mccabe.pdf); [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf).
+  - [McCabe, 1976](https://www.literateprogramming.com/mccabe.pdf); [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf).
 - **Cognitive Complexity** aligns better with **human understandability**, especially via nesting penalties; meta-analysis shows positive correlation with task time and perceived difficulty.
-  — [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf); [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520).
-- **2023 finding:** Complexity perception saturates—methods with CC 15 vs 20 show similar perceived difficulty.
-  — [Neuroscience study](https://pmc.ncbi.nlm.nih.gov/articles/PMC9942489/).
+  - [Sonar whitepaper](https://www.sonarsource.com/docs/CognitiveComplexity.pdf); [Muñoz Barón et al., 2020](https://arxiv.org/pdf/2007.12520).
+- **2023 finding:** Complexity perception saturates-methods with CC 15 vs 20 show similar perceived difficulty.
+  - [Neuroscience study](https://pmc.ncbi.nlm.nih.gov/articles/PMC9942489/).
 - **Guardrails.** Keep methods at **≤10** cognitive complexity where feasible; pay extra attention to nested conditionals.
 
 #### 3) Method length
 
 - **Why it matters.** Larger units often combine more decisions, names, and data-flow (compounding effects).
 - **Evidence.** Proposals derived from large codebases suggest **"maintainable" sizes ≈ a few tens of SLOC**; readability models also weigh shorter snippets higher.
-  — [Giordano & Roveda, 2022](https://arxiv.org/pdf/2204.12553); [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf).
+  - [Giordano & Roveda, 2022](https://arxiv.org/pdf/2204.12553); [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf).
 - **Industry tools:** CodeClimate defaults to 25 lines, Visual Studio suggests <20 for maintainability.
 - **Guardrails.** Aim for **≤20** SLOC (low risk), review at **50+**, and refactor above **100** SLOC.
 
@@ -124,15 +124,15 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 
 - **Why it matters.** Parameters are **vocabulary items** a reader must hold in mind.
 - **Evidence.** "Long Parameter List" is a common smell at **≥5**; the **number of parameters** correlates with **brain activation** in language/working-memory areas.
-  — [Giordano et al., 2021](https://dl.acm.org/doi/10.1145/3453483.3454069); [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf).
+  - [Giordano et al., 2021](https://dl.acm.org/doi/10.1145/3453483.3454069); [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf).
 - **Industry standard:** 4 parameters (convergence across tools).
-- **Guardrails.** Prefer **≤3**; treat **4–5** as "explain why," **6+** as "refactor (object/params object)."
+- **Guardrails.** Prefer **≤3**; treat **4-5** as "explain why," **6+** as "refactor (object/params object)."
 
 #### 5) Line length & whitespace
 
 - **Why it matters.** Long lines reduce eye-saccade anchors and mix more tokens per visual chunk.
 - **Evidence.** PEP 8 caps at **79** (with room up to ~99), Google Java at **100**; readability models find **characters per line** and **blank lines** predictive.
-  — [PEP 8](https://peps.python.org/pep-0008/), [Google Java style](https://google.github.io/styleguide/javaguide.html), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf).
+  - [PEP 8](https://peps.python.org/pep-0008/), [Google Java style](https://google.github.io/styleguide/javaguide.html), [Buse & Weimer, 2010](https://www.cs.virginia.edu/~weimer/2010/rsrch/readability/TSE_readability.pdf).
 - **Guardrails.** Use **≤100** cols for code (≤80 for prose/comments); **add blank lines** between logical chunks.
 
 #### 6) Identifier naming (length, semantics, consistency)
@@ -140,11 +140,11 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 - **Why it matters.** Names are the **primary carriers of meaning**.
 - **Evidence.**
   - Pros were ~**19% faster** with **full-word** names than with letters/abbreviations.
-    — [Hofmeister et al., 2017](https://www.se.cs.uni-saarland.de/publications/docs/HoSeHo17.pdf).
+    - [Hofmeister et al., 2017](https://www.se.cs.uni-saarland.de/publications/docs/HoSeHo17.pdf).
   - **Misleading** names can be worse than meaningless; consistent vocabulary aids comprehension.
-    — [Avidan & Feitelson, 2017](https://www.cs.huji.ac.il/w~feit/papers/Mislead17ICPC.pdf), [Lawrie et al., 2007](https://cs.uwlax.edu/~dmathias/cs419-s2013/lawrie.pdf), overview [Feitelson, 2021](https://arxiv.org/pdf/2102.08314).
-  - **2022 meta-analysis:** Identifier naming appears in 16 studies as primary comprehension factor—more than any complexity metric.
-    — [40-year systematic review](https://arxiv.org/abs/2206.11102).
+    - [Avidan & Feitelson, 2017](https://www.cs.huji.ac.il/w~feit/papers/Mislead17ICPC.pdf), [Lawrie et al., 2007](https://cs.uwlax.edu/~dmathias/cs419-s2013/lawrie.pdf), overview [Feitelson, 2021](https://arxiv.org/pdf/2102.08314).
+  - **2022 meta-analysis:** Identifier naming appears in 16 studies as primary comprehension factor-more than any complexity metric.
+    - [40-year systematic review](https://arxiv.org/abs/2206.11102).
 - **Guardrails.** Prefer multi-word, descriptive names; avoid opaque abbreviations except in tiny scopes; **rename misleading identifiers** first.
 
 #### 7) Expression complexity (booleans, chained calls) & "explaining variables"
@@ -152,30 +152,30 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 - **Why it matters.** Dense boolean logic and long method chains increase the number of predicates and operands to track.
 - **Evidence.**
   - For experts, **flat vs nested** boolean forms are often equivalent; **names** and **intermediate variables** help **when the expression is hard**.
-    — [Ajami et al., 2017](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf), [Cates et al., 2021](https://www.cs.huji.ac.il/~feit/papers/TempVar21ICPC.pdf).
+    - [Ajami et al., 2017](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf), [Cates et al., 2021](https://www.cs.huji.ac.il/~feit/papers/TempVar21ICPC.pdf).
   - Method chaining has mixed results; comments may not reliably improve comprehension alone.
-    — [Börstler & Paech, 2016](https://research.amanote.com/publication/So2A03MBKQvf0BhifpRP/the-role-of-method-chains-and-comments-in-software-readability-and-comprehensionan).
+    - [Börstler & Paech, 2016](https://research.amanote.com/publication/So2A03MBKQvf0BhifpRP/the-role-of-method-chains-and-comments-in-software-readability-and-comprehensionan).
 - **Guardrails.** Prefer **≤4** boolean terms; introduce **well-named temporaries** for readability; avoid long fluent chains without breaks.
 
 #### 8) Recursion
 
 - **Why it matters.** Readers must simulate call stack & termination conditions; novices especially taxed.
 - **Evidence.** Longstanding difficulty for novices; recent work with experienced developers confirms **base-case clarity** and **state transparency** are critical.
-  — [Stöckert et al., 2024](https://dl.acm.org/doi/10.1145/3649217.3653634).
+  - [Stöckert et al., 2024](https://dl.acm.org/doi/10.1145/3649217.3653634).
 - **Guardrails.** Prefer **tail/simple recursion**; isolate base/termination logic; consider iterative versions when depth/state is non-obvious.
 
 #### 9) Data-flow dependencies (def-use)
 
 - **Why it matters.** Interleaved definitions & uses force readers to back-reference.
 - **Evidence.** **DepDegree** and related PDG metrics show stronger associations with cognitive load than control-flow-only metrics.
-  — [Beyer et al., 2014](https://www.sosy-lab.org/research/pub/2014-ICPC.A_Formal_Evaluation_of_DepDegree_Based_on_Weyukers_Properties.pdf), [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf).
+  - [Beyer et al., 2014](https://www.sosy-lab.org/research/pub/2014-ICPC.A_Formal_Evaluation_of_DepDegree_Based_on_Weyukers_Properties.pdf), [Peitek et al., 2021](https://www.tu-chemnitz.de/informatik/ST/publications/papers/ICSE21.pdf).
 - **Guardrails.** Keep variable lifespans short; reduce cross-branch sharing; prefer single-purpose variables per block.
 
 #### 10) Regularity / repetition
 
 - **Why it matters.** Once a reader "learns the pattern," repeated instances cost less attention.
 - **Evidence.** Eye-tracking shows **decreasing reading effort** across repeated patterns.
-  — [Jbara & Feitelson, 2017](https://www.cs.huji.ac.il/~feit/papers/RegEye17EmpSE.pdf).
+  - [Jbara & Feitelson, 2017](https://www.cs.huji.ac.il/~feit/papers/RegEye17EmpSE.pdf).
 - **Guardrails.** Prefer consistent idioms & small variations; avoid needless irregularity.
 
 ### New factors from advanced research (2021-2025)
@@ -189,7 +189,7 @@ The table below maps each factor to approximate ranges and **qualitative impact 
   - **MPC (Message Passing Coupling):** Method calls between classes.
   - **DAC (Data Abstraction Coupling):** Abstract data type dependencies.
 - **Evidence:** High coupling correlates with defect density and comprehension difficulty.
-  — [Coupling overview](https://www.techtarget.com/searchapparchitecture/tip/The-basics-of-software-coupling-metrics-and-concepts).
+  - [Coupling overview](https://www.techtarget.com/searchapparchitecture/tip/The-basics-of-software-coupling-metrics-and-concepts).
 - **Guardrails:** CBO ≤9, Instability matched to component role (stable for core, flexible for adapters).
 
 #### 12) Cohesion metrics (class focus)
@@ -199,7 +199,7 @@ The table below maps each factor to approximate ranges and **qualitative impact 
   - **LCOM4:** Number of connected components. 1 = perfect, 2+ = consider splitting.
   - **TCC/LCC (Tight/Loose Class Cohesion):** Direct vs indirect method relationships. Values closer to 1 = better.
 - **Evidence:** Low cohesion predicts maintenance problems and comprehension issues.
-  — [Cohesion metrics guide](https://www.aivosto.com/project/help/pm-oo-cohesion.html).
+  - [Cohesion metrics guide](https://www.aivosto.com/project/help/pm-oo-cohesion.html).
 - **Guardrails:** LCOM4 = 1 ideal, refactor at ≥3; TCC ≥0.5 for well-designed classes.
 
 #### 13) AST complexity (structural patterns)
@@ -218,35 +218,35 @@ The table below maps each factor to approximate ranges and **qualitative impact 
   - Non-linear reading (scan → focus → verify)
   - Fixation duration correlates with complexity
   - Regression patterns indicate comprehension difficulty
-  — [2024 gaze-code alignment](https://2024.esec-fse.org/details/fse-2024-research-papers/58/Predicting-Code-Comprehension-A-Novel-Approach-to-Align-Human-Gaze-with-Code-Using-D).
+  - [2024 gaze-code alignment](https://2024.esec-fse.org/details/fse-2024-research-papers/58/Predicting-Code-Comprehension-A-Novel-Approach-to-Align-Human-Gaze-with-Code-Using-D).
 
 - **EEG markers:**
   - Theta (4-8 Hz) ↑ with complexity
   - Alpha (8-13 Hz) ↓ with mental effort
   - 97% accuracy in expertise prediction
-  — [EEG programmer assessment](https://www.mdpi.com/1424-8220/21/7/2338).
+  - [EEG programmer assessment](https://www.mdpi.com/1424-8220/21/7/2338).
 
 - **fNIRS measurements:**
   - Prefrontal cortex oxygenation
   - 89% accuracy in load detection
   - Scale-invariant dynamics via Hurst exponent
-  — [fNIRS cognitive load](https://www.sciencedirect.com/science/article/abs/pii/S0010945222001551).
+  - [fNIRS cognitive load](https://www.sciencedirect.com/science/article/abs/pii/S0010945222001551).
 
 #### 15) Programming paradigm factors
 
 - **Reactive vs OOP:** 15-25% comprehension improvement with reactive patterns
-  — [IEEE study](https://ieeexplore.ieee.org/document/7827078/).
+  - [IEEE study](https://ieeexplore.ieee.org/document/7827078/).
 
 - **Static vs Dynamic typing:**
   - Static: Better maintainability, IDE support
   - Dynamic: 30-40% faster initial development
-  — [Type system experiment](https://www.researchgate.net/publication/221321863_An_Experiment_About_Static_and_Dynamic_Type_Systems_Doubts_About_the_Positive_Impact_of_Static_Type_Systems_on_Development_Time).
+  - [Type system experiment](https://www.researchgate.net/publication/221321863_An_Experiment_About_Static_and_Dynamic_Type_Systems_Doubts_About_the_Positive_Impact_of_Static_Type_Systems_on_Development_Time).
 
 - **Async patterns:** 30% debugging time reduction with async/await vs callbacks
-  — Industry reports and [Wikipedia async/await](https://en.wikipedia.org/wiki/Async/await).
+  - Industry reports and [Wikipedia async/await](https://en.wikipedia.org/wiki/Async/await).
 
 - **DSLs:** Superior comprehension for domain experts when scope is focused
-  — [DSL comprehension study](https://www.researchgate.net/publication/225150322_Program_comprehension_of_domain-specific_and_general-purpose_languages_Comparison_using_a_family_of_experiments).
+  - [DSL comprehension study](https://www.researchgate.net/publication/225150322_Program_comprehension_of_domain-specific_and_general-purpose_languages_Comparison_using_a_family_of_experiments).
 
 #### 16) Collaborative comprehension factors
 
@@ -254,16 +254,16 @@ The table below maps each factor to approximate ranges and **qualitative impact 
   - Effectiveness drops faster than linearly with size
   - <200 lines enables linear reading
   - Tool-assisted produces 2× accepted comments
-  — [ICPC 2025](https://conf.researchr.org/details/icpc-2025/icpc-2025-research/5/Code-Review-Comprehension-Reviewing-Strategies-Seen-Through-Code-Comprehension-Theor).
+  - [ICPC 2025](https://conf.researchr.org/details/icpc-2025/icpc-2025-research/5/Code-Review-Comprehension-Reviewing-Strategies-Seen-Through-Code-Comprehension-Theor).
 
 - **Pair programming:** 15% individual slowdown, significant quality improvement
-  — Industry studies and [knowledge transfer research](https://codingsans.com/blog/knowledge-transfer-methods-for-software-teams).
+  - Industry studies and [knowledge transfer research](https://codingsans.com/blog/knowledge-transfer-methods-for-software-teams).
 
 - **Documentation quality metrics:**
   - Search success rate
   - Time-to-resolution
   - Support deflection ratio
-  — [Documentation KPIs](https://document360.com/blog/technical-documentation-kpi/).
+  - [Documentation KPIs](https://document360.com/blog/technical-documentation-kpi/).
 
 ---
 
@@ -416,7 +416,7 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 ### Nesting, indentation, formatting
 - SonarSource, **Cognitive Complexity whitepaper** (2017). [PDF](https://www.sonarsource.com/docs/CognitiveComplexity.pdf)
 - Miara et al., **"Program Indentation and Comprehensibility"** (CACM 1983). [PDF](https://www.cs.umd.edu/~ben/papers/Miara1983Program.pdf)
-- Hanenberg et al., **"Indentation and Reading Time—RCT"** (ESE 2024). [Abstract](https://link.springer.com/article/10.1007/s10664-024-10531-y)
+- Hanenberg et al., **"Indentation and Reading Time-RCT"** (ESE 2024). [Abstract](https://link.springer.com/article/10.1007/s10664-024-10531-y)
 - PEP 8 **Maximum Line Length** & justification (2025). [PEP 8](https://peps.python.org/pep-0008/)
 - Google Java Style, **100-column limit**. [Guide](https://google.github.io/styleguide/javaguide.html)
 
@@ -428,9 +428,9 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 - **"40 Years of Designing Code Comprehension Experiments: A Systematic Mapping Study"** (2022). [arXiv](https://arxiv.org/abs/2206.11102)
 
 ### Expressions, booleans, intermediate variables
-- Ajami, Woodbridge & Feitelson, **"Syntax, Predicates, Idioms—What Really Affects Code Complexity?"** (ICPC 2017). [PDF](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf)
+- Ajami, Woodbridge & Feitelson, **"Syntax, Predicates, Idioms-What Really Affects Code Complexity?"** (ICPC 2017). [PDF](https://www.cs.huji.ac.il/~feit/papers/Complexity17ICPC.pdf)
 - Cates, Yunik & Feitelson, **"On Using and Naming Intermediate Variables"** (ICPC 2021). [PDF](https://www.cs.huji.ac.il/~feit/papers/TempVar21ICPC.pdf)
-- Börstler & Paech, **"Method Chains & Comments—An Experiment"** (TSE 2016). [ToC / refs](https://www.computer.org/csdl/journal/ts/2016/09)
+- Börstler & Paech, **"Method Chains & Comments-An Experiment"** (TSE 2016). [ToC / refs](https://www.computer.org/csdl/journal/ts/2016/09)
 
 ### Recursion & novices
 - Stöckert et al., **"Why Is Recursion Hard to Comprehend?"** (ITiCSE 2024). [Abstract](https://dl.acm.org/doi/10.1145/3649217.3653634)
@@ -486,7 +486,7 @@ The table below maps each factor to approximate ranges and **qualitative impact 
 - **Address CBO ≥10** (high coupling)
 
 ### Should-fix (moderate impact)
-- **Cap lines at 80–100 columns**
+- **Cap lines at 80-100 columns**
 - **Add blank lines between logical blocks**
 - **Flatten complex booleans (>4 terms)**
 - **Introduce explaining variables** for dense expressions

--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -120,8 +120,8 @@ internal bool SingleVerticalBorderAdded
 
 ### Span-walking hot paths
 
-1. Read [Span Performance on .NET Framework](framework-span-performance.md) before optimizing any helper that walks `ReadOnlySpan<T>` / `Span<T>` per element. On `net472`/`net481` the span indexer is ~8 µops per element (slow-span layout) versus ~1 µop on net10; the hoist-`ref T`-with-`MemoryMarshal.GetReference`-and-`Unsafe.Add` pattern recovers 19&ndash;44% on Framework while staying safe (no `unsafe` keyword).
-1. Prefer a single simple implementation when its measurements are within ~5% of any Framework-tuned variant on net10 &mdash; the simpler source keeps accruing future RyuJIT vectorization/PGO wins. Split via `#if NET` / `#else` only when the simple shape regresses net10 measurably; pin with `fixed` (not `Unsafe.AsPointer` tricks) when the Framework path needs raw pointers.
+1. Read [Span Performance on .NET Framework](framework-span-performance.md) before optimizing any helper that walks `ReadOnlySpan<T>` / `Span<T>` per element. On `net472`/`net481` the span indexer is ~8 µops per element (slow-span layout) versus ~1 µop on net10; the hoist-`ref T`-with-`MemoryMarshal.GetReference`-and-`Unsafe.Add` pattern recovers 19-44% on Framework while staying safe (no `unsafe` keyword).
+1. Prefer a single simple implementation when its measurements are within ~5% of any Framework-tuned variant on net10 - the simpler source keeps accruing future RyuJIT vectorization/PGO wins. Split via `#if NET` / `#else` only when the simple shape regresses net10 measurably; pin with `fixed` (not `Unsafe.AsPointer` tricks) when the Framework path needs raw pointers.
 
 ### Fields
 

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -63,7 +63,7 @@ using SingleOptimizedList<string, ArrayPoolList<string>> matches = new();
 
 matches.Add("first");
 
-// Still inline — no array allocation yet.
+// Still inline - no array allocation yet.
 
 if (alsoMatchesSecond)
 {

--- a/docs/dotnet-perf-discoveries.md
+++ b/docs/dotnet-perf-discoveries.md
@@ -5,7 +5,7 @@ optimizing `touki`. Each entry captures a measurement-backed observation, why
 it matters, the mitigation we landed on (or considered), and a follow-up that
 might still be worth investigating.
 
-These are **not bug reports** — every observation listed is consistent with
+These are **not bug reports** - every observation listed is consistent with
 documented BCL behavior. They exist here so future optimization work doesn't
 re-discover them from scratch.
 
@@ -19,7 +19,7 @@ see [framework-span-performance.md](framework-span-performance.md).
 
 ---
 
-## 1. `MemoryExtensions.Equals(span, span, StringComparison.OrdinalIgnoreCase)` has a perf valley at length 6–15
+## 1. `MemoryExtensions.Equals(span, span, StringComparison.OrdinalIgnoreCase)` has a perf valley at length 6-15
 
 ### Observation (both TFMs)
 
@@ -33,7 +33,7 @@ on equal-length all-letter ASCII spans of mixed case:
 | 20 | 2.6 ns | 41.5 ns |
 | 64 | 6.3 ns | 69.6 ns |
 
-On net10.0 there is a **non-monotonic valley** around length 6–15 where the
+On net10.0 there is a **non-monotonic valley** around length 6-15 where the
 BCL path is ~3× slower than at length 5 or 20. The shape is consistent with
 the BCL having (a) a length≤5 small-string special case, (b) a length≥16
 vectorized path that handles two `Vector128<short>` registers per iteration,
@@ -46,9 +46,9 @@ linearly with length and the cost-per-char is ~1 ns even on a high-end CPU.
 
 `LiteralGlobMatcher.IsMatch` for `IgnoreCase=true` used to call
 `input.Equals(_literal.AsSpan(), StringComparison.OrdinalIgnoreCase)` directly.
-Typical glob literals are 5–15 chars (file names) — squarely inside the
+Typical glob literals are 5-15 chars (file names) - squarely inside the
 valley. The benchmark `Touki_Literal_Hit IgnoreCase=True` measured 10.04 ns
-against the equivalent `RegexGen_Literal_Hit` at 10.4 ns on net10 — far
+against the equivalent `RegexGen_Literal_Hit` at 10.4 ns on net10 - far
 slower than it should be for what is functionally a 10-char compare.
 
 ### Mitigation (applied)
@@ -56,7 +56,7 @@ slower than it should be for what is functionally a 10-char compare.
 `Touki.SpanExtensions.EqualsOrdinalIgnoreCase`. The helper:
 
 - Length-mismatch returns `false` in one compare.
-- Length ≥ 16 (`BclCrossoverLength`) delegates to BCL — the vectorized path
+- Length ≥ 16 (`BclCrossoverLength`) delegates to BCL - the vectorized path
   there is faster than any scalar loop.
 - Length < 16 runs an inlined ASCII fold compare with a per-character
   non-ASCII guard. On the first non-ASCII char, hands the tail to BCL with
@@ -87,7 +87,7 @@ real-application detection floor for typical glob workloads.
 ### Follow-up
 
 - Watch the .NET 11 / .NET 12 servicing notes for changes to
-  `Ordinal.EqualsIgnoreCase` — if the valley closes, this helper becomes
+  `Ordinal.EqualsIgnoreCase` - if the valley closes, this helper becomes
   pure overhead and can be removed.
 - `MemoryExtensions.StartsWith(span, span, OrdinalIgnoreCase)` and
   `EndsWith(...)` likely have the same valley. We have not benchmarked them
@@ -139,20 +139,20 @@ Two separate experiments hit the same wall:
 1. **`SpanReader<char>` in `GlobMatcherFactory.EncodeProgram`**: replacing a
    scalar `pattern[i++]` index loop with `SpanReader.TryRead`/`TryPeek`
    plus `TryReadToAny` (which uses `IndexOfAny`) regressed *every* compile
-   row by 60–150%, including `Compile_Any` which doesn't even reach
+   row by 60-150%, including `Compile_Any` which doesn't even reach
    `EncodeProgram`. The wrapper method-call overhead plus vector setup cost
-   dominates for 5–10-char pattern reads.
+   dominates for 5-10-char pattern reads.
 2. **`IndexOf(']') + Append(span)` in `EmitClass`**: replacing a
    `for (i; ; i++) sb.Append(c)` loop over a class body with one
    `pattern.IndexOf(']')` + one `sb.Append(span)` regressed
-   `Compile_ManyClasses` by +11%. Real class bodies are 3–7 chars (`[abc]`,
+   `Compile_ManyClasses` by +11%. Real class bodies are 3-7 chars (`[abc]`,
    `[0-9]`); below the `IndexOf` vector-setup amortization point.
 
 ### Why this matters
 
 Section 6 of the reference document on character parsing says vectorization
 becomes a win past ~16 chars of input. The actual breakeven on this
-hardware appears to be ~8–12 chars for the BCL primitives we tested.
+hardware appears to be ~8-12 chars for the BCL primitives we tested.
 Glob patterns and their class bodies, literal runs, and segment lengths
 typically sit **below** that threshold.
 
@@ -162,7 +162,7 @@ typically sit **below** that threshold.
 > (`IndexOf`, `IndexOfAny`, `MemoryExtensions.Equals(StringComparison)`,
 > `SequenceEqual` for char), measure at the realistic input length. The
 > primitive only wins past the vector setup amortization threshold, which
-> on i9-class hardware sits around **8–12 chars for `char`-typed spans**.
+> on i9-class hardware sits around **8-12 chars for `char`-typed spans**.
 > Below that, the inlined loop with `ref char` indexing and the
 > `pattern[i++]` form is faster than any vectorized call.
 
@@ -170,7 +170,7 @@ typically sit **below** that threshold.
 
 - A `SearchValues<char>`-based class-membership matcher for
   `CompiledGlobMatcher` was deferred because typical glob classes are
-  2–7 chars (`[de]`, `[0-9]`, `[A-Z]`). Re-evaluate once we have a
+  2-7 chars (`[de]`, `[0-9]`, `[A-Z]`). Re-evaluate once we have a
   benchmark with realistic long classes like `[A-Za-z0-9_]`.
 
 ---
@@ -180,13 +180,13 @@ typically sit **below** that threshold.
 ### Observation
 
 Slice 1 (this document, item 1) applied an inlined ASCII fold compare to
-`LiteralGlobMatcher.IgnoreCase` — replacing
+`LiteralGlobMatcher.IgnoreCase` - replacing
 `MemoryExtensions.Equals(span, span, OrdinalIgnoreCase)`. Won by 5+ ns at
 typical glob lengths.
 
 The identical code structure applied to `CompiledGlobMatcher.EqualsIgnoreCase`
-— replacing a tight static `for (i) AsciiFold(a[i]) != AsciiFold(b[i])`
-loop — **regressed** `Touki_Compiled_Hit IgnoreCase` by +16% (15.32 →
+- replacing a tight static `for (i) AsciiFold(a[i]) != AsciiFold(b[i])`
+loop - **regressed** `Touki_Compiled_Hit IgnoreCase` by +16% (15.32 →
 17.76 ns). The pre-existing tight loop already had no framework dispatch
 to amortize against; the added branches in the "fast path" cost more than
 they save.
@@ -242,7 +242,7 @@ no measurable effect.
 
 .NET Framework 4.8.1 RyuJIT's inliner is less aggressive than modern .NET
 RyuJIT's. When a small helper contains a moderately sized fold loop, the
-net481 inliner declines to inline at call sites — so even the
+net481 inliner declines to inline at call sites - so even the
 delegating-to-BCL path eats a real call. Modern RyuJIT inlines the same
 method body without the hint.
 
@@ -272,7 +272,7 @@ the JIT auto-inlines.
 
 ### Follow-up
 
-None. Confirmed dead end — do not re-apply without new evidence that a
+None. Confirmed dead end - do not re-apply without new evidence that a
 specific call site is failing to inline.
 
 ---
@@ -309,11 +309,11 @@ analysis.
 ## Index of pinned rules
 
 1. **§3**: Vectorized BCL primitives only beat inlined scalar loops past
-   8–12 chars on i9-class hardware for `char`-typed spans.
+   8-12 chars on i9-class hardware for `char`-typed spans.
 2. **§4**: ASCII inline fast-path is a win iff replacing framework dispatch,
    not iff replacing an existing tight loop.
 3. **§5**: For small dispatch wrappers delegating to BCL, mark the wrapper
-   `AggressiveInlining` and keep the loop in a separate method — fixes a
+   `AggressiveInlining` and keep the loop in a separate method - fixes a
    real net481 inlining cost.
 4. **§7**: ASCII fast-path threshold on `char` spans is 16, controlled by
    `Vector128<short>.Count × 2`.

--- a/docs/extglob.md
+++ b/docs/extglob.md
@@ -4,7 +4,7 @@ Reference for the extended-glob feature surface in
 [`Touki.Io.Globbing`](../touki/Touki/Io/Globbing/). Covers the five extglob
 constructs, how they relate to the &quot;normal&quot; glob metacharacters
 (`*`, `?`, `[...]`), how to turn the feature on, and where touki agrees with
-&mdash; or deliberately diverges from &mdash; bash.
+- or deliberately diverges from - bash.
 
 If you only need the surface-level API contract, the
 [`GlobOptions.AllowExtGlob`](../touki/Touki/Io/Globbing/GlobOptions.cs) doc
@@ -21,10 +21,10 @@ escape characters:
 | ------- | -------------------------------------------------------------------- |
 | `?`     | match exactly one character (path-aware dialects: not the separator) |
 | `*`     | match zero or more characters (path-aware: not the separator)        |
-| `**`    | globstar: match zero or more path segments &mdash; only when `AllowGlobStar` is set or the dialect has implicit globstar (`MSBuild`, `FileSystemGlobbing`, `Git`) |
-| `[...]` | character class &mdash; only on dialects with `HasCharacterClasses()` (POSIX family, Bash, Git, FSG) |
+| `**`    | globstar: match zero or more path segments - only when `AllowGlobStar` is set or the dialect has implicit globstar (`MSBuild`, `FileSystemGlobbing`, `Git`) |
+| `[...]` | character class - only on dialects with `HasCharacterClasses()` (POSIX family, Bash, Git, FSG) |
 | `[!...]` / `[^...]` | negated character class (same dialects)                    |
-| `\<c>`  | escape `<c>` to its literal form &mdash; only on dialects with an escape character (POSIX family, Bash, Git use `\\`; PowerShell uses `` ` ``) |
+| `\<c>`  | escape `<c>` to its literal form - only on dialects with an escape character (POSIX family, Bash, Git use `\\`; PowerShell uses `` ` ``) |
 
 Each `?` consumes exactly one character. `*` is greedy at the matcher's NFA
 level. Neither `*` nor `?` crosses the path separator on path-aware
@@ -50,7 +50,7 @@ immediately by `(`, a `|`-separated list of inner patterns, and a closing
 | `@(p1\|p2\|...)`   | match **exactly one** occurrence of any alternative                                 |
 | `!(p1\|p2\|...)`   | match **any string that is not** one of the alternatives, as a single consumed slice |
 
-Each inner pattern is itself a full glob &mdash; it may contain `*`, `?`,
+Each inner pattern is itself a full glob - it may contain `*`, `?`,
 character classes, escapes, and other extglob constructs recursively.
 
 ### Side-by-side examples
@@ -59,7 +59,7 @@ character classes, escapes, and other extglob constructs recursively.
 | ------------------- | -------------------------------------- | ----------------------------- |
 | `*.cs`              | `foo.cs`, `bar.cs`                     | `foo.txt`, `foo.cs.bak`       |
 | `@(*.cs\|*.txt)`    | `foo.cs`, `foo.txt`                    | `foo.json`, `foo.cs.bak`      |
-| `*.cs`              | `foo.cs` (one extension)               | &mdash;                       |
+| `*.cs`              | `foo.cs` (one extension)               | -                       |
 | `?(*.cs)`           | `foo.cs`, *empty string*               | `foo.cs.bak`                  |
 | `+(a\|b)`           | `a`, `b`, `ab`, `aabb`                 | `empty string`, `c`           |
 | `*(a\|b)`           | `a`, `b`, `ab`, `aabb`, *empty string* | `c`, `ac`                     |
@@ -124,11 +124,11 @@ bool ignored = spec.IsMatch("foo.json");    // false
 
 When `AllowExtGlob` is omitted, the pattern `@(*.cs|*.txt)` is interpreted
 as the literal characters `@(*.cs|*.txt)` and matches no real-world file
-name &mdash; the parser does not warn, so the silent no-match can be
+name - the parser does not warn, so the silent no-match can be
 surprising. If your pattern is user-supplied, prefer to pass the flag
 unconditionally.
 
-The same flag lights the feature up regardless of dialect &mdash; it is
+The same flag lights the feature up regardless of dialect - it is
 honored by every dialect that uses the bytecode interpreter
 (`Posix`, `PosixPath`, `Bash`, `Git`, `Simple`, `PowerShell`,
 `FileSystemGlobbing`, `MSBuild`). Bash callers can think of it as the
@@ -167,7 +167,7 @@ On path-aware dialects (`PosixPath`, `Bash`, `Git`, `MSBuild`,
 
 - Inner wildcards (`*`, `?`, char classes) inside an extglob alternative do
   not cross `/`. `@(*.cs|*.txt)` against `src/foo.cs` is **no match**
-  &mdash; the inner `*` can't consume `src/`.
+  - the inner `*` can't consume `src/`.
 - `!(...)` similarly cannot consume past `/`. Use explicit separators in the
   outer pattern to span segments: `dir/!(foo)` matches `dir/bar`,
   `dir/baz`; never `dir/foo` and never `dir/sub/bar`.
@@ -194,7 +194,7 @@ On path-aware dialects (`PosixPath`, `Bash`, `Git`, `MSBuild`,
   alternation semantics.
 - The compile-time tail-anchor optimization
   (`EndsWith` fast-fail on a literal suffix) is also suppressed for
-  extglob programs &mdash; an alternative may consume what looks like a
+  extglob programs - an alternative may consume what looks like a
   trailing literal.
 
 ## Bash parity
@@ -236,11 +236,11 @@ the un-extended `[abc]` character class is still the cheapest answer:
 
 ## See also
 
-- [`GlobOptions.cs`](../touki/Touki/Io/Globbing/GlobOptions.cs) &mdash;
+- [`GlobOptions.cs`](../touki/Touki/Io/Globbing/GlobOptions.cs) -
   per-flag reference.
-- [`GlobDialect.cs`](../touki/Touki/Io/Globbing/GlobDialect.cs) &mdash;
+- [`GlobDialect.cs`](../touki/Touki/Io/Globbing/GlobDialect.cs) -
   per-dialect defaults.
-- [`globbing-feature-plan.md`](globbing-feature-plan.md) &mdash; internal
+- [`globbing-feature-plan.md`](globbing-feature-plan.md) - internal
   planning, including the F1.3 / F1.4 rollout history.
 - [bash Pattern Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html)
 - [fnmatch(3) FNM_EXTMATCH](https://man7.org/linux/man-pages/man3/fnmatch.3.html)

--- a/docs/framework-span-performance.md
+++ b/docs/framework-span-performance.md
@@ -9,12 +9,12 @@ under `BenchmarkDotNet.Artifacts/results/`.
 
 The numbers and disassembly in this document are pulled from a Raptor
 Lake i9-14900K running .NET 10.0.7 and .NET Framework 4.8.1. The shapes
-generalize to any net472+ target — there is one RyuJIT for desktop
+generalize to any net472+ target - there is one RyuJIT for desktop
 Framework and it has not received vectorization or PGO work in years.
 
 The companion document is
 [bcl-ignorecase-valley-rca.md](bcl-ignorecase-valley-rca.md), which
-captures one specific case study (`OrdinalIgnoreCase` at length 8–15)
+captures one specific case study (`OrdinalIgnoreCase` at length 8-15)
 in detail. This document is the general field manual.
 
 ---
@@ -43,7 +43,7 @@ public readonly ref struct Span<T>
 Indexing `span[i]` compiles to a single indexed load (`movzx eax, word
 ptr [reg + i*2]` for `Span<char>`).
 
-On .NET Framework (and any "slow span" target — `netstandard2.0` via the
+On .NET Framework (and any "slow span" target - `netstandard2.0` via the
 `System.Memory` NuGet, `net472`, `net481`) `Span<T>` is approximately:
 
 ```csharp
@@ -97,7 +97,7 @@ fold work.
 Framework RyuJIT does not recognize the `System.Runtime.Intrinsics`
 APIs. `Vector<T>` (the old "agnostic" SIMD type) still works but is
 significantly slower than the modern intrinsics. The BCL itself does
-not vectorize most string/span operations when running on Framework —
+not vectorize most string/span operations when running on Framework -
 even calls like `MemoryExtensions.Equals(span, span, OrdinalIgnoreCase)`
 fall through to a scalar per-character loop.
 
@@ -155,7 +155,7 @@ algorithm wants. Benchmark on **both** net10 and net481.
 
 Three outcomes:
 
-1. **Both TFMs within target.** Done — ship it.
+1. **Both TFMs within target.** Done - ship it.
 2. **net10 fine, net481 slow.** Continue to Strategy B.
 3. **Both slow.** Algorithmic issue. The strategies in this document
    only help with constant-factor JIT/runtime overhead.
@@ -173,7 +173,7 @@ slow-span pointer dance **once** outside the loop and walk a real `ref T`
 inside it.
 
 ```csharp
-// Before — pays the slow-span tax per character on net481
+// Before - pays the slow-span tax per character on net481
 for (int i = 0; i < a.Length; i++)
 {
     char x = a[i];
@@ -181,7 +181,7 @@ for (int i = 0; i < a.Length; i++)
     // ...
 }
 
-// After — pays it once at method entry
+// After - pays it once at method entry
 ref char pa = ref MemoryMarshal.GetReference(a);
 ref char pb = ref MemoryMarshal.GetReference(b);
 int n = a.Length;
@@ -203,18 +203,18 @@ input):
 | 20 | 46.67 ns | 27.04 ns | **−42%** |
 | 64 | 105.81 ns| 59.70 ns | **−44%** |
 
-On net10 the same change is a 14–16% win at short lengths and zero at
-long lengths — modern RyuJIT was already keeping the operand in a
+On net10 the same change is a 14-16% win at short lengths and zero at
+long lengths - modern RyuJIT was already keeping the operand in a
 register, but `Unsafe.Add` saves the bounds check the indexer would
 otherwise emit.
 
-**This pattern is safe** in the C# sense — no `unsafe` block, no
+**This pattern is safe** in the C# sense - no `unsafe` block, no
 pinning, no GC concerns. `Unsafe.Add` on a managed `ref T` is GC-aware:
 the runtime tracks the byref the same way it tracks the original span
 reference, and a moving GC updates both.
 
 The one cost: `MemoryMarshal.GetReference` does **not** inline on
-net481 — it's a non-inlined `call`. That ~2 ns per call (~4 ns total
+net481 - it's a non-inlined `call`. That ~2 ns per call (~4 ns total
 for two operands) is why the L=5 row above is a wash. Continue to
 Strategy C only if you need to recover that.
 
@@ -258,7 +258,7 @@ at L ≥ 20 because every additional iteration the pinned pointer pays
 nothing the `ref T` doesn't, and the `fixed` block has a small
 GC-frame-update cost on entry/exit that `Unsafe.Add` avoids.
 
-**Pinning is explicit `unsafe`.** That is a feature, not a drawback —
+**Pinning is explicit `unsafe`.** That is a feature, not a drawback -
 the keyword forces a reviewer to look at the pointer arithmetic. Treat
 `Unsafe.Add` as "safe but easy to misread" and `fixed` as "unsafe and
 obviously unsafe". Both ship the same machine code shape; the
@@ -328,7 +328,7 @@ private static unsafe bool EqualsPinned(ReadOnlySpan<char> a, ReadOnlySpan<char>
 ```
 
 This pattern lets the modern .NET source remain a target for the JIT's
-own optimizer — when .NET 12 or 13 adds a new vectorization pass, the
+own optimizer - when .NET 12 or 13 adds a new vectorization pass, the
 simple loop picks it up automatically. The Framework implementation
 stays frozen at "whatever runs well on RyuJIT 4.8", because RyuJIT 4.8
 is itself frozen.
@@ -344,7 +344,7 @@ The **within-noise** test for whether to split:
 
 ### 2.5 Strategy E: kill the call frame (force-inline)
 
-Orthogonal to A–D, but worth listing. Framework's per-call overhead
+Orthogonal to A-D, but worth listing. Framework's per-call overhead
 (~6 ns: 88-byte frame + 48-byte `rep stosd` + epilogue) is irreducible
 *within a called function*. The only way to delete it is to not be a
 called function.
@@ -353,7 +353,7 @@ called function.
 [MethodImpl(MethodImplOptions.AggressiveInlining)]
 public static bool Equals(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
 {
-    // Tiny dispatcher — inlines into the caller.
+    // Tiny dispatcher - inlines into the caller.
     if (a.Length != b.Length) return false;
     if (a.Length < SomeThreshold) return EqualsCore(a, b);
     return BclEquals(a, b);
@@ -363,7 +363,7 @@ public static bool Equals(ReadOnlySpan<char> a, ReadOnlySpan<char> b)
 The dispatcher inlines and the per-call frame for `Equals` disappears
 on Framework. The work-doing method (`EqualsCore`) stays out-of-line
 to avoid bloating every call site. On net481 each eliminated call
-frame is worth ~5–6 ns, which is significant for short-input hot
+frame is worth ~5-6 ns, which is significant for short-input hot
 paths.
 
 **Caveat**: `AggressiveInlining` is a *hint*. Framework's JIT will
@@ -379,7 +379,7 @@ quickly estimate how much a given strategy might save:
 
 | Cost | Approx ns | Notes |
 |---|---:|---|
-| Function-call frame (88 B stack + 48 B `rep stosd` + epilogue) | ~5–6 | Per call, irreducible. `[SkipLocalsInit]` is ignored. |
+| Function-call frame (88 B stack + 48 B `rep stosd` + epilogue) | ~5-6 | Per call, irreducible. `[SkipLocalsInit]` is ignored. |
 | Non-inlined `MemoryMarshal.GetReference<T>(span)` | ~2 | Per call. Doubled if you walk two spans. |
 | Slow-span indexer `span[i]` | ~1.5 µops × ~2.5 cycles | Per character. Compare to ~0.3 cycles on net10. |
 | `vzeroupper` in prologue | ~1 µop | Emitted whenever the JIT sees AVX state needs clearing. |
@@ -432,32 +432,32 @@ Benchmark on net10 AND net481.
   (Strategy E). Re-bench.
                   │
                   ▼
-  Still hot? ──── algorithm issue. Strategies A–E exhaust the
+  Still hot? ──── algorithm issue. Strategies A-E exhaust the
                   constant-factor recovery options.
 ```
 
 ---
 
-## 5. Worked example — the `OrdinalIgnoreCase` ASCII fast-path
+## 5. Worked example - the `OrdinalIgnoreCase` ASCII fast-path
 
 Sequence of decisions taken for the helper that became
 `Touki.SpanExtensions.EqualsOrdinalIgnoreCase` /
 `CompareOrdinalIgnoreCase`. Reference trace.
 
-**Start (Strategy A)** — straightforward `for (int i = 0; i < a.Length;
+**Start (Strategy A)** - straightforward `for (int i = 0; i < a.Length;
 i++)` reading `a[i]` and `b[i]`. Measured at L=10 on net10: 6.6 ns.
 Measured at L=10 on net481: 26.7 ns.
 
-**Diagnosis** — net10 fine, net481 hot. The disassembly (§B.3 of the
+**Diagnosis** - net10 fine, net481 hot. The disassembly (§B.3 of the
 RCA) shows ~16 µops per loop iteration are slow-span pointer-dance for
 the two indexer reads.
 
-**Strategy B applied (experimentally)** — `MemoryMarshal.GetReference`
+**Strategy B applied (experimentally)** - `MemoryMarshal.GetReference`
 + `Unsafe.Add`. Net481 L=10 drops to ~22 ns. Net10 L=10 drops to 5.6
 ns. Both improved; net10 win is small.
 
-**Within-noise test** — At L=10 on net10, Strategy B is 5.62 ns vs
-Strategy A's 6.55 ns. Within 14% — *not* within the 5% noise band, but
+**Within-noise test** - At L=10 on net10, Strategy B is 5.62 ns vs
+Strategy A's 6.55 ns. Within 14% - *not* within the 5% noise band, but
 both are tiny absolute values. At L=64 they tie (42.7 vs 43.4 ns). The
 unified Strategy B code is *not* losing anything visible on net10, so
 ship it unified.
@@ -469,7 +469,7 @@ split: net10 keeps the simple indexer; net481 gets the Strategy-B
 rewrite under `#if !NET`.
 
 **Strategy C applied (after the helper was hoisted into a public
-extension method)** — when the work moved into `SpanExtensions` as a
+extension method)** - when the work moved into `SpanExtensions` as a
 public API, the extra call-frame overhead on net481 surfaced: routing
 the `StringSegment.CompareTo` path through `MemoryMarshal.GetReference`
 (non-inlined on net481) regressed the L=5 path from ~10 ns to ~19 ns.
@@ -481,7 +481,7 @@ returned to baseline. See
 [touki/Touki/Buffers/SpanExtensions.IgnoreCase.cs](../touki/Touki/Buffers/SpanExtensions.IgnoreCase.cs)
 for the resulting layout.
 
-**Strategy E (force-inline)** — applied. The extension entry points
+**Strategy E (force-inline)** - applied. The extension entry points
 (`Equals*` / `StartsWith*` / `EndsWith*`) carry
 `[MethodImpl(AggressiveInlining)]` so their length-dispatch check
 (`< 16` &rarr; scalar; `>= 16` &rarr; BCL vectorized) folds into the
@@ -507,14 +507,14 @@ keeps the per-call overhead bounded.
   it as a mitigation.
 - **`Unsafe.AsPointer(ref MemoryMarshal.GetReference(span))` instead of
   `fixed`.** Same machine semantics, harder for a reviewer to spot the
-  pinning requirement (there isn't one — the pointer is bare, and a
+  pinning requirement (there isn't one - the pointer is bare, and a
   moving GC will invalidate it). If you need a raw pointer, use
   `fixed`. If you only need a `ref T`, use `MemoryMarshal.GetReference`
   with `Unsafe.Add`.
 - **`stackalloc` to avoid spans.** `stackalloc` returns a `Span<T>`
   on modern .NET and an `IntPtr` cast-shimmed thing on Framework via
   polyfill. Allocating on the stack does not help with the slow-span
-  indexer tax — it's the *span type* that's slow, not the backing
+  indexer tax - it's the *span type* that's slow, not the backing
   storage. (`stackalloc` is still the right answer for buffer
   ownership; just don't expect it to fix span-indexer performance.)
 
@@ -522,18 +522,18 @@ keeps the per-call overhead bounded.
 
 ## 7. References
 
-- [bcl-ignorecase-valley-rca.md](bcl-ignorecase-valley-rca.md) — the
+- [bcl-ignorecase-valley-rca.md](bcl-ignorecase-valley-rca.md) - the
   worked case study with full disassembly captures for both TFMs.
-- `touki.perf/AsciiIgnoreCaseUnsafePerf.cs` — the Span vs Ref vs
+- `touki.perf/AsciiIgnoreCaseUnsafePerf.cs` - the Span vs Ref vs
   Pinned A/B/C harness this document's measurements come from.
-- `touki.perf/StringSegmentIgnoreCasePerf.cs` — before/after baseline
+- `touki.perf/StringSegmentIgnoreCasePerf.cs` - before/after baseline
   for the `StringSegment.CompareTo OrdinalIgnoreCase` refactor that
   drove the Strategy-C decision in &sect;5.
 - `BenchmarkDotNet.Artifacts/results/touki.perf.AsciiIgnoreCaseUnsafePerf-asm.md`
-  — generated disassembly. Regenerate with `[DisassemblyDiagnoser]`
+  - generated disassembly. Regenerate with `[DisassemblyDiagnoser]`
   on the perf class and `dotnet run -c Release --project touki.perf
   -f net481 -- --filter '*AsciiIgnoreCaseUnsafePerf*'`.
-- `docs/dotnet-perf-discoveries.md` — short-form running list of perf
+- `docs/dotnet-perf-discoveries.md` - short-form running list of perf
   observations across the codebase.
 - [touki/Touki/Buffers/SpanExtensions.IgnoreCase.cs](../touki/Touki/Buffers/SpanExtensions.IgnoreCase.cs)
-  — the production helpers that resulted from this experiment.
+  - the production helpers that resulted from this experiment.

--- a/docs/globbing-feature-plan.md
+++ b/docs/globbing-feature-plan.md
@@ -1,9 +1,9 @@
-# Glob matcher — feature implementation plan
+# Glob matcher - feature implementation plan
 
 Tracks remaining glob functionality not yet shipped on the
 `feature/globbing-phase1` branch. Companion to
 [globbing-optimization-plan.md](globbing-optimization-plan.md) (which tracks
-match-time perf work) — this doc tracks **feature coverage**: dialects, options,
+match-time perf work) - this doc tracks **feature coverage**: dialects, options,
 and pattern syntax not yet supported.
 
 For the per-dialect ignore-case semantic mapping (already implemented) see
@@ -25,18 +25,18 @@ it needs a dedicated `Win32GlobMatcher`.
 `NoEscape`, `AllowGlobStar`, `AllowExtGlob`.
 
 **Tests:** 333 glob tests cover the implemented surface (both TFMs). New
-tests must be added alongside each feature below &mdash; see
+tests must be added alongside each feature below - see
 `touki.tests/Touki/Io/Globbing/`.
 
 ---
 
-## Phase 1 finish &mdash; path-unaware dialects and extglob
+## Phase 1 finish - path-unaware dialects and extglob
 
 Goal: bring every dialect that does *not* need path-mode semantics to feature
 parity, plus the `AllowExtGlob` option. After this slice the matcher is a
 complete drop-in for non-path use cases.
 
-### F1.1 `PowerShell` dialect &mdash; **done**
+### F1.1 `PowerShell` dialect - **done**
 
 PowerShell `-like` / `WildcardPattern` semantics. Smallest delta from `Posix`:
 no `FNM_PERIOD` (a leading `.` in input is matched by `*` or `?` like any other
@@ -65,7 +65,7 @@ rather than `\`.
   per-dialect mappings.
 - **Ref:** [about_Wildcards](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_wildcards).
 
-### F1.2 `Win32` dialect &mdash; **deferred (low priority)**
+### F1.2 `Win32` dialect - **deferred (low priority)**
 
 Goal: bit-for-bit parity with
 [`FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression).
@@ -82,12 +82,12 @@ That API does two things the matcher today does not:
    position per input character. The DOS metachars (`<`, `>`, `"`)
    have semantics that don't fit the current single-savepoint
    backtracker:
-   - `<` (DOS_STAR) &mdash; zero or more chars, must stop before the
+   - `<` (DOS_STAR) - zero or more chars, must stop before the
      **last** `.` in the name (requires lookahead to know which `.` is
      last).
-   - `>` (DOS_QM) &mdash; zero or one char; on `.` or end-of-name,
+   - `>` (DOS_QM) - zero or one char; on `.` or end-of-name,
      advances the expression past any contiguous run of `>`s.
-   - `"` (DOS_DOT) &mdash; matches a `.` **or** matches zero chars at
+   - `"` (DOS_DOT) - matches a `.` **or** matches zero chars at
      end-of-name (epsilon).
 
    These epsilon transitions and the "skip contiguous `>`s" behavior
@@ -97,7 +97,7 @@ That API does two things the matcher today does not:
 
 **Implementation plan:** port the BCL `MatchPattern` algorithm
 (`useExtendedWildcards: true` branch) directly into a new
-`Win32GlobMatcher` &mdash; the current `CompiledGlobMatcher` NFA is
+`Win32GlobMatcher` - the current `CompiledGlobMatcher` NFA is
 the wrong shape and trying to shoehorn DOS semantics into it costs
 more than just keeping the dedicated implementation. Pre-translate
 the pattern at compile time so the matcher only ever sees the
@@ -107,20 +107,20 @@ extended-wildcard form.
 [D4](#d4-win32-dialect-ignorecase-is-the-default).
 
 - **Touches:** New `Win32GlobMatcher.cs`; `GlobMatcherFactory` routes
-  `Win32` patterns to it directly (no shape detection &mdash; the
+  `Win32` patterns to it directly (no shape detection - the
   factory's specialized shapes don't survive the pre-translation).
   `GlobMatcher.TryCompile` adds `Win32` to its allow-list. No changes
   to `GlobOpCodes` or the shared `CompiledGlobMatcher`.
 - **Tests:** Golden cross-reference against
   `System.IO.Enumeration.FileSystemName.MatchesWin32Expression` (net10
-  only &mdash; the API is not on net472) for every case in the BCL's
+  only - the API is not on net472) for every case in the BCL's
   own test suite. Spot-checks for `*.*`, `*.`, `*.foo`, `a?b`, raw
   `<`/`>`/`"` already present in patterns (the pre-translation is
   idempotent for those characters).
 - **Ref:** [FsRtlIsNameInExpression](https://learn.microsoft.com/windows-hardware/drivers/ddi/ntifs/nf-ntifs-fsrtlisnameinexpression),
   [`FileSystemName.cs` source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs).
 
-### F1.2b `WinNT` dialect &mdash; **deferred (low priority)**
+### F1.2b `WinNT` dialect - **deferred (low priority)**
 
 Same NFA as F1.2 but **without** the `TranslateWin32Expression`
 pre-pass. Exposes raw `FsRtlIsNameInExpression` semantics so callers
@@ -131,16 +131,16 @@ matches. Requires a new `GlobDialect.WinNT` enum entry and an
 `Win32`. Same case-insensitive default as `Win32`. Shares the
 `Win32GlobMatcher` implementation behind a "translate?" bool.
 
-### F1.3 `AllowExtGlob` option &mdash; **done**
+### F1.3 `AllowExtGlob` option - **done**
 
 Bash/POSIX extglob alternation constructs (also reachable via POSIX
 `FNM_EXTMATCH`):
 
-- `?(pat1|pat2|...)` &mdash; zero or one occurrence of any alternative
-- `*(pat1|pat2|...)` &mdash; zero or more occurrences of any alternative
-- `+(pat1|pat2|...)` &mdash; one or more occurrences of any alternative
-- `@(pat1|pat2|...)` &mdash; exactly one occurrence
-- `!(pat1|pat2|...)` &mdash; anything that doesn't match any alternative
+- `?(pat1|pat2|...)` - zero or one occurrence of any alternative
+- `*(pat1|pat2|...)` - zero or more occurrences of any alternative
+- `+(pat1|pat2|...)` - one or more occurrences of any alternative
+- `@(pat1|pat2|...)` - exactly one occurrence
+- `!(pat1|pat2|...)` - anything that doesn't match any alternative
 
 Shipped surface:
 
@@ -165,7 +165,7 @@ Shipped surface:
 - Compile-time error codes: `UnterminatedExtGlob`, `InvalidExtGlobBody`,
   `FeatureLimitExceeded`.
 
-Tests: `ExtGlobScannerTests` (compile-shape + error codes &mdash; 47 rows),
+Tests: `ExtGlobScannerTests` (compile-shape + error codes - 47 rows),
 `ExtGlobPositiveMatchTests` (~110 rows across `?` / `@` / `+` / `*`),
 `ExtGlobNegationMatchTests` (33 rows for `!`).
 
@@ -176,24 +176,24 @@ exactly" as failing because `*` matches the empty slice).
 - **Ref:** [fnmatch(3) FNM_EXTMATCH](https://man7.org/linux/man-pages/man3/fnmatch.3.html),
   [bash Pattern Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html).
 
-### F1.4 Bring `AllowExtGlob` online for Bash &mdash; **done**
+### F1.4 Bring `AllowExtGlob` online for Bash - **done**
 
 `Bash` dialect compiles patterns with extglob enabled when `shopt -s extglob`
 is set, off otherwise. Touki's user opts in via `GlobOptions.AllowExtGlob`
-explicitly &mdash; matches what the consumer has to do in bash. The
+explicitly - matches what the consumer has to do in bash. The
 oracle parity check lives in `ExtGlobOracleTests.Bash` (~552 rows across
 24 patterns &times; 23 inputs) and runs against `bash -O extglob -O globstar`
 via `BashInterop`. Skipped automatically on macOS (bash 3.2 too divergent).
 
 ---
 
-## Phase 2 &mdash; path-aware matching
+## Phase 2 - path-aware matching
 
 Goal: support five dialects whose distinguishing feature is path-mode
 matching. The bytecode interpreter is path-unaware today; this phase adds
 the separator-aware machinery.
 
-### F2.1 Separator-aware `Any` and `AnyRun` &mdash; **done**
+### F2.1 Separator-aware `Any` and `AnyRun` - **done**
 
 Add a `pathMode` flag and a `Separator` char to `CompiledGlobMatcher`
 (passed in by the factory; the char comes from
@@ -205,7 +205,7 @@ When path mode is set:
 - A separate `GlobStar` op ([F2.2](#f22--globstar)) is the only thing that
   crosses separators.
 
-Only one separator char is considered &mdash; the matcher assumes inputs are
+Only one separator char is considered - the matcher assumes inputs are
 normalized to that char (D2). No per-character dual-separator branching.
 
 - **Status:** Shipped on this branch. `Separator` is now a `char` property
@@ -218,7 +218,7 @@ normalized to that char (D2). No per-character dual-separator branching.
   `PosixPath` at the time this slice landed; the remaining path-aware
   dialects (`Bash`, `Git`, `MSBuild`, `FileSystemGlobbing`) and the
   `AllowGlobStar` option were gated to `FeatureNotEnabled` until F2.2
-  shipped globstar &mdash; all are now accepted (see F2.2 / F2.3).
+  shipped globstar - all are now accepted (see F2.2 / F2.3).
 - **Factory routing:** Path-aware patterns skip the specialized
   `Prefix`/`Suffix`/`Contains`/`PrefixSuffix` matchers (none of those
   track the separator yet) and route to `CompiledGlobMatcher`. Pure
@@ -231,22 +231,22 @@ normalized to that char (D2). No per-character dual-separator branching.
   `IgnoreCaseKindTests` rows for `IsPathAware` and `DefaultSeparator`
   across all dialects. Full glob suite: 199 tests, green on both
   net481 and net10.0.
-- **Known follow-up &mdash; per-segment leading-dot:** The current
+- **Known follow-up - per-segment leading-dot:** The current
   `MatchLeadingDot` check only consults `input[0]`. POSIX path-mode
   `FNM_PERIOD` actually applies at the start of *each* path segment, so
   `*/x` against `.foo/x` should fail when `MatchLeadingDot` is off.
   Implementing this requires the NFA to track segment boundaries
-  during `AnyRun` expansion. Deferred &mdash; track alongside F2.2 work
+  during `AnyRun` expansion. Deferred - track alongside F2.2 work
   since globstar's segment-walking machinery will produce the same
   boundary tracking for free.
-- **Specialized-matcher path-aware support &mdash; deferred:** The
+- **Specialized-matcher path-aware support - deferred:** The
   plan called for `Prefix/Suffix/Contains/PrefixSuffix` to grow
   separator-aware fast paths. Treating those as a perf follow-up keeps
   this slice focused; `CompiledGlobMatcher` handles them correctly
   today and any perf delta only matters once a path-aware benchmark
   exists.
 
-### F2.2 `**` (globstar) &mdash; **done**
+### F2.2 `**` (globstar) - **done**
 
 A new opcode `GlobStar` distinct from `AnyRun`. Matches zero or more path
 segments including the separators between them. Honors `GlobOptions.AllowGlobStar`
@@ -288,7 +288,7 @@ Subtleties (all handled by the shipped implementation):
   characters collapse correctly so `a/**/b` matches `a/b` (zero
   directories).
 
-### F2.3 Path-aware dialects on top of F2.1 + F2.2 &mdash; **done for `MSBuild` / `Bash` / `FileSystemGlobbing` / `Git`**
+### F2.3 Path-aware dialects on top of F2.1 + F2.2 - **done for `MSBuild` / `Bash` / `FileSystemGlobbing` / `Git`**
 
 Once F2.1 and F2.2 land, five dialects become a thin wrapping job. Globstar
 defaults are per [D1](#d1-allowglobstar-is-dialect-defaulted); separator
@@ -298,7 +298,7 @@ defaults are per
 | Dialect | `pathMode` | Globstar default | Separator default | Status | Notes |
 |---|---|---|---|---|---|
 | `PosixPath` | yes | off (opt in via `AllowGlobStar`) | `ForwardSlash` | **done** | `FNM_PATHNAME` |
-| `Bash` | yes | off (opt in &mdash; matches `shopt -s globstar`) | `ForwardSlash` | **done** (extglob via `AllowExtGlob` still pending in F1.3) | classes + `\`-escape supported |
+| `Bash` | yes | off (opt in - matches `shopt -s globstar`) | `ForwardSlash` | **done** (extglob via `AllowExtGlob` still pending in F1.3) | classes + `\`-escape supported |
 | `Git` | yes | on | `ForwardSlash` | **done** (F3.1 + F3.2 markers included) | implicit globstar; strips `!`, leading `/`, trailing `/` |
 | `MSBuild` | yes | on | `ForwardSlash` | **done** | case-insensitive by default; no escape char; see below |
 | `FileSystemGlobbing` | yes | on | `ForwardSlash` | **done** | no classes; no escape character; case folding follows `IgnoreCase` flag |
@@ -308,7 +308,7 @@ defaults are per
 - Allowed in `GlobMatcher.TryCompile` (was previously gated).
 - `GlobDialectExtensions.DefaultIgnoreCaseKind` returns
   `IgnoreCaseKind.Unicode` for `MSBuild` regardless of the
-  `GlobOptions.IgnoreCase` flag &mdash; matches MSBuild's documented
+  `GlobOptions.IgnoreCase` flag - matches MSBuild's documented
   case-insensitive behavior.
 - `GlobDialectExtensions.GetEscapeChar` returns `'\0'` for `MSBuild`
   (MSBuild has no escape character).
@@ -341,7 +341,7 @@ defaults are per
     repo).
   - `FileSystemGlobbing`: `Matcher.AddInclude(pattern).Match(...)`.
 
-### F2.4 Wire `GlobPathSeparator` option &mdash; **done**
+### F2.4 Wire `GlobPathSeparator` option - **done**
 
 Implement the enum and `Compile` overload from
 [D2](#d2-matcher-requires-normalized-input-paths-separator-is-chosen-at-compile-time).
@@ -369,12 +369,12 @@ No cross-platform `\` &harr; `/` translation in the matcher; the contract is
 
 ---
 
-## Phase 3 &mdash; `.gitignore` specifics
+## Phase 3 - `.gitignore` specifics
 
 Git's `.gitignore` syntax adds three orthogonal features on top of generic
 path-aware globs:
 
-### F3.1 Leading `!` negation &mdash; **done**
+### F3.1 Leading `!` negation - **done**
 
 A pattern starting with `!` inverts the match. Used in `.gitignore` to
 re-include a file that an earlier pattern excluded.
@@ -389,12 +389,12 @@ re-include a file that an earlier pattern excluded.
 - **Tests:** Negation theory rows + property assertions added in
   `GlobMatcherTests` under the Git section.
 
-### F3.2 Leading `/` anchor + trailing `/` directory-only &mdash; **done**
+### F3.2 Leading `/` anchor + trailing `/` directory-only - **done**
 
 The factory recognizes both markers and strips them from the pattern,
 exposing each as a read-only property on the matcher
 ([D3](#d3-gitignore-directory-only--and-git-specific-attribute-filters-belong-on-the-enumerator)).
-`IsMatch` itself is unchanged &mdash; it answers "does this string match this
+`IsMatch` itself is unchanged - it answers "does this string match this
 pattern?" regardless of file-system attributes. The directory-only flag is
 enforced by the `MatchEnumerator` (when it ships) using `FileAttributes`,
 not by the matcher.
@@ -410,7 +410,7 @@ not by the matcher.
   belongs to the `GlobMatchAdapter` / enumerator layer and ships with
   the F3.3 segment-pruning follow-up.
 
-### F3.3 `GlobMatcher` &rarr; `IEnumerationMatcher` adapter; sets via `MatchSet` &mdash; **partial (adapter + enumerator done; `MatchSet` composition pending)**
+### F3.3 `GlobMatcher` &rarr; `IEnumerationMatcher` adapter; sets via `MatchSet` - **partial (adapter + enumerator done; `MatchSet` composition pending)**
 
 `.gitignore`, MSBuild item-lists, and `Microsoft.Extensions.FileSystemGlobbing.Matcher`
 all evaluate **lists** of patterns, not single patterns. Some patterns
@@ -465,7 +465,7 @@ benchmark exists.
 **Shipped on this branch:**
 
 - [`Touki.Io.Globbing.GlobMatcher`](../touki/Touki/Io/Globbing/GlobMatcher.cs)
-  &mdash; the matcher base class itself implements
+  - the matcher base class itself implements
   [`IEnumerationMatcher`](../touki/Touki/Io/IEnumerationMatcher.cs)
   directly. Setting `GlobMatcher.RootDirectory` opts the matcher in to
   path-relative enumeration; the matcher absorbs the per-directory
@@ -482,7 +482,7 @@ benchmark exists.
   `IsMatch(ReadOnlySpan<char>)` stays as the convenience entry point
   for unit tests and one-shot callers.
 - [`Touki.Io.GlobEnumerator`](../touki/Touki/Io/GlobEnumerator.cs)
-  &mdash; a `MatchEnumerator<string>` factory mirroring
+  - a `MatchEnumerator<string>` factory mirroring
   `MSBuildEnumerator`'s strip-project-directory shape. When there are
   no excludes, the compiled `GlobMatcher` is passed directly as the
   `IEnumerationMatcher`; with excludes, the include matcher plus one
@@ -504,7 +504,7 @@ benchmark exists.
 
 **Still pending:**
 
-- Per-directory cached NFA state &mdash; **done.** The matcher caches
+- Per-directory cached NFA state - **done.** The matcher caches
   the translated relative-directory prefix per directory and
   invalidates it on `DirectoryFinished()`, plus a three-valued
   `PrefixAlignment` derived from `GlobMatcher.LiteralPathPrefix`
@@ -514,7 +514,7 @@ benchmark exists.
   span and the raw file-name span to the matcher without any join.
   Both `LiteralGlobMatcher` and
   [`CompiledGlobMatcher`](../touki/Touki/Io/Globbing/CompiledGlobMatcher.cs)
-  override natively &mdash; the four match loops
+  override natively - the four match loops
   (`MatchOrdinalSimple`, `MatchIgnoreCaseSimple`, `MatchOrdinal`,
   `MatchIgnoreCase`), plus `Backtrack`,
   `FirstValidGlobStarLength`, `NextValidGlobStarLength`, and the
@@ -523,11 +523,11 @@ benchmark exists.
   pattern and a `LiteralMatchesAt` straddle-aware compare helper that
   preserves the vectorized `SequenceEqual` / `EqualsOrdinalIgnoreCase`
   / `EqualsAsciiLetterIgnoreCase` paths on contiguous slices. Per-file
-  work is now `O(pattern complexity)` &mdash; no `CopyTo` of the file
+  work is now `O(pattern complexity)` - no `CopyTo` of the file
   name, no allocation, no pool rental. Full parity with
   [`MatchMSBuild`](../touki/Touki/Io/MatchMSBuild.cs)'s
   rents-nothing-allocates-nothing contract.
-- One-time OS-separator pattern normalization &mdash; **done.**
+- One-time OS-separator pattern normalization - **done.**
   [`GlobMatcherFactory.TryCreate`](../touki/Touki/Io/Globbing/GlobMatcherFactory.cs)
   translates cross-separator characters in the pattern to the resolved
   separator at compile time for dialects with no escape character
@@ -541,14 +541,14 @@ benchmark exists.
   written with portable `/` slashes. Dialects with `\` escape
   (POSIX-family, Bash, Git, PowerShell) skip normalization so escape
   sequences are not corrupted.
-- Segment-level `MatchesDirectory` pruning &mdash; **partial.**
+- Segment-level `MatchesDirectory` pruning - **partial.**
   `MatchesDirectory` already returns `false` for diverged candidates
   with a non-empty literal prefix. Patterns whose literal prefix is
   empty (e.g., `**/*.cs`) still recurse unconditionally; pruning those
   requires a separator-checkpointed NFA savepoint API on the matcher
   (different from the two-span walk above) and is its own follow-up.
-- `MatchSet` composition for matchers &mdash; **done.**
-- `RootAnchored` / `DirectoryOnly` enforcement &mdash; **done.**
+- `MatchSet` composition for matchers - **done.**
+- `RootAnchored` / `DirectoryOnly` enforcement - **done.**
   Per-decision wiring:
   <list type="bullet">
    <item><description>Non-anchored Git patterns: the factory recognizes the
@@ -556,7 +556,7 @@ benchmark exists.
     to Git patterns without an internal separator. Patterns with an internal
     <c>/</c> stay anchored to the gitignore root.</description></item>
    <item><description><see cref="GlobMatcher.MatchesFile"/> short-circuits
-    when <see cref="GlobMatcher.DirectoryOnly"/> is set &mdash; directory-only
+    when <see cref="GlobMatcher.DirectoryOnly"/> is set - directory-only
     patterns never match files.</description></item>
    <item><description><see cref="GlobMatcher.MatchesDirectory"/> with
     <c>matchForExclusion=true</c> consults
@@ -564,7 +564,7 @@ benchmark exists.
     the candidate directory's relative path, the whole subtree is claimed
     for exclusion.</description></item>
   </list>
-- **`OrderedMatchSet`** &mdash; new
+- **`OrderedMatchSet`** - new
   [`Touki.Io.OrderedMatchSet`](../touki/Touki/Io/OrderedMatchSet.cs)
   aggregator implementing gitignore "last matching rule wins" semantics.
   Rules are added via <c>AddInclude</c> / <c>AddExclude</c> in source order.
@@ -572,7 +572,7 @@ benchmark exists.
   rule's verdict. At directory-match time the set only claims subtrees when
   a <c>DirectoryOnly</c> exclude matches AND no later include rule could
   rescue a deeper file; conservative recursion otherwise.
-- **`GitIgnore`** &mdash; new
+- **`GitIgnore`** - new
   [`Touki.Io.GitIgnore`](../touki/Touki/Io/GitIgnore.cs) static loader.
   `Parse(content, root, options)` parses a <c>.gitignore</c> file body
   (comments via leading <c>#</c>, blank lines, <c>\#</c> / <c>\!</c>
@@ -584,7 +584,7 @@ benchmark exists.
 
 ---
 
-## Phase 4 &mdash; brace expansion (`Bash` only)
+## Phase 4 - brace expansion (`Bash` only)
 
 `*.{jpg,jpeg,png}` expands to three separate patterns before glob matching.
 Pure macro substitution, no NFA changes.
@@ -600,7 +600,7 @@ Pure macro substitution, no NFA changes.
 
 ---
 
-## Phase 5 &mdash; POSIX bracket-expression extras &mdash; **done**
+## Phase 5 - POSIX bracket-expression extras - **done**
 
 The current bracket scanner accepts `[abc]`, `[a-z]`, and `[!negated]`. The
 full POSIX bracket-expression grammar also includes:
@@ -609,7 +609,7 @@ full POSIX bracket-expression grammar also includes:
   the brackets, e.g. `[[:alpha:]_]`.
 - **Equivalence classes:** `[=e=]` matches `e`, `é`, `è`, etc. per locale.
 - **Collating elements:** `[.ch.]` matches a single collation element. In the
-  C locale this is identical to `c` followed by `h` &mdash; basically never
+  C locale this is identical to `c` followed by `h` - basically never
   useful outside locale-aware libc.
 
 - **Status:** Shipped on this branch. `EmitClass` recognizes the
@@ -646,7 +646,7 @@ force a kind independent of the dialect.
 regardless of `IgnoreCaseKind`. For Unicode-IC dialects with character
 classes containing non-ASCII characters this is incorrect. Becomes
 user-visible only after Phase 2 (when MSBuild/FileSystemGlobbing patterns
-start hitting class membership at scale) &mdash; defer until there's a
+start hitting class membership at scale) - defer until there's a
 failing test.
 
 ### Match-time perf (
@@ -660,7 +660,7 @@ failing test.
 
 ---
 
-## Oracle tests &mdash; reference sources per dialect
+## Oracle tests - reference sources per dialect
 
 To validate `GlobMatcher`'s behavior on each dialect we want
 &quot;oracle&quot; tests that compare our result against a reference
@@ -673,12 +673,12 @@ platform constraints for running it.
 |---|---|---|---|
 | `Posix` | `fnmatch(3)` (POSIX) without `FNM_PATHNAME` | P/Invoke <c>libc</c> / <c>libSystem.B.dylib</c>, or shell-out to <c>python -c &quot;import fnmatch; ...&quot;</c> | Linux/macOS native; WSL on Windows |
 | `PosixPath` | `fnmatch(3)` with `FNM_PATHNAME` flag set | Same P/Invoke; Python `pathlib.PurePath.match` is approximate, not exact | Linux/macOS native; WSL on Windows |
-| `Simple` | [`System.IO.Enumeration.FileSystemName.MatchesSimpleExpression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matchessimpleexpression) | Direct managed call | Any TFM net5+ &mdash; **net10 test project, cross-platform** |
+| `Simple` | [`System.IO.Enumeration.FileSystemName.MatchesSimpleExpression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matchessimpleexpression) | Direct managed call | Any TFM net5+ - **net10 test project, cross-platform** |
 | `PowerShell` | [`System.Management.Automation.WildcardPattern`](https://learn.microsoft.com/dotnet/api/system.management.automation.wildcardpattern) | Reference `System.Management.Automation` (Windows PowerShell SDK / pwsh SDK), or subprocess to <c>pwsh -c</c> | SMA assembly is Windows-only by default; <c>pwsh</c> subprocess works cross-platform if PowerShell 7+ is installed |
-| `Win32` | [`System.IO.Enumeration.FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression) | Direct managed call (algorithm is pure managed) | Any TFM net5+ &mdash; **net10 test project, cross-platform**. Cross-check against <c>RtlIsNameInExpression</c> P/Invoke on Windows-only |
+| `Win32` | [`System.IO.Enumeration.FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression) | Direct managed call (algorithm is pure managed) | Any TFM net5+ - **net10 test project, cross-platform**. Cross-check against <c>RtlIsNameInExpression</c> P/Invoke on Windows-only |
 | `Bash` | <c>bash -O extglob -O globstar -c '[[ &quot;$input&quot; == $pattern ]] ; echo $?'</c> | Subprocess to <c>bash</c> on PATH | bash 4.0+ native on Linux/macOS; Git Bash or WSL on Windows |
-| `MSBuild` | [`Microsoft.Build.Globbing.MSBuildGlob.Parse(pattern).IsMatch(input)`](https://learn.microsoft.com/dotnet/api/microsoft.build.globbing.msbuildglob) | Direct managed call (NuGet: `Microsoft.Build`) | Any TFM net472+ &mdash; **already referenced via `FileMatcherWrapper` for the enumeration parity check** |
-| `FileSystemGlobbing` | [`Microsoft.Extensions.FileSystemGlobbing.Matcher`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher) | Direct managed call (NuGet: `Microsoft.Extensions.FileSystemGlobbing`) | Any TFM netstandard2.0+ &mdash; **cross-platform** |
+| `MSBuild` | [`Microsoft.Build.Globbing.MSBuildGlob.Parse(pattern).IsMatch(input)`](https://learn.microsoft.com/dotnet/api/microsoft.build.globbing.msbuildglob) | Direct managed call (NuGet: `Microsoft.Build`) | Any TFM net472+ - **already referenced via `FileMatcherWrapper` for the enumeration parity check** |
+| `FileSystemGlobbing` | [`Microsoft.Extensions.FileSystemGlobbing.Matcher`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher) | Direct managed call (NuGet: `Microsoft.Extensions.FileSystemGlobbing`) | Any TFM netstandard2.0+ - **cross-platform** |
 | `Git` (pattern-level) | <c>git check-ignore --no-index --verbose -- &lt;path&gt;</c> against a temporary <c>.gitignore</c> | Subprocess to <c>git</c> on PATH | Git installed on all major platforms |
 | `Git` (in-process) | [`LibGit2Sharp`](https://github.com/libgit2/libgit2sharp) <c>Repository.Ignore.IsPathIgnored</c> | NuGet: `LibGit2Sharp` (native lib bundled) | Cross-platform; LibGit2Sharp ships native binaries for Windows/Linux/macOS |
 
@@ -707,7 +707,7 @@ platform constraints for running it.
   both `pattern` and `input` as bash variables (not interpolated into the
   command string) to avoid shell-quoting nightmares with <c>*</c>, <c>?</c>,
   brackets, and escapes. The result is the exit code of the `[[ ... == ... ]]`
-  test. Per-call cost is ~10&ndash;30 ms on Linux native, ~50&ndash;100 ms via
+  test. Per-call cost is ~10-30 ms on Linux native, ~50-100 ms via
   Git Bash on Windows; theory size should be bounded accordingly.
 - **`MSBuild`** and **`FileSystemGlobbing`** are the cheapest oracle paths
   for path-aware dialects. Both are pure managed, no subprocess, and the
@@ -717,10 +717,10 @@ platform constraints for running it.
   the context of a <c>.gitignore</c> file plus a working tree. The simplest
   setup is a per-test scratch directory containing a single-line
   <c>.gitignore</c> + a touched file, then <c>git check-ignore</c>. Per-call
-  cost is ~30&ndash;80 ms. For a high-row theory, batch multiple patterns
+  cost is ~30-80 ms. For a high-row theory, batch multiple patterns
   into one <c>.gitignore</c> and one <c>git check-ignore</c> invocation per
   batch.
-- **`Git` (in-process)** via `LibGit2Sharp` is faster (~1&ndash;5 ms per
+- **`Git` (in-process)** via `LibGit2Sharp` is faster (~1-5 ms per
   query) but adds a native-binary dependency to the test project. Worth it
   for high-row Git theories, optional for small ones.
 
@@ -752,7 +752,7 @@ platforms via `Microsoft.PowerShell.SDK` if the test surface grows.
    The `MatchesSimpleExpression` / `MatchesWin32Expression` algorithms are
    already in the BCL, so the test class is a thin theory comparing
    `GlobMatcher.Compile(..., Simple).IsMatch(input)` against the BCL.
-2. **`MSBuild` oracle** via `MSBuildGlob.Parse` &mdash; complements the
+2. **`MSBuild` oracle** via `MSBuildGlob.Parse` - complements the
    existing enumeration parity check by isolating the pattern-level match.
 3. **`FileSystemGlobbing` oracle** via `Matcher.AddInclude(pattern).Match`
    for path-aware semantics.
@@ -769,11 +769,11 @@ rows covering the dialect's own characteristic features (e.g.,
 POSIX bracket classes, MSBuild `**/`-style globstar, gitignore
 `!` re-includes). The oracle invocation is gated by a static
 `[ConditionalFact]`-style attribute or by the test class's TFM/OS
-constraints; failures should report &quot;pattern X input Y &ndash;
+constraints; failures should report &quot;pattern X input Y -
 matcher returned Z, oracle returned W&quot; so divergences are
 self-diagnosing.
 
-### Sequential-separator behavior &mdash; findings (in-progress)
+### Sequential-separator behavior - findings (in-progress)
 
 First oracle suite landed: per-dialect `[Theory]` covering runs of
 sequential `/` in the **pattern** (doubled, tripled, quadrupled, leading,
@@ -783,18 +783,18 @@ file under
 
 Empirical ground truth captured by running each row through both the
 oracle and `GlobMatcher` for the dialect. The table below states the
-dialect's own rule, established by the oracle &mdash; not what touki
+dialect's own rule, established by the oracle - not what touki
 currently does.
 
 | Dialect | Sequential separators in the pattern | Notes |
 |---|---|---|
-| `MSBuild` | **Coalesced**: a run of `/` after the first character collapses to a single `/`, both at pattern-parse time and at input-match time. A *leading* `//` is preserved as a UNC-style root anchor. | `a//b` &equiv; `a///b` &equiv; `a/b` (matches inputs `a/b`, `a//b`, `a///b`). `**//*.cs` &equiv; `**/*.cs`. `a//**//b` &equiv; `a/**/b`. `//a` only matches `//a` &mdash; the leading double-separator is not collapsed. |
+| `MSBuild` | **Coalesced**: a run of `/` after the first character collapses to a single `/`, both at pattern-parse time and at input-match time. A *leading* `//` is preserved as a UNC-style root anchor. | `a//b` &equiv; `a///b` &equiv; `a/b` (matches inputs `a/b`, `a//b`, `a///b`). `**//*.cs` &equiv; `**/*.cs`. `a//**//b` &equiv; `a/**/b`. `//a` only matches `//a` - the leading double-separator is not collapsed. |
 | `FileSystemGlobbing` | **Not coalesced**: an internal empty pattern segment between two `/` is a one-non-empty-segment wildcard (i.e. `*`). Leading empty segments are dropped; trailing empty segments are tolerated via input-side normalization. | `a//b` &equiv; `a/*/b` (matches `a/x/b`, *not* `a/b` and *not* `a//b`). `**//*.cs` &equiv; `**/*/*.cs` (does *not* match `Foo.cs`; requires at least one intermediate component). `//a` &equiv; `a`. `a//` matches `a/` and `a//`. |
 | `Simple` | **Not coalesced**: `/` is a plain literal character with no separator role. Runs are preserved verbatim on both sides. | `a//b` matches *only* `a//b`. No special handling of leading or trailing `/`. Validated against [`FileSystemName.MatchesSimpleExpression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matchessimpleexpression). |
-| `Git` | **Touki already agrees with `LibGit2Sharp`** &mdash; all 21 sequential-separator rows pass. Empirically, the gitignore evaluator treats embedded `//` as a literal empty segment that fails to match any normal path component, so most `a//b` / `**//*.cs` / `a//**//b` patterns simply never match real files. Touki produces the same verdicts. | Pinned via [`LibGit2Sharp.Repository.Ignore.IsPathIgnored`](https://github.com/libgit2/libgit2sharp). Cross-platform; oracle runs on every CI runner. |
+| `Git` | **Touki already agrees with `LibGit2Sharp`** - all 21 sequential-separator rows pass. Empirically, the gitignore evaluator treats embedded `//` as a literal empty segment that fails to match any normal path component, so most `a//b` / `**//*.cs` / `a//**//b` patterns simply never match real files. Touki produces the same verdicts. | Pinned via [`LibGit2Sharp.Repository.Ignore.IsPathIgnored`](https://github.com/libgit2/libgit2sharp). Cross-platform; oracle runs on every CI runner. |
 | `Posix`, `PosixPath` | **Not coalesced**: runs of `/` are preserved verbatim in the pattern; `fnmatch(3)` (with or without `FNM_PATHNAME`) treats each `/` as a literal. Validated against P/Invoke <c>fnmatch(3)</c> on Linux. | All rows green on Linux. Encapsulated in [`FnmatchInterop`](../touki.tests/Touki/Io/Globbing/FnmatchInterop.cs); the glibc/macOS `FNM_PATHNAME` bit difference is the only platform-specific detail. |
 | `Bash` (with `extglob` + `globstar`) | **Not coalesced**: bash's `[[ str == pat ]]` preserves runs of `/` in the pattern. Validated against <c>bash -O extglob -O globstar -c '[[ "$INPUT" == $PATTERN ]]'</c>, with pattern/input passed through env vars to side-step shell quoting. | All rows green on Linux native bash and Windows Git Bash. |
-| `PowerShell`, `Win32` | _TBD._ `Win32` is not implemented in touki's compile yet; oracle suite deferred. `PowerShell` requires `System.Management.Automation` (Windows-only in net481, `Microsoft.PowerShell.SDK` cross-platform on net10) &mdash; deferred to avoid bloating the test project until needed. | &nbsp; |
+| `PowerShell`, `Win32` | _TBD._ `Win32` is not implemented in touki's compile yet; oracle suite deferred. `PowerShell` requires `System.Management.Automation` (Windows-only in net481, `Microsoft.PowerShell.SDK` cross-platform on net10) - deferred to avoid bloating the test project until needed. | &nbsp; |
 
 **Implementation status vs. the contract above.** All compile-time
 normalization landed in `GlobMatcherFactory.TryNormalizeRuns` plus
@@ -818,10 +818,10 @@ green on Windows:
 
 The Posix-family (Linux/macOS oracles via P/Invoke `fnmatch` and `bash`
 subprocess) and `PowerShell` / `Win32` rules will be added to the table
-above once their oracle runs produce data &mdash; the Posix/PosixPath/Bash
+above once their oracle runs produce data - the Posix/PosixPath/Bash
 suites are checked in and ready, just skipped on Windows hosts.
 
-### Multiple-asterisk-run behavior &mdash; findings (in-progress)
+### Multiple-asterisk-run behavior - findings (in-progress)
 
 Second oracle suite landed: per-dialect `[Theory]` covering runs of
 three-or-more consecutive `*` in the **pattern** (`***`, `****`),
@@ -832,12 +832,12 @@ with the 26 shared rows in [MultipleAsteriskRows.cs](../touki.tests/Touki/Io/Glo
 | Dialect | Multi-asterisk-run rule | Touki status |
 |---|---|---|
 | `MSBuild` | **A pattern containing 3 or more consecutive `*` matches nothing.** `MSBuildGlob.Parse` parses the pattern but the resulting glob rejects every input (true for `***`, `a***b`, `a/***/b`, `***/foo`, etc.). The parser only recognizes `*` and `**` as wildcard tokens; anything longer poisons the match. | **26 / 26 green.** Compile-time normalization routes any pattern with a 3+ `*` run to `NeverMatchGlobMatcher`. |
-| `FileSystemGlobbing` | **`***`+ collapses to a single `*` (one path component, does not cross `/`).** `a***b` &equiv; `a*b`, `***/foo` &equiv; `*/foo`, `a/***/b` &equiv; `a/*/b`. Notably *not* equivalent to `**` &mdash; a run of `*` never gains globstar semantics. | **26 / 26 green.** Compile-time `***`+ &rarr; `*` plus `DisallowEmptyInput = true` to match `Matcher`'s empty-input rejection. |
+| `FileSystemGlobbing` | **`***`+ collapses to a single `*` (one path component, does not cross `/`).** `a***b` &equiv; `a*b`, `***/foo` &equiv; `*/foo`, `a/***/b` &equiv; `a/*/b`. Notably *not* equivalent to `**` - a run of `*` never gains globstar semantics. | **26 / 26 green.** Compile-time `***`+ &rarr; `*` plus `DisallowEmptyInput = true` to match `Matcher`'s empty-input rejection. |
 | `Simple` | **`***`+ behaves like `*` for any non-empty input.** Path-unaware. One outlier: `***` does not match the empty string in the BCL while touki currently matches it. | **26 / 26 green.** Compile-time `***`+ &rarr; `*` plus `DisallowEmptyInput = true` to match `MatchesSimpleExpression`'s blanket empty-input rejection. |
 | `Git` | **`***`+ behaves like `**` (globstar across path components)** in `wildmatch`. `***` matches every file in the tree; `a/***` matches `a/b` and `a/b/c` but not `a/` alone; `a/***/b` matches every depth `a/.../b`. | **25 / 26 green, 1 documented divergence.** Compile-time `***`+ &rarr; `**` plus `DisallowEmptyInput = true`. The remaining row (`a/***` vs `a/`) is gitignore's "trailing globstar requires &ge;1 input segment" rule, which our engine's `GlobStar` opcode doesn't enforce. Skipped with reason; trivial engine fix when needed. |
-| `Bash` (with `extglob` + `globstar`) | **`***`+ behaves like `**` (globstar)** under `globstar`. Crosses path separators, with the standard globstar carve-out that a `**` enclosed by separators (e.g. `***/foo`) requires at least one path component on its globstar side. | **22 / 26 green, 4 documented divergences.** Compile-time `***`+ &rarr; `**`. The remaining four rows are the shell-glob vs `[[ == ]]` semantic split &mdash; touki models bash's *shell-glob* `**` (segment-bounded; `*` doesn't cross `/`); the oracle uses bash's *string-match* `[[ ]]` semantics. Closing these needs a per-context flag; deferred until a real user need. |
+| `Bash` (with `extglob` + `globstar`) | **`***`+ behaves like `**` (globstar)** under `globstar`. Crosses path separators, with the standard globstar carve-out that a `**` enclosed by separators (e.g. `***/foo`) requires at least one path component on its globstar side. | **22 / 26 green, 4 documented divergences.** Compile-time `***`+ &rarr; `**`. The remaining four rows are the shell-glob vs `[[ == ]]` semantic split - touki models bash's *shell-glob* `**` (segment-bounded; `*` doesn't cross `/`); the oracle uses bash's *string-match* `[[ ]]` semantics. Closing these needs a per-context flag; deferred until a real user need. |
 | `Posix`, `PosixPath` | All 26 rows green on Linux against `fnmatch(3)` with and without `FNM_PATHNAME`. Compile-time `***`+ &rarr; `*` matches `fnmatch` exactly. Suites skip on Windows. | **26 / 26 green** (Linux). |
-| `PowerShell`, `Win32` | TBD &mdash; oracle not implemented (see notes above). | &nbsp; |
+| `PowerShell`, `Win32` | TBD - oracle not implemented (see notes above). | &nbsp; |
 
 Cross-dialect summary: **only `Bash` and `Git` give `***`+ a globstar
 meaning. Every other dialect treats it as either invalid (MSBuild) or as
@@ -848,7 +848,7 @@ implemented compile-time normalization is dialect-specific:
 - `FileSystemGlobbing`, `Simple`, `Posix` &rarr; collapse runs to a single `*`.
 - `Git`, `Bash` &rarr; collapse runs to `**` (globstar).
 
-### Normalization implementation &mdash; landed, with documented gaps
+### Normalization implementation - landed, with documented gaps
 
 The dialect-specific rules above are implemented as a compile-time pass
 in [`GlobMatcherFactory.TryNormalizeRuns`](../touki/Touki/Io/Globbing/GlobMatcherFactory.cs)
@@ -889,14 +889,14 @@ compile-time normalization; each is marked with `Assert.Skip` and a
 documented reason so the test suite goes fully green while the
 divergence stays catalogued:
 
-- **Bash dialect, 4 rows** &mdash; `***/foo` vs `foo`, `***.cs` vs
+- **Bash dialect, 4 rows** - `***/foo` vs `foo`, `***.cs` vs
   `a/foo.cs`, `a/***/b` vs `a/b`, `a***b` vs `a/b`. Touki's Bash dialect
   models bash's *shell-glob* `**` (segment-bounded; `*` does not cross
   `/`). The `[[ str == pat ]]` oracle uses bash's *string-match*
   semantics, where `*` matches any string including `/` and `**` doesn't
   get a distinct globstar meaning. Closing these needs a per-context
   flag distinguishing the two modes; deferred until a real user need.
-- **Git dialect, 1 row** &mdash; `a/***` (&rarr; `a/**`) vs `a/`. Touki's
+- **Git dialect, 1 row** - `a/***` (&rarr; `a/**`) vs `a/`. Touki's
   trailing globstar matches zero or more path components including the
   empty case; gitignore requires &ge;1. Closing this needs an engine
   flag on the trailing GlobStar opcode that suppresses the zero-segment
@@ -907,7 +907,7 @@ flagging for anyone touching the Bash oracle on Windows:
 
 - `BashInterop.ResolveBashPath` explicitly prefers Git for Windows
   install paths over `bash.exe` discovered on `PATH`, and skips
-  `%LocalAppData%\Microsoft\WindowsApps\bash.exe` &mdash; the WSL
+  `%LocalAppData%\Microsoft\WindowsApps\bash.exe` - the WSL
   launcher stub installed by `wsl --install`. The stub doesn't forward
   process-level environment variables (so the oracle's `PATTERN` /
   `INPUT` env vars come through empty) and doesn't handle `[[ ]]` the
@@ -937,7 +937,7 @@ its documented default; the flag is consulted only when set explicitly.
 | `Bash` | off (matches `shopt -s globstar` being off by default) |
 | `Git`, `MSBuild`, `FileSystemGlobbing` | on (their documented behavior) |
 
-Same pattern as `IgnoreCaseKind` &mdash; computed once in the factory from
+Same pattern as `IgnoreCaseKind` - computed once in the factory from
 `(Dialect, Options)` and stored on the matcher.
 
 ### D2. Matcher requires normalized input paths; separator is chosen at compile time
@@ -984,7 +984,7 @@ the new `GlobPathSeparator` enum.
 
 This replaces the earlier idea of accepting both separators on Windows for
 `MSBuild`/`FileSystemGlobbing`/`Win32`. If a consumer needs both, they
-normalize first &mdash; usually a single `ReadOnlySpan<char>` walk with
+normalize first - usually a single `ReadOnlySpan<char>` walk with
 `string.Replace` or a `Touki.Buffers` helper.
 
 ### D3. `.gitignore` directory-only `/` and Git-specific attribute filters belong on the enumerator
@@ -992,7 +992,7 @@ normalize first &mdash; usually a single `ReadOnlySpan<char>` walk with
 Trailing `/` (directory-only), leading `/` (root-anchor relative to the
 gitignore file), and the other path-attribute predicates are **not** the
 matcher's concern. `GlobMatcher.IsMatch(ReadOnlySpan<char>)` answers
-"does this string match this pattern?" &mdash; nothing more.
+"does this string match this pattern?" - nothing more.
 
 The directory-only flag, root anchor, and any future attribute predicates
 (symlink-only, hidden-only, ACL-based filters, etc.) are wired in at the
@@ -1057,7 +1057,7 @@ implementation of this pattern and the model to follow:
   many `MatchesFile` calls against it cheaply.
 - **Three-valued directory result.** `MatchesDirectory` distinguishes
   `FullMatch` (recurse and files match), `PartialMatch` (recurse only
-  &mdash; a deeper subdirectory may match), and `NoMatch` (skip the
+  - a deeper subdirectory may match), and `NoMatch` (skip the
   subtree entirely). `IEnumerationMatcher.MatchesDirectory` collapses
   partial vs full to a single bool, but uses `matchForExclusion` so a
   partial-match exclude doesn't block recursion. Path-aware glob
@@ -1076,7 +1076,7 @@ implementation of this pattern and the model to follow:
 
 **Sets compose at this interface, not below it.** Multiple include /
 exclude patterns are aggregated through an `IEnumerationMatcher`
-composite &mdash; today
+composite - today
 [`MatchSet`](../touki/Touki/Io/MatchSet.cs) does exactly this for the MSBuild
 matcher (excludes first, includes second, breadth-first cache invalidation
 fanned out to every child). There is no separate parallel "GlobSet"
@@ -1085,7 +1085,7 @@ that is also path-aware exposes an `IEnumerationMatcher` adapter (or
 implements the interface directly), and consumers compose them with
 `MatchSet`. This keeps the include/exclude evaluation order, the
 per-directory cache invalidation, and the partial-vs-full match
-collapse in one place &mdash; the same place MSBuild already uses &mdash;
+collapse in one place - the same place MSBuild already uses -
 and lets `MatchEnumerator<TResult>` drive a heterogeneous mix of glob
 dialects, MSBuild specs, and bespoke matchers through a single
 uniform call site.
@@ -1099,7 +1099,7 @@ Implementation implications:
 - F3.3 ships as a thin path-aware adapter (`GlobMatcher` &rarr;
   `IEnumerationMatcher`) plus documentation that users compose via
   `MatchSet`. The `GlobSet` aggregator originally sketched in this
-  doc is **dropped** &mdash; `MatchSet` covers the use case.
+  doc is **dropped** - `MatchSet` covers the use case.
 - Gitignore order-sensitivity (later override wins) is handled by
   configuring `MatchSet` accordingly or by adding an ordered variant
   alongside `MatchSet`; either way it lives at the `IEnumerationMatcher`
@@ -1113,20 +1113,20 @@ The cheapest items first, building toward the path-aware phase:
 
 | # | Item | Estimated effort | Unlocks |
 |---:|---|---|---|
-| 1 | F1.1 `PowerShell` dialect &mdash; **done** | ~half-day | One dialect closed |
-| 2 | F2.1 separator-aware `Any` / `AnyRun` &mdash; **done** | ~1 day | `PosixPath` dialect unlocked; lays the groundwork for F2.2 |
-| 3 | F2.2 `**` globstar &mdash; **done** | ~2&ndash;3 days | Four more path-aware dialects unblocked (Bash / Git / MSBuild / FileSystemGlobbing) |
-| 4 | F2.3 `MSBuild` / `Bash` / `FileSystemGlobbing` dialect wiring &mdash; **done** | ~1 day | Three more dialects closed |
-| 5 | F3.1 + F3.2 + Git dialect wiring &mdash; **done** | ~1 day | `Git` dialect feature-complete (`!`, leading `/`, trailing `/` markers exposed as init properties) |
-| 6 | F3.3 `IEnumerationMatcher` adapter + `GlobEnumerator` &mdash; **done (partial; no segment pruning, no `MatchSet` composition yet)** | ~1 day | Drives enumerator integration; perf comparison against `MsBuildEnumerator` |
-| 7 | F1.3 + F1.4 `AllowExtGlob` + Bash extglob wiring | ~2&ndash;3 days | One option closed; full `Bash` coverage; introduces savepoint-stack NFA reused by F1.2 |
-| 8 | F2.4 `GlobPathSeparator` option &mdash; **done** | ~half-day | Caller-controlled separator (forward-slash / back-slash / OS default) |
-| 9 | F3.3 segment-level pruning + `MatchSet` composition + `RootAnchored`/`DirectoryOnly` enforcement | ~1&ndash;2 days | Subtree skipping for literal-prefix excludes; mixed-dialect include/exclude sets; gitignore enforcement |
+| 1 | F1.1 `PowerShell` dialect - **done** | ~half-day | One dialect closed |
+| 2 | F2.1 separator-aware `Any` / `AnyRun` - **done** | ~1 day | `PosixPath` dialect unlocked; lays the groundwork for F2.2 |
+| 3 | F2.2 `**` globstar - **done** | ~2-3 days | Four more path-aware dialects unblocked (Bash / Git / MSBuild / FileSystemGlobbing) |
+| 4 | F2.3 `MSBuild` / `Bash` / `FileSystemGlobbing` dialect wiring - **done** | ~1 day | Three more dialects closed |
+| 5 | F3.1 + F3.2 + Git dialect wiring - **done** | ~1 day | `Git` dialect feature-complete (`!`, leading `/`, trailing `/` markers exposed as init properties) |
+| 6 | F3.3 `IEnumerationMatcher` adapter + `GlobEnumerator` - **done (partial; no segment pruning, no `MatchSet` composition yet)** | ~1 day | Drives enumerator integration; perf comparison against `MsBuildEnumerator` |
+| 7 | F1.3 + F1.4 `AllowExtGlob` + Bash extglob wiring | ~2-3 days | One option closed; full `Bash` coverage; introduces savepoint-stack NFA reused by F1.2 |
+| 8 | F2.4 `GlobPathSeparator` option - **done** | ~half-day | Caller-controlled separator (forward-slash / back-slash / OS default) |
+| 9 | F3.3 segment-level pruning + `MatchSet` composition + `RootAnchored`/`DirectoryOnly` enforcement | ~1-2 days | Subtree skipping for literal-prefix excludes; mixed-dialect include/exclude sets; gitignore enforcement |
 | 10 | F4 brace expansion | ~1 day | `Bash` feature-complete |
-| 11 | F5 POSIX bracket extras &mdash; **done** | ~half-day | `Posix` `[[:class:]]` parity |
-| &mdash; | F1.2 / F1.2b `Win32` + `WinNT` &mdash; **deferred, low priority** | ~2&ndash;3 days | Two dialects closed; needs dedicated `Win32GlobMatcher` (BCL `MatchPattern` port) |
+| 11 | F5 POSIX bracket extras - **done** | ~half-day | `Posix` `[[:class:]]` parity |
+| - | F1.2 / F1.2b `Win32` + `WinNT` - **deferred, low priority** | ~2-3 days | Two dialects closed; needs dedicated `Win32GlobMatcher` (BCL `MatchPattern` port) |
 
-Stop conditions between slices &mdash; same as
+Stop conditions between slices - same as
 [globbing-optimization-plan.md §4](globbing-optimization-plan.md#4-proposed-slice-order):
 each slice runs the full test suite on both TFMs and re-runs the relevant
 benchmark rows; zero match-time allocations on `IsMatch_DoesNotAllocate`.

--- a/docs/polyfill-layout.md
+++ b/docs/polyfill-layout.md
@@ -31,7 +31,7 @@ the BCL namespace means callers reach the polyfill through the same
 `using System;` they already have for the BCL type.
 
 Anything outside `Polyfills/` is **not** a polyfill of public BCL
-surface &mdash; it is either Touki-specific functionality
+surface - it is either Touki-specific functionality
 (under `touki/Framework/Touki/`) or shared library code (under
 [touki/Touki/](../touki/Touki/)).
 
@@ -45,7 +45,7 @@ The wrapper class lives in the BCL namespace but adds **members**, not a
 new type.
 
 If a future Microsoft package backports the same member to net472,
-**the BCL member wins lookup automatically** &mdash; instance and static
+**the BCL member wins lookup automatically** - instance and static
 members defined on the type itself bind in preference to extension members.
 The polyfill silently becomes inert and can be removed in a later Touki
 release. **No `extern alias` is needed for callers** in this case.
@@ -67,7 +67,7 @@ so Touki adds it:
 If a future Microsoft package ships these same types on net472, your
 project will see two types with the same fully qualified name (one from
 `KlutzyNinja.Touki`, one from the new package). The compiler reports
-**CS0436** or **CS0433** &mdash; *the type exists in multiple referenced
+**CS0436** or **CS0433** - *the type exists in multiple referenced
 assemblies*.
 
 To pick a specific one, use **`extern alias`**:

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -2,7 +2,7 @@
 
 String creation is one of the most frequently executed operations in many .NET programs. Every time a string is built or modified a new instance is allocated and old instances eventually need to be reclaimed by the garbage collector.
 
-On modern .NET platforms (from .NET 6 onward) the compiler rewrites interpolated strings into a lower‑level representation using **interpolated string handlers** — see *String Interpolation in C# 10 and .NET 6* ([.NET Blog](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/)). Benchmarks published in that post show a ~40 % throughput improvement and about a five‑fold reduction in memory allocation compared with `string.Format`.
+On modern .NET platforms (from .NET 6 onward) the compiler rewrites interpolated strings into a lower‑level representation using **interpolated string handlers** - see *String Interpolation in C# 10 and .NET 6* ([.NET Blog](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/)). Benchmarks published in that post show a ~40 % throughput improvement and about a five‑fold reduction in memory allocation compared with `string.Format`.
 
 For developers who need to target .NET Framework 4.8 or earlier, these improvements are not available because the framework lacks the built‑in interpolated‑string handler and many of the supporting APIs. The **Touki** library bridges that gap by providing a default interpolated string handler and polyfills for .NET Framework 4.7.2 and later.
 
@@ -12,9 +12,9 @@ For developers who need to target .NET Framework 4.8 or earlier, these improve
 
 Strings in .NET are immutable. Every time you use `string.Concat`, `StringBuilder.Append` or `string.Format`, a new string instance is created. Frequent allocations lead to:
 
-* **Garbage‑collection pressure** – short‑lived strings can quickly accumulate to dramatic weight on the GC.
-* **Hidden boxing** – `string.Format` boxes value‑type arguments into an `object[]` array and creates the array itself (see the .NET Blog post above), generating unnecessary heap activity.
-* **Parsing costs** – `string.Format` interprets the composite format string at run‑time, so when you don’t know the format string until run‑time you miss out on compile‑time parsing or optimized code paths.
+* **Garbage‑collection pressure** - short‑lived strings can quickly accumulate to dramatic weight on the GC.
+* **Hidden boxing** - `string.Format` boxes value‑type arguments into an `object[]` array and creates the array itself (see the .NET Blog post above), generating unnecessary heap activity.
+* **Parsing costs** - `string.Format` interprets the composite format string at run‑time, so when you don’t know the format string until run‑time you miss out on compile‑time parsing or optimized code paths.
 
 ## Touki’s approach
 
@@ -40,7 +40,7 @@ using Touki.Text;
 
 // ...
 
-string fmt = "{0} – {1:F2}";
+string fmt = "{0} - {1:F2}";
 double num = 3.14159;
 
 // No boxing for either the string or the double, no intermediate strings

--- a/touki.perf/EnumExtensionsInliningPerf.cs
+++ b/touki.perf/EnumExtensionsInliningPerf.cs
@@ -17,7 +17,7 @@ namespace touki.perf;
 ///  <para>
 ///   The production extensions are extension members on a generic
 ///   <c>T : unmanaged, Enum</c>. To isolate the inlining decision we copy each
-///   body into a pair of static generic helpers below — <c>_NoInline</c>
+///   body into a pair of static generic helpers below - <c>_NoInline</c>
 ///   variants get <c>NoInlining</c> so we always pay a real call+ret, and
 ///   <c>_Aggressive</c> variants get <c>AggressiveInlining</c>. The
 ///   <c>_Default</c> column lets the JIT pick its own heuristic (which on
@@ -147,7 +147,7 @@ public unsafe class EnumExtensionsInliningPerf
 
     // ============== Helper implementations ==============
     // Bodies copied verbatim from EnumExtensions.cs (the net472 polyfill
-    // path for AreFlagsSet — equivalent to the modern HasFlag intrinsic).
+    // path for AreFlagsSet - equivalent to the modern HasFlag intrinsic).
 
     private static bool AreFlagsSet_Default<T>(T value, T flags) where T : unmanaged, Enum
     {

--- a/touki.perf/GlobEnumerateExtGlobPerf.cs
+++ b/touki.perf/GlobEnumerateExtGlobPerf.cs
@@ -37,14 +37,14 @@ namespace touki.perf;
 ///   <see cref="GlobDialect.Bash"/> dialect. The factory recognizes this
 ///   suffix-set shape and lowers it to a <c>MultiSuffixGlobStrategy</c> wrapped
 ///   in <c>GlobStarFileNameStrategy</c>, so the per-file hot path is a tight
-///   <c>EndsWith</c> sweep &#8212; not the recursive bytecode interpreter.
+///   <c>EndsWith</c> sweep - not the recursive bytecode interpreter.
 ///   Other extglob shapes (e.g. <c>+(...)</c>, alternatives that are not pure
 ///   <c>*literal</c>) skip this specialization and flow through the recursive
 ///   walker in <c>CompiledGlobStrategy</c>.
 ///  </para>
 ///  <para>
 ///   <b>Excludes:</b> none. Both walkers descend the same tree, so the
-///   difference is the per-file matching cost &#8212; not directory pruning,
+///   difference is the per-file matching cost - not directory pruning,
 ///   not I/O, not exclude-list compile cost.
 ///  </para>
 ///  <para>

--- a/touki.perf/GlobSpecificationComplexCompilePerf.cs
+++ b/touki.perf/GlobSpecificationComplexCompilePerf.cs
@@ -7,7 +7,7 @@ using Touki.Io.Globbing;
 namespace touki.perf;
 
 /// <summary>
-///  Compile-time cost baseline for complex <see cref="GlobSpecification"/> inputs —
+///  Compile-time cost baseline for complex <see cref="GlobSpecification"/> inputs -
 ///  the kind that hit the full bytecode encoder, the
 ///  <c>TryNormalizeRuns</c> per-dialect normalization, the gitignore marker strip,
 ///  and the segment-bounded globstar emitter. Use this as the regression line for

--- a/touki.perf/MsBuildEnumeratePerf2.cs
+++ b/touki.perf/MsBuildEnumeratePerf2.cs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Linq;
 using Touki.Io;
+using Touki.Io.Globbing;
 
 using File = System.IO.File;
 using Path = System.IO.Path;
@@ -45,6 +47,28 @@ public class MsBuildEnumeratePerf2
         "obj/**"
     ];
 
+    // Single extglob alternation that covers the same two excluded subtrees.
+    // `@(bin|obj)/**` matches the root-anchored `bin/` or `obj/` directories
+    // and any descendants - equivalent to MSBuild's root-anchored
+    // `bin/**` / `obj/**` pair, but as one compiled spec.
+    private static readonly List<string> s_extGlobExclude =
+    [
+        "@(bin|obj)/**"
+    ];
+
+    // Single-pattern collapse: bash extglob negation at the first segment. A path
+    // matches when its first directory segment is not `bin` or `obj` and the
+    // remaining path ends in `*.cs`. Equivalent to the include + reduced
+    // excludes pair under the assumption (true for this repo) that there are
+    // no `.cs` files at the project root. Compiled with one GlobSpecification.
+    private const string ExtGlobSingleInclude = "!(bin|obj)/**/*.cs";
+
+    // Option-2 single-pattern collapse with root-level fallback: outer @(...)
+    // alternation between the nested-file case and the root-file case. Matches
+    // the same files as `**/*.cs` minus root-anchored `bin/**` and `obj/**`
+    // including `.cs` files sitting at the project root, in one compiled spec.
+    private const string ExtGlobSingleIncludeWithRoot = "@(!(bin|obj)/**/*.cs|*.cs)";
+
     private string _directory = string.Empty;
 
     [GlobalSetup]
@@ -60,12 +84,61 @@ public class MsBuildEnumeratePerf2
 
         _directory = dir ?? throw new InvalidOperationException(
             "Could not locate touki.slnx walking up from " + AppContext.BaseDirectory);
+
+        // Sanity check: every scenario in this file must enumerate the same set of
+        // files so the timing comparison is meaningful. Run each one and compare
+        // counts; mismatch aborts the benchmark run with a descriptive message.
+        HashSet<string> baseline = new(MSBuild(), StringComparer.OrdinalIgnoreCase);
+
+        AssertSet(nameof(MSBuildReduced), MSBuildReduced(), baseline);
+        AssertSet(nameof(MsBuildEnumerator), MsBuildEnumerator(), baseline);
+        AssertSet(nameof(MsBuildEnumeratorResult), MsBuildEnumeratorResult(), baseline);
+        AssertSet(nameof(GlobEnumerator), GlobEnumerator(), baseline);
+        AssertSet(nameof(GlobEnumeratorReduced), GlobEnumeratorReduced(), baseline);
+        AssertSet(nameof(GlobEnumeratorExtGlobExclude), GlobEnumeratorExtGlobExclude(), baseline);
+        AssertSet(nameof(GlobEnumeratorExtGlobSingle), GlobEnumeratorExtGlobSingle(), baseline);
+        AssertSet(nameof(GlobEnumeratorExtGlobSingleWithRoot), GlobEnumeratorExtGlobSingleWithRoot(), baseline);
     }
+
+    private static void AssertSet(string name, IReadOnlyList<string> actual, HashSet<string> expected)
+    {
+        HashSet<string> actualSet = new(actual, StringComparer.OrdinalIgnoreCase);
+        if (actualSet.SetEquals(expected))
+        {
+            return;
+        }
+
+        string[] missingFromActual = [.. expected.Except(actualSet, StringComparer.OrdinalIgnoreCase)];
+        string[] extraInActual = [.. actualSet.Except(expected, StringComparer.OrdinalIgnoreCase)];
+
+        throw new InvalidOperationException(
+            $"Benchmark '{name}' result set differs from baseline: "
+            + $"{missingFromActual.Length} missing (e.g. {Sample(missingFromActual)}), "
+            + $"{extraInActual.Length} extra (e.g. {Sample(extraInActual)}).");
+    }
+
+    private static string Sample(IReadOnlyList<string> items) => string.Join(
+        ", ",
+        items.Take(5).Select(s => "'" + s.Replace(s_directoryRoot, "<root>", StringComparison.OrdinalIgnoreCase) + "'"));
+
+    private static readonly string s_directoryRoot = string.Empty;
 
     [Benchmark(Baseline = true)]
     public IReadOnlyList<string> MSBuild()
     {
         var results = FileMatcherWrapper.GetFilesSimple(_directory, Filespec, s_excludes);
+        return results;
+    }
+
+    /// <summary>
+    ///  MSBuild's <c>FileMatcher</c> driven with the minimum semantically-equivalent
+    ///  exclude set. Isolates the redundant-rule processing cost in the MSBuild
+    ///  baseline from the actual per-file matching work.
+    /// </summary>
+    [Benchmark]
+    public IReadOnlyList<string> MSBuildReduced()
+    {
+        var results = FileMatcherWrapper.GetFilesSimple(_directory, Filespec, s_reducedExcludes);
         return results;
     }
 
@@ -106,7 +179,7 @@ public class MsBuildEnumeratePerf2
             Filespec,
             s_excludes,
             _directory,
-            Touki.Io.Globbing.GlobDialect.MSBuild);
+            GlobDialect.MSBuild);
         List<string> results = [];
         while (enumerator.MoveNext())
         {
@@ -128,7 +201,79 @@ public class MsBuildEnumeratePerf2
             Filespec,
             s_reducedExcludes,
             _directory,
-            Touki.Io.Globbing.GlobDialect.MSBuild);
+            GlobDialect.MSBuild);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    ///  Single extglob alternation as the exclude pattern. Compiles the two
+    ///  subtrees into one specification; <see cref="MatchSet"/> still wraps it
+    ///  for the include + 1-exclude shape.
+    /// </summary>
+    [Benchmark]
+    public IReadOnlyList<string> GlobEnumeratorExtGlobExclude()
+    {
+        using GlobEnumerator enumerator = Touki.Io.GlobEnumerator.Create(
+            Filespec,
+            s_extGlobExclude,
+            _directory,
+            GlobDialect.MSBuild,
+            GlobOptions.AllowExtGlob);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    ///  Single extglob include that collapses the include and excludes into one
+    ///  specification: <c>!(bin|obj)/**/*.cs</c>. No <see cref="MatchSet"/>
+    ///  involvement; the include matcher answers per-file directly.
+    /// </summary>
+    [Benchmark]
+    public IReadOnlyList<string> GlobEnumeratorExtGlobSingle()
+    {
+        using GlobEnumerator enumerator = Touki.Io.GlobEnumerator.Create(
+            ExtGlobSingleInclude,
+            excludePattern: null,
+            _directory,
+            GlobDialect.MSBuild,
+            GlobOptions.AllowExtGlob);
+        List<string> results = [];
+        while (enumerator.MoveNext())
+        {
+            results.Add(enumerator.Current);
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    ///  Single extglob include that also covers root-level <c>*.cs</c>:
+    ///  <c>@(!(bin|obj)/**/*.cs|*.cs)</c>. Outer alternation, exactly-one of
+    ///  the two arms. The true apples-to-apples shape vs
+    ///  <c>GlobEnumeratorReduced</c>: both forms match the same result set on
+    ///  any repo (root <c>.cs</c> files included), in one compiled
+    ///  <c>GlobSpecification</c> instead of an include + 2 excludes.
+    /// </summary>
+    [Benchmark]
+    public IReadOnlyList<string> GlobEnumeratorExtGlobSingleWithRoot()
+    {
+        using GlobEnumerator enumerator = Touki.Io.GlobEnumerator.Create(
+            ExtGlobSingleIncludeWithRoot,
+            excludePattern: null,
+            _directory,
+            GlobDialect.MSBuild,
+            GlobOptions.AllowExtGlob);
         List<string> results = [];
         while (enumerator.MoveNext())
         {

--- a/touki.perf/OracleMatchMSBuildPerf.cs
+++ b/touki.perf/OracleMatchMSBuildPerf.cs
@@ -10,7 +10,7 @@ namespace touki.perf;
 /// <summary>
 ///  Per-pattern-shape match-throughput comparison between
 ///  <see cref="GlobSpecification"/>(<see cref="GlobDialect.MSBuild"/>) and
-///  <see cref="MSBuildGlob"/> — the oracle used by the multi-asterisk and
+///  <see cref="MSBuildGlob"/> - the oracle used by the multi-asterisk and
 ///  sequential-separator suites. Reads a compiled matcher's <c>IsMatch</c> per
 ///  invocation; setup cost is paid once.
 /// </summary>

--- a/touki.perf/OracleMatchSimplePerf.cs
+++ b/touki.perf/OracleMatchSimplePerf.cs
@@ -13,7 +13,7 @@ namespace touki.perf;
 ///  Per-pattern-shape match-throughput comparison between
 ///  <see cref="GlobSpecification"/>(<see cref="GlobDialect.Simple"/>) and the BCL
 ///  <see cref="FileSystemName.MatchesSimpleExpression(System.ReadOnlySpan{char}, System.ReadOnlySpan{char}, bool)"/>
-///  helper. The BCL implementation is the reference for the Simple dialect —
+///  helper. The BCL implementation is the reference for the Simple dialect -
 ///  every <see cref="Directory.EnumerateFiles(string, string)"/>-style call routes
 ///  through it.
 /// </summary>

--- a/touki.perf/ReplaceUnsafeAsPerf.cs
+++ b/touki.perf/ReplaceUnsafeAsPerf.cs
@@ -149,7 +149,7 @@ public class ReplaceUnsafeAsPerf
     // Separate blocks per signed/unsigned primitive. Reading sbyte through a
     // matching Unsafe.As<T, sbyte> followed by a (byte) cast forces a
     // conv.u1 in the IL, which RyuJIT lowers to either a movsx+movzx pair or
-    // a constant fold to 0xFF for a literal -1 — never the buggy 32-bit
+    // a constant fold to 0xFF for a literal -1 - never the buggy 32-bit
     // sign-extended compare immediate.
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static unsafe void ReplaceSplitBlocks<T>(Span<T> span, T oldValue, T newValue)

--- a/touki.tests/Framework/System/BigIntegerTests.cs
+++ b/touki.tests/Framework/System/BigIntegerTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -1134,7 +1134,7 @@ public class BigIntegerTests
     public void HeuristicDivide_LargerDividend_RecoversFullQuotient()
     {
         // dividend = 7 * divisor + r where r < divisor. Construct dividend with
-        // simple primitives only (SetUInt64 + ShiftLeft + Add) — using more complex
+        // simple primitives only (SetUInt64 + ShiftLeft + Add) - using more complex
         // helpers triggers ref-struct escape analysis errors on net481 when the
         // resulting locals are passed by ref to other ref-struct methods.
         BigInteger.SetUInt32(out BigInteger divisor, 0x100u);

--- a/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
+++ b/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
@@ -278,7 +278,7 @@ public class SmallPolyfillCoverageTests
             {
                 global::System.ReadOnlySpan<int> args = stackalloc int[] { 1 };
                 // "{}" is malformed: '{' followed by '}' (not an escape, since they don't match
-                // for an escape — '{{' or '}}' would). The check is `if (brace != next)` for the
+                // for an escape - '{{' or '}}' would). The check is `if (brace != next)` for the
                 // escape path; "{}" reaches that with brace='{' next='}' which does NOT match,
                 // so FormatError is invoked.
                 builder.AppendFormat("{}".AsSpan(), args);

--- a/touki.tests/System/ArrayExtensionsTests.cs
+++ b/touki.tests/System/ArrayExtensionsTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace System.Tests;
+namespace System;
 
 public class ArrayExtensionsTests
 {

--- a/touki.tests/System/ConvertBase64PolyfillTests.cs
+++ b/touki.tests/System/ConvertBase64PolyfillTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace System.Tests;
+namespace System;
 
 public class ConvertBase64PolyfillTests
 {

--- a/touki.tests/System/EnumExtensionsTests.cs
+++ b/touki.tests/System/EnumExtensionsTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace System.Tests;
+namespace System;
 
 public class EnumExtensionsTests
 {

--- a/touki.tests/System/StringExtensionsPolyfillTests.cs
+++ b/touki.tests/System/StringExtensionsPolyfillTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace System.Tests;
+namespace System;
 
 public class StringExtensionsPolyfillTests
 {

--- a/touki.tests/TestSupport/MemoryWatch.cs
+++ b/touki.tests/TestSupport/MemoryWatch.cs
@@ -16,7 +16,7 @@ namespace Touki.TestSupport;
 ///   monotonically increasing count of bytes the current thread has
 ///   allocated on the managed heap. Capturing that value at one point and
 ///   comparing it later gives a precise, deterministic, single-threaded
-///   measurement — unlike GC counters or memory diagnosers, no
+///   measurement - unlike GC counters or memory diagnosers, no
 ///   collection has to run and no warm-up iterations are required.
 ///  </para>
 ///  <para>
@@ -36,7 +36,7 @@ namespace Touki.TestSupport;
 ///  </para>
 ///  <para>
 ///   For incremental checks, store the watch and call
-///   <see cref="Validate"/> at each checkpoint — the helper resets
+///   <see cref="Validate"/> at each checkpoint - the helper resets
 ///   its baseline after each successful validation so subsequent calls
 ///   measure only the bytes allocated since the previous call:
 ///   <code>
@@ -61,7 +61,7 @@ namespace Touki.TestSupport;
 ///   </code>
 ///  </para>
 ///  <para>
-///   <b>Limitations.</b> Only single-threaded code can be measured —
+///   <b>Limitations.</b> Only single-threaded code can be measured -
 ///   <see cref="GC.GetAllocatedBytesForCurrentThread"/> returns a
 ///   per-thread counter, so allocations on other threads are invisible.
 ///   Boxing, closure captures, and any reference-type literal in the
@@ -125,7 +125,7 @@ public ref struct MemoryWatch
     ///   watch can validate multiple sequential checkpoints. The reset
     ///   happens by reading <see cref="GC.GetAllocatedBytesForCurrentThread"/>
     ///   again rather than by reusing the prior baseline plus the
-    ///   observed delta — producing the exception message itself
+    ///   observed delta - producing the exception message itself
     ///   can allocate, and that allocation must not be counted against
     ///   the next checkpoint.
     ///  </para>

--- a/touki.tests/Touki/Io/EscapingUtilitiesOracleTests.cs
+++ b/touki.tests/Touki/Io/EscapingUtilitiesOracleTests.cs
@@ -25,7 +25,7 @@ public class EscapingUtilitiesOracleTests
     [InlineData("%2A.cs")]                    // %2A = '*'
     [InlineData("dir%2Fname")]                // %2F = '/'
     [InlineData("100%25done")]                // %25 = '%'
-    [InlineData("%00")]                       // %00 = NUL — decoded but illegal at the spec layer
+    [InlineData("%00")]                       // %00 = NUL - decoded but illegal at the spec layer
     [InlineData("file%2Bname")]               // %2B = '+'
     [InlineData("hex%41%42%43")]              // %41-%43 = 'A','B','C'
     // Lowercase hex digits.

--- a/touki.tests/Touki/Io/Globbing/BashInterop.cs
+++ b/touki.tests/Touki/Io/Globbing/BashInterop.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -54,7 +54,7 @@ internal static class BashInterop
         // On Windows, prefer the Git for Windows install over whatever `bash.exe`
         // happens to be on PATH first. The WSL launcher stub at
         // `%LocalAppData%\Microsoft\WindowsApps\bash.exe` is installed automatically
-        // when WSL is enabled and would otherwise win the PATH walk &mdash; but it's
+        // when WSL is enabled and would otherwise win the PATH walk - but it's
         // a wrapper around `wsl.exe`, doesn't forward environment variables, and
         // doesn't handle bash's `[[ ... ]]` conditional syntax the same way. Git
         // Bash ships a real GNU bash 5.x and is what our oracle assumes.

--- a/touki.tests/Touki/Io/Globbing/ExtGlobExcludeProbeTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobExcludeProbeTests.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+public class ExtGlobExcludeProbeTests
+{
+    [Theory]
+    [InlineData("bin/**", "src/bin/foo.cs", false)]    // 'bin/**' is root-anchored under MSBuild; shouldn't match nested.
+    [InlineData("bin/**", "bin/foo.cs", true)]
+    [InlineData("@(bin|obj)/**", "src/bin/foo.cs", false)]
+    [InlineData("@(bin|obj)/**", "bin/foo.cs", true)]
+    [InlineData("@(bin|obj)/**", "obj/foo.cs", true)]
+    [InlineData("@(bin|obj)/**", "src/foo.cs", false)]
+    public void MsBuildDialect_RootAnchored(string pattern, string input, bool expected)
+    {
+        bool actual = GlobSpecification
+            .Compile(pattern, GlobDialect.MSBuild, GlobOptions.AllowExtGlob)
+            .IsMatch(input);
+        actual.Should().Be(expected, $"pattern='{pattern}' input='{input}'");
+    }
+}

--- a/touki.tests/Touki/Io/Globbing/ExtGlobNegationMatchTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobNegationMatchTests.cs
@@ -13,7 +13,7 @@ namespace Touki.Io.Globbing;
 /// <remarks>
 ///  <para>
 ///   Bash diverges on a handful of edge cases (notably <c>!(*)</c> against the
-///   empty string &#8212; bash accepts, touki rejects because <c>*</c> matches
+///   empty string - bash accepts, touki rejects because <c>*</c> matches
 ///   the empty alternative slice). Those divergences will be tracked as
 ///   documented oracle deltas in step 5 when the bash oracle goes live.
 ///  </para>

--- a/touki.tests/Touki/Io/Globbing/ExtGlobOracleTests.Bash.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobOracleTests.Bash.cs
@@ -8,7 +8,7 @@ namespace Touki.Io.Globbing;
 
 /// <summary>
 ///  Oracle tests for the <see cref="GlobOptions.AllowExtGlob"/> option on the
-///  <see cref="GlobDialect.Bash"/> dialect &#8212; compares touki against
+///  <see cref="GlobDialect.Bash"/> dialect - compares touki against
 ///  <c>bash -O extglob -O globstar</c> via <see cref="BashInterop"/>. This is
 ///  the F1.4 component of the extglob rollout: the option is honored against
 ///  the bash oracle and any divergence surfaces as a row failure.

--- a/touki.tests/Touki/Io/Globbing/ExtGlobPositiveMatchTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobPositiveMatchTests.cs
@@ -5,7 +5,7 @@
 namespace Touki.Io.Globbing;
 
 /// <summary>
-///  Match tests for the four positive extended-glob constructs &#8212;
+///  Match tests for the four positive extended-glob constructs -
 ///  <c>?(...)</c>, <c>*(...)</c>, <c>+(...)</c>, and <c>@(...)</c>. Negation
 ///  (<c>!(...)</c>) is covered in a later step and intentionally still
 ///  reports no match here.

--- a/touki.tests/Touki/Io/Globbing/ExtGlobScannerTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobScannerTests.cs
@@ -13,7 +13,7 @@ namespace Touki.Io.Globbing;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   The interpreter does not yet recognize the new opcodes &#8212; that comes in
+///   The interpreter does not yet recognize the new opcodes - that comes in
 ///   step 3 of the F1.3 rollout. Until then runtime matching against an extglob
 ///   pattern silently returns <see langword="false"/>, which the compile-shape
 ///   tests in this file <i>don't</i> exercise (they inspect the emitted bytecode

--- a/touki.tests/Touki/Io/Globbing/FnmatchInterop.cs
+++ b/touki.tests/Touki/Io/Globbing/FnmatchInterop.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -9,7 +9,7 @@ namespace Touki.Io.Globbing;
 /// <summary>
 ///  Thin wrapper around POSIX <c>fnmatch(3)</c> via P/Invoke for use as an oracle by the
 ///  per-dialect oracle test classes. Linux and macOS use different bit values for the
-///  <c>FNM_*</c> flags — this class encapsulates the platform shim.
+///  <c>FNM_*</c> flags - this class encapsulates the platform shim.
 /// </summary>
 internal static class FnmatchInterop
 {

--- a/touki.tests/Touki/Io/Globbing/MultiSuffixGlobStrategyTests.cs
+++ b/touki.tests/Touki/Io/Globbing/MultiSuffixGlobStrategyTests.cs
@@ -90,10 +90,10 @@ public class MultiSuffixGlobStrategyTests
     // Shapes the specialization intentionally rejects fall through to the
     // bytecode interpreter, which must still answer correctly. These tests
     // pin the safety net.
-    //   `?(...)`  &mdash; wrong extglob kind
-    //   `+(...)`  &mdash; wrong extglob kind
-    //   `*(...)`  &mdash; wrong extglob kind
-    //   `!(...)`  &mdash; wrong extglob kind
+    //   `?(...)`  - wrong extglob kind
+    //   `+(...)`  - wrong extglob kind
+    //   `*(...)`  - wrong extglob kind
+    //   `!(...)`  - wrong extglob kind
     //   mixed-shape body (literal alt next to `*lit` alt)
     [InlineData("**/?(*.cs)", "src/", "foo.cs", true)]
     [InlineData("**/?(*.cs)", "src/", "foo.md", false)]
@@ -157,11 +157,11 @@ public class MultiSuffixGlobStrategyTests
     // criteria must still compile and match correctly through the recursive
     // walker. Pins the rejection arms so the factory paths stay covered.
     //
-    //   - `*` (bare AnyRun-only alt) — zero suffix length, rejected.
-    //   - `*[a]` — bracket class inside the suffix.
-    //   - `*?` — `?` inside the suffix (any-char wildcard).
-    //   - `foo` — alt missing the leading `*`.
-    //   - `*foo|@(bar)` — alt that opens a nested extglob in the suffix.
+    //   - `*` (bare AnyRun-only alt) - zero suffix length, rejected.
+    //   - `*[a]` - bracket class inside the suffix.
+    //   - `*?` - `?` inside the suffix (any-char wildcard).
+    //   - `foo` - alt missing the leading `*`.
+    //   - `*foo|@(bar)` - alt that opens a nested extglob in the suffix.
     [InlineData("**/@(*)", "src/", "anything", true)]
     [InlineData("**/@(*[ab])", "src/", "fooa", true)]
     [InlineData("**/@(*[ab])", "src/", "fooc", false)]

--- a/touki.tests/Touki/Io/Globbing/MultipleAsteriskOracleTests.FileSystemGlobbing.cs
+++ b/touki.tests/Touki/Io/Globbing/MultipleAsteriskOracleTests.FileSystemGlobbing.cs
@@ -3,9 +3,8 @@
 // See LICENSE file in the project root for full license information
 
 using Microsoft.Extensions.FileSystemGlobbing;
-using Touki.Io.Globbing;
 
-namespace Touki.Tests.Text.Globbing;
+namespace Touki.Io.Globbing;
 
 /// <summary>
 ///  Oracle tests that pin down how the <see cref="GlobDialect.FileSystemGlobbing"/> dialect

--- a/touki.tests/Touki/Io/Globbing/MultipleAsteriskOracleTests.Git.cs
+++ b/touki.tests/Touki/Io/Globbing/MultipleAsteriskOracleTests.Git.cs
@@ -24,7 +24,7 @@ public sealed class MultipleAsteriskGitOracleTests : IClassFixture<SequentialSep
     {
         // Documented Git dialect divergence. After `***`+ &rarr; `**` normalization
         // touki compiles `a/**` as a trailing globstar that matches zero or more
-        // segments &mdash; including the empty case `a/` &mdash; while gitignore
+        // segments - including the empty case `a/` - while gitignore
         // requires at least one path component after the prefix. Tracked in
         // docs/globbing-feature-plan.md "Multiple-asterisk-run behavior" findings.
         if ((pattern, input) == ("a/***", "a/"))

--- a/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.FileSystemGlobbing.cs
+++ b/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.FileSystemGlobbing.cs
@@ -22,7 +22,7 @@ namespace Touki.Io.Globbing;
 ///  </para>
 ///  <para>
 ///   If a row here fails, either touki's FileSystemGlobbing dialect drifted or
-///   <c>Microsoft.Extensions.FileSystemGlobbing</c> changed its tokenizer &#8212; both
+///   <c>Microsoft.Extensions.FileSystemGlobbing</c> changed its tokenizer - both
 ///   warrant a deliberate update to the dialect contract in <c>docs/globbing.md</c>.
 ///  </para>
 /// </remarks>

--- a/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.Git.cs
+++ b/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.Git.cs
@@ -20,7 +20,7 @@ namespace Touki.Io.Globbing;
 ///  </para>
 ///  <para>
 ///   The fixture creates a one-shot scratch repository in the temp directory; per-row
-///   evaluation swaps the temporary ignore rule. Per-call cost is ~1–5 ms with
+///   evaluation swaps the temporary ignore rule. Per-call cost is ~1-5 ms with
 ///   LibGit2Sharp.
 ///  </para>
 /// </remarks>

--- a/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.MSBuild.cs
+++ b/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.MSBuild.cs
@@ -21,7 +21,7 @@ namespace Touki.Io.Globbing;
 ///  </para>
 ///  <para>
 ///   If a row here ever fails, either touki's MSBuild dialect drifted or MSBuild's
-///   <c>MSBuildGlob</c> changed its coalescing rules &#8212; both warrant a deliberate
+///   <c>MSBuildGlob</c> changed its coalescing rules - both warrant a deliberate
 ///   update to the dialect contract documented in <c>docs/globbing.md</c>.
 ///  </para>
 /// </remarks>

--- a/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.Posix.cs
+++ b/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.Posix.cs
@@ -14,7 +14,7 @@ namespace Touki.Io.Globbing;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   Linux/macOS only — the oracle calls <c>libc</c>'s <c>fnmatch</c> via P/Invoke.
+///   Linux/macOS only - the oracle calls <c>libc</c>'s <c>fnmatch</c> via P/Invoke.
 ///   Windows runs skip via <see cref="Assert.Skip(string)"/>.
 ///  </para>
 /// </remarks>

--- a/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.PosixPath.cs
+++ b/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.PosixPath.cs
@@ -15,7 +15,7 @@ namespace Touki.Io.Globbing;
 /// <remarks>
 ///  <para>
 ///   Linux/macOS only. With <c>FNM_PATHNAME</c>, runs of <c>/</c> in the pattern are
-///   <b>not</b> coalesced by the libc implementation — each <c>/</c> is a literal
+///   <b>not</b> coalesced by the libc implementation - each <c>/</c> is a literal
 ///   separator that must appear in the input at the corresponding position. This contrasts
 ///   with the MSBuild dialect (which coalesces).
 ///  </para>

--- a/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.Simple.cs
+++ b/touki.tests/Touki/Io/Globbing/SequentialSeparatorOracleTests.Simple.cs
@@ -13,7 +13,7 @@ namespace Touki.Io.Globbing;
 ///  <para>
 ///   <see cref="GlobDialect.Simple"/> is path-unaware: it has no separator concept, so
 ///   <c>/</c> is a plain literal and runs of <c>/</c> in the pattern are <b>not</b>
-///   coalesced &#8212; the input must contain the same number of <c>/</c> characters in
+///   coalesced - the input must contain the same number of <c>/</c> characters in
 ///   the same position. The compiled <see cref="GlobSpecification"/> must agree with the BCL
 ///   reference on every row.
 ///  </para>

--- a/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
+++ b/touki.tests/Touki/Io/MSBuildEnumerationResultTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -50,7 +50,7 @@ public class MSBuildEnumerationResultTests
     [Fact]
     public void IsDriveRootRecursion_NotFullyQualified_ReturnsFalse()
     {
-        // Not fully qualified — the gate only fires post-qualification because that's the only point at
+        // Not fully qualified - the gate only fires post-qualification because that's the only point at
         // which we know what root the spec resolves against.
         MSBuildSpecification spec = new("**");
         spec.IsDriveRootRecursion.Should().BeFalse();
@@ -111,7 +111,7 @@ public class MSBuildEnumerationResultTests
     [InlineData(@"C:\**\**")]                    // duplicate ** (Normalize dedupes)
     [InlineData(@"C:\.\**")]                     // current-directory segment
     [InlineData(@"C:\foo\..\**")]                // parent segment that cancels back to root
-    [InlineData(@"\**")]                         // root-relative — Path.GetFullPath resolves to current drive root, so the gate fires
+    [InlineData(@"\**")]                         // root-relative - Path.GetFullPath resolves to current drive root, so the gate fires
     public void IsDriveRootRecursion_WindowsDriveRootVariants_ReturnTrue(string spec)
     {
         if (Environment.OSVersion.Platform != PlatformID.Win32NT)
@@ -124,7 +124,7 @@ public class MSBuildEnumerationResultTests
     }
 
     [Theory]
-    [InlineData(@"C:**")]                        // drive-relative (no separator) — not fully qualified
+    [InlineData(@"C:**")]                        // drive-relative (no separator) - not fully qualified
     [InlineData(@"C:relative\**")]               // drive-relative path
     [InlineData(@"..\**")]                       // parent-relative
     [InlineData(@".\**")]                        // current-relative
@@ -240,7 +240,7 @@ public class MSBuildEnumerationResultTests
 
         result.Action.Should().Be(MSBuildSearchAction.RunSearch);
         result.GlobFailure.Should().BeNull();
-        // Don't materialize — that would actually walk the drive. Just confirm the enumerator was built.
+        // Don't materialize - that would actually walk the drive. Just confirm the enumerator was built.
         result.Enumerator.Should().NotBeNull();
         result.Enumerator!.Dispose();
     }

--- a/touki.tests/Touki/Io/MatchAnyTests.cs
+++ b/touki.tests/Touki/Io/MatchAnyTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -26,7 +26,7 @@ public class MatchAnyTests
 
         // Include (matchForExclusion = false)
         matcher.MatchesDirectory("".AsSpan(), directoryName.AsSpan(), false).Should().Be(expectedResult);
-        // Exclude (matchForExclusion = true) — directory matcher result should be the same
+        // Exclude (matchForExclusion = true) - directory matcher result should be the same
         matcher.MatchesDirectory("".AsSpan(), directoryName.AsSpan(), true).Should().Be(expectedResult);
     }
 
@@ -49,7 +49,7 @@ public class MatchAnyTests
         iMatcher.MatchesDirectory("".AsSpan(), "build-output".AsSpan(), false).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "tests".AsSpan(), false).Should().BeFalse();
         iMatcher.MatchesDirectory("".AsSpan(), "SRC".AsSpan(), false).Should().BeFalse();
-        // Exclude — same results for directory matcher
+        // Exclude - same results for directory matcher
         iMatcher.MatchesDirectory("".AsSpan(), "docs".AsSpan(), true).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "src".AsSpan(), true).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "build".AsSpan(), true).Should().BeTrue();
@@ -77,7 +77,7 @@ public class MatchAnyTests
         iMatcher.MatchesDirectory("".AsSpan(), "SRC".AsSpan(), false).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "docs".AsSpan(), false).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "build".AsSpan(), false).Should().BeFalse();
-        // Exclude — same results for directory matcher
+        // Exclude - same results for directory matcher
         iMatcher.MatchesDirectory("".AsSpan(), "src".AsSpan(), true).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "SRC".AsSpan(), true).Should().BeTrue();
         iMatcher.MatchesDirectory("".AsSpan(), "docs".AsSpan(), true).Should().BeTrue();
@@ -214,7 +214,7 @@ public class MatchAnyTests
         // Include within root
         matcher.MatchesDirectory(root.AsSpan(), "subdir".AsSpan(), matchForExclusion: false).Should().BeTrue();
 
-        // Exclude within root — file matcher should return false when excluding directories
+        // Exclude within root - file matcher should return false when excluding directories
         matcher.MatchesDirectory(root.AsSpan(), "subdir".AsSpan(), matchForExclusion: true).Should().BeFalse();
         matcher.DirectoryFinished();
 
@@ -256,7 +256,7 @@ public class MatchAnyTests
 
         // Include (matchForExclusion = false)
         matcher.MatchesDirectory(currentDir.AsSpan(), dirName.AsSpan(), false).Should().Be(expectedResult);
-        // Exclude (matchForExclusion = true) — directory matcher result should be the same
+        // Exclude (matchForExclusion = true) - directory matcher result should be the same
         matcher.MatchesDirectory(currentDir.AsSpan(), dirName.AsSpan(), true).Should().Be(expectedResult);
     }
 

--- a/touki.tests/Touki/Io/OrderedMatchSetTests.cs
+++ b/touki.tests/Touki/Io/OrderedMatchSetTests.cs
@@ -227,7 +227,7 @@ public class OrderedMatchSetTests
         // Strict gitignore semantics: `bin/` claims the whole subtree at the
         // walker's recurse decision. Per gitignore(5) you can't re-include a
         // file whose parent directory is excluded, so the per-file evaluation
-        // never has to deal with descendants &mdash; the walker just doesn't
+        // never has to deal with descendants - the walker just doesn't
         // recurse.
         using OrderedMatchSet set = new(includeByDefault: true);
         set.AddExclude(CompileGit("bin/"));

--- a/touki.tests/Touki/Text/StringSegmentTests.cs
+++ b/touki.tests/Touki/Text/StringSegmentTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -2188,7 +2188,7 @@ public class StringSegmentTests
 
     // ---- Branch-coverage tests for the lower-coverage methods ----
 
-#pragma warning disable IDE0057 // Use range operator — the whole point of these tests is to exercise the Slice methods directly.
+#pragma warning disable IDE0057 // Use range operator - the whole point of these tests is to exercise the Slice methods directly.
 
     [Fact]
     public void Slice_DirectMethodCall_ReturnsCorrectSegment()

--- a/touki.tests/Touki/Value/CoverageGaps.cs
+++ b/touki.tests/Touki/Value/CoverageGaps.cs
@@ -4,7 +4,7 @@
 
 using Touki.Text;
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class CoverageGaps
 {

--- a/touki.tests/Touki/Value/Creation.cs
+++ b/touki.tests/Touki/Value/Creation.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class Creation
 {

--- a/touki.tests/Touki/Value/StoringArrays.cs
+++ b/touki.tests/Touki/Value/StoringArrays.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringArrays
 {

--- a/touki.tests/Touki/Value/StoringBoolean.cs
+++ b/touki.tests/Touki/Value/StoringBoolean.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringBoolean
 {

--- a/touki.tests/Touki/Value/StoringByte.cs
+++ b/touki.tests/Touki/Value/StoringByte.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringByte
 {

--- a/touki.tests/Touki/Value/StoringChar.cs
+++ b/touki.tests/Touki/Value/StoringChar.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringChar
 {

--- a/touki.tests/Touki/Value/StoringDateTime.cs
+++ b/touki.tests/Touki/Value/StoringDateTime.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringDateTime
 {

--- a/touki.tests/Touki/Value/StoringDateTimeOffset.cs
+++ b/touki.tests/Touki/Value/StoringDateTimeOffset.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringDateTimeOffset
 {

--- a/touki.tests/Touki/Value/StoringDecimal.cs
+++ b/touki.tests/Touki/Value/StoringDecimal.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringDecimal
 {

--- a/touki.tests/Touki/Value/StoringDouble.cs
+++ b/touki.tests/Touki/Value/StoringDouble.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringDouble
 {

--- a/touki.tests/Touki/Value/StoringEnum.cs
+++ b/touki.tests/Touki/Value/StoringEnum.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringEnum
 {

--- a/touki.tests/Touki/Value/StoringFloat.cs
+++ b/touki.tests/Touki/Value/StoringFloat.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringFloat
 {

--- a/touki.tests/Touki/Value/StoringInt.cs
+++ b/touki.tests/Touki/Value/StoringInt.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringInt
 {

--- a/touki.tests/Touki/Value/StoringLong.cs
+++ b/touki.tests/Touki/Value/StoringLong.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringLong
 {

--- a/touki.tests/Touki/Value/StoringNull.cs
+++ b/touki.tests/Touki/Value/StoringNull.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringNull
 {

--- a/touki.tests/Touki/Value/StoringObject.cs
+++ b/touki.tests/Touki/Value/StoringObject.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringObject
 {

--- a/touki.tests/Touki/Value/StoringSByte.cs
+++ b/touki.tests/Touki/Value/StoringSByte.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringSByte
 {

--- a/touki.tests/Touki/Value/StoringShort.cs
+++ b/touki.tests/Touki/Value/StoringShort.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringShort
 {

--- a/touki.tests/Touki/Value/StoringStringSegment.cs
+++ b/touki.tests/Touki/Value/StoringStringSegment.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
 using Touki.Text;
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringStringSegment
 {

--- a/touki.tests/Touki/Value/StoringUInt.cs
+++ b/touki.tests/Touki/Value/StoringUInt.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringUInt
 {

--- a/touki.tests/Touki/Value/StoringUShort.cs
+++ b/touki.tests/Touki/Value/StoringUShort.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringUShort
 {

--- a/touki.tests/Touki/Value/StoringUlong.cs
+++ b/touki.tests/Touki/Value/StoringUlong.cs
@@ -1,8 +1,8 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 public class StoringULong
 {

--- a/touki.tests/Touki/Value/ValueJitWarmup.cs
+++ b/touki.tests/Touki/Value/ValueJitWarmup.cs
@@ -4,7 +4,7 @@
 
 using Touki.Text;
 
-namespace Touki.ValueTests;
+namespace Touki;
 
 /// <summary>
 ///  Forces JIT compilation of the <see cref="Value"/> generic

--- a/touki.testsupport/README.md
+++ b/touki.testsupport/README.md
@@ -15,10 +15,10 @@ extensions used by the touki test suite.
 
 ## Notes
 
-This package is **not AOT-friendly** — it uses reflection to reach private
+This package is **not AOT-friendly** - it uses reflection to reach private
 members. It is intended for use from test projects only. Do not take a
 dependency on it from production code.
 
 ## License
 
-MIT — see [LICENSE](https://github.com/JeremyKuhne/touki/blob/main/LICENSE).
+MIT - see [LICENSE](https://github.com/JeremyKuhne/touki/blob/main/LICENSE).

--- a/touki/Touki/Buffers/SpanExtensions.IgnoreCase.cs
+++ b/touki/Touki/Buffers/SpanExtensions.IgnoreCase.cs
@@ -28,7 +28,7 @@ namespace Touki;
 ///    <item>
 ///     <description>
 ///      <see cref="System.Text.Ascii.EqualsIgnoreCase(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
-///      &#8211; <b>strict ASCII</b>; non-ASCII characters force a <see langword="false"/>
+///      - <b>strict ASCII</b>; non-ASCII characters force a <see langword="false"/>
 ///      return even if both sides are byte-identical. Use this for ASCII protocols (HTTP
 ///      headers, MIME, identifiers) where non-ASCII data is itself an error condition.
 ///     </description>
@@ -36,7 +36,7 @@ namespace Touki;
 ///    <item>
 ///     <description>
 ///      <c>EqualsAsciiLetterIgnoreCase</c> / <c>StartsWithAsciiLetterIgnoreCase</c> /
-///      <c>EndsWithAsciiLetterIgnoreCase</c> &#8211; <b>ASCII-letter case fold, ordinal
+///      <c>EndsWithAsciiLetterIgnoreCase</c> - <b>ASCII-letter case fold, ordinal
 ///      everything else</b>. The 26 ASCII letter pairs (<c>A..Z</c>/<c>a..z</c>) compare
 ///      equal; non-ASCII characters compare ordinal (so <c>caf\u00e9</c> equals
 ///      <c>caf\u00e9</c> but not <c>caf\u00c9</c>). This matches the documented behavior
@@ -47,7 +47,7 @@ namespace Touki;
 ///    <item>
 ///     <description>
 ///      <c>EqualsOrdinalIgnoreCase</c> / <c>CompareOrdinalIgnoreCase</c> /
-///      <c>StartsWithOrdinalIgnoreCase</c> / <c>EndsWithOrdinalIgnoreCase</c> &#8211;
+///      <c>StartsWithOrdinalIgnoreCase</c> / <c>EndsWithOrdinalIgnoreCase</c> -
 ///      <b>full Unicode ordinal ignore-case</b>, matching <c>string</c>'s behavior under
 ///      <see cref="StringComparison.OrdinalIgnoreCase"/>. Use these for MSBuild-style
 ///      globs, .NET <c>Microsoft.Extensions.FileSystemGlobbing</c> parity, and any
@@ -303,7 +303,7 @@ internal static class OrdinalIgnoreCaseHelpers
     /// <summary>
     ///  Tests two equal-length spans for "ASCII-letter case fold, ordinal everything else"
     ///  equality. Differs from <see cref="CompareAscii"/> by not bailing on non-ASCII
-    ///  characters &#8211; they simply compare ordinal. Matches POSIX
+    ///  characters - they simply compare ordinal. Matches POSIX
     ///  <c>fnmatch(FNM_CASEFOLD)</c> / bash <c>nocaseglob</c> / git <c>core.ignoreCase</c>.
     /// </summary>
     /// <remarks>

--- a/touki/Touki/EnumExtensions.cs
+++ b/touki/Touki/EnumExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Jeremy W Kuhne
+// Copyright (c) 2025 Jeremy W Kuhne
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
@@ -29,13 +29,13 @@ public static unsafe partial class EnumExtensions
     // Why AggressiveInlining on every method?
     //
     //  On modern .NET (.NET 5+) the size-of(T) ladder is folded and the
-    //  helper is inlined regardless — AggressiveInlining is a no-op there.
+    //  helper is inlined regardless - AggressiveInlining is a no-op there.
     //
     //  On .NET Framework 4.7.2 the JIT looks at the *unfolded* IL size of
     //  the four-arm ladder and decides the method is too big to inline.
     //  The fold still happens (the helper body is only one `and; cmp; sete`
     //  for AreFlagsSet, for example), but the caller pays a real call/ret
-    //  plus a stack spill — roughly +0.35 ns per call. AggressiveInlining
+    //  plus a stack spill - roughly +0.35 ns per call. AggressiveInlining
     //  overrides that heuristic so the call site gets the same flat code
     //  as on modern .NET. Confirmed in touki.perf/EnumExtensionsInliningPerf.cs
     //  asm output: with the attribute the call disappears and the inlined

--- a/touki/Touki/Io/GitIgnore.cs
+++ b/touki/Touki/Io/GitIgnore.cs
@@ -23,7 +23,7 @@ namespace Touki.Io;
 ///   <item><description>Lines starting with <c>#</c> are comments. Escape a leading
 ///    <c>#</c> with <c>\#</c> if the literal <c>#</c> is needed at the start.</description></item>
 ///   <item><description>Trailing whitespace is stripped unless escaped with
-///    <c>\&#160;</c> &#8212; this implementation strips trailing whitespace
+///    <c>\&#160;</c> - this implementation strips trailing whitespace
 ///    unconditionally (the rare escaped-trailing-space case can be added later).</description></item>
 ///   <item><description>A leading <c>\</c> escapes <c>!</c> or <c>#</c> at the start
 ///    of a line (e.g., <c>\!important.txt</c> matches a file literally named

--- a/touki/Touki/Io/GlobEnumerator.cs
+++ b/touki/Touki/Io/GlobEnumerator.cs
@@ -19,8 +19,8 @@ namespace Touki.Io;
 ///   This is a thin wrapper provided to make it easy to drive the
 ///   <see cref="Globbing"/> matcher across a real file system, primarily for
 ///   performance comparison against <see cref="MSBuildEnumerator"/>. The two enumerators
-///   accept different pattern dialects&#8212;<see cref="GlobDialect.PosixPath"/> for this
-///   one, MSBuild-style globs for <see cref="MSBuildEnumerator"/>&#8212;and have
+///   accept different pattern dialects-<see cref="GlobDialect.PosixPath"/> for this
+///   one, MSBuild-style globs for <see cref="MSBuildEnumerator"/>-and have
 ///   different recursion-pruning trade-offs, so they are not drop-in replacements for
 ///   each other.
 ///  </para>
@@ -194,7 +194,7 @@ public sealed class GlobEnumerator : MatchEnumerator<string>
         MatchSet matchSet = new(include);
 
         // Dedupe before compiling each exclude. The two rules mirror
-        // MSBuildSpecification's normalize/dedupe pass &#8212; together they remove
+        // MSBuildSpecification's normalize/dedupe pass - together they remove
         // ~15-20% of the per-file matcher work on net481 (and ~5% on net10) for
         // realistic exclude lists that include redundant subtree rules and
         // file-name patterns that can't match the include's file shape.
@@ -291,7 +291,7 @@ public sealed class GlobEnumerator : MatchEnumerator<string>
     /// <summary>
     ///  Returns <see langword="true"/> when <paramref name="pattern"/> ends with
     ///  <c>/**</c> or <c>\**</c> (optionally with a trailing path separator),
-    ///  reporting the length of the body that precedes the <c>**</c> &#8212;
+    ///  reporting the length of the body that precedes the <c>**</c> -
     ///  inclusive of the separator that splits the body from <c>**</c>.
     /// </summary>
     private static bool EndsWithSlashStarStar(string pattern, out int bodyLength)
@@ -322,7 +322,7 @@ public sealed class GlobEnumerator : MatchEnumerator<string>
 
     /// <summary>
     ///  Extracts the trailing literal of <paramref name="pattern"/>'s last segment
-    ///  &#8212; the characters after the last <c>*</c> in the last separator-bounded
+    ///  - the characters after the last <c>*</c> in the last separator-bounded
     ///  segment. Returns <see langword="true"/> when the segment is suitable for the
     ///  file-name disjointness check; the resulting <paramref name="literal"/> is a
     ///  <see cref="StringSegment"/> view over <paramref name="pattern"/> (no
@@ -379,8 +379,8 @@ public sealed class GlobEnumerator : MatchEnumerator<string>
 
     /// <summary>
     ///  Returns <see langword="true"/> when the exclude <paramref name="pattern"/>'s
-    ///  trailing literal is disjoint from <paramref name="includeLiteral"/> &#8212;
-    ///  neither is a suffix of the other &#8212; meaning no file can satisfy both.
+    ///  trailing literal is disjoint from <paramref name="includeLiteral"/> -
+    ///  neither is a suffix of the other - meaning no file can satisfy both.
     /// </summary>
     private static bool IsFileNameDisjoint(StringSegment includeLiteral, string pattern)
     {

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
@@ -93,7 +93,7 @@ internal sealed partial class CompiledGlobStrategy
     ///   pays a per-frame cost to re-materialize those spans on entry. Folding
     ///   the deterministic advances into a <c>while</c> loop removed the
     ///   majority of the recursive frames for typical patterns
-    ///   (e.g. <c>**/@(*.cs|*.md|...)</c> processes each file in 1&#8211;3
+    ///   (e.g. <c>**/@(*.cs|*.md|...)</c> processes each file in 1-3
     ///   frames instead of one frame per opcode); on the enumeration benchmark
     ///   this closed the bulk of the net481 throughput gap. Modern .NET RyuJIT
     ///   handles span tail-calls efficiently and sees only a small win, but the

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.cs
@@ -38,7 +38,7 @@ internal sealed partial class CompiledGlobStrategy : GlobStrategy
     ///  <see langword="true"/> when the encoded program contains at least one
     ///  <see cref="GlobOpCodes.GlobStar"/> opcode. Captured at compile time so the match
     ///  loop can dispatch to a simpler single-savepoint variant when globstar is absent
-    ///  (the common case&#8212;only a handful of patterns in a typical project use
+    ///  (the common case - only a handful of patterns in a typical project use
     ///  <c>**</c>).
     /// </summary>
     private readonly bool _hasGlobStar;
@@ -168,6 +168,16 @@ internal sealed partial class CompiledGlobStrategy : GlobStrategy
         // Tail-anchor fast-fail. When the encoded program ends in a Literal op, the
         // factory pre-extracts that literal so we can verify it with a single
         // contiguous compare (vectorized when not straddling) before running the NFA.
+        //
+        // For non-extglob programs the Literal is the program's last opcode, so
+        // matching the tail also consumes it: we trim the tail off the input and
+        // run the NFA on the prefix only.
+        //
+        // For extglob programs the tail is the common literal suffix shared by
+        // every alternative the walker could choose. Failing to match the tail
+        // proves no alternative can match, but a successful match doesn't tell
+        // us which alternative actually applies - the walker still needs the
+        // full input. So we EndsWith-check and skip the trim.
         if (_tailLength > 0)
         {
             if (totalLength < _tailLength)
@@ -182,22 +192,25 @@ internal sealed partial class CompiledGlobStrategy : GlobStrategy
                 return false;
             }
 
-            // Trim the tail off the virtual input. The tail either fits in `second`
-            // entirely, fits in `first` entirely (when `second` is empty or short),
-            // or straddles the boundary; in each case we slice the appropriate end.
-            int trimmed = totalLength - _tailLength;
-            if (trimmed >= firstLength)
+            if (!_hasExtGlob)
             {
-                second = second[..(trimmed - firstLength)];
-            }
-            else
-            {
-                first = first[..trimmed];
-                second = default;
-            }
+                // Trim the tail off the virtual input. The tail either fits in `second`
+                // entirely, fits in `first` entirely (when `second` is empty or short),
+                // or straddles the boundary; in each case we slice the appropriate end.
+                int trimmed = totalLength - _tailLength;
+                if (trimmed >= firstLength)
+                {
+                    second = second[..(trimmed - firstLength)];
+                }
+                else
+                {
+                    first = first[..trimmed];
+                    second = default;
+                }
 
-            firstLength = first.Length;
-            totalLength = trimmed;
+                firstLength = first.Length;
+                totalLength = trimmed;
+            }
         }
 
         ReadOnlySpan<char> program = _program.AsSpan(0, _nfaProgramLength);
@@ -389,7 +402,7 @@ internal sealed partial class CompiledGlobStrategy : GlobStrategy
 
     /// <summary>
     ///  Ordinal match path for programs without <see cref="GlobOpCodes.GlobStar"/>.
-    ///  Single AnyRun savepoint, no shared backtrack helper&#8212;keeps the JIT happy and
+    ///  Single AnyRun savepoint, no shared backtrack helper - keeps the JIT happy and
     ///  avoids the two-slot backtrack overhead of <see cref="MatchOrdinal"/> on the
     ///  globstar-free common case. Walks the virtual
     ///  <paramref name="first"/> + <paramref name="second"/> concatenation.

--- a/touki/Touki/Io/Globbing/GlobDialect.cs
+++ b/touki/Touki/Io/Globbing/GlobDialect.cs
@@ -41,7 +41,7 @@ public enum GlobDialect
     /// <remarks>
     ///  <para>
     ///   See <see href="https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html">
-    ///   GNU Bash — Pattern Matching</see>.
+    ///   GNU Bash - Pattern Matching</see>.
     ///  </para>
     /// </remarks>
     Bash,

--- a/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
+++ b/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
@@ -100,8 +100,8 @@ internal static class GlobDialectExtensions
     ///   <see cref="GlobDialect.PosixPath"/>, <see cref="GlobDialect.Bash"/>,
     ///   <see cref="GlobDialect.Git"/>) treat a leading <c>.</c> as a "hidden" marker
     ///   per <c>fnmatch</c>'s <c>FNM_PERIOD</c> rule, requiring a literal <c>.</c>
-    ///   in the pattern. All other dialects &#8212; including PowerShell, Win32,
-    ///   Simple, MSBuild, FileSystemGlobbing &#8212; do not.
+    ///   in the pattern. All other dialects - including PowerShell, Win32,
+    ///   Simple, MSBuild, FileSystemGlobbing - do not.
     ///  </para>
     /// </remarks>
     public static bool MatchesLeadingDotByDefault(this GlobDialect dialect) => dialect switch
@@ -125,7 +125,7 @@ internal static class GlobDialectExtensions
     ///   <see cref="GlobDialect.Bash"/>, <see cref="GlobDialect.Git"/>,
     ///   <see cref="GlobDialect.MSBuild"/>,
     ///   <see cref="GlobDialect.FileSystemGlobbing"/>. All other dialects
-    ///   &#8212; including <see cref="GlobDialect.Posix"/> &#8212; are
+    ///   - including <see cref="GlobDialect.Posix"/> - are
     ///   path-unaware.
     ///  </para>
     /// </remarks>

--- a/touki/Touki/Io/Globbing/GlobOpCodes.cs
+++ b/touki/Touki/Io/Globbing/GlobOpCodes.cs
@@ -41,9 +41,9 @@ internal static class GlobOpCodes
     ///  absorbed into this opcode: bit 0 (<see cref="GlobStarFlagLead"/>) means the
     ///  pattern had a separator immediately before the <c>**</c> token; bit 1
     ///  (<see cref="GlobStarFlagTrail"/>) means a separator followed it. The two bits
-    ///  together describe four shapes&#8212;whole-pattern <c>**</c> (neither),
+    ///  together describe four shapes-whole-pattern <c>**</c> (neither),
     ///  leading <c>**/</c> (trail only), trailing <c>/**</c> (lead only), and middle
-    ///  <c>/**/</c> (both)&#8212;each with their own validity constraints on the
+    ///  <c>/**/</c> (both)-each with their own validity constraints on the
     ///  absorbed input slice.
     /// </summary>
     public const char GlobStar = '\uFDD5';

--- a/touki/Touki/Io/Globbing/GlobOptions.cs
+++ b/touki/Touki/Io/Globbing/GlobOptions.cs
@@ -73,7 +73,7 @@ public enum GlobOptions
     ///     <description>
     ///      <see cref="GlobDialect.Posix"/>, <see cref="GlobDialect.PosixPath"/>,
     ///      <see cref="GlobDialect.Bash"/>, and <see cref="GlobDialect.Git"/> use
-    ///      <b>ASCII-only</b> case folding &#8211; only the 26 ASCII letter pairs match
+    ///      <b>ASCII-only</b> case folding - only the 26 ASCII letter pairs match
     ///      case-insensitively; non-ASCII characters compare strictly. This matches the
     ///      documented behavior of POSIX
     ///      <see href="https://man7.org/linux/man-pages/man3/fnmatch.3.html"><c>fnmatch(FNM_CASEFOLD)</c></see>,
@@ -144,7 +144,7 @@ public enum GlobOptions
     ///   Models bash extglob (<c>shopt -s extglob</c>) and POSIX
     ///   <c>fnmatch(FNM_EXTMATCH)</c>. Each construct is a
     ///   <c>|</c>-separated list of inner glob patterns. Inner wildcards still
-    ///   respect path semantics &#8212; <c>*</c> and <c>?</c> inside an
+    ///   respect path semantics - <c>*</c> and <c>?</c> inside an
     ///   alternative do not cross the path separator on path-aware dialects.
     ///  </para>
     ///  <para>

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -263,7 +263,7 @@ public sealed partial class GlobSpecification
             // Path-unaware specialized matchers (Prefix/Suffix/Contains/PrefixSuffix/Any).
             // Path-aware dialects route everything through the bytecode interpreter so the
             // separator-aware semantics are honored. Extglob patterns also skip these
-            // specializations &mdash; they fall through to the general path so the
+            // specializations - they fall through to the general path so the
             // bytecode interpreter handles the alternation.
             if (!pathAware && !shape.HasExtGlob
                 && TryCreatePathUnawareSpecialized(pattern, ref shape, dialect, options, escape, out result))
@@ -279,7 +279,7 @@ public sealed partial class GlobSpecification
             // ...) and benefits enormously from bypassing the bytecode interpreter and
             // the per-file path concatenation. Globstar must be enabled (implicitly for
             // MSBuild / FSG / Git, or via GlobOptions.AllowGlobStar). Patterns with an
-            // extglob construct in the segment are still routed here &#8212; the helper
+            // extglob construct in the segment are still routed here - the helper
             // recognizes the `@(*lit1|*lit2|...)` shape and lowers it to
             // <see cref="MultiSuffixGlobStrategy"/>; segments with extglob constructs
             // the helper cannot specialize return false and fall through to the
@@ -433,7 +433,7 @@ public sealed partial class GlobSpecification
         ///   (<c>?</c>, <c>+</c>, <c>*</c>, <c>!</c>), mixed alternative shapes, and
         ///   anything containing a metacharacter inside the literal portion all
         ///   return <see langword="false"/> so the general bytecode path picks them
-        ///   up. Widening the criteria requires re-validating the net481 win &#8212;
+        ///   up. Widening the criteria requires re-validating the net481 win -
         ///   each kind has different match semantics and the simple endswith sweep
         ///   does not generalize cleanly.
         ///  </para>
@@ -509,7 +509,7 @@ public sealed partial class GlobSpecification
                 // Each alternative must be exactly `*literal` where literal is at least
                 // one character. Pure literal alternatives (no `*`) and zero-suffix
                 // alternatives (just `*`, which would match anything) are intentionally
-                // not specialized today &#8212; widening this requires verifying the
+                // not specialized today - widening this requires verifying the
                 // leading-dot semantics on each shape.
                 if (alt.Length < 2 || alt[0] != '*')
                 {
@@ -922,17 +922,31 @@ public sealed partial class GlobSpecification
             // Tail-anchor optimization: when the program ends in a Literal op, the matcher
             // can EndsWith-fast-fail on the tail before running the NFA. We pass the tail
             // offset/length within the same program string so no extra allocation is needed.
-            // The tail-anchor only applies to programs without extglob &mdash; an
-            // alternation may consume the trailing literal as part of one of its
-            // alternatives, so the EndsWith fast-fail would produce false negatives.
+            //
+            // For non-extglob programs the tail is SUFFICIENT (matches mean the input ends
+            // exactly in this literal) so the matcher both EndsWith-checks and trims.
+            //
+            // For extglob programs the tail is NECESSARY but not sufficient: when every
+            // top-level execution path through the outermost alternation ends in the same
+            // literal suffix, an EndsWith check still rules out the (typically large
+            // majority of) inputs that don't end that way. We do not trim - the
+            // alternation walker still needs the full input to resolve which alternative
+            // matches. <see cref="ComputeExtGlobCommonTailSlice"/> returns the longest
+            // common literal suffix as a (start, length) slice within the program string
+            // (pointing at any one alternative's matching Literal payload tail); it returns
+            // (-1, 0) when no common tail exists, in which case we run the walker without
+            // a pre-check.
             int nfaProgramLength;
             int tailStart;
             int tailLength;
             if (hasExtGlob)
             {
                 nfaProgramLength = program.Length;
-                tailStart = 0;
-                tailLength = 0;
+                if (!ComputeExtGlobCommonTailSlice(program, out tailStart, out tailLength))
+                {
+                    tailStart = 0;
+                    tailLength = 0;
+                }
             }
             else
             {
@@ -1019,6 +1033,248 @@ public sealed partial class GlobSpecification
                 tailStart = -1;
                 tailLength = 0;
             }
+        }
+
+        /// <summary>
+        ///  Compute-time helper for the extglob tail-anchor optimization. Walks an
+        ///  encoded program with one or more <see cref="GlobOpCodes.AltStart"/>
+        ///  blocks and computes the longest literal suffix common to every
+        ///  top-level execution path. Returns <see langword="true"/> with
+        ///  <paramref name="tailStart"/> / <paramref name="tailLength"/> pointing
+        ///  at a contiguous slice of <paramref name="program"/> containing that
+        ///  literal when one exists, otherwise <see langword="false"/>.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   The tail returned here is a <b>necessary</b> condition for a match,
+        ///   not a sufficient one: the caller still needs to run the full
+        ///   alternation walker on the untrimmed input. See
+        ///   <see cref="CompiledGlobStrategy.MatchCore(ReadOnlySpan{char}, ReadOnlySpan{char})"/>
+        ///   for the per-call <c>EndsWith</c> pre-check.
+        ///  </para>
+        ///  <para>
+        ///   Common cases handled:
+        ///  </para>
+        ///  <para>
+        ///   - Program ends in a plain <see cref="GlobOpCodes.Literal"/> after
+        ///     all alternation blocks. Returns that literal verbatim.<br/>
+        ///   - Program ends in an <see cref="GlobOpCodes.AltStart"/> block where
+        ///     every alternative ends in a literal and those literals share a
+        ///     common trailing run of characters (e.g.
+        ///     <c>&#x40;(*.cs|*.cs)</c> &#8594; <c>.cs</c>;
+        ///     <c>&#x40;(foo.cs|bar.cs)</c> &#8594; <c>.cs</c>).<br/>
+        ///   - Anything else (negation alternation, mixed extensions with no
+        ///     shared suffix, alternatives that end in non-literal opcodes)
+        ///     returns <see langword="false"/>; the caller falls back to running
+        ///     the walker without a pre-check.
+        ///  </para>
+        ///  <para>
+        ///   The negation kind <c>!(...)</c> is treated as &quot;no common tail
+        ///   from this block&quot; even when its alternatives share a suffix:
+        ///   a negation succeeds on input slices that <i>don't</i> match its
+        ///   alternatives, so the alternation's success tail is whatever the
+        ///   parent program contributes after the negation block, not the
+        ///   alternatives' tails.
+        ///  </para>
+        /// </remarks>
+        private static bool ComputeExtGlobCommonTailSlice(string program, out int tailStart, out int tailLength)
+        {
+            ReadOnlySpan<char> span = program.AsSpan();
+            ReadOnlySpan<char> commonTail = ComputeProgramTailLiteral(span, out int sliceStart);
+            if (commonTail.IsEmpty)
+            {
+                tailStart = -1;
+                tailLength = 0;
+                return false;
+            }
+
+            tailStart = sliceStart;
+            tailLength = commonTail.Length;
+            return true;
+        }
+
+        /// <summary>
+        ///  Recursively computes the longest literal suffix common to every
+        ///  execution path through <paramref name="program"/>. Returns the
+        ///  matching slice of <paramref name="program"/> (so the caller can
+        ///  reuse the program string as the literal source without allocating)
+        ///  via <paramref name="sliceStartInProgram"/>.
+        /// </summary>
+        private static ReadOnlySpan<char> ComputeProgramTailLiteral(
+            ReadOnlySpan<char> program,
+            out int sliceStartInProgram)
+        {
+            sliceStartInProgram = -1;
+            if (program.IsEmpty)
+            {
+                return default;
+            }
+
+            // Walk forward to locate the program's last top-level opcode. Top
+            // level here means outside any AltStart..AltEnd block; AltStart is
+            // treated as the unit (we descend into it only if it's the tail).
+            int i = 0;
+            int lastTopStart = -1;
+            char lastTopOp = '\0';
+            while (i < program.Length)
+            {
+                char opcode = program[i];
+                switch (opcode)
+                {
+                    case GlobOpCodes.Literal:
+                    case GlobOpCodes.Class:
+                    case GlobOpCodes.NegClass:
+                        lastTopStart = i;
+                        lastTopOp = opcode;
+                        i += 2 + program[i + 1];
+                        break;
+                    case GlobOpCodes.GlobStar:
+                        lastTopStart = i;
+                        lastTopOp = opcode;
+                        i += 2;
+                        break;
+                    case GlobOpCodes.AltStart:
+                        lastTopStart = i;
+                        lastTopOp = opcode;
+                        i += program[i + 2];
+                        break;
+                    case GlobOpCodes.Any:
+                    case GlobOpCodes.AnyRun:
+                        lastTopStart = i;
+                        lastTopOp = opcode;
+                        i++;
+                        break;
+                    default:
+                        // AltSep / AltEnd should not appear at top level; bail
+                        // without a tail rather than risking a wrong answer.
+                        return default;
+                }
+            }
+
+            if (lastTopOp == GlobOpCodes.Literal)
+            {
+                int payloadStart = lastTopStart + 2;
+                int payloadLength = program[lastTopStart + 1];
+                sliceStartInProgram = payloadStart;
+                return program.Slice(payloadStart, payloadLength);
+            }
+
+            if (lastTopOp != GlobOpCodes.AltStart)
+            {
+                // Class / NegClass / AnyRun / Any / GlobStar at the tail: no
+                // single-literal suffix the EndsWith check can verify.
+                return default;
+            }
+
+            int blockStart = lastTopStart;
+            int blockLen = program[blockStart + 2];
+            char altKind = program[blockStart + 1];
+
+            // `?(...)` (zero or one) and `*(...)` (zero or more) can match
+            // empty - no guaranteed tail from the block itself. `!(...)`
+            // succeeds on input that does NOT match its alternatives, so its
+            // success-tail isn't the alternatives' tails either. Only `@(...)`
+            // (exactly one) and `+(...)` (one or more) always contribute one
+            // alternative's tail to the matched input; restrict the
+            // optimization to those kinds.
+            if (altKind is not '@' and not '+')
+            {
+                return default;
+            }
+
+            int altsStart = blockStart + 3;
+            int altEndIndex = blockStart + blockLen - 1;
+            if (altsStart > altEndIndex)
+            {
+                return default;
+            }
+
+            // Walk the alternatives, recursing on each to compute its tail,
+            // then take the longest common suffix across all.
+            ReadOnlySpan<char> commonSuffix = default;
+            int chosenSliceStart = -1;
+            int altStart = altsStart;
+            int cursor = altsStart;
+            bool first = true;
+            while (true)
+            {
+                bool atEnd = cursor >= altEndIndex;
+                bool atSep = !atEnd && program[cursor] == GlobOpCodes.AltSep;
+                if (atEnd || atSep)
+                {
+                    ReadOnlySpan<char> altBody = program[altStart..cursor];
+                    ReadOnlySpan<char> altTail = ComputeProgramTailLiteral(altBody, out int altSliceOffset);
+                    if (altTail.IsEmpty)
+                    {
+                        return default;
+                    }
+
+                    // altSliceOffset is into altBody; translate to program offset.
+                    int altSliceInProgram = altStart + altSliceOffset;
+
+                    if (first)
+                    {
+                        commonSuffix = altTail;
+                        chosenSliceStart = altSliceInProgram;
+                        first = false;
+                    }
+                    else
+                    {
+                        int commonLen = 0;
+                        int max = Math.Min(commonSuffix.Length, altTail.Length);
+                        while (commonLen < max
+                            && commonSuffix[commonSuffix.Length - 1 - commonLen]
+                                == altTail[altTail.Length - 1 - commonLen])
+                        {
+                            commonLen++;
+                        }
+
+                        if (commonLen == 0)
+                        {
+                            return default;
+                        }
+
+                        // Trim commonSuffix to the new common length, keeping the
+                        // existing slice anchor (its trailing commonLen chars are
+                        // exactly the common suffix).
+                        if (commonLen < commonSuffix.Length)
+                        {
+                            chosenSliceStart += commonSuffix.Length - commonLen;
+                            commonSuffix = commonSuffix[^commonLen..];
+                        }
+                    }
+
+                    if (atEnd)
+                    {
+                        break;
+                    }
+
+                    altStart = cursor + 1;
+                    cursor++;
+                    continue;
+                }
+
+                char op = program[cursor];
+                if (op == GlobOpCodes.AltStart)
+                {
+                    cursor += program[cursor + 2];
+                }
+                else if (op is GlobOpCodes.Literal or GlobOpCodes.Class or GlobOpCodes.NegClass)
+                {
+                    cursor += 2 + program[cursor + 1];
+                }
+                else if (op == GlobOpCodes.GlobStar)
+                {
+                    cursor += 2;
+                }
+                else
+                {
+                    cursor++;
+                }
+            }
+
+            sliceStartInProgram = chosenSliceStart;
+            return commonSuffix;
         }
 
         /// <summary>
@@ -1835,7 +2091,7 @@ public sealed partial class GlobSpecification
         ///     (<c>[:</c>) and colon-bracket (<c>:]</c>) delimiters.&quot; The standard
         ///     character class names are <c>alpha</c>, <c>upper</c>, <c>lower</c>,
         ///     <c>digit</c>, <c>xdigit</c>, <c>alnum</c>, <c>space</c>, <c>blank</c>,
-        ///     <c>print</c>, <c>punct</c>, <c>graph</c>, and <c>cntrl</c> &#8212; expanded
+        ///     <c>print</c>, <c>punct</c>, <c>graph</c>, and <c>cntrl</c> - expanded
         ///     inline to their ASCII range equivalent by
         ///     <see cref="AppendPosixNamedClass"/>.<br/>
         ///   - <c>[[=c=]]</c>: equivalence class. &quot;An equivalence class expression

--- a/touki/Touki/Io/Globbing/GlobSpecification.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.cs
@@ -145,7 +145,7 @@ public sealed partial class GlobSpecification : DisposableBase
     ///   <see cref="StringSegment"/>), this property slices that string rather
     ///   than allocating. Dialect-specific normalization that the factory may
     ///   apply (separator coalescing, gitignore marker stripping, etc.) does
-    ///   <em>not</em> flow back into this property &#8211; it always reflects
+    ///   <em>not</em> flow back into this property - it always reflects
     ///   the user-supplied input.
     ///  </para>
     /// </remarks>

--- a/touki/Touki/Io/Globbing/MultiSuffixGlobStrategy.cs
+++ b/touki/Touki/Io/Globbing/MultiSuffixGlobStrategy.cs
@@ -31,7 +31,7 @@ namespace Touki.Io.Globbing;
 ///   win on net481, closing the gap with the <c>MatchSet</c> baseline
 ///   on the canonical <c>**/&#x40;(*.cs|*.md|...)</c> shape. If you
 ///   change the strategy's selection criteria, verify the benchmark
-///   on net481 first &#8212; modern .NET RyuJIT will tolerate
+///   on net481 first - modern .NET RyuJIT will tolerate
 ///   regressions the framework JIT cannot.
 ///  </para>
 /// </remarks>

--- a/touki/Touki/Io/Globbing/NeverMatchGlobStrategy.cs
+++ b/touki/Touki/Io/Globbing/NeverMatchGlobStrategy.cs
@@ -6,7 +6,7 @@ namespace Touki.Io.Globbing;
 
 /// <summary>
 ///  Matcher that returns <see langword="false"/> for every input. Used when a dialect
-///  considers the source pattern invalid in a non-throwing way — e.g., MSBuild's
+///  considers the source pattern invalid in a non-throwing way - e.g., MSBuild's
 ///  <c>MSBuildGlob.Parse</c> accepts patterns containing three or more consecutive
 ///  <c>*</c> characters but returns a glob that never matches anything.
 /// </summary>

--- a/touki/Touki/Io/OrderedMatchSet.cs
+++ b/touki/Touki/Io/OrderedMatchSet.cs
@@ -138,7 +138,7 @@ public sealed class OrderedMatchSet : DisposableBase, IEnumerationMatcher
         // (the matcher's Negated flag flips the result), so this layer can only
         // detect exclude-side claims. A later DirectoryOnly include (`!bin/`)
         // therefore cannot rescue a previously-excluded subtree at this layer
-        // &mdash; consistent with the strict-gitignore intent.
+        // - consistent with the strict-gitignore intent.
         bool excluded = false;
         for (int i = 0; i < _rules.Count; i++)
         {

--- a/touki/Touki/Io/Providers/MacClipboardProvider.cs
+++ b/touki/Touki/Io/Providers/MacClipboardProvider.cs
@@ -55,7 +55,7 @@ internal sealed unsafe partial class MacClipboardProvider : IClipboardProvider
     // NSPasteboardTypeString = @"public.utf8-plain-text" since OS X 10.6.
     private const string PasteboardTypeString = "public.utf8-plain-text";
 
-    // Lazily-resolved class and selector handles. Resolution is idempotent — the
+    // Lazily-resolved class and selector handles. Resolution is idempotent - the
     // Objective-C runtime returns the same pointer for repeated lookups. AppKit
     // must be loaded first (see <see cref="s_appKitHandle"/>) for NSPasteboard
     // to be registered; the field initializer order matters.
@@ -205,7 +205,7 @@ internal sealed unsafe partial class MacClipboardProvider : IClipboardProvider
                 return false;
             }
 
-            // [pasteboard clearContents] — ignore the returned NSInteger changeCount.
+            // [pasteboard clearContents] - ignore the returned NSInteger changeCount.
             objc_msgSend_void(pasteboard, s_selClearContents);
 
             // BOOL ok = [pasteboard setString:value forType:type]


### PR DESCRIPTION
Three bundled cleanups plus one perf optimization.

## Typography sweep

Replace em-dashes (`—`, `&mdash;`, `&#8212;`) and en-dashes (`–`, `&ndash;`, `&#8211;`) with plain ASCII `-` across 100+ files (docs, source comments, tests, perf, agent customization). Adds an `AGENTS.md` guideline preferring plain ASCII over typographic Unicode or HTML entities, and to avoid escaping defensively when raw characters wouldn't be parsed as markup.

## Test namespace alignment

Rename 28 test files so each test class lives in the **exact same namespace** as the production type under test - no `Tests` suffix on the namespace, no `Tests.` segment:

- `Touki.ValueTests` → `Touki`
- `System.Tests` → `System`
- `Touki.Tests.Text.Globbing` → `Touki.Io.Globbing`

Codifies the rule in `.github/instructions/tests.instructions.md`. Also clarifies the `[Theory]` vs `[Fact]` guidance (3+ distinct test cases, not parameters per case).

## Extglob tail-anchor optimization

When an extglob program has a literal suffix common to every top-level positive alternative (`@(...)` / `+(...)` only), compute and use it as the tail anchor in `CompiledGlobStrategy.MatchCore`. Skip the trim (alternation may consume the trailing literal at match time), but keep the `EndsWith` short-circuit.

Adds `ExtGlobExcludeProbeTests` pinning `bin/**` / `@(bin|obj)/**` root-anchored behavior under `GlobDialect.MSBuild` with `GlobOptions.AllowExtGlob`. Adds extglob scenarios to `MsBuildEnumeratePerf2`.

Measured wins: net10 single-pattern extglob enumerate 56→48 ms (-16%), net481 73→65 ms.

## Validation

All 7263 net481 + 5918 net10 tests pass.