### PR TITLE
FileSystemGlobbing: port dotnet/runtime pattern tests; align dialect semantics

### DIFF
--- a/touki.perf/FileSystemGlobbingNormalizePerf.cs
+++ b/touki.perf/FileSystemGlobbingNormalizePerf.cs
@@ -1,0 +1,294 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.CompilerServices;
+using Touki.Text;
+
+namespace touki.perf;
+
+/// <summary>
+///  Compares two strategies for the FileSystemGlobbing compile-time normalization
+///  pass on <see cref="Touki.Io.Globbing.GlobSpecification"/>:
+/// </summary>
+/// <remarks>
+///  <para>
+///   <b>TwoPass</b> walks the source pattern once with an allocation-free scan to
+///   decide whether any rewrite would fire, then walks it again into a stack-seeded
+///   <see cref="ValueStringBuilder"/> only when a rewrite is needed. Patterns that
+///   need no rewrite (the common case in real codebases - <c>**/*.cs</c>,
+///   <c>src/**/*.cs</c>, etc.) pay zero allocations and zero string work.
+///  </para>
+///  <para>
+///   <b>SinglePass</b> always builds the normalized form into a stack-seeded
+///   <see cref="ValueStringBuilder"/>, then compares the buffer against the source
+///   and only materializes a <see cref="string"/> when they differ. Patterns that
+///   need no rewrite avoid the final allocation but still pay for the full build
+///   pass and the equality scan.
+///  </para>
+///  <para>
+///   The benchmark covers both shapes: realistic patterns that don't need any
+///   rewrite, and a couple that exercise every rule in the rewrite catalogue.
+///   Result counts and contents are validated against each other in
+///   <see cref="GlobalSetup"/>.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 5, launchCount: 1)]
+public class FileSystemGlobbingNormalizePerf
+{
+    private const char Separator = '/';
+
+    /// <summary>
+    ///  Pattern class under test:
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   - <see cref="PatternKind.NoChange"/>: realistic shapes that need no rewrite -
+    ///     the common case in real-world usage.<br/>
+    ///   - <see cref="PatternKind.LeadingDot"/>: <c>./**/hello.txt</c> - one segment
+    ///     dropped, no rewrite of internal segments.<br/>
+    ///   - <see cref="PatternKind.HeavyRewrite"/>:
+    ///     <c>././**/./**/*.*</c> - every rule fires (leading <c>./</c>, internal
+    ///     <c>/./</c>, adjacent <c>**/**/</c>, <c>*.*</c> segment).
+    ///  </para>
+    /// </remarks>
+    public enum PatternKind
+    {
+        NoChange,
+        LeadingDot,
+        HeavyRewrite,
+    }
+
+    [Params(PatternKind.NoChange, PatternKind.LeadingDot, PatternKind.HeavyRewrite)]
+    public PatternKind Kind { get; set; }
+
+    private string _pattern = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _pattern = Kind switch
+        {
+            PatternKind.NoChange => "src/**/*.cs",
+            PatternKind.LeadingDot => "./**/hello.txt",
+            PatternKind.HeavyRewrite => "././**/./**/*.*",
+            _ => throw new InvalidOperationException(),
+        };
+
+        // Sanity check: both strategies must agree on the rewritten output.
+        ReadOnlySpan<char> twoPass = _pattern.AsSpan();
+        NormalizeTwoPass(ref twoPass, Separator);
+
+        ReadOnlySpan<char> singlePass = _pattern.AsSpan();
+        NormalizeSinglePass(ref singlePass, Separator);
+
+        if (!twoPass.SequenceEqual(singlePass))
+        {
+            throw new InvalidOperationException(
+                $"Strategies disagree on '{_pattern}': two-pass='{twoPass.ToString()}', single-pass='{singlePass.ToString()}'.");
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public int TwoPass()
+    {
+        ReadOnlySpan<char> pattern = _pattern.AsSpan();
+        NormalizeTwoPass(ref pattern, Separator);
+        return pattern.Length;
+    }
+
+    [Benchmark]
+    public int SinglePass()
+    {
+        ReadOnlySpan<char> pattern = _pattern.AsSpan();
+        NormalizeSinglePass(ref pattern, Separator);
+        return pattern.Length;
+    }
+
+    // ---- Two-pass: detect, then rewrite only when needed ----
+
+    [SkipLocalsInit]
+    private static void NormalizeTwoPass(ref ReadOnlySpan<char> pattern, char separator)
+    {
+        if (!NeedsRewrite(pattern, separator))
+        {
+            return;
+        }
+
+        ValueStringBuilder builder = new(stackalloc char[256]);
+        BuildRewritten(pattern, separator, ref builder);
+        pattern = builder.ToStringAndDispose().AsSpan();
+    }
+
+    private static bool NeedsRewrite(ReadOnlySpan<char> pattern, char separator)
+    {
+        int n = pattern.Length;
+        if (n == 0)
+        {
+            return false;
+        }
+
+        if (pattern[0] == separator && (n == 1 || pattern[1] != separator))
+        {
+            return true;
+        }
+
+        if (n >= 2 && pattern[0] == '.' && pattern[1] == separator)
+        {
+            return true;
+        }
+
+        int segStart = 0;
+        int segIndex = 0;
+        bool prevWasDoubleStar = false;
+
+        for (int i = 0; i <= n; i++)
+        {
+            if (i < n && pattern[i] != separator)
+            {
+                continue;
+            }
+
+            ReadOnlySpan<char> seg = pattern[segStart..i];
+
+            if (seg.Length == 1 && seg[0] == '.')
+            {
+                return true;
+            }
+
+            if (seg.Length == 3 && seg[0] == '*' && seg[1] == '.' && seg[2] == '*')
+            {
+                return true;
+            }
+
+            bool isDoubleStar = seg.Length == 2 && seg[0] == '*' && seg[1] == '*';
+
+            if (isDoubleStar && prevWasDoubleStar)
+            {
+                return true;
+            }
+
+            if (isDoubleStar && i == n && segIndex > 0)
+            {
+                return true;
+            }
+
+            prevWasDoubleStar = isDoubleStar;
+            segIndex++;
+            segStart = i + 1;
+        }
+
+        return false;
+    }
+
+    // ---- Single-pass: always build, allocate only on difference ----
+
+    [SkipLocalsInit]
+    private static void NormalizeSinglePass(ref ReadOnlySpan<char> pattern, char separator)
+    {
+        if (pattern.IsEmpty)
+        {
+            return;
+        }
+
+        ValueStringBuilder builder = new(stackalloc char[256]);
+        BuildRewritten(pattern, separator, ref builder);
+
+        if (builder.AsSpan().SequenceEqual(pattern))
+        {
+            builder.Dispose();
+            return;
+        }
+
+        pattern = builder.ToStringAndDispose().AsSpan();
+    }
+
+    // ---- Shared rewrite body ----
+
+    private static void BuildRewritten(ReadOnlySpan<char> pattern, char separator, ref ValueStringBuilder builder)
+    {
+        int n = pattern.Length;
+        int i = 0;
+
+        while (i < n)
+        {
+            if (i + 1 < n && pattern[i] == '.' && pattern[i + 1] == separator)
+            {
+                i += 2;
+                continue;
+            }
+
+            if (pattern[i] == separator && (i + 1 >= n || pattern[i + 1] != separator))
+            {
+                i++;
+                continue;
+            }
+
+            break;
+        }
+
+        bool firstEmitted = true;
+        bool prevWasDoubleStar = false;
+        int segStart = i;
+
+        while (true)
+        {
+            while (i < n && pattern[i] != separator)
+            {
+                i++;
+            }
+
+            ReadOnlySpan<char> seg = pattern[segStart..i];
+            bool atEnd = i == n;
+
+            bool dropSeg = seg.Length == 1 && seg[0] == '.';
+
+            if (!dropSeg)
+            {
+                if (seg.Length == 3 && seg[0] == '*' && seg[1] == '.' && seg[2] == '*')
+                {
+                    seg = "*".AsSpan();
+                }
+
+                bool isDoubleStar = seg.Length == 2 && seg[0] == '*' && seg[1] == '*';
+
+                if (isDoubleStar && prevWasDoubleStar)
+                {
+                    // Drop adjacent "**" segment.
+                }
+                else
+                {
+                    if (!firstEmitted)
+                    {
+                        builder.Append(separator);
+                    }
+
+                    builder.Append(seg);
+                    firstEmitted = false;
+                    prevWasDoubleStar = isDoubleStar;
+                }
+            }
+
+            if (atEnd)
+            {
+                break;
+            }
+
+            i++;
+            segStart = i;
+        }
+
+        if (builder.Length > 3
+            && builder[builder.Length - 1] == '*'
+            && builder[builder.Length - 2] == '*'
+            && builder[builder.Length - 3] == separator)
+        {
+            builder.Length -= 2;
+            builder.Append('*');
+            builder.Append(separator);
+            builder.Append('*');
+            builder.Append('*');
+        }
+    }
+}

--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.FileSystemGlobbing.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.FileSystemGlobbing.cs
@@ -39,10 +39,10 @@ public partial class GlobSpecificationTests
         // FileSystemGlobbing has no escape character. At compile time the factory
         // normalizes cross-separator characters to the matcher's separator (mirroring
         // MSBuildSpecification.Normalize) so the runtime matcher never has to
-        // translate. Pattern `\foo` therefore matches input `/foo` (and not the literal
-        // backslash form).
+        // translate. Pattern `\foo` is therefore equivalent to `/foo`, which is
+        // anchored to the implicit root and matches the relative file name `foo`.
         GlobSpecification matcher = GlobSpecification.Compile("\\foo", GlobDialect.FileSystemGlobbing);
-        matcher.IsMatch("/foo").Should().BeTrue();
+        matcher.IsMatch("foo").Should().BeTrue();
         matcher.IsMatch("\\foo").Should().BeFalse();
     }
 

--- a/touki.tests/Touki/Io/Globbing/PortedTests.FileSystemGlobbing.cs
+++ b/touki.tests/Touki/Io/Globbing/PortedTests.FileSystemGlobbing.cs
@@ -1,0 +1,208 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+/// <summary>
+///  Pattern-level scenarios ported from the upstream
+///  <c>Microsoft.Extensions.FileSystemGlobbing</c> test suite.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Source: <see href="https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/PatternMatchingTests.cs"><c>dotnet/runtime/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/PatternMatchingTests.cs</c></see>,
+///   licensed under the MIT license to the .NET Foundation.
+///  </para>
+///  <para>
+///   Upstream tests exercise the full include/exclude/sub-directory enumerator
+///   (<c>Matcher.AddInclude / AddExclude / Execute</c>). These rows are
+///   distilled to pattern-level matches against <see cref="GlobSpecification.IsMatch"/>
+///   on <see cref="GlobDialect.FileSystemGlobbing"/>. Scenarios that depend on
+///   include/exclude composition, sub-directory traversal state, or stem
+///   extraction are excluded - those belong with the enumerator-level tests
+///   for <see cref="GlobEnumerator"/>.
+///  </para>
+/// </remarks>
+public class PortedTests_FileSystemGlobbing
+{
+    // From PatternMatchingTests.PatternMatchingWorks.
+    [Theory]
+    [InlineData("*.txt", "alpha.txt", true)]
+    [InlineData("*.txt", "beta.txt", true)]
+    [InlineData("*.txt", "gamma.dat", false)]
+    [InlineData("alpha.*", "alpha.txt", true)]
+    [InlineData("alpha.*", "beta.txt", false)]
+    [InlineData("*.*", "alpha.txt", true)]
+    [InlineData("*.*", "gamma.dat", true)]
+    [InlineData("*", "alpha.txt", true)]
+    [InlineData("*", "gamma.dat", true)]
+    [InlineData("*et*", "alpha.txt", false)]
+    [InlineData("*et*", "beta.txt", true)]
+    [InlineData("*et*", "gamma.dat", false)]
+    [InlineData("b*et*t", "alpha.txt", false)]
+    [InlineData("b*et*t", "beta.txt", true)]
+    [InlineData("b*et*x", "beta.txt", false)]
+    public void IsMatch_PatternMatchingWorks(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.PatternBeginAndEndCantOverlap. Confirms that the prefix
+    // and suffix portions of a `*`-bracketed pattern cannot share characters in the input.
+    [Theory]
+    [InlineData("1234*5678", "12345678", true)]
+    [InlineData("12345*5678", "12345678", false)]
+    [InlineData("12*3456*78", "12345678", true)]
+    [InlineData("12*23*", "12345678", false)]
+    [InlineData("*67*78", "12345678", false)]
+    [InlineData("*45*56", "12345678", false)]
+    public void IsMatch_PatternBeginAndEndCantOverlap(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.PatternMatchingWorksInFolders. Files under test:
+    // alpha/hello.txt, beta/hello.txt, gamma/hello.txt.
+    [Theory]
+    [InlineData("*mm*/*", "gamma/hello.txt", true)]
+    [InlineData("*mm*/*", "alpha/hello.txt", false)]
+    [InlineData("*mm*/*", "beta/hello.txt", false)]
+    [InlineData("/*mm*/*", "gamma/hello.txt", true)]
+    [InlineData("/*mm*/*", "alpha/hello.txt", false)]
+    [InlineData("*alpha*/*", "alpha/hello.txt", true)]
+    [InlineData("*alpha*/*", "beta/hello.txt", false)]
+    [InlineData("/*alpha*/*", "alpha/hello.txt", true)]
+    [InlineData("*/*", "alpha/hello.txt", true)]
+    [InlineData("*/*", "beta/hello.txt", true)]
+    [InlineData("*/*", "gamma/hello.txt", true)]
+    [InlineData("/*/*", "alpha/hello.txt", true)]
+    [InlineData("/*/*", "beta/hello.txt", true)]
+    [InlineData("*.*/*", "alpha/hello.txt", true)]
+    [InlineData("*.*/*", "beta/hello.txt", true)]
+    [InlineData("/*.*/*", "gamma/hello.txt", true)]
+    public void IsMatch_PatternMatchingWorksInFolders(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.PatternMatchingCurrent. Patterns with leading `./` or
+    // embedded `/./` should be equivalent to the same pattern with the dot-segments
+    // removed. Files: alpha/hello.txt, beta/hello.txt, gamma/hello.txt.
+    [Theory]
+    [InlineData("./alpha/hello.txt", "alpha/hello.txt", true)]
+    [InlineData("./alpha/hello.txt", "beta/hello.txt", false)]
+    [InlineData("./**/hello.txt", "alpha/hello.txt", true)]
+    [InlineData("./**/hello.txt", "gamma/hello.txt", true)]
+    [InlineData("././**/hello.txt", "alpha/hello.txt", true)]
+    [InlineData("././**/./hello.txt", "alpha/hello.txt", true)]
+    [InlineData("././**/./**/hello.txt", "alpha/hello.txt", true)]
+    [InlineData("./*mm*/hello.txt", "gamma/hello.txt", true)]
+    [InlineData("./*mm*/hello.txt", "alpha/hello.txt", false)]
+    [InlineData("./*mm*/*", "gamma/hello.txt", true)]
+    [InlineData("./*mm*/*", "beta/hello.txt", false)]
+    public void IsMatch_PatternMatchingCurrent(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.StarDotStarIsSameAsStar. Pattern `*.*` matches every
+    // file regardless of whether it actually contains a dot.
+    [Theory]
+    [InlineData("*.*", "alpha.txt", true)]
+    [InlineData("*.*", "alpha.", true)]
+    [InlineData("*.*", ".txt", true)]
+    [InlineData("*.*", ".", true)]
+    [InlineData("*.*", "alpha", true)]
+    [InlineData("*.*", "txt", true)]
+    public void IsMatch_StarDotStarMatchesEverything(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.IncompletePatternsDoNotInclude. `*/*.txt` requires a
+    // directory component; bare `x.txt` does not match.
+    [Theory]
+    [InlineData("*/*.txt", "one/x.txt", true)]
+    [InlineData("*/*.txt", "two/x.txt", true)]
+    [InlineData("*/*.txt", "x.txt", false)]
+    public void IsMatch_IncompletePatternsRequireSegments(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.TrailingRecursiveWildcardMatchesAllFiles.
+    [Theory]
+    [InlineData("one/**", "one/x.txt", true)]
+    [InlineData("one/**", "two/x.txt", false)]
+    [InlineData("one/**", "one/x/y.txt", true)]
+    public void IsMatch_TrailingRecursiveWildcardMatchesAllFiles(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.LeadingRecursiveWildcardMatchesAllLeadingPaths.
+    [Theory]
+    [InlineData("**/*.cs", "one/x.cs", true)]
+    [InlineData("**/*.cs", "two/x.cs", true)]
+    [InlineData("**/*.cs", "one/two/x.cs", true)]
+    [InlineData("**/*.cs", "x.cs", true)]
+    [InlineData("**/*.cs", "one/x.txt", false)]
+    [InlineData("**/*.cs", "x.txt", false)]
+    public void IsMatch_LeadingRecursiveWildcardMatchesAllLeadingPaths(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.InnerRecursiveWildcardMuseStartWithAndEndWith [sic].
+    [Theory]
+    [InlineData("one/**/*.cs", "one/x.cs", true)]
+    [InlineData("one/**/*.cs", "two/x.cs", false)]
+    [InlineData("one/**/*.cs", "one/two/x.cs", true)]
+    [InlineData("one/**/*.cs", "x.cs", false)]
+    [InlineData("one/**/*.cs", "one/x.txt", false)]
+    public void IsMatch_InnerRecursiveWildcardMustStartAndEnd(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.RecursiveWildcardSurroundingContainsWith [sic].
+    [Theory]
+    [InlineData("**/x/**", "x/1", true)]
+    [InlineData("**/x/**", "1/x/2", true)]
+    [InlineData("**/x/**", "1/x", false)]
+    [InlineData("**/x/**", "x", false)]
+    [InlineData("**/x/**", "1", false)]
+    [InlineData("**/x/**", "1/2", false)]
+    public void IsMatch_RecursiveWildcardSurrounding(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.SequentialFoldersMayBeRequired. Long pattern with
+    // multiple globstars and required literal segments.
+    [Theory]
+    [InlineData("a/b/**/1/2/**/2/3/**", "1/2/2/3/x", false)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "1/2/3/y", false)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "a/1/2/4/2/3/b", false)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "a/2/3/1/2/b", false)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "a/b/1/2/2/3/x", true)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "a/b/1/2/3/y", false)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "a/b/a/1/2/4/2/3/b", true)]
+    [InlineData("a/b/**/1/2/**/2/3/**", "a/b/a/2/3/1/2/b", false)]
+    public void IsMatch_SequentialFoldersMayBeRequired(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.RecursiveAloneIncludesEverything.
+    [Theory]
+    [InlineData("**", "1/2/2/3/x", true)]
+    [InlineData("**", "1/2/3/y", true)]
+    [InlineData("**", "x", true)]
+    public void IsMatch_RecursiveAloneIncludesEverything(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+
+    // From PatternMatchingTests.LeadingDotDotCanComeThroughPattern. The `..` segment
+    // is treated as a literal path component at the matcher level (the enumerator is
+    // what resolves it against the current sub-directory).
+    [Theory]
+    [InlineData("../2/*.cs", "../2/x.cs", true)]
+    [InlineData("../2/*.cs", "../2/x.txt", false)]
+    [InlineData("../2/**/*.cs", "../2/x.cs", true)]
+    [InlineData("../2/**/*.cs", "../2/3/x.cs", true)]
+    [InlineData("../2/**/*.cs", "../2/3/4/z.cs", true)]
+    [InlineData("../2/**/*.cs", "../2/3/x.txt", false)]
+    public void IsMatch_LeadingDotDotCanComeThroughPattern(string pattern, string input, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.FileSystemGlobbing)
+            .IsMatch(input).Should().Be(expected);
+}

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -149,6 +149,20 @@ public sealed partial class GlobSpecification
                 (negated, rootAnchored, directoryOnly) = StripGitignoreMarkers(ref pattern);
             }
 
+            if (dialect == GlobDialect.FileSystemGlobbing && resolvedSeparator != '\0')
+            {
+                // FSG-specific compile-time rewrites that mirror Matcher's own behavior
+                // captured by the upstream PatternMatchingTests in dotnet/runtime:
+                //
+                //  - Leading "/" anchors to the implicit root and is stripped.
+                //  - Leading "./" and embedded "/./" dot-segments are normalized away.
+                //  - A segment that is exactly "*.*" is equivalent to "*" (StarDotStarIsSameAsStar).
+                //  - Trailing "/**" requires at least one path component beyond the prior
+                //    literal; rewrite to "/*/**" so the engine enforces the same rule
+                //    without a new opcode flag.
+                Normalization.FileSystemGlobbing(ref pattern, resolvedSeparator);
+            }
+
             // Dialect-specific normalization of runs of `*` and runs of `/`. The rules
             // captured by the per-dialect oracle tests are:
             //

--- a/touki/Touki/Io/Globbing/GlobSpecification.Normalization.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Normalization.cs
@@ -1,0 +1,216 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+public sealed partial class GlobSpecification
+{
+    /// <summary>
+    ///  Compile-time pattern normalization helpers shared by
+    ///  <see cref="Factory"/>. Each helper takes a <see cref="ReadOnlySpan{T}"/>
+    ///  reference and rewrites it only when the dialect's rule set actually
+    ///  requires a change; the no-op path is allocation-free.
+    /// </summary>
+    private static class Normalization
+    {
+        /// <summary>
+        ///  Applies the FileSystemGlobbing-specific compile-time rewrites that
+        ///  <c>Microsoft.Extensions.FileSystemGlobbing.Matcher</c> applies
+        ///  internally. See the factory call site for the catalogue of rules.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Two-pass design: a single forward scan via
+        ///   <see cref="NeedsFileSystemGlobbing"/> decides whether any rewrite
+        ///   would fire. When none does, <paramref name="pattern"/> is returned
+        ///   untouched and no string is allocated. When a rewrite is needed
+        ///   the helper walks the pattern once into a
+        ///   <see cref="ValueStringBuilder"/> seeded on the stack and produces
+        ///   exactly one string via <see cref="ValueStringBuilder.ToStringAndDispose"/>.
+        ///   Verified via
+        ///   <c>touki.perf/FileSystemGlobbingNormalizePerf.cs</c> to outperform
+        ///   a single-pass build-then-compare on the common case (real-world
+        ///   patterns rarely need any rewrite), especially on net481 RyuJIT
+        ///   where the build pass costs over 50 ns even without an allocation.
+        ///  </para>
+        /// </remarks>
+        [SkipLocalsInit]
+        public static void FileSystemGlobbing(ref ReadOnlySpan<char> pattern, char separator)
+        {
+            if (!NeedsFileSystemGlobbing(pattern, separator))
+            {
+                return;
+            }
+
+            ValueStringBuilder builder = new(stackalloc char[256]);
+
+            int n = pattern.Length;
+            int i = 0;
+
+            // Strip leading "./" segments and any single leading separator
+            // ("//"+ is left for Factory.TryNormalizeRuns to turn into "/*/").
+            while (i < n)
+            {
+                if (i + 1 < n && pattern[i] == '.' && pattern[i + 1] == separator)
+                {
+                    i += 2;
+                    continue;
+                }
+
+                if (pattern[i] == separator && (i + 1 >= n || pattern[i + 1] != separator))
+                {
+                    i++;
+                    continue;
+                }
+
+                break;
+            }
+
+            // Walk remaining segments. Empty segments (from internal "//") are
+            // preserved verbatim so Factory.TryNormalizeRuns can still see them.
+            bool firstEmitted = true;
+            bool prevWasDoubleStar = false;
+            int segStart = i;
+
+            while (true)
+            {
+                while (i < n && pattern[i] != separator)
+                {
+                    i++;
+                }
+
+                ReadOnlySpan<char> seg = pattern[segStart..i];
+                bool atEnd = i == n;
+
+                // Drop "." segments (collapses "/./" and trailing "/.").
+                bool dropSeg = seg.Length == 1 && seg[0] == '.';
+
+                if (!dropSeg)
+                {
+                    // Replace "*.*" segment with "*".
+                    if (seg.Length == 3 && seg[0] == '*' && seg[1] == '.' && seg[2] == '*')
+                    {
+                        seg = "*".AsSpan();
+                    }
+
+                    bool isDoubleStar = seg.Length == 2 && seg[0] == '*' && seg[1] == '*';
+
+                    if (isDoubleStar && prevWasDoubleStar)
+                    {
+                        // Collapse adjacent "**" segments.
+                    }
+                    else
+                    {
+                        if (!firstEmitted)
+                        {
+                            builder.Append(separator);
+                        }
+
+                        builder.Append(seg);
+                        firstEmitted = false;
+                        prevWasDoubleStar = isDoubleStar;
+                    }
+                }
+
+                if (atEnd)
+                {
+                    break;
+                }
+
+                i++;
+                segStart = i;
+            }
+
+            // Trailing "/**" requires at least one path component beyond the prior
+            // literal. Rewrite "X/**" -> "X/*/**" so the leading "/*" forces the
+            // required segment while the trailing "/**" continues to allow zero or
+            // more deeper segments. Bare "**" (length 2, no leading segment) is left
+            // alone - it means "everything", including the implicit root.
+            if (builder.Length > 3
+                && builder[^1] == '*'
+                && builder[^2] == '*'
+                && builder[^3] == separator)
+            {
+                builder.Length -= 2;
+                builder.Append('*');
+                builder.Append(separator);
+                builder.Append("**");
+            }
+
+            pattern = builder.ToStringAndDispose().AsSpan();
+        }
+
+        /// <summary>
+        ///  Allocation-free detection scan. Returns <see langword="true"/> when
+        ///  <see cref="FileSystemGlobbing"/> would change <paramref name="pattern"/>,
+        ///  otherwise <see langword="false"/>. Mirrors the rule set in the
+        ///  rewrite body so the two stay in sync.
+        /// </summary>
+        private static bool NeedsFileSystemGlobbing(ReadOnlySpan<char> pattern, char separator)
+        {
+            int n = pattern.Length;
+            if (n == 0)
+            {
+                return false;
+            }
+
+            // Single leading separator (the "//"+ case is left for Factory.TryNormalizeRuns).
+            if (pattern[0] == separator && (n == 1 || pattern[1] != separator))
+            {
+                return true;
+            }
+
+            // Leading "./" segment.
+            if (n >= 2 && pattern[0] == '.' && pattern[1] == separator)
+            {
+                return true;
+            }
+
+            int segStart = 0;
+            int segIndex = 0;
+            bool prevWasDoubleStar = false;
+
+            for (int i = 0; i <= n; i++)
+            {
+                if (i < n && pattern[i] != separator)
+                {
+                    continue;
+                }
+
+                ReadOnlySpan<char> seg = pattern[segStart..i];
+
+                // "." segment: came from "/./" or trailing "/.".
+                if (seg.Length == 1 && seg[0] == '.')
+                {
+                    return true;
+                }
+
+                // "*.*" segment -> "*".
+                if (seg.Length == 3 && seg[0] == '*' && seg[1] == '.' && seg[2] == '*')
+                {
+                    return true;
+                }
+
+                bool isDoubleStar = seg.Length == 2 && seg[0] == '*' && seg[1] == '*';
+
+                if (isDoubleStar && prevWasDoubleStar)
+                {
+                    return true;
+                }
+
+                // Trailing "**" segment with at least one preceding non-empty segment.
+                if (isDoubleStar && i == n && segIndex > 0)
+                {
+                    return true;
+                }
+
+                prevWasDoubleStar = isDoubleStar;
+                segIndex++;
+                segStart = i + 1;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Ports pattern-level scenarios from dotnet/runtime's `Microsoft.Extensions.FileSystemGlobbing` [`PatternMatchingTests`](https://github.com/dotnet/runtime/blob/main/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/PatternMatchingTests.cs) (75 rows across 12 theories) into a new `PortedTests.FileSystemGlobbing.cs` test class, attributed to the upstream source.

## Semantic alignment

Five divergences from upstream `Matcher` surfaced. All fixed by adding a FileSystemGlobbing-specific compile-time normalization pass in a new `GlobSpecification.Normalization` partial:

- Leading `/` anchors to the implicit root and is stripped.
- Leading `./` and embedded `/./` dot-segments are normalized away.
- Trailing `/.` collapses to `/`.
- Segment `*.*` is equivalent to `*` (the `StarDotStarIsSameAsStar` upstream rule).
- Trailing `/**` requires at least one path component beyond the prior literal; rewrite `X/**` → `X/*/**` so the existing engine enforces the rule without a new opcode flag.
- Adjacent `**/**` runs collapse to a single `**`.

## Allocation-free fast path

The normalization is two-pass and allocation-free on the common case (patterns that need no rewrite — `**/*.cs`, `src/**/*.cs`, etc.):

- `NeedsFileSystemGlobbing` does a single forward scan.
- Only when a rewrite would fire does the helper walk the pattern into a stack-seeded `ValueStringBuilder` and emit exactly one string via `ToStringAndDispose`.

Verified via new [`touki.perf/FileSystemGlobbingNormalizePerf.cs`](touki.perf/FileSystemGlobbingNormalizePerf.cs):

| Runtime | Case | TwoPass | SinglePass | Ratio |
|---|---|---|---|---|
| net10.0 | `NoChange` (`src/**/*.cs`) | 9.84 ns / 0 B | 13.43 ns / 0 B | **1.37× faster** |
| net481 | `NoChange` | 26.13 ns / 0 B | 80.35 ns / 0 B | **3.08× faster** |
| both | heavy-rewrite cases | — | — | tie within noise |

## Other changes

- Updates `Compile_FileSystemGlobbing_BackslashNormalizedToSeparator` to reflect the new strip-leading-separator behavior (prior test expected `\foo` to match literal `/foo`; upstream `Matcher` matches relative `foo`).

## Validation

All 7357 net481 + 6012 net10 tests pass.