### PR TITLE
Factory: thread StringSegment through compile-time pattern surface

### DIFF
--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.Git.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.Git.cs
@@ -105,4 +105,26 @@ public partial class GlobSpecificationTests
         matcher.IsMatch("Foo.cs").Should().BeFalse();
         matcher.IsMatch("!Foo.cs").Should().BeTrue();
     }
+
+    // Regression: StripGitignoreMarkers must not throw IndexOutOfRangeException
+    // for patterns that become empty between strips. Reported by Copilot review
+    // on PR #160. Each input below crashed before the fix:
+    //   "!"   -> strip '!' -> empty, then pattern[0] == '/' threw.
+    //   "/"   -> strip '/' -> empty, then pattern[^1] == '/' threw.
+    //   "!/"  -> strip '!' -> "/", strip '/' -> empty, then pattern[^1] threw.
+    [Theory]
+    [InlineData("!", true, false, false)]
+    [InlineData("/", false, true, false)]
+    [InlineData("!/", true, true, false)]
+    public void Compile_Git_PathologicalShortPatterns_DoesNotThrow(
+        string pattern,
+        bool expectedNegated,
+        bool expectedRootAnchored,
+        bool expectedDirectoryOnly)
+    {
+        GlobSpecification matcher = GlobSpecification.Compile(pattern, GlobDialect.Git);
+        matcher.Negated.Should().Be(expectedNegated);
+        matcher.RootAnchored.Should().Be(expectedRootAnchored);
+        matcher.DirectoryOnly.Should().Be(expectedDirectoryOnly);
+    }
 }

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -577,6 +577,11 @@ public sealed partial class GlobSpecification
                 // Leading '!' negates the match; the '!' is stripped and the flag is reported
                 negated = true;
                 pattern = pattern[1..];
+
+                if (pattern.IsEmpty)
+                {
+                    return (negated, rootAnchored, directoryOnly);
+                }
             }
 
             if (pattern[0] == '/')
@@ -585,6 +590,11 @@ public sealed partial class GlobSpecification
                 // stripped but the pattern is no longer subject to the "match anywhere" rule.
                 rootAnchored = true;
                 pattern = pattern[1..];
+
+                if (pattern.IsEmpty)
+                {
+                    return (negated, rootAnchored, directoryOnly);
+                }
             }
 
             if (pattern[^1] == '/')

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -56,7 +56,7 @@ public sealed partial class GlobSpecification
 
         /// <summary>
         ///  Default upper bound (in characters) applied by the
-        ///  <see cref="TryCreate(ReadOnlySpan{char}, GlobDialect, GlobOptions, GlobPathSeparator, out GlobStrategy?, out GlobCompileError)"/>
+        ///  <see cref="TryCreate(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, out GlobStrategy?, out GlobCompileError)"/>
         ///  overload that omits an explicit <c>maxPatternLength</c>. Sized to comfortably
         ///  cover real-world path-matching patterns (Linux <c>PATH_MAX</c> is 4096, Windows
         ///  long-path is ~32K, and typical globs are well under 200 chars) while still
@@ -66,7 +66,7 @@ public sealed partial class GlobSpecification
         ///  <para>
         ///   Callers that need to compile patterns larger than this (e.g. machine-generated
         ///   exclusion lists) should call the
-        ///   <see cref="TryCreate(ReadOnlySpan{char}, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobStrategy?, out GlobCompileError)"/>
+        ///   <see cref="TryCreate(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobStrategy?, out GlobCompileError)"/>
         ///   overload directly with a larger limit, or pass <c>-1</c> to disable the check.
         ///  </para>
         /// </remarks>
@@ -79,7 +79,7 @@ public sealed partial class GlobSpecification
         ///  six-argument overload directly.
         /// </summary>
         public static bool TryCreate(
-            ReadOnlySpan<char> pattern,
+            StringSegment pattern,
             GlobDialect dialect,
             GlobOptions options,
             GlobPathSeparator separator,
@@ -93,7 +93,7 @@ public sealed partial class GlobSpecification
         ///  that limit are rejected with <see cref="GlobCompileErrorCode.PatternTooLarge"/>.
         /// </summary>
         public static bool TryCreate(
-            ReadOnlySpan<char> pattern,
+            StringSegment pattern,
             GlobDialect dialect,
             GlobOptions options,
             GlobPathSeparator separator,
@@ -129,12 +129,11 @@ public sealed partial class GlobSpecification
             if (resolvedSeparator != '\0' && escape == '\0')
             {
                 char altSeparator = resolvedSeparator == '/' ? '\\' : '/';
-                if (pattern.IndexOf(altSeparator) >= 0)
-                {
-                    // Compile is not a hot path; one string allocation here keeps every
-                    // subsequent runtime match-time translation away.
-                    pattern = pattern.ToString().Replace(altSeparator, resolvedSeparator).AsSpan();
-                }
+
+                // StringSegment.Replace returns `this` unchanged (zero alloc) when the
+                // character isn't present, so the common case where the caller already
+                // wrote portable separators pays only one IndexOf.
+                pattern = pattern.Replace(altSeparator, resolvedSeparator);
             }
 
             bool negated = false;
@@ -244,7 +243,7 @@ public sealed partial class GlobSpecification
                     if (!startsWithGlobStarToken)
                     {
                         // Compile-path string allocation; not on the match hot path.
-                        pattern = $"**{resolvedSeparator}{pattern}".AsSpan();
+                        pattern = $"**{resolvedSeparator}{pattern}";
                     }
                 }
             }
@@ -562,7 +561,7 @@ public sealed partial class GlobSpecification
         ///  Strips the gitignore-specific metadata markers from <paramref name="pattern"/>
         /// </summary>
         private static (bool Negated, bool RootAnchored, bool DirectoryOnly) StripGitignoreMarkers(
-            ref ReadOnlySpan<char> pattern)
+            ref StringSegment pattern)
         {
             bool negated = false;
             bool rootAnchored = false;
@@ -615,7 +614,7 @@ public sealed partial class GlobSpecification
         ///  </para>
         /// </remarks>
         private static bool TryNormalizeRuns(
-            ref ReadOnlySpan<char> pattern,
+            ref StringSegment pattern,
             GlobDialect dialect,
             char separator,
             out bool neverMatch,
@@ -810,7 +809,7 @@ public sealed partial class GlobSpecification
                 k++;
             }
 
-            pattern = builder.ToStringAndDispose().AsSpan();
+            pattern = builder.ToStringAndDispose();
             return true;
         }
 

--- a/touki/Touki/Io/Globbing/GlobSpecification.Normalization.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Normalization.cs
@@ -8,9 +8,11 @@ public sealed partial class GlobSpecification
 {
     /// <summary>
     ///  Compile-time pattern normalization helpers shared by
-    ///  <see cref="Factory"/>. Each helper takes a <see cref="ReadOnlySpan{T}"/>
+    ///  <see cref="Factory"/>. Each helper takes a <see cref="StringSegment"/>
     ///  reference and rewrites it only when the dialect's rule set actually
-    ///  requires a change; the no-op path is allocation-free.
+    ///  requires a change; the no-op path is allocation-free and the
+    ///  <see cref="StringSegment"/> still points into the caller's original
+    ///  source string.
     /// </summary>
     private static class Normalization
     {
@@ -36,29 +38,30 @@ public sealed partial class GlobSpecification
         ///  </para>
         /// </remarks>
         [SkipLocalsInit]
-        public static void FileSystemGlobbing(ref ReadOnlySpan<char> pattern, char separator)
+        public static void FileSystemGlobbing(ref StringSegment pattern, char separator)
         {
-            if (!NeedsFileSystemGlobbing(pattern, separator))
+            ReadOnlySpan<char> source = pattern.AsSpan();
+            if (!NeedsFileSystemGlobbing(source, separator))
             {
                 return;
             }
 
             ValueStringBuilder builder = new(stackalloc char[256]);
 
-            int n = pattern.Length;
+            int n = source.Length;
             int i = 0;
 
             // Strip leading "./" segments and any single leading separator
             // ("//"+ is left for Factory.TryNormalizeRuns to turn into "/*/").
             while (i < n)
             {
-                if (i + 1 < n && pattern[i] == '.' && pattern[i + 1] == separator)
+                if (i + 1 < n && source[i] == '.' && source[i + 1] == separator)
                 {
                     i += 2;
                     continue;
                 }
 
-                if (pattern[i] == separator && (i + 1 >= n || pattern[i + 1] != separator))
+                if (source[i] == separator && (i + 1 >= n || source[i + 1] != separator))
                 {
                     i++;
                     continue;
@@ -75,12 +78,12 @@ public sealed partial class GlobSpecification
 
             while (true)
             {
-                while (i < n && pattern[i] != separator)
+                while (i < n && source[i] != separator)
                 {
                     i++;
                 }
 
-                ReadOnlySpan<char> seg = pattern[segStart..i];
+                ReadOnlySpan<char> seg = source[segStart..i];
                 bool atEnd = i == n;
 
                 // Drop "." segments (collapses "/./" and trailing "/.").
@@ -138,7 +141,7 @@ public sealed partial class GlobSpecification
                 builder.Append("**");
             }
 
-            pattern = builder.ToStringAndDispose().AsSpan();
+            pattern = builder.ToStringAndDispose();
         }
 
         /// <summary>

--- a/touki/Touki/Io/Globbing/GlobSpecification.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.cs
@@ -127,7 +127,7 @@ public sealed partial class GlobSpecification : DisposableBase
             return false;
         }
 
-        if (!Factory.TryCreate(pattern.AsSpan(), dialect, options, separator, maxPatternLength, out GlobStrategy? strategy, out error))
+        if (!Factory.TryCreate(pattern, dialect, options, separator, maxPatternLength, out GlobStrategy? strategy, out error))
         {
             return false;
         }


### PR DESCRIPTION
`GlobSpecification.Compile` / `TryCompile` have always accepted `StringSegment`, but `Factory.TryCreate` re-wrapped to `ReadOnlySpan<char>` at the boundary and lost the ability to round-trip slices back into a `StringSegment` without re-allocating. Push `StringSegment` through the mutating helpers so we can keep the original backing string when no rewrite fires.

## Changes

- `Factory.TryCreate` overloads now take `StringSegment`.
- `StripGitignoreMarkers`, `Normalization.FileSystemGlobbing`, and `TryNormalizeRuns` take `ref StringSegment`. Their slicing uses `pattern[1..]`, `pattern[..^1]`, etc. (StringSegment supports the full Range surface, so these are zero-alloc.)
- Cross-separator translation now uses `StringSegment.Replace`, which returns `this` unchanged (zero alloc) when the character isn't present. Drops the redundant outer `IndexOf` guard.
- `ValueStringBuilder.ToStringAndDispose()` results assign straight into `StringSegment` via the implicit `string -> StringSegment` conversion.
- The Git `**/`-prepend keeps the interpolated form; it allocates one string anyway.
- `GlobSpecification.cs` drops the `.AsSpan()` at the Factory call.

Inner read-only helpers (`Scan`, `TryEncodeProgram`, `UnescapeToString`, `TryCreatePathUnawareSpecialized`, `TryCreateGlobStarFileNameStrategy`, etc.) keep `ReadOnlySpan<char>` and get the span via the implicit StringSegment-to-span conversion.

## Validation

All 7357 net481 + 6012 net10 tests pass.