### PR TITLE
Posix/PosixPath: port glibc fnmatch tests; fix [[:cntrl:]] and unterminated '['

### DIFF
--- a/touki.tests/Touki/Io/Globbing/ExtGlobScannerTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobScannerTests.cs
@@ -305,14 +305,17 @@ public class ExtGlobScannerTests
     }
 
     [Fact]
-    public void Compile_AllowExtGlobOn_UnterminatedClassInsideBody_ReportsUnterminatedClass()
+    public void Compile_AllowExtGlobOn_UnterminatedClassInsideBody_TreatedAsLiteral()
     {
-        Action act = () => GlobSpecification.Compile(
+        // Per fnmatch semantics: an unterminated '[' is treated as a literal
+        // character. The extglob body inherits the same behavior so the pattern
+        // compiles successfully and the '[bc' alternative becomes a literal run.
+        GlobSpecification matcher = GlobSpecification.Compile(
             "@(a|[bc)",
             GlobDialect.Bash,
             GlobOptions.AllowGlobStar | GlobOptions.AllowExtGlob);
 
-        act.Should().Throw<GlobFormatException>()
-            .Which.Error.Code.Should().Be(GlobCompileErrorCode.UnterminatedClass);
+        matcher.IsMatch("a").Should().BeTrue();
+        matcher.IsMatch("[bc").Should().BeTrue();
     }
 }

--- a/touki.tests/Touki/Io/Globbing/ExtGlobScannerTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobScannerTests.cs
@@ -13,11 +13,11 @@ namespace Touki.Io.Globbing;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   The interpreter does not yet recognize the new opcodes - that comes in
-///   step 3 of the F1.3 rollout. Until then runtime matching against an extglob
-///   pattern silently returns <see langword="false"/>, which the compile-shape
-///   tests in this file <i>don't</i> exercise (they inspect the emitted bytecode
-///   directly via <c>TestAccessor</c>).
+///   This file covers compile-shape behavior - emitted bytecode and error
+///   reporting - inspected directly via <c>TestAccessor</c>. Runtime
+///   match behavior for the same opcodes is covered by
+///   <c>ExtGlobPositiveMatchTests</c>, <c>ExtGlobNegationMatchTests</c>,
+///   <c>ExtGlobPathAwareMatchTests</c>, and <c>ExtGlobOracleTests.Bash</c>.
 ///  </para>
 /// </remarks>
 public class ExtGlobScannerTests

--- a/touki.tests/Touki/Io/Globbing/GlobAdditionalCoverageTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobAdditionalCoverageTests.cs
@@ -214,10 +214,12 @@ public class GlobAdditionalCoverageTests
     [Fact]
     public void TryCompile_InvalidPattern_ReportsError()
     {
-        // Unterminated class produces a compile error; the TryCompile entry point
-        // exposes the error path that the throwing Compile wraps.
+        // Dangling escape produces a compile error; the TryCompile entry point
+        // exposes the error path that the throwing Compile wraps. (An unterminated
+        // '[' is no longer an error - fnmatch semantics treat it as a literal
+        // character; see PortedTests.Posix.cs.)
         bool ok = GlobSpecification.TryCompile(
-            "[abc",
+            "abc\\",
             GlobDialect.Posix,
             GlobOptions.None,
             out GlobSpecification? matcher,
@@ -226,7 +228,7 @@ public class GlobAdditionalCoverageTests
         ok.Should().BeFalse();
         matcher.Should().BeNull();
         error.IsError.Should().BeTrue();
-        error.Code.Should().Be(GlobCompileErrorCode.UnterminatedClass);
+        error.Code.Should().Be(GlobCompileErrorCode.DanglingEscape);
         error.Position.Should().BeGreaterThanOrEqualTo(0);
         error.Message.Should().NotBeNullOrEmpty();
     }
@@ -252,7 +254,7 @@ public class GlobAdditionalCoverageTests
     [Fact]
     public void Compile_InvalidPattern_Throws()
     {
-        Action act = () => GlobSpecification.Compile("[abc", GlobDialect.Posix);
+        Action act = () => GlobSpecification.Compile("abc\\", GlobDialect.Posix);
         act.Should().Throw<GlobFormatException>();
     }
 }

--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
@@ -154,11 +154,14 @@ public partial class GlobSpecificationTests
     }
 
     [Fact]
-    public void Compile_UnterminatedClass_Throws()
+    public void Compile_UnterminatedClass_TreatedAsLiteral()
     {
-        Action act = () => GlobSpecification.Compile("[abc", GlobDialect.Posix);
-        act.Should().Throw<GlobFormatException>()
-            .Which.Error.Code.Should().Be(GlobCompileErrorCode.UnterminatedClass);
+        // Per fnmatch / glibc semantics: an unterminated '[' is treated as a
+        // literal character rather than rejected. See PortedTests.Posix.cs for
+        // the row that pinned this down (B.6 031: "/[", "\\/[", 0).
+        GlobSpecification matcher = GlobSpecification.Compile("[abc", GlobDialect.Posix);
+        matcher.IsMatch("[abc").Should().BeTrue();
+        matcher.IsMatch("abc").Should().BeFalse();
     }
 
     [Fact]

--- a/touki.tests/Touki/Io/Globbing/PortedTests.Posix.cs
+++ b/touki.tests/Touki/Io/Globbing/PortedTests.Posix.cs
@@ -1,0 +1,308 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+/// <summary>
+///  Pattern-level scenarios ported from the GNU C Library
+///  <c>tst-fnmatch.input</c> corpus.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Source:
+///   <see href="https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=posix/tst-fnmatch.input"><c>glibc/posix/tst-fnmatch.input</c></see>
+///   (also mirrored at
+///   <see href="https://github.com/bminor/glibc/blob/master/posix/tst-fnmatch.input">bminor/glibc</see>).
+///   Licensed under LGPL-2.1+; rows are paraphrased into <c>InlineData</c>
+///   form rather than copied verbatim, but the test intent and inputs are
+///   the upstream corpus's. The corpus itself is derived from the
+///   IEEE 1003.2-1992 POSIX test material.
+///  </para>
+///  <para>
+///   Flag mapping between <c>tst-fnmatch.input</c> and touki:
+///   <list type="bullet">
+///    <item><description>
+///     No flag and <c>NOESCAPE</c> rows -&gt; <see cref="GlobDialect.Posix"/>.
+///     Because <c>fnmatch</c> without <c>FNM_PERIOD</c> matches a leading
+///     <c>.</c>, those rows pass <see cref="GlobOptions.MatchLeadingDot"/>;
+///     touki's <see cref="GlobDialect.Posix"/> defaults to "leading dot must
+///     be literal" (FNM_PERIOD on).
+///    </description></item>
+///    <item><description>
+///     <c>PATHNAME</c> rows -&gt; <see cref="GlobDialect.PosixPath"/>.
+///    </description></item>
+///    <item><description>
+///     <c>PERIOD</c> rows -&gt; the dialect's default (no extra option).
+///    </description></item>
+///    <item><description>
+///     <c>NOESCAPE</c> rows -&gt; <see cref="GlobOptions.NoEscape"/>.
+///    </description></item>
+///   </list>
+///  </para>
+///  <para>
+///   Per-character <c>[[:alnum:]]</c> enumeration rows in the upstream
+///   corpus (~100 rows asserting one character class member at a time) are
+///   condensed here to a representative subset; the full ASCII enumeration
+///   is covered indirectly by the
+///   <see href="https://github.com/JeremyKuhne/touki/blob/main/touki.tests/Touki/Io/Globbing/FnmatchInterop.cs"><c>FnmatchInterop</c></see>
+///   live oracle which runs on Linux/macOS.
+///  </para>
+///  <para>
+///   Equivalence classes <c>[[=a=]]</c> and collating elements
+///   <c>[[.a.]]</c> rows are omitted: touki's POSIX-bracket implementation
+///   treats their contents as literal runs (see
+///   <c>GlobSpecification.Factory.TryEmitClass</c>), which is a documented
+///   divergence from glibc that would produce many off-by-one failures with
+///   no useful signal.
+///  </para>
+/// </remarks>
+public class PortedTests_Posix
+{
+    // B.6 004 / 005: literals (smoke test that the basic literal pass works).
+    [Theory]
+    [InlineData("!#%+,-./01234567889", "!#%+,-./01234567889", true)]
+    [InlineData("PQRSTUVWXYZ]abcdefg", "PQRSTUVWXYZ]abcdefg", true)]
+    [InlineData("^_{}~", "^_{}~", true)]
+    [InlineData("\"$&'()", "\\\"\\$\\&\\'\\(\\)", true)]
+    [InlineData("*?[\\`|", "\\*\\?\\[\\\\\\`\\|", true)]
+    [InlineData("<>", "\\<\\>", true)]
+    public void IsMatch_Posix_LiteralsAndEscapes(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 006 / 007: '?' wildcard with and without path-aware semantics.
+    [Theory]
+    [InlineData("?*[", "[?*[][?*[][?*[]", true)]
+    [InlineData("a/b", "?/b", true)]
+    [InlineData("a/b", "a?b", true)]
+    [InlineData("a/b", "a/?", true)]
+    [InlineData("aa/b", "?/b", false)]
+    [InlineData("aa/b", "a?b", false)]
+    [InlineData("a/bb", "a/?", false)]
+    public void IsMatch_Posix_QuestionWildcard(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 009 / 010 / 011: bracket classes.
+    [Theory]
+    [InlineData("abc", "[abc]", false)]
+    [InlineData("x", "[abc]", false)]
+    [InlineData("a", "[abc]", true)]
+    [InlineData("[", "[[abc]", true)]
+    [InlineData("a", "[][abc]", true)]
+    [InlineData("xyz", "[!abc]", false)]
+    [InlineData("x", "[!abc]", true)]
+    [InlineData("a", "[!abc]", false)]
+    [InlineData("]", "[][abc]", true)]
+    [InlineData("abc]", "[][abc]", false)]
+    [InlineData("]", "[!]]", false)]
+    [InlineData("]", "[!a]", true)]
+    [InlineData("]]", "[!a]]", true)]
+    public void IsMatch_Posix_BracketClasses(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 017: POSIX named classes. The full per-character enumeration in the
+    // upstream corpus is condensed to one or two rows per class plus the
+    // negation and embedded-in-class shapes.
+    [Theory]
+    [InlineData("a", "[[:alnum:]]", true)]
+    [InlineData("9", "[[:alnum:]]", true)]
+    [InlineData("-", "[[:alnum:]]", false)]
+    [InlineData("a", "[![:alnum:]]", false)]
+    [InlineData("-", "[![:alnum:]]", true)]
+    [InlineData("-", "[[:alnum:]-]", true)]
+    [InlineData("aa", "[[:alnum:]]a", true)]
+    [InlineData("a]a", "[[:alnum:]]a", false)]
+    [InlineData("\t", "[[:cntrl:]]", true)]
+    [InlineData("t", "[[:cntrl:]]", false)]
+    [InlineData("t", "[[:lower:]]", true)]
+    [InlineData("T", "[[:lower:]]", false)]
+    [InlineData("\t", "[[:space:]]", true)]
+    [InlineData("t", "[[:space:]]", false)]
+    [InlineData("t", "[[:alpha:]]", true)]
+    [InlineData("\t", "[[:alpha:]]", false)]
+    [InlineData("0", "[[:digit:]]", true)]
+    [InlineData("t", "[[:digit:]]", false)]
+    [InlineData("t", "[[:print:]]", true)]
+    [InlineData("\t", "[[:print:]]", false)]
+    [InlineData("T", "[[:upper:]]", true)]
+    [InlineData("t", "[[:upper:]]", false)]
+    [InlineData("\t", "[[:blank:]]", true)]
+    [InlineData("t", "[[:blank:]]", false)]
+    [InlineData("t", "[[:graph:]]", true)]
+    [InlineData("\t", "[[:graph:]]", false)]
+    [InlineData(".", "[[:punct:]]", true)]
+    [InlineData("t", "[[:punct:]]", false)]
+    [InlineData("0", "[[:xdigit:]]", true)]
+    [InlineData("a", "[[:xdigit:]]", true)]
+    [InlineData("A", "[[:xdigit:]]", true)]
+    [InlineData("t", "[[:xdigit:]]", false)]
+    public void IsMatch_Posix_NamedClasses(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 018 / 019 / 020 / 021: ranges.
+    [Theory]
+    [InlineData("a", "[a-c]", true)]
+    [InlineData("b", "[a-c]", true)]
+    [InlineData("c", "[a-c]", true)]
+    [InlineData("d", "[a-c]", false)]
+    [InlineData("B", "[a-c]", false)]
+    [InlineData("", "[a-c]", false)]
+    [InlineData("as", "[a-ca-z]", false)]
+    [InlineData("a", "[c-a]", false)]            // inverted range matches nothing
+    [InlineData("c", "[c-a]", false)]
+    [InlineData("a", "[a-c0-9]", true)]
+    [InlineData("d", "[a-c0-9]", false)]
+    [InlineData("-", "[-a]", true)]
+    [InlineData("a", "[-b]", false)]
+    [InlineData("-", "[!-a]", false)]
+    [InlineData("a", "[!-b]", true)]
+    public void IsMatch_Posix_Ranges(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 024 / 025 / 026 / 027: wildcards over multi-segment inputs.
+    [Theory]
+    [InlineData("", "*", true)]
+    [InlineData("asd/sdf", "*", true)]
+    [InlineData("as", "[a-c][a-z]", true)]
+    [InlineData("as", "??", true)]
+    [InlineData("asd/sdf", "as*df", true)]
+    [InlineData("asd/sdf", "as*", true)]
+    [InlineData("asd/sdf", "*df", true)]
+    [InlineData("asd/sdf", "as*dg", false)]
+    [InlineData("asdf", "as*df", true)]
+    [InlineData("asdf", "as*df?", false)]
+    [InlineData("asdf", "as*??", true)]
+    [InlineData("asdf", "a*???", true)]
+    [InlineData("asdf", "*????", true)]
+    [InlineData("asdf", "????*", true)]
+    [InlineData("asdf", "??*?", true)]
+    [InlineData("/", "/", true)]
+    [InlineData("/", "/*", true)]
+    [InlineData("/", "*/", true)]
+    [InlineData("/", "/?", false)]
+    [InlineData("/", "?/", false)]
+    [InlineData("/", "?", true)]
+    [InlineData(".", "?", true)]
+    [InlineData("/.", "??", true)]
+    [InlineData("/", "[!a-c]", true)]
+    [InlineData(".", "[!a-c]", true)]
+    public void IsMatch_Posix_StarWildcard(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 029 / 030: PATHNAME (PosixPath dialect).
+    [Theory]
+    [InlineData("/", "/", true)]
+    [InlineData("//", "//", true)]
+    [InlineData("/.a", "/*", true)]
+    [InlineData("/.a", "/?a", true)]
+    [InlineData("/.a", "/[!a-z]a", true)]
+    [InlineData("/.a/.b", "/*/?b", true)]
+    [InlineData("/", "?", false)]
+    [InlineData("/", "*", false)]
+    [InlineData("a/b", "a?b", false)]
+    [InlineData("/.a/.b", "/*b", false)]
+    public void IsMatch_PosixPath_PathnameSemantics(string input, string pattern, bool expected) =>
+        PosixPath(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 031: escape handling at the matcher (no NOESCAPE).
+    [Theory]
+    [InlineData("/$", "\\/\\$", true)]
+    [InlineData("/[", "\\/\\[", true)]
+    [InlineData("/[", "\\/[", true)]
+    [InlineData("/[]", "\\/\\[]", true)]
+    public void IsMatch_Posix_BackslashEscape(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // B.6 032: NOESCAPE flag (backslash becomes literal).
+    [Theory]
+    [InlineData("/$", "\\/\\$", false)]
+    [InlineData("/\\$", "\\/\\$", false)]
+    [InlineData("\\/\\$", "\\/\\$", true)]
+    public void IsMatch_Posix_NoEscape(string input, string pattern, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.Posix, GlobOptions.NoEscape)
+            .IsMatch(input).Should().Be(expected);
+
+    // B.6 033 / 034: PERIOD flag. Upstream PERIOD means the leading '.' must be
+    // matched by a literal '.'; that is touki's default for `Posix`, so these rows
+    // compile without `GlobOptions.MatchLeadingDot`.
+    [Theory]
+    [InlineData(".asd", ".*", true)]
+    [InlineData(".asd", "*", false)]
+    [InlineData(".asd", "?asd", false)]
+    [InlineData(".asd", "[!a-z]*", false)]
+    public void IsMatch_Posix_LeadingDot_Restricted(string input, string pattern, bool expected) =>
+        GlobSpecification.Compile(pattern, GlobDialect.Posix).IsMatch(input).Should().Be(expected);
+
+    // B.6 035 / 036: PATHNAME|PERIOD combined. Both flags are upstream-set;
+    // PosixPath supplies the path-aware semantics and the default of leading-dot
+    // restricted matches the PERIOD flag.
+    //
+    // Rows where the leading dot appears AFTER a separator (e.g. "/." or
+    // "/.b." after another segment) require per-segment FNM_PERIOD enforcement:
+    // the rule must fire at the start of every path segment, not only at
+    // input[0]. Touki's current implementation only consults input[0]; the
+    // per-segment work is tracked in docs/globbing-feature-plan.md
+    // (F2.1 "Known follow-up - per-segment leading-dot") and folded into the
+    // F2.2 globstar follow-up. Affected rows are marked with Assert.Skip so the
+    // suite stays green; remove the skip when the per-segment behavior lands.
+    [Theory]
+    [InlineData("/.", "/.", true, false)]
+    [InlineData("/.a./.b.", "/.*/.*", true, false)]
+    [InlineData("/.a./.b.", "/.??/.??", true, false)]
+    [InlineData("/.", "*", false, false)]
+    [InlineData("/.", "/*", false, true)]                  // per-segment dot rule
+    [InlineData("/.", "/?", false, true)]                  // per-segment dot rule
+    [InlineData("/.", "/[!a-z]", false, true)]             // per-segment dot rule
+    [InlineData("/a./.b.", "/*/*", false, true)]           // per-segment dot rule
+    [InlineData("/a./.b.", "/??/???", false, true)]        // per-segment dot rule
+    public void IsMatch_PosixPath_PathnameAndPeriod(
+        string input,
+        string pattern,
+        bool expected,
+        bool requiresPerSegmentDotRule)
+    {
+        if (requiresPerSegmentDotRule)
+        {
+            Assert.Skip(
+                "Per-segment FNM_PERIOD enforcement (leading '.' restricted at every path segment, not only input[0]) is deferred; see docs/globbing-feature-plan.md F2.1 'Known follow-up - per-segment leading-dot'.");
+        }
+
+        GlobSpecification.Compile(pattern, GlobDialect.PosixPath).IsMatch(input).Should().Be(expected);
+    }
+
+    // Home-grown rows from the upstream corpus.
+    [Theory]
+    [InlineData("foobar", "foo*[abc]z", false)]
+    [InlineData("foobaz", "foo*[abc][xyz]", true)]
+    [InlineData("foobaz", "foo?*[abc][xyz]", true)]
+    [InlineData("foobaz", "foo?*[abc][x/yz]", true)]
+    [InlineData("az", "[a-]z", true)]
+    [InlineData("bz", "[ab-]z", true)]
+    [InlineData("cz", "[ab-]z", false)]
+    [InlineData("-z", "[ab-]z", true)]
+    [InlineData("az", "[-a]z", true)]
+    [InlineData("bz", "[-ab]z", true)]
+    [InlineData("cz", "[-ab]z", false)]
+    [InlineData("-z", "[-ab]z", true)]
+    public void IsMatch_Posix_HomeGrown(string input, string pattern, bool expected) =>
+        Posix(pattern).IsMatch(input).Should().Be(expected);
+
+    // PATHNAME home-grown rows.
+    [Theory]
+    [InlineData("foobaz", "foo?*[abc]/[xyz]", false)]
+    [InlineData("a", "a/", false)]
+    [InlineData("a/", "a", false)]
+    [InlineData("//a", "/a", false)]
+    [InlineData("/a", "//a", false)]
+    public void IsMatch_PosixPath_HomeGrown(string input, string pattern, bool expected) =>
+        PosixPath(pattern).IsMatch(input).Should().Be(expected);
+
+    // Helpers: compile with the standard option set for each port row class.
+    // Posix without PERIOD flag in the upstream corpus means leading '.' is
+    // matched; touki opts in via MatchLeadingDot.
+    private static GlobSpecification Posix(string pattern) =>
+        GlobSpecification.Compile(pattern, GlobDialect.Posix, GlobOptions.MatchLeadingDot);
+
+    private static GlobSpecification PosixPath(string pattern) =>
+        GlobSpecification.Compile(pattern, GlobDialect.PosixPath, GlobOptions.MatchLeadingDot);
+}

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -1376,7 +1376,7 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[')
+                if (allowClasses && current == '[' && HasClassClose(pattern, i))
                 {
                     shape.HasClasses = true;
                     if (!SkipClass(pattern, ref i, out error))
@@ -1507,7 +1507,7 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[')
+                if (allowClasses && current == '[' && HasClassClose(pattern, i))
                 {
                     if (!SkipClass(pattern, ref i, out error))
                     {
@@ -1539,6 +1539,56 @@ public sealed partial class GlobSpecification
                 GlobCompileErrorCode.UnterminatedExtGlob,
                 position: kindIndex,
                 message: "Extended-glob construct is not terminated.");
+            return false;
+        }
+
+        /// <summary>
+        ///  Returns <see langword="true"/> when <paramref name="pattern"/> contains a
+        ///  closing <c>]</c> for the <c>[</c> at <paramref name="openIndex"/>, honoring
+        ///  POSIX bracket-expression sub-forms (<c>[:class:]</c>, <c>[=equiv=]</c>,
+        ///  <c>[.collate.]</c>) so their inner <c>]</c> is not mistaken for the outer
+        ///  close. Used as a pre-check by <see cref="Scan"/> and the encoder loops so
+        ///  an unterminated <c>[</c> can fall through to literal handling rather than
+        ///  failing the compile - <c>fnmatch</c> and friends treat the trailing <c>[</c>
+        ///  as a literal character in that case.
+        /// </summary>
+        private static bool HasClassClose(ReadOnlySpan<char> pattern, int openIndex)
+        {
+            int i = openIndex + 1;
+
+            if (i < pattern.Length && (pattern[i] == '!' || pattern[i] == '^'))
+            {
+                i++;
+            }
+
+            bool firstChar = true;
+            while (i < pattern.Length)
+            {
+                char current = pattern[i];
+                if (current == ']' && !firstChar)
+                {
+                    return true;
+                }
+
+                if (current == '[' && i + 1 < pattern.Length)
+                {
+                    char marker = pattern[i + 1];
+                    if (marker is ':' or '=' or '.')
+                    {
+                        int close = FindPosixBracketClose(pattern, i + 2, marker);
+                        if (close > 0)
+                        {
+                            i = close + 2;
+                            firstChar = false;
+                            continue;
+                        }
+                    }
+                }
+
+                firstChar = false;
+                i++;
+            }
+
             return false;
         }
 
@@ -1683,7 +1733,7 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[')
+                if (allowClasses && current == '[' && HasClassClose(pattern, i))
                 {
                     int classStart = i;
                     if (!TryEmitClass(pattern, ref i, ref builder))
@@ -1855,7 +1905,7 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[')
+                if (allowClasses && current == '[' && HasClassClose(pattern, i))
                 {
                     int classStart = i;
                     if (!TryEmitClass(pattern, ref i, ref builder))
@@ -2038,7 +2088,8 @@ public sealed partial class GlobSpecification
             while (i < pattern.Length)
             {
                 char current = pattern[i];
-                if (current == '*' || current == '?' || (allowClasses && current == '['))
+                if (current == '*' || current == '?'
+                    || (allowClasses && current == '[' && HasClassClose(pattern, i)))
                 {
                     break;
                 }
@@ -2350,9 +2401,9 @@ public sealed partial class GlobSpecification
 
             if (name.SequenceEqual("cntrl".AsSpan()))
             {
-                // 0x00-0x1F and 0x7F.
+                // 0x00-0x1F and 0x7F. Body is 4 chars: '\0', '-', '\u001F', '\u007F'.
                 builder.Append("\0-\u001F\u007F");
-                return 5;
+                return 4;
             }
 
             if (name.SequenceEqual("print".AsSpan()))

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -1376,14 +1376,16 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[' && HasClassClose(pattern, i))
+                if (allowClasses && current == '[')
                 {
-                    shape.HasClasses = true;
-                    if (!SkipClass(pattern, ref i, out error))
+                    if (SkipClass(pattern, ref i))
                     {
-                        return false;
+                        shape.HasClasses = true;
                     }
 
+                    // SkipClass leaves `i` at the closing ']' on success or at the
+                    // opening '[' on no-close; the outer for-loop's i++ moves past
+                    // the right character in both cases.
                     continue;
                 }
 
@@ -1507,13 +1509,16 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[' && HasClassClose(pattern, i))
+                if (allowClasses && current == '[')
                 {
-                    if (!SkipClass(pattern, ref i, out error))
+                    if (SkipClass(pattern, ref i))
                     {
-                        return false;
+                        continue;
                     }
 
+                    // Unterminated '[' inside extglob body: treat as literal,
+                    // advance past it, and continue parsing the body.
+                    i++;
                     continue;
                 }
 
@@ -1543,87 +1548,47 @@ public sealed partial class GlobSpecification
         }
 
         /// <summary>
-        ///  Returns <see langword="true"/> when <paramref name="pattern"/> contains a
-        ///  closing <c>]</c> for the <c>[</c> at <paramref name="openIndex"/>, honoring
-        ///  POSIX bracket-expression sub-forms (<c>[:class:]</c>, <c>[=equiv=]</c>,
-        ///  <c>[.collate.]</c>) so their inner <c>]</c> is not mistaken for the outer
-        ///  close. Used as a pre-check by <see cref="Scan"/> and the encoder loops so
-        ///  an unterminated <c>[</c> can fall through to literal handling rather than
-        ///  failing the compile - <c>fnmatch</c> and friends treat the trailing <c>[</c>
-        ///  as a literal character in that case.
+        ///  Tries to advance <paramref name="i"/> past a bracket-class starting at
+        ///  the <c>[</c> at <paramref name="i"/>. POSIX <c>fnmatch</c> semantics
+        ///  treat an unterminated <c>[</c> as a literal character; on no-close the
+        ///  helper resets <paramref name="i"/> to the opening <c>[</c> and returns
+        ///  <see langword="false"/> so the caller's outer loop bumps past the
+        ///  literal <c>[</c> on the next iteration. On success <paramref name="i"/>
+        ///  is positioned at the closing <c>]</c>. Single forward walk - no
+        ///  thrown-away pre-scan.
         /// </summary>
-        private static bool HasClassClose(ReadOnlySpan<char> pattern, int openIndex)
+        private static bool SkipClass(ReadOnlySpan<char> pattern, ref int i)
         {
-            int i = openIndex + 1;
+            int openIndex = i;
+            int j = i + 1;
 
-            if (i < pattern.Length && (pattern[i] == '!' || pattern[i] == '^'))
+            if (j < pattern.Length && (pattern[j] == '!' || pattern[j] == '^'))
             {
-                i++;
-            }
-
-            bool firstChar = true;
-            while (i < pattern.Length)
-            {
-                char current = pattern[i];
-                if (current == ']' && !firstChar)
-                {
-                    return true;
-                }
-
-                if (current == '[' && i + 1 < pattern.Length)
-                {
-                    char marker = pattern[i + 1];
-                    if (marker is ':' or '=' or '.')
-                    {
-                        int close = FindPosixBracketClose(pattern, i + 2, marker);
-                        if (close > 0)
-                        {
-                            i = close + 2;
-                            firstChar = false;
-                            continue;
-                        }
-                    }
-                }
-
-                firstChar = false;
-                i++;
-            }
-
-            return false;
-        }
-
-        private static bool SkipClass(ReadOnlySpan<char> pattern, ref int i, out GlobCompileError error)
-        {
-            error = default;
-            int start = i;
-            i++;
-
-            if (i < pattern.Length && (pattern[i] == '!' || pattern[i] == '^'))
-            {
-                i++;
+                j++;
             }
 
             // A leading ']' is a literal member of the class.
             bool firstChar = true;
-            while (i < pattern.Length)
+            while (j < pattern.Length)
             {
-                char current = pattern[i];
+                char current = pattern[j];
                 if (current == ']' && !firstChar)
                 {
+                    i = j;
                     return true;
                 }
 
                 // Skip POSIX bracket-expression sub-forms ([:class:], [=equiv=], [.collate.])
                 // so the inner ']' that terminates them isn't mistaken for the outer class close.
-                if (current == '[' && i + 1 < pattern.Length)
+                if (current == '[' && j + 1 < pattern.Length)
                 {
-                    char marker = pattern[i + 1];
+                    char marker = pattern[j + 1];
                     if (marker is ':' or '=' or '.')
                     {
-                        int close = FindPosixBracketClose(pattern, i + 2, marker);
+                        int close = FindPosixBracketClose(pattern, j + 2, marker);
                         if (close > 0)
                         {
-                            i = close + 2;
+                            j = close + 2;
                             firstChar = false;
                             continue;
                         }
@@ -1631,13 +1596,12 @@ public sealed partial class GlobSpecification
                 }
 
                 firstChar = false;
-                i++;
+                j++;
             }
 
-            error = new GlobCompileError(
-                GlobCompileErrorCode.UnterminatedClass,
-                position: start,
-                message: "Character class '[' is not terminated.");
+            // No close: treat '[' as a literal. Reset to openIndex so the for-loop's
+            // i++ moves past the '['.
+            i = openIndex;
             return false;
         }
 
@@ -1733,15 +1697,26 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[' && HasClassClose(pattern, i))
+                if (allowClasses && current == '[')
                 {
                     int classStart = i;
-                    if (!TryEmitClass(pattern, ref i, ref builder))
+                    ClassEmitResult classResult = TryEmitClass(pattern, ref i, ref builder);
+                    if (classResult == ClassEmitResult.Emitted)
+                    {
+                        lastLiteral = LiteralCursor.None;
+                        continue;
+                    }
+
+                    if (classResult == ClassEmitResult.Overflow)
                     {
                         overflowPosition = classStart;
                         break;
                     }
-                    lastLiteral = LiteralCursor.None;
+
+                    // ClassEmitResult.NotClass: TryEmitClass rewound the builder and
+                    // reset i to the '['. Emit a literal '[' and advance.
+                    EmitSingleCharLiteral(ref builder, '[', out lastLiteral);
+                    i++;
                     continue;
                 }
 
@@ -1905,16 +1880,27 @@ public sealed partial class GlobSpecification
                     continue;
                 }
 
-                if (allowClasses && current == '[' && HasClassClose(pattern, i))
+                if (allowClasses && current == '[')
                 {
                     int classStart = i;
-                    if (!TryEmitClass(pattern, ref i, ref builder))
+                    ClassEmitResult classResult = TryEmitClass(pattern, ref i, ref builder);
+                    if (classResult == ClassEmitResult.Emitted)
+                    {
+                        lastLiteral = LiteralCursor.None;
+                        continue;
+                    }
+
+                    if (classResult == ClassEmitResult.Overflow)
                     {
                         overflowPosition = classStart;
                         return false;
                     }
 
-                    lastLiteral = LiteralCursor.None;
+                    // ClassEmitResult.NotClass: emit '[' as a literal of length 1
+                    // and let the surrounding loop pick up what follows. The body's
+                    // '|' / ')' termination still applies on the next iteration.
+                    EmitSingleCharLiteral(ref builder, '[', out lastLiteral);
+                    i++;
                     continue;
                 }
 
@@ -2060,6 +2046,26 @@ public sealed partial class GlobSpecification
         }
 
         /// <summary>
+        ///  Emits a single-character <see cref="GlobOpCodes.Literal"/> opcode for
+        ///  <paramref name="ch"/>. Used by the unterminated-<c>[</c> rewind path
+        ///  to encode the bracket as a literal character; a consecutive run of
+        ///  literals after this point will produce a second Literal opcode rather
+        ///  than coalesce, which is acceptable given how rarely real patterns
+        ///  contain an unterminated <c>[</c>.
+        /// </summary>
+        private static void EmitSingleCharLiteral(
+            ref ValueStringBuilder builder,
+            char ch,
+            out LiteralCursor lastLiteral)
+        {
+            int start = builder.Length;
+            builder.Append(GlobOpCodes.Literal);
+            builder.Append((char)1);
+            builder.Append(ch);
+            lastLiteral = new LiteralCursor { Start = start, Length = 1 };
+        }
+
+        /// <summary>
         ///  Emits a <see cref="GlobOpCodes.Literal"/> opcode for the run of non-metacharacters
         ///  starting at <paramref name="i"/>. Honors <paramref name="escape"/> by consuming
         ///  the escape character and emitting only the escaped character. Reports the start
@@ -2089,7 +2095,7 @@ public sealed partial class GlobSpecification
             {
                 char current = pattern[i];
                 if (current == '*' || current == '?'
-                    || (allowClasses && current == '[' && HasClassClose(pattern, i)))
+                    || (allowClasses && current == '['))
                 {
                     break;
                 }
@@ -2142,6 +2148,18 @@ public sealed partial class GlobSpecification
         }
 
         /// <summary>
+        ///  Outcome of <see cref="TryEmitClass"/>: a real bracket-class was emitted,
+        ///  the <c>[</c> was unterminated and should be treated as a literal, or the
+        ///  class body exceeded <see cref="MaxOpcodeBodyLength"/>.
+        /// </summary>
+        private enum ClassEmitResult
+        {
+            Emitted,
+            NotClass,
+            Overflow,
+        }
+
+        /// <summary>
         ///  Emits a <see cref="GlobOpCodes.Class"/> / <see cref="GlobOpCodes.NegClass"/>
         ///  opcode for a bracket expression starting at <paramref name="i"/>. Recognizes
         ///  the bracket-expression sub-forms defined by
@@ -2149,6 +2167,13 @@ public sealed partial class GlobSpecification
         ///   IEEE Std 1003.1-2024 &#167;9.3.5 (RE Bracket Expression)</see>.
         /// </summary>
         /// <remarks>
+        ///  <para>
+        ///   Single forward walk: the encoder appends the class header speculatively
+        ///   and the body chars as it scans. If no closing <c>]</c> is found, the
+        ///   builder is rewound to the pre-call length and <paramref name="i"/> is
+        ///   reset to the opening <c>[</c>; the caller emits the <c>[</c> as a
+        ///   literal and continues. No throw-away pre-scan.
+        ///  </para>
         ///  <para>
         ///   Grammar (quoting the POSIX standard):
         ///  </para>
@@ -2190,9 +2215,12 @@ public sealed partial class GlobSpecification
         ///   <c>[:NAME:]</c> POSIX form recognized here.
         ///  </para>
         /// </remarks>
-        private static bool TryEmitClass(ReadOnlySpan<char> pattern, ref int i, ref ValueStringBuilder builder)
+        private static ClassEmitResult TryEmitClass(ReadOnlySpan<char> pattern, ref int i, ref ValueStringBuilder builder)
         {
             Debug.Assert(pattern[i] == '[');
+
+            int openIndex = i;
+            int headerIndex = builder.Length;
 
             // Walk a sliding slice of pattern instead of indexing through it. The body loop
             // re-slices on every step; on exit we recover the new caller-visible index from
@@ -2206,18 +2234,19 @@ public sealed partial class GlobSpecification
                 remaining = remaining[1..];
             }
 
-            int headerIndex = builder.Length;
             builder.Append(negated ? GlobOpCodes.NegClass : GlobOpCodes.Class);
             builder.Append('\0'); // length placeholder
 
             int bodyLength = 0;
             bool firstChar = true;
+            bool closed = false;
             while (!remaining.IsEmpty)
             {
                 char current = remaining[0];
                 if (current == ']' && !firstChar)
                 {
                     remaining = remaining[1..];
+                    closed = true;
                     break;
                 }
 
@@ -2238,14 +2267,22 @@ public sealed partial class GlobSpecification
                 firstChar = false;
             }
 
+            if (!closed)
+            {
+                // Unterminated '[': rewind builder, reset i, signal not-a-class.
+                builder.Length = headerIndex;
+                i = openIndex;
+                return ClassEmitResult.NotClass;
+            }
+
             i = pattern.Length - remaining.Length;
             if (bodyLength > MaxOpcodeBodyLength)
             {
-                return false;
+                return ClassEmitResult.Overflow;
             }
 
             builder[headerIndex + 1] = (char)bodyLength;
-            return true;
+            return ClassEmitResult.Emitted;
 
             // Recognizes a POSIX bracket-expression sub-form at the start of `remaining`.
             // On success advances `remaining` past the consumed run, appends its expansion


### PR DESCRIPTION
Ports pattern-level scenarios from the GNU C Library `tst-fnmatch.input` corpus (~145 rows across 11 theories) into a new `PortedTests.Posix.cs` test class, attributed to the upstream source. Two real touki bugs surfaced and were fixed along the way; a follow-up commit refactors the class-detection path to a single forward walk.

## Source

[`glibc/posix/tst-fnmatch.input`](https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=posix/tst-fnmatch.input) (also mirrored at [bminor/glibc](https://github.com/bminor/glibc/blob/master/posix/tst-fnmatch.input)). Derived from IEEE 1003.2-1992 POSIX test material; licensed under LGPL-2.1+. Rows are paraphrased into `[InlineData]` form.

Flag mapping:

| Upstream | Touki |
|---|---|
| No flag | `GlobDialect.Posix` + `GlobOptions.MatchLeadingDot` |
| `PATHNAME` | `GlobDialect.PosixPath` |
| `PERIOD` | dialect default (no extra option) |
| `NOESCAPE` | `GlobOptions.NoEscape` |

The full ASCII enumeration of `[[:alnum:]]` rows in the upstream corpus (~100 single-character class members) is condensed to a representative subset; the full enumeration is exercised indirectly by the existing `FnmatchInterop` live oracle on Linux/macOS.

Equivalence-class (`[[=a=]]`) and collating-element (`[[.a.]]`) rows are omitted: touki's POSIX-bracket implementation treats their contents as literal runs, which is a documented divergence from glibc; porting those rows would produce dozens of failures with no useful signal.

## Touki bug fixes (commit 1)

- **`[[:cntrl:]]` `ArgumentOutOfRangeException`.** `AppendPosixNamedClass` claimed a body length of 5 but appended only 4 characters (`"\0-\u001F\u007F"`). The bad length flowed into the encoded program header; the class-body walker then sliced past the body and threw on any pattern using `[[:cntrl:]]`. Returns 4 now.

- **Unterminated `[` was throwing `UnterminatedClass`.** POSIX `fnmatch` / glibc / shell glob all treat a trailing unterminated `[` as a literal character. Updated 3 existing tests that asserted the old throw behavior; switched the `GlobAdditionalCoverageTests.{Compile,TryCompile}_InvalidPattern_*` tests to dangling-escape patterns so the error path remains exercised.

Five ported rows are marked `Assert.Skip` with a documented reason — they require per-segment FNM_PERIOD enforcement (leading `.` restricted at every path segment, not only `input[0]`). Tracked in [docs/globbing-feature-plan.md](docs/globbing-feature-plan.md) F2.1.

## Class-detection refactor (commit 2)

Initial fix used a `HasClassClose` pre-check at every `[` site, which meant 2-3 forward walks per `[`. Refactored to single-walk speculative-then-rewind:

- `SkipClass`: on no-close, reset `i` to the opening `[` and return `false` (no error). The Scan for-loop's `i++` bumps past the literal `[` on the next iteration.
- `TryEmitClass`: returns `ClassEmitResult { Emitted, NotClass, Overflow }`. On `NotClass`, the builder is rewound to its pre-call length and `i` is reset to the `[`; the encoder loop emits a single-char Literal opcode and continues.
- `TryEmitLiteralRun`: breaks on `[` unconditionally when `allowClasses` (no inner scan).
- New `EmitSingleCharLiteral` helper for the rewind path.
- `HasClassClose` removed.

Per-`[` walks: was 2-3, now 1. Patterns with no `[` are unchanged. Patterns containing a literal `[` followed by literal chars produce one extra Literal-of-1 opcode (no coalescing across the rewind), accepted as a minor sub-optimal encoding for a rare edge case.

## Validation

All 7588 net481 + 6243 net10 tests pass (5 new documented skips, no regressions).