### PR TITLE
Git: port wildmatch tests; collapse adjacent globstars at emit time

### DIFF
--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationOpcodeCharCollisionTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationOpcodeCharCollisionTests.cs
@@ -1,0 +1,258 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+/// <summary>
+///  Regression tests pinning down the encoder's handling of literal
+///  characters that collide with the Unicode private-use noncharacter
+///  block (<c>U+FDD0..U+FDD8</c>) that <see cref="GlobOpCodes"/> reserves
+///  for opcodes. These chars are private-use noncharacters per the
+///  Unicode standard but are nonetheless valid in arbitrary
+///  <see cref="string"/> input, so the encoder and matcher must treat
+///  them as ordinary chars when they appear in a pattern literal or
+///  class body.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The original trigger was PR #164 review feedback: the
+///   <c>**/**</c>-collapse optimization had been peeking at the
+///   encoder's buffer tail for <see cref="GlobOpCodes.GlobStar"/>
+///   (<c>U+FDD5</c>), which a literal ending in that char could
+///   accidentally satisfy. The fix uses an explicit
+///   <c>LiteralCursor.GlobStar</c> sentinel instead. These tests
+///   enumerate every adjacent collision shape we can construct against
+///   the other opcode chars too, so any future optimization that
+///   re-introduces a buffer peek will trip one of them.
+///  </para>
+/// </remarks>
+public class GlobSpecificationOpcodeCharCollisionTests
+{
+    // GlobOpCodes from touki/Touki/Io/Globbing/GlobOpCodes.cs. Repeated
+    // here as locals so a hypothetical reassignment in production code
+    // breaks these tests instead of silently shifting the foot-gun.
+    private const char Any = '\uFDD0';
+    private const char AnyRun = '\uFDD1';
+    private const char Literal = '\uFDD2';
+    private const char Class = '\uFDD3';
+    private const char NegClass = '\uFDD4';
+    private const char GlobStar = '\uFDD5';
+    private const char AltStart = '\uFDD6';
+    private const char AltSep = '\uFDD7';
+    private const char AltEnd = '\uFDD8';
+
+    // (1) Reviewer's case: literal ending in GlobStar char, followed by '/**'.
+    [Fact]
+    public void Compile_LiteralEndsInGlobStar_FollowedByDoubleStar_EmitsGlobStar()
+    {
+        GlobSpecification matcher = PosixPath($"foo{GlobStar}/**/bar");
+        matcher.IsMatch($"foo{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch($"foo{GlobStar}/x/bar").Should().BeTrue();
+        matcher.IsMatch($"foo{GlobStar}/x/y/bar").Should().BeTrue();
+        matcher.IsMatch("foo/bar").Should().BeFalse();
+    }
+
+    // (2) Literal ending in every other opcode char, followed by '/**'.
+    // Defensive coverage in case a future optimization peeks for any of
+    // these.
+    [Theory]
+    [InlineData(Any)]
+    [InlineData(AnyRun)]
+    [InlineData(Literal)]
+    [InlineData(Class)]
+    [InlineData(NegClass)]
+    [InlineData(GlobStar)]
+    [InlineData(AltStart)]
+    [InlineData(AltSep)]
+    [InlineData(AltEnd)]
+    public void Compile_LiteralEndsInOpcodeChar_FollowedByDoubleStar_StillMatches(char opcodeChar)
+    {
+        GlobSpecification matcher = PosixPath($"foo{opcodeChar}/**/bar");
+        matcher.IsMatch($"foo{opcodeChar}/bar").Should().BeTrue();
+        matcher.IsMatch($"foo{opcodeChar}/x/bar").Should().BeTrue();
+    }
+
+    // (3) Pattern that is a bare literal opcode char (or a leading one
+    // followed by other literals) round-trips through the encoder.
+    [Theory]
+    [InlineData(Any)]
+    [InlineData(AnyRun)]
+    [InlineData(Literal)]
+    [InlineData(Class)]
+    [InlineData(NegClass)]
+    [InlineData(GlobStar)]
+    [InlineData(AltStart)]
+    [InlineData(AltSep)]
+    [InlineData(AltEnd)]
+    public void Compile_BareLiteralOpcodeChar_RoundTrips(char opcodeChar)
+    {
+        GlobSpecification matcher = Posix(opcodeChar.ToString());
+        matcher.IsMatch(opcodeChar.ToString()).Should().BeTrue();
+        matcher.IsMatch("x").Should().BeFalse();
+    }
+
+    // (4) Class body containing every opcode char.
+    [Theory]
+    [InlineData(Any)]
+    [InlineData(AnyRun)]
+    [InlineData(Literal)]
+    [InlineData(Class)]
+    [InlineData(NegClass)]
+    [InlineData(GlobStar)]
+    [InlineData(AltStart)]
+    [InlineData(AltSep)]
+    [InlineData(AltEnd)]
+    public void Compile_ClassWithOpcodeChar_MatchesAndExcludes(char opcodeChar)
+    {
+        GlobSpecification matcher = Posix($"[a{opcodeChar}b]");
+        matcher.IsMatch(opcodeChar.ToString()).Should().BeTrue();
+        matcher.IsMatch("a").Should().BeTrue();
+        matcher.IsMatch("b").Should().BeTrue();
+        matcher.IsMatch("c").Should().BeFalse();
+    }
+
+    // (5) Negated class with opcode char.
+    [Theory]
+    [InlineData(GlobStar)]
+    [InlineData(AltStart)]
+    [InlineData(Literal)]
+    public void Compile_NegatedClassWithOpcodeChar_ExcludesIt(char opcodeChar)
+    {
+        GlobSpecification matcher = Posix($"[!{opcodeChar}]");
+        matcher.IsMatch(opcodeChar.ToString()).Should().BeFalse();
+        matcher.IsMatch("a").Should().BeTrue();
+        matcher.IsMatch("z").Should().BeTrue();
+    }
+
+    // (6) Class whose body ends in GlobStar, followed by '/**'. Mirrors
+    // the reviewer's case but for the Class opcode (whose body tail is
+    // the position a buffer-peek collapse would see).
+    [Fact]
+    public void Compile_ClassEndingInGlobStarChar_FollowedByDoubleStar_EmitsGlobStar()
+    {
+        GlobSpecification matcher = PosixPath($"[a{GlobStar}]/**/bar");
+        matcher.IsMatch("a/bar").Should().BeTrue();
+        matcher.IsMatch($"{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch("a/x/y/bar").Should().BeTrue();
+        matcher.IsMatch("c/bar").Should().BeFalse();
+    }
+
+    // (7) Class body ending in two adjacent GlobStar chars (covers a
+    // hypothetical [^2] peek even when [^1] is also the opcode char).
+    [Fact]
+    public void Compile_ClassEndingInTwoGlobStarChars_FollowedByDoubleStar_EmitsGlobStar()
+    {
+        GlobSpecification matcher = PosixPath($"[a{GlobStar}{GlobStar}]/**/bar");
+        matcher.IsMatch("a/bar").Should().BeTrue();
+        matcher.IsMatch($"{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch($"{GlobStar}/x/bar").Should().BeTrue();
+        matcher.IsMatch("z/bar").Should().BeFalse();
+    }
+
+    // (8) Any / AnyRun immediately before a '/**'. The encoder emits
+    // these as single-char opcodes; a hypothetical optimization that
+    // peeks at [^1] for a GlobStar must distinguish them.
+    [Fact]
+    public void Compile_AnyRunFollowedByDoubleStar_BothEmitted()
+    {
+        GlobSpecification matcher = PosixPath("foo*/**/bar");
+        matcher.IsMatch("fooX/bar").Should().BeTrue();
+        matcher.IsMatch("fooX/x/y/bar").Should().BeTrue();
+        // `*` matches the empty string, so "foo/" satisfies "foo*/".
+        matcher.IsMatch("foo/bar").Should().BeTrue();
+        matcher.IsMatch("xfoo/bar").Should().BeFalse();    // pattern starts at "foo"
+    }
+
+    [Fact]
+    public void Compile_AnyFollowedByDoubleStar_BothEmitted()
+    {
+        GlobSpecification matcher = PosixPath("foo?/**/bar");
+        matcher.IsMatch("fooX/bar").Should().BeTrue();
+        matcher.IsMatch("fooX/x/y/bar").Should().BeTrue();
+        matcher.IsMatch("foo/bar").Should().BeFalse();
+    }
+
+    // (9) Multi-segment pattern with literal opcode chars mid-segment
+    // -- after a '**'.
+    [Fact]
+    public void Compile_DoubleStarFollowedByLiteralOpcodeChar_RoundTrips()
+    {
+        GlobSpecification matcher = PosixPath($"**/foo{GlobStar}bar");
+        matcher.IsMatch($"foo{GlobStar}bar").Should().BeTrue();
+        matcher.IsMatch($"x/foo{GlobStar}bar").Should().BeTrue();
+        matcher.IsMatch($"x/y/foo{GlobStar}bar").Should().BeTrue();
+        matcher.IsMatch("foobar").Should().BeFalse();
+    }
+
+    // (10) Extglob alternative whose body ends in GlobStar char.
+    [Fact]
+    public void Compile_ExtGlobAlternativeEndsInGlobStarChar_FollowedByDoubleStar_EmitsGlobStar()
+    {
+        GlobSpecification matcher = GlobSpecification.Compile(
+            $"@(foo|bar{GlobStar})/**/baz",
+            GlobDialect.Bash,
+            GlobOptions.AllowGlobStar | GlobOptions.AllowExtGlob | GlobOptions.MatchLeadingDot);
+
+        matcher.IsMatch("foo/baz").Should().BeTrue();
+        matcher.IsMatch($"bar{GlobStar}/baz").Should().BeTrue();
+        matcher.IsMatch("foo/x/y/baz").Should().BeTrue();
+        matcher.IsMatch("nope/baz").Should().BeFalse();
+    }
+
+    // (11) Class header (`[...]`) immediately followed by '/**'. The
+    // class' bytecode header is `Class + length` where `length` is a
+    // single char; in the worst case a 0xFDD5-length class body could
+    // accidentally produce the byte pattern `Class + GlobStar-char`.
+    // 0xFDD5 = 64981 chars is a large class body but well within the
+    // MaxOpcodeBodyLength (0xFFFF) limit. Building a literal pattern
+    // with 64981 distinct chars is large but constructable; here we
+    // exercise the easier case of any class followed by '/**' to lock
+    // in correct behavior, and let the tail-of-class collision tests
+    // above cover the malicious shape.
+    [Fact]
+    public void Compile_ClassFollowedByDoubleStar_BothEmitted()
+    {
+        GlobSpecification matcher = PosixPath("[abc]/**/x");
+        matcher.IsMatch("a/x").Should().BeTrue();
+        matcher.IsMatch("b/y/x").Should().BeTrue();
+        matcher.IsMatch("c/y/z/x").Should().BeTrue();
+        matcher.IsMatch("d/x").Should().BeFalse();
+    }
+
+    // (12) Three adjacent globstars where the first absorbs a `/` from a
+    // prior literal containing GlobStar char. Regression for the
+    // interaction between the GlobStar-cursor collapse and the
+    // strip-trailing-separator-from-prior-Literal logic.
+    [Fact]
+    public void Compile_LiteralWithGlobStarChar_ThenTripleGlobStarChain_AllCollapse()
+    {
+        GlobSpecification matcher = PosixPath($"foo{GlobStar}/**/**/**/bar");
+        matcher.IsMatch($"foo{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch($"foo{GlobStar}/x/bar").Should().BeTrue();
+        matcher.IsMatch($"foo{GlobStar}/x/y/z/bar").Should().BeTrue();
+        matcher.IsMatch("foo/bar").Should().BeFalse();
+    }
+
+    // (13) Single GlobStar where the input also contains the GlobStar
+    // opcode char. Validates that the runtime walker doesn't accidentally
+    // confuse the input.
+    [Fact]
+    public void IsMatch_GlobStarPattern_InputContainsGlobStarChar_Matches()
+    {
+        GlobSpecification matcher = PosixPath("**/bar");
+        matcher.IsMatch($"foo{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch($"{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch($"foo/{GlobStar}/bar").Should().BeTrue();
+        matcher.IsMatch($"foo{GlobStar}bar").Should().BeFalse();
+    }
+
+    private static GlobSpecification Posix(string pattern) =>
+        GlobSpecification.Compile(pattern, GlobDialect.Posix, GlobOptions.MatchLeadingDot);
+
+    private static GlobSpecification PosixPath(string pattern) =>
+        GlobSpecification.Compile(
+            pattern,
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar | GlobOptions.MatchLeadingDot);
+}

--- a/touki.tests/Touki/Io/Globbing/PortedTests.GitWildmatch.cs
+++ b/touki.tests/Touki/Io/Globbing/PortedTests.GitWildmatch.cs
@@ -1,0 +1,262 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+/// <summary>
+///  Pattern-level scenarios ported from git's <c>t/t3070-wildmatch.sh</c>
+///  test corpus.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Source:
+///   <see href="https://github.com/git/git/blob/master/t/t3070-wildmatch.sh"><c>git/t/t3070-wildmatch.sh</c></see>.
+///   Licensed under GPL-2.0. The upstream <c>match</c> helper asserts four
+///   columns per row:
+///   <list type="number">
+///    <item><description><c>wildmatch</c> - <c>WM_PATHNAME</c> on (case-sensitive).</description></item>
+///    <item><description><c>iwildmatch</c> - <c>WM_PATHNAME</c> on (case-insensitive).</description></item>
+///    <item><description><c>pathmatch</c> - <c>WM_PATHNAME</c> off (case-sensitive).</description></item>
+///    <item><description><c>ipathmatch</c> - <c>WM_PATHNAME</c> off (case-insensitive).</description></item>
+///   </list>
+///   This port mines the <c>wildmatch</c> column (column 1 / argument 1) -
+///   the <c>WM_PATHNAME</c>-on, case-sensitive variant - because git's own
+///   gitignore and pathspec evaluation use that mode
+///   (<c>core_wildmatch_flags = WM_PATHNAME</c> in git's source). Rows are
+///   asserted against <see cref="GlobSpecification.IsMatch"/> on
+///   <see cref="GlobDialect.PosixPath"/> with
+///   <see cref="GlobOptions.AllowGlobStar"/> +
+///   <see cref="GlobOptions.MatchLeadingDot"/> (wildmatch defaults to
+///   matching a leading dot; the <c>WM_PERIOD</c> flag git uses for the
+///   period-aware variant is not enabled here).
+///  </para>
+///  <para>
+///   Touki's existing live Git oracle suites
+///   (<c>SequentialSeparatorGitOracleTests</c>,
+///   <c>MultipleAsteriskOracleTests.Git</c>) cover the gitignore-layer
+///   semantics via <c>LibGit2Sharp.Repository.Ignore.IsPathIgnored</c>; this
+///   port instead pins the underlying wildmatch engine on every CI runner
+///   without needing the native LibGit2Sharp binary or a real git binary on
+///   PATH.
+///  </para>
+/// </remarks>
+public class PortedTests_GitWildmatch
+{
+    // ----- Basic wildmatch features (column 1 from t3070) -----
+    [Theory]
+    [InlineData("foo", "foo", true)]
+    [InlineData("foo", "bar", false)]
+    [InlineData("", "", true)]
+    [InlineData("foo", "???", true)]
+    [InlineData("foo", "??", false)]
+    [InlineData("foo", "*", true)]
+    [InlineData("foo", "f*", true)]
+    [InlineData("foo", "*f", false)]
+    [InlineData("foo", "*foo*", true)]
+    [InlineData("foobar", "*ob*a*r*", true)]
+    [InlineData("aaaaaaabababab", "*ab", true)]
+    [InlineData("foo*", "foo\\*", true)]
+    [InlineData("foobar", "foo\\*bar", false)]
+    [InlineData("f\\oo", "f\\\\oo", true)]
+    [InlineData("ball", "*[al]?", true)]
+    [InlineData("ten", "[ten]", false)]
+    [InlineData("ten", "**[!te]", true)]
+    [InlineData("ten", "**[!ten]", false)]
+    [InlineData("ten", "t[a-g]n", true)]
+    [InlineData("ten", "t[!a-g]n", false)]
+    [InlineData("ton", "t[!a-g]n", true)]
+    [InlineData("ton", "t[^a-g]n", true)]
+    [InlineData("a]b", "a[]]b", true)]
+    [InlineData("a-b", "a[]-]b", true)]
+    [InlineData("a]b", "a[]-]b", true)]
+    [InlineData("aab", "a[]-]b", false)]
+    [InlineData("aab", "a[]a-]b", true)]
+    [InlineData("]", "]", true)]
+    public void IsMatch_GitWildmatch_BasicFeatures(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // ----- Extended slash-matching features (WM_PATHNAME on) -----
+    [Theory]
+    [InlineData("foo/baz/bar", "foo*bar", false)]
+    [InlineData("foo/baz/bar", "foo**bar", false)]
+    [InlineData("foobazbar", "foo**bar", true)]
+    [InlineData("foo/baz/bar", "foo/**/bar", true)]
+    [InlineData("foo/baz/bar", "foo/**/**/bar", true)]
+    [InlineData("foo/b/a/z/bar", "foo/**/bar", true)]
+    [InlineData("foo/b/a/z/bar", "foo/**/**/bar", true)]
+    [InlineData("foo/bar", "foo/**/bar", true)]
+    [InlineData("foo/bar", "foo/**/**/bar", true)]
+    [InlineData("foo/bar", "foo?bar", false)]
+    [InlineData("foo/bar", "foo[/]bar", false)]
+    [InlineData("foo/bar", "foo[^a-z]bar", false)]
+    [InlineData("foo/bar", "f[^eiu][^eiu][^eiu][^eiu][^eiu]r", false)]
+    [InlineData("foo-bar", "f[^eiu][^eiu][^eiu][^eiu][^eiu]r", true)]
+    [InlineData("foo", "**/foo", true)]
+    [InlineData("XXX/foo", "**/foo", true)]
+    [InlineData("bar/baz/foo", "**/foo", true)]
+    [InlineData("bar/baz/foo", "*/foo", false)]
+    [InlineData("foo/bar/baz", "**/bar*", false)]
+    [InlineData("deep/foo/bar/baz", "**/bar/*", true)]
+    [InlineData("deep/foo/bar", "**/bar/*", false)]
+    [InlineData("foo/bar/baz", "**/bar**", false)]
+    [InlineData("foo/bar/baz/x", "*/bar/**", true)]
+    [InlineData("deep/foo/bar/baz/x", "*/bar/**", false)]
+    [InlineData("deep/foo/bar/baz/x", "**/bar/*/*", true)]
+    public void IsMatch_GitWildmatch_ExtendedSlash(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // ----- Various additional tests -----
+    [Theory]
+    [InlineData("acrt", "a[c-c]st", false)]
+    [InlineData("acrt", "a[c-c]rt", true)]
+    [InlineData("]", "[!]-]", false)]
+    [InlineData("a", "[!]-]", true)]
+    [InlineData("XXX/\\", "*/\\\\", true)]
+    [InlineData("foo", "foo", true)]
+    [InlineData("@foo", "@foo", true)]
+    [InlineData("foo", "@foo", false)]
+    [InlineData("[ab]", "\\[ab]", true)]
+    [InlineData("[ab]", "[[]ab]", true)]
+    [InlineData("[ab]", "[[:]ab]", true)]
+    [InlineData("[ab]", "[[:digit]ab]", true)]
+    [InlineData("[ab]", "[\\[:]ab]", true)]
+    [InlineData("?a?b", "\\??\\?b", true)]
+    [InlineData("abc", "\\a\\b\\c", true)]
+    [InlineData("foo/bar/baz/to", "**/t[o]", true)]
+    public void IsMatch_GitWildmatch_VariousAdditional(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // ----- Character class tests -----
+    [Theory]
+    [InlineData("a1B", "[[:alpha:]][[:digit:]][[:upper:]]", true)]
+    [InlineData("A", "[[:digit:][:upper:][:space:]]", true)]
+    [InlineData("1", "[[:digit:][:upper:][:space:]]", true)]
+    [InlineData("1", "[[:digit:][:upper:][:spaci:]]", false)]
+    [InlineData(" ", "[[:digit:][:upper:][:space:]]", true)]
+    [InlineData(".", "[[:digit:][:upper:][:space:]]", false)]
+    [InlineData(".", "[[:digit:][:punct:][:space:]]", true)]
+    [InlineData("5", "[[:xdigit:]]", true)]
+    [InlineData("f", "[[:xdigit:]]", true)]
+    [InlineData("D", "[[:xdigit:]]", true)]
+    [InlineData(
+        "_",
+        "[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]",
+        true)]
+    [InlineData("5", "[a-c[:digit:]x-z]", true)]
+    [InlineData("b", "[a-c[:digit:]x-z]", true)]
+    [InlineData("y", "[a-c[:digit:]x-z]", true)]
+    [InlineData("q", "[a-c[:digit:]x-z]", false)]
+    public void IsMatch_GitWildmatch_CharacterClasses(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // ----- Malformed / misc bracket-class rows -----
+    [Theory]
+    [InlineData("]", "[\\\\-^]", true)]
+    [InlineData("[", "[\\\\-^]", false)]
+    [InlineData("ab", "a[]b", false)]
+    [InlineData("ab", "[!", false)]
+    [InlineData("ab", "[-", false)]
+    [InlineData("-", "[-]", true)]
+    [InlineData("-", "[a-", false)]
+    [InlineData("-", "[!a-", false)]
+    [InlineData("-", "[--A]", true)]
+    [InlineData("5", "[--A]", true)]
+    [InlineData(" ", "[ --]", true)]
+    [InlineData("$", "[ --]", true)]
+    [InlineData("-", "[ --]", true)]
+    [InlineData("0", "[ --]", false)]
+    [InlineData("-", "[---]", true)]
+    [InlineData("-", "[------]", true)]
+    [InlineData("j", "[a-e-n]", false)]
+    [InlineData("-", "[a-e-n]", true)]
+    [InlineData("a", "[!------]", true)]
+    [InlineData("[", "[]-a]", false)]
+    [InlineData("^", "[]-a]", true)]
+    [InlineData("^", "[!]-a]", false)]
+    [InlineData("[", "[!]-a]", true)]
+    [InlineData("^", "[a^bc]", true)]
+    [InlineData("-b]", "[a-]b]", true)]
+    [InlineData("\\", "[\\\\]", true)]
+    [InlineData("\\", "[!\\\\]", false)]
+    [InlineData("G", "[A-\\\\]", true)]
+    [InlineData("aaabbb", "b*a", false)]
+    [InlineData("aabcaa", "*ba*", false)]
+    [InlineData(",", "[,]", true)]
+    [InlineData(",", "[\\\\,]", true)]
+    [InlineData("\\", "[\\\\,]", true)]
+    [InlineData("-", "[,-.]", true)]
+    [InlineData("+", "[,-.]", false)]
+    [InlineData("-.]", "[,-.]", false)]
+    public void IsMatch_GitWildmatch_MalformedAndMisc(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // ----- Test recursion (deep paths and X-style font names) -----
+    [Theory]
+    [InlineData(
+        "-adobe-courier-bold-o-normal--12-120-75-75-m-70-iso8859-1",
+        "-*-*-*-*-*-*-12-*-*-*-m-*-*-*",
+        true)]
+    [InlineData(
+        "-adobe-courier-bold-o-normal--12-120-75-75-X-70-iso8859-1",
+        "-*-*-*-*-*-*-12-*-*-*-m-*-*-*",
+        false)]
+    [InlineData(
+        "-adobe-courier-bold-o-normal--12-120-75-75-/-70-iso8859-1",
+        "-*-*-*-*-*-*-12-*-*-*-m-*-*-*",
+        false)]
+    [InlineData(
+        "XXX/adobe/courier/bold/o/normal//12/120/75/75/m/70/iso8859/1",
+        "XXX/*/*/*/*/*/*/12/*/*/*/m/*/*/*",
+        true)]
+    [InlineData(
+        "XXX/adobe/courier/bold/o/normal//12/120/75/75/X/70/iso8859/1",
+        "XXX/*/*/*/*/*/*/12/*/*/*/m/*/*/*",
+        false)]
+    [InlineData(
+        "abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt",
+        "**/*a*b*g*n*t",
+        true)]
+    [InlineData(
+        "abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txtz",
+        "**/*a*b*g*n*t",
+        false)]
+    [InlineData("foo", "*/*/*", false)]
+    [InlineData("foo/bar", "*/*/*", false)]
+    [InlineData("foo/bba/arr", "*/*/*", true)]
+    [InlineData("foo/bb/aa/rr", "*/*/*", false)]
+    [InlineData("foo/bb/aa/rr", "**/**/**", true)]
+    [InlineData("abcXdefXghi", "*X*i", true)]
+    [InlineData("ab/cXd/efXg/hi", "*X*i", false)]
+    [InlineData("ab/cXd/efXg/hi", "*/*X*/*/*i", true)]
+    [InlineData("ab/cXd/efXg/hi", "**/*X*/**/*i", true)]
+    public void IsMatch_GitWildmatch_Recursion(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // ----- Extra pathmatch rows (wildmatch column = WM_PATHNAME on) -----
+    [Theory]
+    [InlineData("foo", "fo", false)]
+    [InlineData("foo/bar", "foo/bar", true)]
+    [InlineData("foo/bar", "foo/*", true)]
+    [InlineData("foo/bba/arr", "foo/*", false)]
+    [InlineData("foo/bba/arr", "foo/**", true)]
+    [InlineData("foo/bba/arr", "foo*", false)]
+    [InlineData("foo/bba/arr", "foo/*arr", false)]
+    [InlineData("foo/bba/arr", "foo/**arr", false)]
+    [InlineData("foo/bba/arr", "foo/*z", false)]
+    [InlineData("foo/bba/arr", "foo/**z", false)]
+    [InlineData("foo/bar", "foo?bar", false)]
+    [InlineData("foo/bar", "foo[/]bar", false)]
+    [InlineData("foo/bar", "foo[^a-z]bar", false)]
+    [InlineData("ab/cXd/efXg/hi", "*Xg*i", false)]
+    public void IsMatch_GitWildmatch_ExtraPathmatch(string input, string pattern, bool expected) =>
+        Wm(pattern).IsMatch(input).Should().Be(expected);
+
+    // Helper: compile under PosixPath with globstar + leading-dot-matches
+    // (wildmatch with WM_PATHNAME, without WM_PERIOD).
+    private static GlobSpecification Wm(string pattern) =>
+        GlobSpecification.Compile(
+            pattern,
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar | GlobOptions.MatchLeadingDot);
+}

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -467,7 +467,7 @@ public sealed partial class GlobSpecification
             if (segment.Length < 4
                 || segment[0] != '@'
                 || segment[1] != '('
-                || segment[segment.Length - 1] != ')')
+                || segment[^1] != ')')
             {
                 return false;
             }
@@ -2018,20 +2018,45 @@ public sealed partial class GlobSpecification
             }
 
             int flags = 0;
-
-            // After the early return both `leadOk` and `trailOk` hold, so an `i > 0`
-            // automatically means `pattern[i - 1] == separator`; the same simplification
-            // applies on the trailing side. No need to re-test the character.
             if (i > 0)
             {
                 flags |= GlobOpCodes.GlobStarFlagLead;
-                StripTrailingSeparatorFromLastLiteral(ref builder, ref lastLiteral, separator);
             }
 
             if (runEnd < pattern.Length)
             {
                 flags |= GlobOpCodes.GlobStarFlagTrail;
                 next = runEnd + 1;
+            }
+
+            // Inline collapse: when the previous emitted opcode is already a
+            // GlobStar (encoded as `GlobStar` + 1 flag char at the tail of
+            // the builder), an adjacent `**/**` run is redundant - each
+            // `**` matches zero or more path segments per wildmatch / FSG /
+            // bash globstar semantics. The merged op inherits the prior
+            // op's Lead flag (it's still adjacent to whatever came before)
+            // and the new op's Trail flag (the new op is the one bordering
+            // whatever follows). Lead is overwritten via OR because the
+            // prior already had it set when needed; Trail is overwritten
+            // via mask+OR because the prior may have had it set when this
+            // is now the terminal globstar (e.g. `**/**/**` at end of
+            // pattern, where the final `**` has no trailing `/`).
+            if (builder.Length >= 2 && builder[^2] == GlobOpCodes.GlobStar)
+            {
+                int flagIndex = builder.Length - 1;
+                int merged =
+                    (builder[flagIndex] & ~GlobOpCodes.GlobStarFlagTrail)
+                    | (flags & GlobOpCodes.GlobStarFlagTrail);
+                builder[flagIndex] = (char)merged;
+                return true;
+            }
+
+            // After the early return both `leadOk` and `trailOk` hold, so an `i > 0`
+            // automatically means `pattern[i - 1] == separator`; the same simplification
+            // applies on the trailing side. No need to re-test the character.
+            if (i > 0)
+            {
+                StripTrailingSeparatorFromLastLiteral(ref builder, ref lastLiteral, separator);
             }
 
             builder.Append(GlobOpCodes.GlobStar);
@@ -2052,7 +2077,7 @@ public sealed partial class GlobSpecification
             char separator)
         {
             Debug.Assert(lastLiteral.IsValid && lastLiteral.Length > 0);
-            Debug.Assert(builder[builder.Length - 1] == separator);
+            Debug.Assert(builder[^1] == separator);
 
             if (lastLiteral.Length == 1)
             {

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -1648,7 +1648,11 @@ public sealed partial class GlobSpecification
 
             // Track the most recent Literal opcode position so we can retroactively strip
             // its trailing separator when the next token is a segment-boundary GlobStar
-            // that absorbs the leading separator.
+            // that absorbs the leading separator. The same cursor doubles as a
+            // last-emit-was-GlobStar marker via LiteralCursor.GlobStar so the GlobStar
+            // emitter can collapse adjacent `**/**` runs in place without confusing a
+            // literal byte that happens to equal the GlobStar opcode character (which is
+            // a Unicode private-use noncharacter, but still a valid char in user input).
             LiteralCursor lastLiteral = LiteralCursor.None;
             hasGlobStar = false;
             hasExtGlob = false;
@@ -1971,6 +1975,9 @@ public sealed partial class GlobSpecification
         ///  separator from the prior Literal when a segment-bounded <c>**</c> absorbs it.
         ///  <see cref="None"/> represents "no Literal currently at the tail of the buffer"
         ///  (the most recent opcode is something else, or the buffer is empty).
+        ///  <see cref="GlobStar"/> tags the cursor as "most recent opcode is a GlobStar
+        ///  whose flag byte is at <c>Start</c>"; used by the GlobStar emitter to collapse
+        ///  adjacent `**/**` runs without relying on a fragile buffer-tail char peek.
         /// </summary>
         private struct LiteralCursor
         {
@@ -1979,7 +1986,22 @@ public sealed partial class GlobSpecification
 
             public static LiteralCursor None => new() { Start = -1, Length = 0 };
 
-            public readonly bool IsValid => Start >= 0;
+            /// <summary>
+            ///  Tags the cursor as "the most recently emitted opcode is a
+            ///  <see cref="GlobOpCodes.GlobStar"/> with its flag byte at
+            ///  <paramref name="flagIndex"/>". Read back via
+            ///  <see cref="IsGlobStar"/> and <see cref="GlobStarFlagIndex"/>.
+            ///  Uses <c>Length = -1</c> as the sentinel so the existing
+            ///  <see cref="IsValid"/> check (<c>Start &gt;= 0</c>) keeps reporting
+            ///  "not a Literal".
+            /// </summary>
+            public static LiteralCursor GlobStar(int flagIndex) => new() { Start = flagIndex, Length = -1 };
+
+            public readonly bool IsValid => Start >= 0 && Length >= 0;
+
+            public readonly bool IsGlobStar => Start >= 0 && Length == -1;
+
+            public readonly int GlobStarFlagIndex => Start;
         }
 
         /// <summary>
@@ -2029,21 +2051,27 @@ public sealed partial class GlobSpecification
                 next = runEnd + 1;
             }
 
-            // Inline collapse: when the previous emitted opcode is already a
-            // GlobStar (encoded as `GlobStar` + 1 flag char at the tail of
-            // the builder), an adjacent `**/**` run is redundant - each
-            // `**` matches zero or more path segments per wildmatch / FSG /
-            // bash globstar semantics. The merged op inherits the prior
-            // op's Lead flag (it's still adjacent to whatever came before)
-            // and the new op's Trail flag (the new op is the one bordering
-            // whatever follows). Lead is overwritten via OR because the
-            // prior already had it set when needed; Trail is overwritten
-            // via mask+OR because the prior may have had it set when this
-            // is now the terminal globstar (e.g. `**/**/**` at end of
-            // pattern, where the final `**` has no trailing `/`).
-            if (builder.Length >= 2 && builder[^2] == GlobOpCodes.GlobStar)
+            // Inline collapse: when the previously emitted op is already a
+            // GlobStar (recorded in `lastLiteral` via the GlobStar sentinel),
+            // an adjacent `**/**` run is redundant - each `**` matches zero
+            // or more path segments per wildmatch / FSG / bash globstar
+            // semantics. The merged op inherits the prior op's Lead flag and
+            // the new op's Trail flag (mask+OR, not just OR) so the merged
+            // op terminates correctly when the new globstar is the last
+            // segment of the pattern (e.g. `**/**/**` at end of pattern,
+            // where the final `**` has no trailing `/` and the prior had
+            // Trail set when bordering its absorbed `/`).
+            //
+            // Using the explicit cursor (rather than peeking at the buffer's
+            // tail char) is required: `GlobOpCodes.GlobStar` is a Unicode
+            // private-use noncharacter (`U+FDD5`) but is still a valid char
+            // in a user pattern. A Literal or Class whose payload contained
+            // a literal `U+FDD5` at its tail would otherwise be mistaken
+            // for a prior GlobStar emission and the next char would be
+            // overwritten with flag bits.
+            if (lastLiteral.IsGlobStar)
             {
-                int flagIndex = builder.Length - 1;
+                int flagIndex = lastLiteral.GlobStarFlagIndex;
                 int merged =
                     (builder[flagIndex] & ~GlobOpCodes.GlobStarFlagTrail)
                     | (flags & GlobOpCodes.GlobStarFlagTrail);
@@ -2061,7 +2089,7 @@ public sealed partial class GlobSpecification
 
             builder.Append(GlobOpCodes.GlobStar);
             builder.Append((char)flags);
-            lastLiteral = LiteralCursor.None;
+            lastLiteral = LiteralCursor.GlobStar(builder.Length - 1);
             return true;
         }
 


### PR DESCRIPTION
Ports pattern-level scenarios from git's [`t/t3070-wildmatch.sh`](https://github.com/git/git/blob/master/t/t3070-wildmatch.sh) (~160 rows across 7 theories) into a new `PortedTests.GitWildmatch.cs` test class, attributed to the upstream source.

The port mines the **column-1 `wildmatch` (WM_PATHNAME on, case-sensitive)** verdicts — the mode git's own gitignore and pathspec evaluation use (`core_wildmatch_flags = WM_PATHNAME` in git's source) — and asserts them against `PosixPath` + `AllowGlobStar` + `MatchLeadingDot`. Touki's existing live Git oracle suites (`SequentialSeparatorGitOracleTests`, `MultipleAsteriskOracleTests.Git`) cover the gitignore-layer semantics via `LibGit2Sharp`; this port pins the underlying wildmatch engine on every CI runner without needing the native LibGit2Sharp binary or a real git binary on PATH.

## Touki bug fix: adjacent globstar collapse

Patterns containing adjacent globstar runs — `foo/**/**/bar`, `**/**/**`, etc. — returned `false` when each component matched. Wildmatch, `Microsoft.Extensions.FileSystemGlobbing.Matcher`, and bash globstar all treat `**` as "zero or more path segments", so adjacent `**`s are redundant.

**Fix:** inline collapse in `TryEmitGlobStar`, mirroring the class-closure rewind pattern from #162. Instead of a separate pre-pass that walks the whole pattern, the GlobStar emitter peeks at the last 2 chars of the builder. When the prior emitted op is already a `GlobStar`, the new op's Trail flag is masked into the prior flag byte and the second op is not emitted.

**Cost:**
- Patterns without `**/**` adjacency: 1 char comparison that always falls through. **No allocation, no extra scan.**
- Patterns with `**/**`: 3 chars read, 1 char written. **No allocation, no extra scan.**

Trail-flag merge uses mask+OR (not just OR) so the merged op inherits the *last* collapsed globstar's Trail bit — critical for `**/**/**` at end of pattern where the final `**` has no trailing `/` and the prior had Trail set when bordering its absorbed `/`.

## Validation

All 7816 net481 + 6471 net10 tests pass (160 new ported rows, no regressions).