### PR TITLE
Reorganize span/buffer helpers into Touki.Buffers and Touki.Io namespaces

### DIFF
--- a/docs/fuzz-testing-plan.md
+++ b/docs/fuzz-testing-plan.md
@@ -27,7 +27,7 @@
    the narrow, low-level primitives. `unmanaged`/`unsafe` ref structs with
    `Position` setters, `Try*`/`Advance*` methods, and `UnsafeAdvance` -
    exactly the kind of bounds/offset logic worth fuzzing first.
-2. RLE codec in [touki/Touki/RunLengthEncoder.cs](../touki/Touki/RunLengthEncoder.cs) -
+2. RLE codec in [touki/Touki/Buffers/RunLengthEncoder.cs](../touki/Touki/Buffers/RunLengthEncoder.cs) -
    `GetEncodedLength` / `GetDecodedLength` / `TryEncode` / `TryDecode` (encode
    and decode both live in this type). Round-trip and length-invariant fuzzing
    builds directly on the `SpanReader`/`SpanWriter` work since RLE is

--- a/touki.fuzz/GlobalUsings.cs
+++ b/touki.fuzz/GlobalUsings.cs
@@ -5,3 +5,6 @@
 global using System;
 
 global using SharpFuzz;
+
+global using Touki.Buffers;
+global using Touki.Io;

--- a/touki.fuzz/README.md
+++ b/touki.fuzz/README.md
@@ -18,8 +18,8 @@ own command-line arguments, so an environment variable is used instead):
 
 | `FUZZ_TARGET` | Exercises | File |
 | --- | --- | --- |
-| `SpanReader` (default) | `Touki.SpanReader<byte>` reads/advances/splits | [SpanReaderTarget.cs](SpanReaderTarget.cs) |
-| `SpanWriter` | `Touki.SpanWriter<byte>` writes/advances/rewinds | [SpanWriterTarget.cs](SpanWriterTarget.cs) |
+| `SpanReader` (default) | `Touki.Io.SpanReader<byte>` reads/advances/splits | [SpanReaderTarget.cs](SpanReaderTarget.cs) |
+| `SpanWriter` | `Touki.Io.SpanWriter<byte>` writes/advances/rewinds | [SpanWriterTarget.cs](SpanWriterTarget.cs) |
 | `RunLength` | `Touki.Buffers.RunLengthEncoder` encode roundtrip / arbitrary decode | [RunLengthTarget.cs](RunLengthTarget.cs) |
 
 Each target uses the fuzz input as an opcode stream that drives a sequence of

--- a/touki.fuzz/README.md
+++ b/touki.fuzz/README.md
@@ -20,7 +20,7 @@ own command-line arguments, so an environment variable is used instead):
 | --- | --- | --- |
 | `SpanReader` (default) | `Touki.SpanReader<byte>` reads/advances/splits | [SpanReaderTarget.cs](SpanReaderTarget.cs) |
 | `SpanWriter` | `Touki.SpanWriter<byte>` writes/advances/rewinds | [SpanWriterTarget.cs](SpanWriterTarget.cs) |
-| `RunLength` | `Touki.RunLengthEncoder` encode roundtrip / arbitrary decode | [RunLengthTarget.cs](RunLengthTarget.cs) |
+| `RunLength` | `Touki.Buffers.RunLengthEncoder` encode roundtrip / arbitrary decode | [RunLengthTarget.cs](RunLengthTarget.cs) |
 
 Each target uses the fuzz input as an opcode stream that drives a sequence of
 operations, then re-checks structural invariants (position in range, span

--- a/touki.tests/Docs/SampleTests.cs
+++ b/touki.tests/Docs/SampleTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using Touki.Io;
 using Touki.Text;
 
 namespace Touki.Docs;

--- a/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
+++ b/touki.tests/Framework/Touki/SmallPolyfillCoverageTests.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using Touki.Io;
 using Touki.Text;
 
 namespace Framework.Touki;

--- a/touki.tests/GlobalUsings.cs
+++ b/touki.tests/GlobalUsings.cs
@@ -25,7 +25,9 @@ global using System.IO;
 global using System.IO.Enumeration;
 #endif
 
+global using Touki.Buffers;
 global using Touki.Exceptions;
+global using Touki.Io;
 global using Touki.TestSupport;
 
 #pragma warning restore IDE0005

--- a/touki.tests/Touki/Buffers/BufferScopeTests.cs
+++ b/touki.tests/Touki/Buffers/BufferScopeTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Buffers;
 
 public unsafe class BufferScopeTests
 {

--- a/touki.tests/Touki/Buffers/RunLengthEncoderTests.cs
+++ b/touki.tests/Touki/Buffers/RunLengthEncoderTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Buffers;
 
 public class RunLengthEncoderTests
 {

--- a/touki.tests/Touki/Io/SpanReaderEdgeCaseTests.cs
+++ b/touki.tests/Touki/Io/SpanReaderEdgeCaseTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Io;
 
 /// <summary>
 /// Edge case and bug validation tests for SpanReader{T}.

--- a/touki.tests/Touki/Io/SpanReaderExtensionsTests.cs
+++ b/touki.tests/Touki/Io/SpanReaderExtensionsTests.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Io;
 
 /// <summary>
 ///  Tests for <see cref="SpanReaderExtensions"/>.

--- a/touki.tests/Touki/Io/SpanReaderTests.cs
+++ b/touki.tests/Touki/Io/SpanReaderTests.cs
@@ -4,7 +4,7 @@
 
 using System.Drawing;
 
-namespace Touki;
+namespace Touki.Io;
 
 public class SpanReaderTests
 {

--- a/touki.tests/Touki/Io/SpanWriterTests.cs
+++ b/touki.tests/Touki/Io/SpanWriterTests.cs
@@ -4,7 +4,7 @@
 
 using System.Drawing;
 
-namespace Touki;
+namespace Touki.Io;
 
 public class SpanWriterTests
 {

--- a/touki.tests/Touki/StreamExtensionsTests.cs
+++ b/touki.tests/Touki/StreamExtensionsTests.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information
 
 using System.Text;
-using Touki.Io;
 using Touki.Text;
 #if NETFRAMEWORK
 using System.IO;

--- a/touki/Framework/Polyfills/System.Globalization/DateTimeFormat.cs
+++ b/touki/Framework/Polyfills/System.Globalization/DateTimeFormat.cs
@@ -5,7 +5,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Touki;
 using Touki.Framework.Resources;
 
 namespace System.Globalization;

--- a/touki/GlobalUsings.cs
+++ b/touki/GlobalUsings.cs
@@ -35,6 +35,7 @@ global using StringBuilder = System.Text.StringBuilder;
 
 global using Touki.Exceptions;
 global using Touki.Text;
+global using Touki.Buffers;
 global using Touki.Io;
 
 #pragma warning restore IDE0005 // Using directive is unnecessary.

--- a/touki/Touki/Buffers/BufferScope.cs
+++ b/touki/Touki/Buffers/BufferScope.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Buffers;
 
 /// <summary>
 ///  Allows renting a buffer from <see cref="ArrayPool{T}"/> with a using statement. Can be used directly as if it

--- a/touki/Touki/Buffers/RunLengthEncoder.cs
+++ b/touki/Touki/Buffers/RunLengthEncoder.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Buffers;
 
 /// <summary>
 ///  Simple run length encoder (RLE) that works on spans.

--- a/touki/Touki/Io/SpanReader.cs
+++ b/touki/Touki/Io/SpanReader.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Io;
 
 /// <summary>
 ///  Fast stack based <see cref="ReadOnlySpan{T}"/> reader.

--- a/touki/Touki/Io/SpanReaderExtensions.cs
+++ b/touki/Touki/Io/SpanReaderExtensions.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Io;
 
 /// <summary>
 ///  Extensions for <see cref="SpanReader{T}"/>.

--- a/touki/Touki/Io/SpanWriter.cs
+++ b/touki/Touki/Io/SpanWriter.cs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-namespace Touki;
+namespace Touki.Io;
 
 /// <summary>
 ///  Fast stack based <see cref="Span{T}"/> writer.


### PR DESCRIPTION
Moves span and buffer helper types into dedicated namespaces that match their folder layout.

## Changes

- `RunLengthEncoder` and `BufferScope<T>` moved to the `Touki.Buffers` namespace (under `touki/Touki/Buffers/`).
- `SpanReader<T>`, `SpanWriter<T>`, and `SpanReaderExtensions` moved to the `Touki.Io` namespace (under `touki/Touki/Io/`).
- Added `global using Touki.Buffers;` to the library and test `GlobalUsings.cs`; added `global using Touki.Io;` to the test and fuzz `GlobalUsings.cs` (the library already had it).
- Updated test collateral namespaces, fuzz targets, and doc references; removed local usings made redundant by the new global usings.

## Validation

`dotnet test -c Release` passes on both TFMs (net481: 7856 passed; net10: 6511 passed).