### PR TITLE
Glob dialect cleanup, perf investigation docs, and extglob guard test

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -14,7 +14,8 @@ The "Disambiguation" section below records every known overlap.
 | ----- | ---------------- | ---------------- |
 | [polyfill-dotnet-api](./polyfill-dotnet-api/SKILL.md) | "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", missing-on-net472-present-on-net10 | `pre-pr-self-review`, `performance-testing`, `framework-jit-optimization`, `create-pr` |
 | [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | hot-path tuning for `net481` in `touki/Framework/`, generic specialization, scalar/unrolled vs BCL delegation, net481 RyuJIT regressions | `performance-testing` |
-| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations | `framework-jit-optimization` |
+| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations | `framework-jit-optimization`, `scratch-buffer-strategy` |
+| [scratch-buffer-strategy](./scratch-buffer-strategy/SKILL.md) | choosing a scratch-buffer strategy (zeroed `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs `ArrayPool` rental), "should I rent or stackalloc?", net481/net10 size crossovers, weighing `[SkipLocalsInit]` | `performance-testing`, `framework-jit-optimization` |
 | [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review checklist before opening or pushing a PR; missing tests, unchecked length sums, empty-span foot-guns, TFM phrasing | `create-pr`, `polyfill-dotnet-api` |
 | [security-review](./security-review/SKILL.md) | "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling"; any member accepting caller-supplied data, any use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, or any BCL API whose name or doc says "unsafe" / "caller must" - abusive-input handling, length / integer overflow, allocation and algorithmic DoS, caller-validated preconditions, argument validation | `pre-pr-self-review`, `performance-testing` |
 | [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", "publish for review" - **initial** publish | `pre-pr-self-review` |
@@ -68,6 +69,20 @@ Adjacent, not overlapping, but easy to confuse:
   `framework-jit-optimization`.
 
 You will frequently use both in sequence.
+
+### `scratch-buffer-strategy` vs `performance-testing`
+
+Both mention "evaluating allocations", but they answer different questions:
+
+- **Which buffer strategy should this hot path use** (zeroed `stackalloc` vs
+  `[SkipLocalsInit]` vs `BufferScope<T>` vs an `ArrayPool` rental), and at what
+  size does renting beat zeroing &rarr; `scratch-buffer-strategy`. It hands back
+  a decision, not a measurement.
+- **How do I measure a buffer/allocation cost** (author a benchmark, add
+  `[MemoryDiagnoser]`, read `Allocated`) &rarr; `performance-testing`.
+
+Use `scratch-buffer-strategy` to pick the design; use `performance-testing` to
+verify it on both TFMs.
 
 ## Maintenance
 

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -24,6 +24,11 @@ packages to prefer, when to hand-roll), see the
 skill picks up after that decision is already made and the polyfill
 lives in `touki/Framework/`.
 
+For choosing how a hot path gets its scratch buffer (zeroed `stackalloc`
+vs `[SkipLocalsInit]` vs `BufferScope<T>` vs an `ArrayPool` rental, and the
+net481/net10 size crossovers), see the
+[`scratch-buffer-strategy`](../scratch-buffer-strategy/SKILL.md) skill.
+
 ## What is and isn't available on `net481`
 
 - **No auto-vectorization.** The BCL `MemoryExtensions` methods on net481 ship with

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -23,6 +23,9 @@ References to those types from a benchmark must be guarded with `#if NETFRAMEWOR
 - [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) -
   decisions about specialization, unrolling, and BCL-delegation on net481 that the
   benchmarks here exist to validate.
+- [`scratch-buffer-strategy`](../scratch-buffer-strategy/SKILL.md) - choosing
+  between zeroed `stackalloc`, `[SkipLocalsInit]`, `BufferScope<T>`, and an
+  `ArrayPool` rental; several benchmarks here exist to validate those crossovers.
 - [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - requires a benchmark
   in `touki.perf/` (or an explicit "not measured" note) for any perf claim that
   drives a code change in `touki/Framework/`.

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: scratch-buffer-strategy
+description: Choose how a hot path gets a short-lived scratch buffer - zeroed `stackalloc`, `[SkipLocalsInit]` + `stackalloc`, `BufferScope<T>` (stack with pool fallback), or an `ArrayPool<T>.Shared` rental - and apply the net481/net10 size crossovers. Use when designing or reviewing a performance-sensitive path that needs a temporary buffer, when deciding "should I rent or stackalloc?", when weighing `[SkipLocalsInit]`, or when evaluating buffer/allocation cost. Defers the backing measurements and full reasoning to `docs/arraypool-performance.md`.
+---
+
+# Scratch buffer strategy (net481 + net10)
+
+Pick the cheapest correct way to get a short-lived scratch buffer on a hot path.
+This skill is the compact decision aid; the measured numbers, the per-call
+ArrayPool autopsy, the inlining traps, and the references live in
+[docs/arraypool-performance.md](../../../docs/arraypool-performance.md). Read
+that doc before quoting a number or making a non-obvious call.
+
+The library multi-targets **net481** (older RyuJIT: unvectorized `memset`, no
+tiered JIT/PGO, weaker inliner) and **net10**. Buffer costs differ enough
+between them that every decision must hold on both. Name the JIT in any writeup
+(repo JIT-naming rule).
+
+## Four options, ranked for the common case
+
+1. **`[SkipLocalsInit]` + `stackalloc`** - fastest (~1-2 ns, both TFMs).
+   Requires: fixed/bounded size, stack-safe, and **every read slot written
+   first**. Put the attribute on the method that physically contains the
+   `stackalloc`.
+2. **Zeroed `stackalloc`** - safe default. Cost scales with byte count;
+   net481 zeroing is ~3.6x net10 for a **compile-time-constant** size (for a
+   runtime-variable size both TFMs zero at ~the same rate - see the doc).
+3. **`BufferScope<T>(stackalloc T[N], minimumLength)`** - variable/unbounded
+   size that is usually small. Stays on the stack for the common case, rents
+   from `ArrayPool` only on overflow. Wrapper overhead ~1 ns net481 / ~0.3 ns
+   net10. Forwards the caller's `[SkipLocalsInit]` to the stack buffer.
+4. **`ArrayPool<T>.Shared` Rent/Return** - large, unbounded, recursive, or must
+   escape the frame. Has a fixed per-call floor that warmup never removes
+   (~10 ns/op net481, ~4 ns/op net10). Rent **once** and reuse across the loop.
+
+## Decision tree
+
+```
+Short-lived scratch buffer on a hot path?
+|
++- Fixed/small (one frame, few KB), not recursive/looped?
+|   +- Write every slot before reading?  --> [SkipLocalsInit] + stackalloc
+|   +- Cannot guarantee that?            --> zeroed stackalloc (or zero only
+|                                            the prefix you read)
+|
++- Usually small but occasionally large (variable size)?
+|   --> BufferScope<T>(stackalloc T[N], minLen); put [SkipLocalsInit] on the
+|       CALLING method to drop the stack-buffer zeroing
+|
++- Large / unbounded / recursive / must escape frame?
+|   --> ArrayPool<T>.Shared, rented once and reused
+|
++- Scratch must live inside a struct passed around?
+    --> fixed-buffer + Unsafe.SkipInit (slower than a bare [SkipLocalsInit]
+        stackalloc; use only when a local stackalloc will not fit the design)
+```
+
+## Crossover thresholds (zeroed stackalloc vs a rental)
+
+For a **runtime-variable** size, zeroing a `stackalloc` is cheaper than renting
+below these sizes; above them the rental's flat floor wins (only if you can use
+the memory uninitialized):
+
+| Rental kind | net481 | net10 |
+|---|--:|--:|
+| Warm TLS hit (first rental) | ~1.3 KB | ~190 B |
+| Locked (second same-bucket rental) | ~3 KB | ~1.8 KB |
+
+A **compile-time-constant** size zeroes far cheaper on net10, pushing its
+crossover higher. If you would have to `Clear()` the rented array, add that cost
+back to the rental side - the crossover then exceeds any sane stack size, so
+just stack-allocate.
+
+## Load-bearing facts (do not re-derive)
+
+- **net481 honors `[SkipLocalsInit]`.** The `localsinit`-flag suppression works
+  on the desktop CLR exactly as on CoreCLR; the attribute *type* is
+  source-generated downlevel by PolySharp. A 4 KB clear drops from ~53 ns to
+  ~1.7 ns on net481.
+- **Only byte count drives zeroing cost** - struct arrays zero exactly like
+  primitive arrays of the same size.
+- **A warm pool is not a free pool.** Rent/Return pays bucket-index math, a
+  one-deep TLS cache (two same-bucket rentals collide into the locked stack),
+  and a separate pool per element type - on every call, net481 ~2.5x worse.
+- **`[SkipLocalsInit]` hands you uninitialized memory.** Use it only where a
+  profile shows the clear is hot, every read slot is provably written first, and
+  no unwritten bytes can escape (info-disclosure risk). The JIT inliner does not
+  spread the attribute; net481's weaker inliner can move where zeroing lands, so
+  verify on both TFMs.
+
+## Stack-safety guardrail
+
+`stackalloc` only belongs on the stack at all if it is bounded: keep a single
+frame's `stackalloc` to a few KB, and never `stackalloc` on a recursive or
+unbounded-loop path (CA2014). Default Windows managed stack is 1 MB, but library
+code may run on a 256 KB partial-trust thread. Past those limits, rent once and
+reuse instead.
+
+## Related
+
+- [docs/arraypool-performance.md](../../../docs/arraypool-performance.md) - the
+  full measured tables, the ArrayPool per-call autopsy, the `BufferScope`
+  overhead numbers, the inlining trap, and references. **This is the backing
+  data; cite it.**
+- [`performance-testing`](../performance-testing/SKILL.md) - author/run the
+  BenchmarkDotNet benchmarks (`StackZeroInitPerf`, `ArrayPoolSeedRentPerf`,
+  `ArrayPoolCrossoverPerf`, `BufferScopeOverheadPerf`) that produced these
+  numbers.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) -
+  net481 loop tuning once a buffer choice is made.
+- [docs/performance-investigation.md](../../../docs/performance-investigation.md)
+  - how to confirm zeroing/pool overhead is actually the hot cost before acting.

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -35,7 +35,7 @@ between them that every decision must hold on both. Name the JIT in any writeup
 
 ## Decision tree
 
-```
+```text
 Short-lived scratch buffer on a hot path?
 |
 +- Fixed/small (one frame, few KB), not recursive/looped?
@@ -48,11 +48,7 @@ Short-lived scratch buffer on a hot path?
 |       CALLING method to drop the stack-buffer zeroing
 |
 +- Large / unbounded / recursive / must escape frame?
-|   --> ArrayPool<T>.Shared, rented once and reused
-|
-+- Scratch must live inside a struct passed around?
-    --> fixed-buffer + Unsafe.SkipInit (slower than a bare [SkipLocalsInit]
-        stackalloc; use only when a local stackalloc will not fit the design)
+    --> ArrayPool<T>.Shared, rented once and reused
 ```
 
 ## Crossover thresholds (zeroed stackalloc vs a rental)
@@ -87,6 +83,15 @@ just stack-allocate.
   no unwritten bytes can escape (info-disclosure risk). The JIT inliner does not
   spread the attribute; net481's weaker inliner can move where zeroing lands, so
   verify on both TFMs.
+- **`Unsafe.SkipInit` does NOT suppress the zeroing.** Common mistake: assuming
+  `Unsafe.SkipInit(out x)` makes a stack buffer un-zeroed. It compiles to a bare
+  `ret` and only satisfies C# definite-assignment so you can read an unassigned
+  local; the runtime still zeroes via the method's `.locals init` flag, which
+  only `[SkipLocalsInit]` (or `[module: SkipLocalsInit]`) removes. A "fixed
+  buffer left uninitialized with `Unsafe.SkipInit`" but *without*
+  `[SkipLocalsInit]` pays full zeroing. See
+  [docs/arraypool-performance.md](../../../docs/arraypool-performance.md)
+  section 8.
 
 ## Stack-safety guardrail
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -291,6 +291,16 @@ catch a mistake.
   - `Touki.Collections.*` (`ContiguousList`, `ArrayPoolList`,
     `SingleOptimizedList`, `EmptyList`) instead of `List<T>` /
     `Dictionary<,>` when the lifetime is bounded.
+- **When choosing how a hot path gets a short-lived scratch buffer** (zeroed
+  `stackalloc` vs `[SkipLocalsInit]` + `stackalloc` vs `BufferScope<T>` vs an
+  `ArrayPool<T>.Shared` rental), follow the
+  [`scratch-buffer-strategy`](../.agents/skills/scratch-buffer-strategy/SKILL.md)
+  skill for the decision tree and the net481/net10 size crossovers, and
+  [docs/arraypool-performance.md](../docs/arraypool-performance.md) for the backing
+  measurements. Key facts: net481 *does* honor `[SkipLocalsInit]`; a warm
+  `ArrayPool` still has a per-call floor warmup cannot remove; and below the
+  crossover (roughly 190 B net10 / 1.3 KB net481 vs a warm rental) a zeroed
+  `stackalloc` beats renting.
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
   prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,

--- a/.github/instructions/perf.instructions.md
+++ b/.github/instructions/perf.instructions.md
@@ -44,9 +44,31 @@ Unqualified "RyuJIT" claims are wrong about half the time. Code changes in
 
 ## Regression threshold
 
-- > 5 % throughput delta vs the prior baseline, **or** any new allocation in a
-  hot path = regression.
-- Below 5 % with no new allocation = noise. Say so explicitly when reporting.
+Judge a delta against the benchmark's own run-to-run noise, not a fixed
+percentage. The procedure:
+
+- **Establish the noise floor first.** Re-run the unchanged baseline (or read
+  `Error` / `StdDev` in the report). A well-formed microbenchmark here is
+  usually stable to ~1-2 %. A change smaller than that spread, in either
+  direction, is noise - say so explicitly and do not claim it.
+- **A consistent slowdown above the noise floor is a regression, even if it is
+  under 5 %.** Do not treat 5 % as a free budget; a reproducible 3-4 % loss is
+  real and needs a justification, not a hand-wave. The only number that matters
+  is "is it reliably outside the noise".
+- **Any new allocation in a documented hot path is a regression**, regardless of
+  throughput.
+- **A small throughput cost is acceptable when it buys an allocation
+  reduction.** A microbenchmark's `Mean` measures the steady-state per-op cost
+  *after* warmup; it does not capture the amortized GC time that the reclaimed
+  allocation would have cost in a real workload (collections, promotions, pause
+  time). Trading a few percent of `Mean` for materially fewer `Allocated` bytes
+  (or removing Gen1/Gen2 promotion) is usually a net win - quote both columns
+  and the reasoning when you make that call. The reverse - spending allocation
+  to win throughput - needs an explicit argument that the workload is
+  allocation-insensitive.
+- **State the comparison.** Always report the delta *and* the noise floor you
+  measured it against ("-4 %, baseline StdDev ~1 %, reproduced over 2 runs"),
+  and name the TFM/JIT. An unqualified percentage is not a conclusion.
 
 ## Authoring conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,16 @@ catch a mistake.
   - `Touki.Collections.*` (`ContiguousList`, `ArrayPoolList`,
     `SingleOptimizedList`, `EmptyList`) instead of `List<T>` /
     `Dictionary<,>` when the lifetime is bounded.
+- **When choosing how a hot path gets a short-lived scratch buffer** (zeroed
+  `stackalloc` vs `[SkipLocalsInit]` + `stackalloc` vs `BufferScope<T>` vs an
+  `ArrayPool<T>.Shared` rental), follow the
+  [`scratch-buffer-strategy`](.agents/skills/scratch-buffer-strategy/SKILL.md)
+  skill for the decision tree and the net481/net10 size crossovers, and
+  [docs/arraypool-performance.md](docs/arraypool-performance.md) for the backing
+  measurements. Key facts: net481 *does* honor `[SkipLocalsInit]`; a warm
+  `ArrayPool` still has a per-call floor warmup cannot remove; and below the
+  crossover (roughly 190 B net10 / 1.3 KB net481 vs a warm rental) a zeroed
+  `stackalloc` beats renting.
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
   prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Some of the design goals include:
 - [IO Helpers (globs, paths, temp folders, stream formatting)](docs/io.md)
 - [.NET Framework Polyfill Layout & Disambiguation](docs/polyfill-layout.md)
 - [Span Performance on .NET Framework (net472+)](docs/framework-span-performance.md)
+- [ArrayPool vs Stack Scratch Buffers (net481/net10)](docs/arraypool-performance.md)
 
 ## Package Installation
 

--- a/docs/arraypool-performance.md
+++ b/docs/arraypool-performance.md
@@ -92,7 +92,7 @@ overhead is **per-call bookkeeping that warmup cannot eliminate**.
 
 `ArrayPoolSeedRentPerf` measures the exact shape the extglob engine uses: five
 buffers (a 28-byte frame struct x32, a 16-byte range struct x128, that range
-struct x32 twice, and an `int[99]`), rented and returned together, ~4.3 KB
+struct x18 twice, and an `int[57]`), rented and returned together, ~3.7 KB
 aggregate, with the pool pre-warmed 64x in `[GlobalSetup]`.
 
 | Operation | net481 RyuJIT | net10 RyuJIT |
@@ -115,7 +115,7 @@ on **every** call:
    (a log2) from the requested length; each Return recomputes it from
    `array.Length`. Ten times for five buffers.
 2. **The thread-local cache holds one array per bucket.** If two rentals hit the
-   same bucket - in the engine, `work` and `rest` are both `ProgramRange[32]` -
+   same bucket - in the engine, `work` and `rest` are both `ProgramRange[18]` -
    the second misses the TLS fast path and falls through to the per-core
    **locked** stack (an interlocked/`Monitor` acquire). So does the second
    return.
@@ -252,27 +252,7 @@ The zeroing essentially vanishes on both TFMs - a ~30x win on net481, ~11x on
 net10. This is the cleanest option: one attribute, one code path, no pool
 bookkeeping, allocation-free.
 
-### 4.2 Fixed-buffer ref struct + `Unsafe.SkipInit` (special cases only)
-
-The pattern the BCL sometimes uses: a struct carrying an inline `fixed` buffer,
-left uninitialized with `Unsafe.SkipInit(out scratch)`, exposing a scoped `Span`
-via an `[UnscopedRef]` property. `Unsafe.SkipInit` ships in the `System.Runtime`
-/ netstandard `Unsafe` surface and **is available on net481**.
-
-| 4 KB scratch | net481 RyuJIT | net10 RyuJIT |
-|---|--:|--:|
-| `[SkipLocalsInit]` `stackalloc` | 1.7 ns | 1.3 ns |
-| fixed-buffer + `Unsafe.SkipInit` | 16.3 ns | 26.3 ns |
-
-**This pattern is slower than plain `[SkipLocalsInit]` on both TFMs, and on net10
-it is slower than just zeroing.** The cost is the `Unsafe.AsPointer` + `Span`
-construction and the fixed-buffer addressing the JIT cannot fold as well as a
-raw `stackalloc`. Reach for it only when you genuinely need the scratch to live
-in a struct that is passed around (so a bare `stackalloc` local will not do) -
-not as a default. For a plain local buffer, `[SkipLocalsInit]` + `stackalloc`
-wins.
-
-### 4.3 `BufferScope<T>`: stack buffer with a pool fallback
+### 4.2 `BufferScope<T>`: stack buffer with a pool fallback
 
 The size sweep in section 3.2 assumes you know the size up front. Often you do
 not: the common size is small and stack-friendly, but a rare large input must
@@ -324,7 +304,7 @@ Two things to take from this:
   rare large input. This is the recommended shape whenever the size is variable
   or unbounded but usually small.
 
-### 4.4 Risks of skipping init (and the inlining trap)
+### 4.3 Risks of skipping init (and the inlining trap)
 
 `[SkipLocalsInit]` is `unsafe` for a reason: it hands you **uninitialized
 memory**. The
@@ -401,18 +381,18 @@ Apply this to the extglob engine seed (`RunEngine`):
 |---|--:|--:|--:|
 | `Frame[]` | 28 B | 32 | 896 |
 | `ProgramRange[]` (arena) | 16 B | 128 | 2048 |
-| `ProgramRange[]` (work) | 16 B | 32 | 512 |
-| `ProgramRange[]` (rest) | 16 B | 32 | 512 |
-| `int[]` (key) | 4 B | 99 | 396 |
-| **Total** | | | **4364 (~4.3 KB)** |
+| `ProgramRange[]` (work) | 16 B | 18 | 288 |
+| `ProgramRange[]` (rest) | 16 B | 18 | 288 |
+| `int[]` (key) | 4 B | 57 | 228 |
+| **Total** | | | **3748 (~3.7 KB)** |
 
 This is safe to keep on the stack because:
 
-- **It is a single frame, ~4.3 KB.** Well under any reasonable per-call budget.
+- **It is a single frame, ~3.7 KB.** Well under any reasonable per-call budget.
 - **It is not on a recursive path.** `RunEngine` allocates the seed once.
   The negation handler's bounded re-entry goes through `RunEngineCore`, which
   reuses caller-supplied probe buffers and does **not** `stackalloc` again, so
-  the 4.3 KB never multiplies with recursion depth.
+  the 3.7 KB never multiplies with recursion depth.
 - **Every slot is written before it is read** (the work/rest/key buffers are
   seeded by `CopyTo` and the per-production builders; frames/arena are written
   before use and spill to `ArrayPool` only when an adversarial input outgrows
@@ -454,12 +434,6 @@ Need a short-lived scratch buffer on a hot path?
 │            (~10 ns/op net481, ~4 ns/op net10); minimize the number
 │            of distinct rentals and avoid two same-bucket rentals
 │            colliding in the TLS cache.
-│
-└─ Need the scratch to live inside a struct that is passed around?
-          fixed-buffer + Unsafe.SkipInit (available on net481), but
-          know it is slower than a bare [SkipLocalsInit] stackalloc -
-          use only when a local stackalloc genuinely will not fit the
-          design.
 ```
 
 Key rules of thumb:
@@ -498,8 +472,44 @@ Key rules of thumb:
 
 - [`SkipLocalsInit` attribute - C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute) - the compiler/CLR `.locals init` mechanism.
 - [`SkipLocalsInitAttribute` class](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute) - the "Applies to: .NET 5-11" type-availability note (polyfilled downlevel by PolySharp).
-- [Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices) - `[SkipLocalsInit]`/`Unsafe.SkipInit` guidance and the GC-reference caveat.
+- [Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices) - `[SkipLocalsInit]` guidance and the GC-reference caveat.
 - [`stackalloc` expression](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc) - unmanaged-type requirement, undefined initial contents, sizing and loop rules.
 - [CA2014: Do not use `stackalloc` in loops](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops).
 - [`Thread` constructor](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor) - 1 MB default stack, 256 KB partial-trust minimum on .NET Framework.
-- Benchmarks backing the numbers: `touki.perf/StackZeroInitPerf.cs`, `touki.perf/ArrayPoolSeedRentPerf.cs`, `touki.perf/ArrayPoolCrossoverPerf.cs` (the size sweep in section 3.2), and `touki.perf/BufferScopeOverheadPerf.cs` (the `BufferScope` overhead in section 4.3).
+- Benchmarks backing the numbers: `touki.perf/StackZeroInitPerf.cs`, `touki.perf/ArrayPoolSeedRentPerf.cs`, `touki.perf/ArrayPoolCrossoverPerf.cs` (the size sweep in section 3.2), and `touki.perf/BufferScopeOverheadPerf.cs` (the `BufferScope` overhead in section 4.2).
+
+---
+
+## 8. Common mistake: `Unsafe.SkipInit` does not suppress `.locals init`
+
+It is easy to assume that `Unsafe.SkipInit(out T value)` is what turns off the
+zero-initialization of a local - the name reads like "skip the init of this
+value." It does not, and a benchmark of the "uninitialized fixed-buffer scratch"
+pattern was wrong for exactly this reason until `[SkipLocalsInit]` was added.
+
+Two different mechanisms are at play, and only one of them clears memory:
+
+- **`Unsafe.SkipInit<T>(out T value)` is a compile-time trick, not a runtime
+  one.** Its body is a bare `ret` - it emits no code. Its only job is to satisfy
+  the C# compiler's *definite-assignment* analysis so you may read a local
+  without first writing it (or writing `= default`), avoiding the "use of
+  unassigned local variable" error. It never touches memory at run time.
+- **The actual zeroing comes from the method's `.locals init` flag.** The C#
+  compiler stamps that flag on every method that declares locals, and the CLR
+  honors it by zeroing **all** of the method's locals on entry - before any of
+  your code, including the `Unsafe.SkipInit` call, runs. The only way to strip
+  that flag is `[SkipLocalsInit]` on the method (or `[module: SkipLocalsInit]`).
+
+So `Unsafe.SkipInit` lets you legally *read* an unassigned local, but the runtime
+has already zeroed it. Without `[SkipLocalsInit]` on the enclosing method, a
+4 KB fixed buffer "left uninitialized" with `Unsafe.SkipInit` is still fully
+zeroed on entry, and a benchmark of that shape measures the zeroing it claims to
+avoid. The two work together: `[SkipLocalsInit]` removes the runtime clear, and
+`Unsafe.SkipInit` makes the resulting un-zeroed read well-formed at compile time.
+Neither one replaces the other.
+
+The practical rule: to actually skip the zeroing, put `[SkipLocalsInit]` on the
+method that physically contains the `stackalloc` (or fixed-buffer local). Reach
+for `Unsafe.SkipInit` only when you additionally need to read a local the
+compiler would otherwise reject as unassigned - and never treat its presence as
+evidence that the zeroing is gone.

--- a/docs/arraypool-performance.md
+++ b/docs/arraypool-performance.md
@@ -1,0 +1,505 @@
+# ArrayPool vs stack scratch: performance on net481 and net10
+
+When a hot path needs a short-lived scratch buffer, there are three ways to get
+one: `stackalloc` (zero-initialized by default), `ArrayPool<T>.Shared`
+rent/return, or a `stackalloc`/fixed buffer with the zeroing suppressed. The
+right choice depends on the buffer's size, lifetime, and - critically - which
+target framework's JIT is running. This document captures the measured costs and
+a decision procedure for choosing between them.
+
+All numbers below come from the BenchmarkDotNet projects in `touki.perf/`
+(listed in section 7), run in Release on this repo's dev machine against
+**.NET Framework 4.8.1 RyuJIT** and **modern .NET RyuJIT** (.NET 10). Per the
+repo's JIT-naming rule, every claim names the JIT, because the two behave very
+differently here.
+
+For the compact decision aid (decision tree + crossover thresholds without the
+backing tables), see the
+[`scratch-buffer-strategy`](../.agents/skills/scratch-buffer-strategy/SKILL.md)
+skill. This document is the data it cites.
+
+---
+
+## 1. The headline result
+
+For a fixed-size scratch buffer whose every slot is written before it is read,
+**`[SkipLocalsInit]` + `stackalloc` is the fastest option on both target
+frameworks** - faster than an `ArrayPool` rental and far faster than a
+zero-initialized `stackalloc`. The pool only wins when the buffer is large,
+unbounded, or must escape the stack frame.
+
+The single most important and most counter-intuitive fact:
+
+> **.NET Framework 4.8.1 RyuJIT honors `[SkipLocalsInit]`.** Suppressing the
+> `localsinit` flag removes the stack zeroing on net481 just as it does on
+> modern .NET. A 4 KB stack buffer drops from ~53 ns to ~1.7 ns on net481.
+
+This corrects the common assumption that Framework "always zeroes stackalloc".
+It does zero by default, but the absence of the `localsinit` flag is respected by
+the desktop runtime, so the zeroing is fully suppressible.
+
+---
+
+## 2. The cost of zeroing
+
+`stackalloc` without `[SkipLocalsInit]` clears the buffer on every call. That
+clear is a `memset` whose cost scales with the **byte size** of the buffer.
+
+### 2.1 Zeroing cost by size
+
+| Buffer | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| `byte[256]` (256 B) | 7.0 ns | 1.7 ns |
+| `byte[1024]` (1 KB) | 14.0 ns | 5.8 ns |
+| `byte[4096]` (4 KB) | 53.4 ns | 14.5 ns |
+
+Two things to read off this:
+
+- The cost is roughly linear in bytes once past the smallest sizes.
+- **net481 zeroing is ~3.6x more expensive than net10 zeroing** for the same
+  buffer (53 ns vs 15 ns at 4 KB). The desktop `memset` path is not vectorized
+  the way the modern runtime's is. This is why a zeroing cost that is a minor
+  line item on net10 can become the dominant per-call cost on net481.
+
+This ~3.6x gap holds for a **compile-time-constant** size, which is what these
+measurements use. For a runtime-variable `stackalloc byte[n]` net10 loses the
+vectorized clear and zeroes at nearly the same rate as net481 - see the note in
+section 3.2.
+
+### 2.2 Struct arrays zero exactly like primitive arrays
+
+A frequent worry is that an array of structs costs more to clear than an array
+of primitives. It does not - zeroing is byte-wise and ignores the element type.
+At an equal 4 KB:
+
+| Buffer | Bytes | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|--:|
+| `byte[4096]` | 4096 | 53.4 ns | 14.5 ns |
+| `int[1024]` | 4096 | 51.3 ns | 14.6 ns |
+| `Range16[256]` (4x `int`) | 4096 | 52.4 ns | 15.0 ns |
+
+The three are within noise of each other on both TFMs. **Only the byte count
+matters.** Do not restructure a struct buffer into a primitive one hoping to
+zero faster - reduce the byte count or suppress the zeroing instead.
+
+---
+
+## 3. The cost of an ArrayPool rental
+
+`ArrayPool<T>.Shared` hands back **uninitialized** memory, so it never pays the
+zeroing tax. But Rent/Return are not free, and - this is the key gotcha - the
+overhead is **per-call bookkeeping that warmup cannot eliminate**.
+
+`ArrayPoolSeedRentPerf` measures the exact shape the extglob engine uses: five
+buffers (a 28-byte frame struct x32, a 16-byte range struct x128, that range
+struct x32 twice, and an `int[99]`), rented and returned together, ~4.3 KB
+aggregate, with the pool pre-warmed 64x in `[GlobalSetup]`.
+
+| Operation | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| 5x Rent + 5x Return (`PoolRent`) | 104.3 ns | 40.6 ns |
+| equivalent zeroed `stackalloc` | 55.2 ns | 20.9 ns |
+| **pool penalty over stackalloc** | **+49 ns** | **+20 ns** |
+
+The pool is **slower than even a zeroing `stackalloc`** on both TFMs for this
+size. Roughly 10 ns per Rent/Return pair on net481, 4 ns on net10.
+
+### 3.1 Why warmup does not hide it
+
+The pool is fully warm - `[GlobalSetup]` and BenchmarkDotNet's own warmup run it
+hundreds of times - yet the cost persists, because it is steady-state work done
+on **every** call:
+
+1. **Bucket-index math per call.** `Shared` is
+   `TlsOverPerCoreLockedStacksArrayPool<T>`. Each Rent computes a bucket index
+   (a log2) from the requested length; each Return recomputes it from
+   `array.Length`. Ten times for five buffers.
+2. **The thread-local cache holds one array per bucket.** If two rentals hit the
+   same bucket - in the engine, `work` and `rest` are both `ProgramRange[32]` -
+   the second misses the TLS fast path and falls through to the per-core
+   **locked** stack (an interlocked/`Monitor` acquire). So does the second
+   return.
+3. **Separate pools per element type.** `Frame`, `ProgramRange`, and `int` are
+   three independent `ArrayPool<T>.Shared` instances with three separate per-core
+   stacks; no sharing, three sets of the above.
+4. **net481 makes all of it ~2.5x worse.** The pool internals are not inlined
+   (no tiered JIT, no dynamic PGO), the locked-stack path is heavier, and the
+   bucket math is not folded into the caller. That is why the penalty is +49 ns
+   on net481 versus +20 ns on net10.
+
+The lesson: **a warm pool is not a free pool.** Rent/Return has a fixed per-call
+floor that no amount of warmup removes.
+
+### 3.2 Where zeroing crosses the rental floor
+
+The previous tables compare a single fixed size. The more actionable question is
+"above what size does zeroing a `stackalloc` cost more than renting?" Because
+zeroing scales with the byte count while a rental is a flat per-call floor, there
+is a crossover size. `ArrayPoolCrossoverPerf` sweeps `stackalloc byte[N]` against
+a rental for `N` from 64 to 8192 bytes, separating the two rental floors:
+
+- **TLS hit** (`RentTls`): the first rental of a bucket, served from the
+  one-deep thread-local cache.
+- **Locked** (`RentLocked`): a second same-bucket rental taken while the first is
+  still checked out, so it falls to the per-core locked stack. Its marginal cost
+  is `RentLocked - RentTls`.
+
+Measured means (ns); the rental rows are essentially flat across size, the
+`ZeroStack` row rises with it:
+
+| Bytes | net481 ZeroStack | net481 RentTls | net481 RentLocked | net10 ZeroStack | net10 RentTls | net10 RentLocked |
+|--:|--:|--:|--:|--:|--:|--:|
+| 64   |   2.1 |  21.4 | 43.3 |   2.3 | 4.9 | 30.2 |
+| 128  |   3.3 |  21.3 | 42.9 |   3.7 | 4.9 | 31.1 |
+| 256  |   5.7 |  20.9 | 42.2 |   6.6 | 5.0 | 31.2 |
+| 512  |   7.3 |  21.1 | 41.8 |  12.4 | 4.9 | 30.9 |
+| 1024 |  16.0 |  20.7 | 41.6 |  22.4 | 5.0 | 30.9 |
+| 2048 |  30.9 |  20.8 | 41.6 |  33.9 | 4.9 | 31.7 |
+| 4096 |  53.8 |  20.7 | 41.9 |  56.9 | 4.8 | 30.8 |
+| 8192 | 100.2 |  20.5 | 41.0 | 103.8 | 5.0 | 31.2 |
+
+> **Why net10's `ZeroStack` here is ~4x its section 2.1 figure.** This sweep uses
+> a runtime-variable `stackalloc byte[size]` (the size is a benchmark parameter),
+> which is the realistic shape of the "should I rent?" question. RyuJIT emits its
+> fast vectorized clear only for a **compile-time-constant** size, so net10's
+> variable-size zeroing (~57 ns at 4 KB) is roughly 4x its constant-size cost
+> (~14.5 ns in section 2.1) and lands right on top of net481. For a
+> runtime-determined size the two TFMs zero at nearly the same rate; net10's
+> ~3.6x advantage applies only to constant sizes. A constant-size buffer
+> therefore pushes net10's crossover well above the figures below.
+
+The rental floors are roughly constant - net481 ~21 ns (TLS) / ~42 ns (locked),
+net10 ~5 ns (TLS) / ~31 ns (locked) - confirming a rental does not scale with
+size, only the zeroing does. The crossover sizes (where `ZeroStack` overtakes the
+flat rental line):
+
+| Rental kind | net481 crossover | net10 crossover |
+|---|--:|--:|
+| TLS hit (first rental) | ~1.3 KB | ~190 bytes |
+| Locked (second rental) | ~3 KB | ~1.8 KB |
+
+How to read it:
+
+- **Below the crossover, the zeroed `stackalloc` is cheaper** than even a warm
+  TLS rental - so for small fixed buffers, do not rent; stack-allocate and (if
+  the write-before-read invariant holds) add `[SkipLocalsInit]` to drop the
+  zeroing entirely.
+- **net10's TLS rental is remarkably cheap (~5 ns)**, so on modern .NET the bar
+  for "rent instead of zero" is low - anything past ~190 bytes that you would
+  otherwise zero is a candidate. **net481's rental is ~4x that floor (~21 ns)**,
+  so on Framework you have to be allocating roughly **1.3 KB** before a rental
+  beats zeroing, and **3 KB** before it beats zeroing if the rental collides on a
+  busy bucket.
+- **The locked (second-rental) floor is the realistic one for hot, concurrent
+  paths** where the one-deep TLS slot is frequently already drained. Against that
+  floor zeroing wins up to ~1.8 KB on net10 and ~3 KB on net481.
+- These crossovers assume the rental memory is **uninitialized-safe** (you write
+  every slot before reading). If you would have to `Clear()` the rented array,
+  add the zeroing cost back to the rental side and the crossover moves much
+  higher - usually past any sane stack size, i.e. just stack-allocate.
+
+---
+
+## 4. Suppressing the zeroing instead
+
+If the buffer is a fixed, stack-friendly size and the code writes every slot
+before reading it, the best move is to keep it on the stack and turn the zeroing
+off. There are two ways; one is clearly better.
+
+### 4.1 `[SkipLocalsInit]` on the method (preferred)
+
+Annotate the method that contains the `stackalloc` with
+`[System.Runtime.CompilerServices.SkipLocalsInit]`. The C# compiler omits the
+`localsinit` flag, and both runtimes skip the clear. Requires
+`<AllowUnsafeBlocks>true</AllowUnsafeBlocks>` in the project (already set in
+`touki.csproj`, and the attribute is already used throughout the library).
+
+`[SkipLocalsInit]` is a **compiler + CLR** mechanism, not a BCL feature. Per the
+[C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute),
+the attribute "prevents the compiler from setting the `.locals init` flag when
+emitting to metadata," and "the `.locals init` flag causes the CLR to initialize
+all of the local variables." The desktop .NET Framework CLR honors the absence
+of that flag exactly as CoreCLR does - which is why the net481 column above
+shows the zeroing disappearing.
+
+A common source of confusion: the
+[`SkipLocalsInitAttribute` API page](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute)
+lists "Applies to: .NET 5-11" and does **not** list .NET Framework. That only
+means the attribute *type* does not ship in the Framework BCL - it says nothing
+about whether the runtime honors the flag. Because the attribute is just a
+marker the compiler reads, you supply the type yourself downlevel; this repo
+source-generates it with **PolySharp** (`PolySharpIncludeRuntimeSupportedAttributes`
+in `touki.csproj`), so `[SkipLocalsInit]` compiles and takes effect on net481.
+
+There is a real caveat, but it does **not** apply to `stackalloc`. The attribute
+only skips zero-init that is otherwise redundant; the JIT still zeroes (and
+GC-tracks) any local that contains **managed references**, for GC safety - see
+the GC-reference note in
+[Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices).
+But `stackalloc T[]` requires `T` to be an
+[unmanaged type](https://learn.microsoft.com/dotnet/csharp/language-reference/builtin-types/unmanaged-types),
+and `fixed` buffers are likewise unmanaged, so a stack scratch buffer has no
+managed references and the zeroing is fully elided. The caveat would only bite
+if you applied `[SkipLocalsInit]` expecting it to skip a plain local (or a
+struct) that holds object references - that is still zeroed.
+
+| 4 KB scratch | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| zeroed `stackalloc` | 53.0 ns | 14.8 ns |
+| `[SkipLocalsInit]` `stackalloc` | **1.7 ns** | **1.3 ns** |
+
+The zeroing essentially vanishes on both TFMs - a ~30x win on net481, ~11x on
+net10. This is the cleanest option: one attribute, one code path, no pool
+bookkeeping, allocation-free.
+
+### 4.2 Fixed-buffer ref struct + `Unsafe.SkipInit` (special cases only)
+
+The pattern the BCL sometimes uses: a struct carrying an inline `fixed` buffer,
+left uninitialized with `Unsafe.SkipInit(out scratch)`, exposing a scoped `Span`
+via an `[UnscopedRef]` property. `Unsafe.SkipInit` ships in the `System.Runtime`
+/ netstandard `Unsafe` surface and **is available on net481**.
+
+| 4 KB scratch | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| `[SkipLocalsInit]` `stackalloc` | 1.7 ns | 1.3 ns |
+| fixed-buffer + `Unsafe.SkipInit` | 16.3 ns | 26.3 ns |
+
+**This pattern is slower than plain `[SkipLocalsInit]` on both TFMs, and on net10
+it is slower than just zeroing.** The cost is the `Unsafe.AsPointer` + `Span`
+construction and the fixed-buffer addressing the JIT cannot fold as well as a
+raw `stackalloc`. Reach for it only when you genuinely need the scratch to live
+in a struct that is passed around (so a bare `stackalloc` local will not do) -
+not as a default. For a plain local buffer, `[SkipLocalsInit]` + `stackalloc`
+wins.
+
+### 4.3 `BufferScope<T>`: stack buffer with a pool fallback
+
+The size sweep in section 3.2 assumes you know the size up front. Often you do
+not: the common size is small and stack-friendly, but a rare large input must
+still be handled without overflowing the stack. `Touki.Buffers.BufferScope<T>`
+is built for exactly this - **start on a `stackalloc` buffer, transparently fall
+back to an `ArrayPool<T>` rental only when the requested capacity exceeds it**:
+
+```csharp
+[SkipLocalsInit]
+static int Process(ReadOnlySpan<char> input)
+{
+    // Common case stays on the stack; large input rents from the pool.
+    using BufferScope<char> buffer = new(stackalloc char[256], input.Length);
+    // ... use buffer as a Span<char> ...
+}
+```
+
+`BufferScope<T>` is a `ref struct` that wraps the caller's `stackalloc` span and
+only rents when `minimumLength` overflows it; `Dispose` returns the rental (and
+is a no-op on the stack-only path). Crucially, **the `stackalloc` lives in the
+caller**, so the caller's `[SkipLocalsInit]` controls whether that buffer is
+zeroed - the wrapper never clears stack memory itself.
+
+`BufferScopeOverheadPerf` measures the wrapper against the hand-written
+equivalent on each path. The 256-byte stack buffer either satisfies the request
+(`StackOnly`) or is overflowed by a 1024-byte request that forces a rental
+(`Rent`):
+
+| Path | net481 RyuJIT | net10 RyuJIT |
+|---|--:|--:|
+| direct `stackalloc`, `[SkipLocalsInit]` | 7.7 ns | 0.90 ns |
+| `BufferScope` stack-only, `[SkipLocalsInit]` | 8.8 ns | 1.23 ns |
+| `BufferScope` stack-only, **zeroed** (no SkipLocalsInit) | 11.6 ns | 2.26 ns |
+| direct pool Rent/Return | 25.3 ns | 4.99 ns |
+| `BufferScope` grow-to-rental | 28.6 ns | 5.20 ns |
+
+Two things to take from this:
+
+- **The wrapper overhead is small** - about +1 ns on net481 / +0.3 ns on net10
+  for the stack-only path, and +3 ns / +0.2 ns for the rental path. You are
+  paying a constructor and a `Dispose` branch on top of the underlying
+  stackalloc-or-rent cost, nothing more.
+- **`BufferScope` is `[SkipLocalsInit]`-friendly.** Compare the stack-only rows:
+  with `[SkipLocalsInit]` on the calling method the scope costs 8.8 ns (net481)
+  / 1.23 ns (net10); without it, the same scope pays the 256-byte zeroing and
+  rises to 11.6 ns / 2.26 ns. The wrapper passes the localsinit decision
+  straight through to the caller's `stackalloc`, so you keep the zeroing-
+  suppression win on the common path **and** get a safe pool fallback for the
+  rare large input. This is the recommended shape whenever the size is variable
+  or unbounded but usually small.
+
+### 4.4 Risks of skipping init (and the inlining trap)
+
+`[SkipLocalsInit]` is `unsafe` for a reason: it hands you **uninitialized
+memory**. The
+[best-practices guidance](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices)
+is to use it only where a profile shows the zeroing is hot. Specific risks:
+
+- **You must write before you read.** With the `localsinit` flag gone, a
+  `stackalloc` (or any local) contains whatever was previously on the stack.
+  Reading a slot you have not assigned yields a garbage value - and worse, it is
+  *non-deterministic*: it passes in tests where the stack happened to be zero and
+  fails in production. Only apply `[SkipLocalsInit]` to a buffer whose every read
+  slot is provably written first (e.g. you fill `[0..count]` and only ever read
+  `[0..count]`).
+- **It is a potential information-disclosure vector.** Uninitialized stack memory
+  can contain remnants of previous frames (other callers' data). If any unwritten
+  portion of the buffer can be observed - returned, copied out, hashed, or
+  serialized - you may leak unrelated data. The `<AllowUnsafeBlocks>` requirement
+  exists precisely to flag this.
+- **The attribute's scope follows inlining, which you do not fully control.**
+  `[SkipLocalsInit]` applied to a method also covers its nested local functions
+  and lambdas, but it does **not** transfer across a normal call boundary: a
+  helper you call keeps its own localsinit setting. The subtle part is the
+  interaction with the JIT inliner:
+  - If method `A` is `[SkipLocalsInit]` and the JIT **inlines** a non-attributed
+    helper `B` into `A`, `B`'s `stackalloc`/locals do **not** retroactively
+    become skip-init - the localsinit decision is fixed by the compiler per
+    method at IL-emit time, before the JIT inlines. So you cannot rely on
+    inlining to "spread" the attribute. Put `[SkipLocalsInit]` on the method that
+    physically contains the `stackalloc`.
+  - Conversely, inlining can move where the zeroing *appears* to happen. A tiny
+    `stackalloc` helper that is **not** `[NoInlining]` may be inlined into a
+    caller, and if that caller is also hot the zeroing folds into the caller's
+    prologue. This is why the benchmarks here force `[NoInlining]` on the touch
+    helpers: to measure the buffer cost in isolation rather than have the JIT
+    relocate or eliminate it. In real code the opposite is true - **let the small
+    helper inline**, and put `[SkipLocalsInit]` on whichever method ends up
+    owning the `stackalloc` after inlining (the one with the attribute, since the
+    compiler honored it there).
+  - On net481 the inliner is weaker (no tiered JIT, no dynamic PGO), so a helper
+    that inlines on net10 may stay a real call on net481, changing where the
+    zeroing lands and how much the surrounding code can be folded. Always verify
+    the win on **both** TFMs rather than assuming the net10 inlining shape
+    carries over.
+
+The safe default remains: prefer plain zeroed `stackalloc` (or `BufferScope`
+without `[SkipLocalsInit]`); reach for `[SkipLocalsInit]` only when a profile
+shows the clear is hot, the write-before-read invariant is guaranteed, and no
+unwritten bytes can escape.
+
+---
+
+## 5. Is the buffer stack-safe? Sizing guidance
+
+Suppressing the zeroing only makes sense if the buffer belongs on the stack at
+all. The constraint is the thread's stack budget. On both .NET Framework and
+modern .NET on Windows the default managed thread stack is **1 MB** (set in the
+executable's PE header; the
+[`Thread` constructor docs](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor)
+state "the default stack size (1 megabyte)" and warn against raising it). But
+library code may run on threads with smaller stacks: under partial trust on
+.NET Framework the minimum is **256 KB**
+([same docs](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor)),
+and some hosts constrain it further. The C# reference for
+[`stackalloc`](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc)
+adds two rules of its own: cap the allocation at a conservative limit (its
+example uses 1024 bytes) and **never `stackalloc` inside a loop** (analyzer
+[CA2014](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops)).
+So the working rule is **keep a single frame's `stackalloc` to a few KB and
+never put a `stackalloc` on a recursive or unbounded-loop path.**
+
+Apply this to the extglob engine seed (`RunEngine`):
+
+| Buffer | Element size | Count | Bytes |
+|---|--:|--:|--:|
+| `Frame[]` | 28 B | 32 | 896 |
+| `ProgramRange[]` (arena) | 16 B | 128 | 2048 |
+| `ProgramRange[]` (work) | 16 B | 32 | 512 |
+| `ProgramRange[]` (rest) | 16 B | 32 | 512 |
+| `int[]` (key) | 4 B | 99 | 396 |
+| **Total** | | | **4364 (~4.3 KB)** |
+
+This is safe to keep on the stack because:
+
+- **It is a single frame, ~4.3 KB.** Well under any reasonable per-call budget.
+- **It is not on a recursive path.** `RunEngine` allocates the seed once.
+  The negation handler's bounded re-entry goes through `RunEngineCore`, which
+  reuses caller-supplied probe buffers and does **not** `stackalloc` again, so
+  the 4.3 KB never multiplies with recursion depth.
+- **Every slot is written before it is read** (the work/rest/key buffers are
+  seeded by `CopyTo` and the per-production builders; frames/arena are written
+  before use and spill to `ArrayPool` only when an adversarial input outgrows
+  the seed). So it does not depend on zero-init and is a correct candidate for
+  `[SkipLocalsInit]`.
+
+Had the aggregate been tens of KB, or had the buffer sat on the recursive
+re-entry path, the answer would flip to a pool rental (rented once and reused
+across the recursion) despite the per-call overhead, to avoid stack overflow.
+
+---
+
+## 6. Decision procedure
+
+```
+Need a short-lived scratch buffer on a hot path?
+│
+├─ Is the size fixed and small (single frame ≲ a few KB),
+│  and NOT on a recursive / unbounded-loop path?
+│  │
+│  ├─ YES ──> stackalloc.
+│  │         Does the code write every slot before reading it?
+│  │         ├─ YES ──> add [SkipLocalsInit]. (best: ~1-2 ns, both TFMs)
+│  │         └─ NO  ──> plain zeroed stackalloc, OR zero only the
+│  │                    prefix you read. (net481 zeroing ~3.6x net10)
+│  │
+│  ├─ Usually small but occasionally large (variable / unbounded
+│  │  size, common case stack-friendly)? ──>
+│  │            BufferScope<T>(stackalloc T[N], minimumLength):
+│  │            stays on the stack for the common case, rents from the
+│  │            pool only when it overflows. Wrapper overhead ~1 ns
+│  │            net481 / ~0.3 ns net10. Put [SkipLocalsInit] on the
+│  │            CALLING method to drop the stack-buffer zeroing; the
+│  │            scope passes it through.
+│  │
+│  └─ NO (large, unbounded, recursive, or must escape the frame) ──>
+│            ArrayPool<T>.Shared, rented ONCE and reused across the
+│            loop/recursion. Accept the per-call Rent/Return floor
+│            (~10 ns/op net481, ~4 ns/op net10); minimize the number
+│            of distinct rentals and avoid two same-bucket rentals
+│            colliding in the TLS cache.
+│
+└─ Need the scratch to live inside a struct that is passed around?
+          fixed-buffer + Unsafe.SkipInit (available on net481), but
+          know it is slower than a bare [SkipLocalsInit] stackalloc -
+          use only when a local stackalloc genuinely will not fit the
+          design.
+```
+
+Key rules of thumb:
+
+- **Measure the zeroing before assuming it is the cost.** Sampling profilers
+  attribute stack zeroing to `System.Buffer.ZeroMemoryInternal` (or `memset`);
+  if that frame is hot, a `[SkipLocalsInit]` experiment is the first thing to
+  try. But scope the profile to the measured workload - warmup/JIT dilute the
+  percentage and a tiny hot frame can be over-attributed by the sampler.
+- **net481 amplifies both costs.** Constant-size zeroing is ~3.6x and pool
+  overhead ~2.5x more expensive than net10. A buffer strategy that looks free on
+  net10 can dominate on Framework; always check both TFMs.
+- **Element type does not change zeroing cost** - only byte count does.
+- **Know the crossover size before choosing rent vs zero** (section 3.2): for a
+  runtime-variable size, a zeroed `stackalloc` is cheaper than a rental below
+  roughly **190 bytes on net10 / 1.3 KB on net481** against a warm TLS rental,
+  and below roughly **1.8 KB on net10 / 3 KB on net481** against a contended
+  (locked) rental. Above those sizes a rental's flat floor wins - provided you
+  can use the uninitialized memory without clearing it. A compile-time-constant
+  size zeroes far cheaper on net10, pushing its crossover higher.
+- **A pool rental is not free even when warm.** Prefer suppressing the zeroing on
+  a stack buffer over renting, whenever the size and lifetime allow it.
+- **For variable sizes, reach for `BufferScope<T>` instead of choosing up front.**
+  It stays on the stack for the common case and rents only when overflowed, for
+  a ~1 ns (net481) / ~0.3 ns (net10) wrapper cost, and forwards the calling
+  method's `[SkipLocalsInit]` to the stack buffer.
+- **`[SkipLocalsInit]` hands you uninitialized memory - use it carefully.** Only
+  where a profile shows the clear is hot, every read slot is written first, and
+  no unwritten bytes can escape. Place it on the method that physically holds the
+  `stackalloc`; the JIT inliner will not spread it for you, and net481's weaker
+  inliner can change where the zeroing lands, so verify on both TFMs.
+
+---
+
+## 7. References
+
+- [`SkipLocalsInit` attribute - C# attribute reference](https://learn.microsoft.com/dotnet/csharp/language-reference/attributes/general#skiplocalsinit-attribute) - the compiler/CLR `.locals init` mechanism.
+- [`SkipLocalsInitAttribute` class](https://learn.microsoft.com/dotnet/api/system.runtime.compilerservices.skiplocalsinitattribute) - the "Applies to: .NET 5-11" type-availability note (polyfilled downlevel by PolySharp).
+- [Unsafe code best practices](https://learn.microsoft.com/dotnet/standard/unsafe-code/best-practices) - `[SkipLocalsInit]`/`Unsafe.SkipInit` guidance and the GC-reference caveat.
+- [`stackalloc` expression](https://learn.microsoft.com/dotnet/csharp/language-reference/operators/stackalloc) - unmanaged-type requirement, undefined initial contents, sizing and loop rules.
+- [CA2014: Do not use `stackalloc` in loops](https://learn.microsoft.com/dotnet/core/compatibility/code-analysis/5.0/ca2014-stackalloc-in-loops).
+- [`Thread` constructor](https://learn.microsoft.com/dotnet/api/system.threading.thread.-ctor) - 1 MB default stack, 256 KB partial-trust minimum on .NET Framework.
+- Benchmarks backing the numbers: `touki.perf/StackZeroInitPerf.cs`, `touki.perf/ArrayPoolSeedRentPerf.cs`, `touki.perf/ArrayPoolCrossoverPerf.cs` (the size sweep in section 3.2), and `touki.perf/BufferScopeOverheadPerf.cs` (the `BufferScope` overhead in section 4.3).

--- a/docs/globbing-feature-plan.md
+++ b/docs/globbing-feature-plan.md
@@ -1236,7 +1236,7 @@ The cheapest items first, building toward the path-aware phase:
 | 9 | F3.3 segment-level pruning + `MatchSet` composition + `RootAnchored`/`DirectoryOnly` enforcement | ~1-2 days | Subtree skipping for literal-prefix excludes; mixed-dialect include/exclude sets; gitignore enforcement |
 | 10 | F4 brace expansion | ~1 day | `Bash` feature-complete |
 | 11 | F5 POSIX bracket extras - **done** | ~half-day | `Posix` `[[:class:]]` parity |
-| - | F1.2 / F1.2b `Win32` + `WinNT` - **deferred, low priority** | ~2-3 days | Two dialects closed; needs dedicated `Win32GlobMatcher` (BCL `MatchPattern` port) |
+| - | F1.2 / F1.2b `Win32` + `WinNT` - **indefinitely postponed (removed from `GlobDialect`)** | ~2-3 days | Two dialects closed; needs dedicated `Win32GlobMatcher` (BCL `MatchPattern` port) |
 
 Stop conditions between slices - same as
 [globbing-optimization-plan.md §4](globbing-optimization-plan.md#4-proposed-slice-order):

--- a/docs/globbing-feature-plan.md
+++ b/docs/globbing-feature-plan.md
@@ -1,32 +1,175 @@
-# Glob matcher - feature implementation plan
+# Glob matcher - status and next steps
 
-Tracks remaining glob functionality not yet shipped on the
-`feature/globbing-phase1` branch. Companion to
-[globbing-optimization-plan.md](globbing-optimization-plan.md) (which tracks
-match-time perf work) - this doc tracks **feature coverage**: dialects, options,
-and pattern syntax not yet supported.
+The glob feature surface is **complete**. Every dialect, option, and pattern
+syntax originally planned for the matcher has shipped, with one deliberate
+exception: the Windows `Win32` / `WinNT` dialects are **indefinitely
+postponed** and have been removed from `GlobDialect` (see
+[Win32 / WinNT - indefinitely postponed](#win32--winnt---indefinitely-postponed)).
 
-For the per-dialect ignore-case semantic mapping (already implemented) see
+This document now serves two purposes:
+
+1. A **record of the completed feature work** (the [Shipped features](#shipped-features)
+   summary and the per-phase notes that follow it).
+2. A **forward-looking plan for continual performance improvement and
+   simplification** - the active section is
+   [Next steps - performance and simplification](#next-steps---performance-and-simplification),
+   which captures the current flame-graph investigation and the directory-pruning
+   work it motivates.
+
+Companion docs: [globbing-optimization-plan.md](globbing-optimization-plan.md)
+(match-time micro-optimization slices) and
+[framework-span-performance.md](framework-span-performance.md) (the net472/net481
+slow-span playbook). For the per-dialect ignore-case mapping see
 [touki/Touki/Io/Globbing/GlobOptions.cs](../touki/Touki/Io/Globbing/GlobOptions.cs)
 `IgnoreCase` and the internal `IgnoreCaseKind` enum.
 
 ## Status snapshot
 
-**Dialects shipped (8 of 9):** `Posix`, `Simple`, `PowerShell`, `PosixPath`
+**Dialects shipped (8):** `Posix`, `Simple`, `PowerShell`, `PosixPath`
 (path-aware + globstar), `MSBuild` (path-aware + globstar, case-insensitive
 by default), `Bash` (path-aware, globstar opt-in, extglob opt-in via
-`AllowExtGlob`),
-`FileSystemGlobbing` (path-aware + implicit globstar, no classes, no
-escape), `Git` (path-aware + implicit globstar, with gitignore-style
-`!` / leading `/` / trailing `/` markers). Only `Win32` remains gated;
-it needs a dedicated `Win32GlobMatcher`.
+`AllowExtGlob`), `FileSystemGlobbing` (path-aware + implicit globstar, no
+classes, no escape), `Git` (path-aware + implicit globstar, with
+gitignore-style `!` / leading `/` / trailing `/` markers).
+
+**Postponed indefinitely:** `Win32` and `WinNT`. Removed from `GlobDialect`;
+the defensive `FeatureNotEnabled` branch in `GlobSpecification.TryCompile`
+covers any out-of-range dialect value.
 
 **`GlobOptions` flags consumed (5 of 5):** `IgnoreCase`, `MatchLeadingDot`,
 `NoEscape`, `AllowGlobStar`, `AllowExtGlob`.
 
-**Tests:** 333 glob tests cover the implemented surface (both TFMs). New
-tests must be added alongside each feature below - see
-`touki.tests/Touki/Io/Globbing/`.
+**Phases complete:** Phase 1 (path-unaware dialects + extglob), Phase 2
+(path-aware matching + globstar), Phase 3 (`.gitignore` negation / anchors /
+directory-only / `OrderedMatchSet` / `GitIgnore` loader), Phase 5 (POSIX
+bracket-expression extras). Phase 4 (brace expansion) remains an optional
+`Bash`-only convenience - see [Phase 4](#phase-4---brace-expansion-bash-only).
+
+**Tests:** the full suite is green on both TFMs (net10.0 and net481),
+including the per-dialect oracle suites. New tests must be added alongside
+each future change - see `touki.tests/Touki/Io/Globbing/`.
+
+---
+
+## Next steps - performance and simplification
+
+This is the active work. The feature surface is frozen; the remaining effort
+is making the enumeration paths faster (especially on the net472/net481
+RyuJIT) and removing avoidable complexity.
+
+### N1. Flame-graph investigation - extglob enumeration (current)
+
+CPU profiling of [`touki.perf/MsBuildEnumeratePerf2.cs`](../touki.perf/MsBuildEnumeratePerf2.cs)
+on the touki repo (`**/*.cs` minus `bin`/`obj`, 4850 `.cs` files) captured
+two extglob-collapse scenarios:
+
+- `GlobEnumeratorExtGlobSingle` - `!(bin|obj)/**/*.cs`
+- `GlobEnumeratorExtGlobSingleWithRoot` - `@(!(bin|obj)/**/*.cs|*.cs)`
+
+Measured means (BenchmarkDotNet, ratio vs the `Microsoft.Build` `FileMatcher`
+baseline):
+
+| Scenario | net10.0 (modern RyuJIT) | net481 (.NET Framework 4.8.1 RyuJIT) |
+|---|---|---|
+| `GlobEnumeratorReduced` (`**/*.cs` + `bin/**`,`obj/**` excludes) | 44.7 ms (0.39) | 49.0 ms (0.56) |
+| `GlobEnumeratorExtGlobSingle` | 52.0 ms (0.46) | 76.3 ms (0.87) |
+| `GlobEnumeratorExtGlobSingleWithRoot` | 51.9 ms (0.46) | 79.1 ms (0.90) |
+
+The extglob collapse is only +15% over the reduced excludes on net10 but
+**+56-65% on net481** - the standout regression and the reason this
+investigation exists.
+
+**Flame-graph reading.** EventPipe `CpuSampling` (net10 only; net481 has no
+in-proc profiler) fully inlines the matcher predicate into
+`FileSystemEnumerator<T>.MoveNext`, so the predicate shows up as `MoveNext`
+self-time. Per workload iteration of the complex extglob, `MoveNext`
+(~8.1 s inclusive in the trace) splits roughly:
+
+- ~38% inlined compiled-extglob predicate (the `ExtGlobEngine` walk run per entry).
+- ~44% OS directory traversal: `FindNextEntry` + per-directory `Kernel32.CloseHandle`.
+- ~13% `Monitor.Enter_Slowpath` inside the BCL enumerator's own buffer/handle
+  machinery (verified: no locks exist in the touki glob stack).
+
+SVGs: [scratch/extglob-single-flame.svg](../scratch/extglob-single-flame.svg)
+and [scratch/extglob-root-flame.svg](../scratch/extglob-root-flame.svg).
+
+**Root cause (verified in source).** `!(bin|obj)/**/*.cs` compiles to a
+program whose first opcode is `AltStart`, so
+`CompiledGlobStrategy.ComputeLiteralPathPrefix` returns an empty literal
+prefix. With no literal prefix, `GlobMatch.MatchesDirectory` returns `true`
+for *every* directory - including `bin` and `obj`. The enumerator therefore
+**descends into `bin`/`obj` and rejects each `.cs` file** via the full
+`ExtGlobEngine` backtracking walk, instead of pruning those subtrees at the
+directory boundary the way the `bin/**`,`obj/**` excludes do. On a .NET repo
+the `bin`/`obj` trees dwarf the source tree, so the extglob variant runs the
+most expensive matcher over the most files - exactly backwards.
+
+### N2. Directory pruning for first-segment negations (primary proposal)
+
+Teach the directory-recursion decision to evaluate a leading negation
+(`!(a|b)/...`) against the *candidate directory name* so matching subtrees are
+never descended.
+
+- **Where:** `GlobMatch.MatchesDirectory` (called from
+  `MatchEnumerator.ShouldRecurseIntoEntry`). Today it short-circuits only on a
+  non-empty `LiteralPathPrefix`; extend it to recognize a leading
+  `AltStart`-with-negation whose alternatives are plain literals (the
+  `!(bin|obj)` shape) and return `false` when the candidate's first segment
+  matches one of the negated literals.
+- **Payoff:** removes the dominant avoidable cost on *both* TFMs (no per-file
+  `ExtGlobEngine` walk over `bin`/`obj`) and should close most of the gap to
+  `GlobEnumeratorReduced`. Largest single win, and it helps net481 most
+  because that path pays the slow-span indexer per engine step.
+- **Risk:** the pruning must be conservative - only prune when the leading
+  construct is provably a first-segment negation of literal alternatives
+  anchored at the path root. Any globstar or nested wildcard before the
+  negation, or alternatives that aren't plain literals, must fall back to
+  descend-and-filter. Add regression tests that pin a non-prunable shape
+  (e.g. `**/!(bin)/*.cs`) still enumerates correctly.
+
+### N3. Specialize the `!(set)/**/suffix` shape (follow-on)
+
+If N2's directory pruning is not enough, add a dedicated `GlobStrategy` for the
+`!(literal-set)/**/suffix` shape - the same approach that produced
+`MultiSuffixGlobStrategy` for `**/@(*.litN|...)`. A first-segment set-exclusion
+check plus a suffix check replaces the general backtracking engine entirely for
+this common MSBuild collapse. Gated behind a benchmark showing N2 alone leaves
+measurable headroom.
+
+### N4. net481 span tuning of the `ExtGlobEngine` inner loop
+
+The +56-65% net481 regression lives in the per-file engine walk. Apply the
+`MemoryMarshal.GetReference` + `Unsafe.Add` hoist from
+[framework-span-performance.md](framework-span-performance.md) to the
+`ExtGlobEngine` opcode and state-serialization loops (the slow-span indexer
+costs ~8 µops/element on net481 vs ~1 on net10). Per that doc, expect a 19-44%
+Framework win at no `unsafe`-keyword cost. **Measure net10 does not regress
+before `#if`-splitting**; prefer a single simple implementation when it stays
+within ~5% on net10.
+
+### N5. Simplification opportunities
+
+- **Specialized-matcher path-aware fast paths (deferred since F2.1).**
+  `Prefix`/`Suffix`/`Contains`/`PrefixSuffix` route to `CompiledGlobMatcher`
+  for path-aware dialects. Either grow separator-aware fast paths *or* delete
+  the dead intent and document that `CompiledGlobMatcher` owns these shapes.
+  Decide based on a path-aware benchmark; do not carry the ambiguity.
+- **Empty-literal-prefix `MatchesDirectory` pruning (deferred since F3.3).**
+  Patterns whose literal prefix is empty (e.g. `**/*.cs`) recurse
+  unconditionally. N2 handles the negation case; a separator-checkpointed NFA
+  savepoint API would generalize pruning to other empty-prefix shapes - only
+  if a benchmark justifies the added matcher surface.
+- **Prefer one implementation over `#if`-split variants** unless net10
+  measurably regresses, so the simple source keeps accruing future RyuJIT
+  improvements (per the repo's span-performance guidance).
+
+---
+
+## Shipped features
+
+The remainder of this document records the completed feature work and the
+design decisions behind it. It is kept for reference; the active plan is
+[Next steps](#next-steps---performance-and-simplification) above.
 
 ---
 
@@ -65,71 +208,14 @@ rather than `\`.
   per-dialect mappings.
 - **Ref:** [about_Wildcards](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_wildcards).
 
-### F1.2 `Win32` dialect - **deferred (low priority)**
+### F1.2 / F1.2b `Win32` and `WinNT` dialects - **indefinitely postponed**
 
-Goal: bit-for-bit parity with
-[`FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression).
-That API does two things the matcher today does not:
-
-1. **Pre-translates the pattern** via `TranslateWin32Expression`: `?`
-   becomes `>` (DOS_QM); a `.` becomes `"` (DOS_DOT) when followed by
-   `?` or `*`; a trailing `*.` becomes `*<` (DOS_STAR). This is the
-   historical 8.3-compat shim that makes `*.*` match files without an
-   extension and `*.foo` match `name.foo` cleanly. The matcher needs
-   to perform the same translation up front so callers can pass
-   un-translated patterns and get BCL behavior.
-2. **Runs a multi-state NFA** that tracks every possible expression
-   position per input character. The DOS metachars (`<`, `>`, `"`)
-   have semantics that don't fit the current single-savepoint
-   backtracker:
-   - `<` (DOS_STAR) - zero or more chars, must stop before the
-     **last** `.` in the name (requires lookahead to know which `.` is
-     last).
-   - `>` (DOS_QM) - zero or one char; on `.` or end-of-name,
-     advances the expression past any contiguous run of `>`s.
-   - `"` (DOS_DOT) - matches a `.` **or** matches zero chars at
-     end-of-name (epsilon).
-
-   These epsilon transitions and the "skip contiguous `>`s" behavior
-   mean a single `(pi, si)` savepoint is insufficient; the NFA needs
-   the BCL's prior/current `Span<int>` match-set or an equivalent
-   stack.
-
-**Implementation plan:** port the BCL `MatchPattern` algorithm
-(`useExtendedWildcards: true` branch) directly into a new
-`Win32GlobMatcher` - the current `CompiledGlobMatcher` NFA is
-the wrong shape and trying to shoehorn DOS semantics into it costs
-more than just keeping the dedicated implementation. Pre-translate
-the pattern at compile time so the matcher only ever sees the
-extended-wildcard form.
-
-`Win32` defaults to case-insensitive matching per
-[D4](#d4-win32-dialect-ignorecase-is-the-default).
-
-- **Touches:** New `Win32GlobMatcher.cs`; `GlobMatcherFactory` routes
-  `Win32` patterns to it directly (no shape detection - the
-  factory's specialized shapes don't survive the pre-translation).
-  `GlobMatcher.TryCompile` adds `Win32` to its allow-list. No changes
-  to `GlobOpCodes` or the shared `CompiledGlobMatcher`.
-- **Tests:** Golden cross-reference against
-  `System.IO.Enumeration.FileSystemName.MatchesWin32Expression` (net10
-  only - the API is not on net472) for every case in the BCL's
-  own test suite. Spot-checks for `*.*`, `*.`, `*.foo`, `a?b`, raw
-  `<`/`>`/`"` already present in patterns (the pre-translation is
-  idempotent for those characters).
-- **Ref:** [FsRtlIsNameInExpression](https://learn.microsoft.com/windows-hardware/drivers/ddi/ntifs/nf-ntifs-fsrtlisnameinexpression),
-  [`FileSystemName.cs` source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs).
-
-### F1.2b `WinNT` dialect - **deferred (low priority)**
-
-Same NFA as F1.2 but **without** the `TranslateWin32Expression`
-pre-pass. Exposes raw `FsRtlIsNameInExpression` semantics so callers
-working at the kernel-name level (file-system filter drivers, NT
-object-namespace scanners) can match the way the Object Manager
-matches. Requires a new `GlobDialect.WinNT` enum entry and an
-`IgnoreCaseKindTests` / `MatchesLeadingDotByDefault` row alongside
-`Win32`. Same case-insensitive default as `Win32`. Shares the
-`Win32GlobMatcher` implementation behind a "translate?" bool.
+See [Win32 / WinNT - indefinitely postponed](#win32--winnt---indefinitely-postponed)
+below. Both dialects were removed from `GlobDialect`; callers needing those
+semantics call
+[`System.IO.Enumeration.FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression)
+directly (reachable on net10 via the BCL; see `Touki.Io.Paths` for the
+`MatchType.Win32` enumeration shim).
 
 ### F1.3 `AllowExtGlob` option - **done**
 
@@ -630,6 +716,43 @@ full POSIX bracket-expression grammar also includes:
 
 ---
 
+## Win32 / WinNT - indefinitely postponed
+
+The Windows-native dialects `Win32` (with the `TranslateWin32Expression`
+8.3-compat pre-pass) and `WinNT` (raw `FsRtlIsNameInExpression` semantics)
+were planned but are **indefinitely postponed**, and the `Win32` member has
+been **removed from `GlobDialect`** along with every doc cref and test row
+that referenced it.
+
+**Why postponed.** Bit-for-bit `FileSystemName.MatchesWin32Expression` parity
+needs a multi-state NFA with epsilon transitions for the DOS metacharacters
+(`<` DOS_STAR, `>` DOS_QM, `"` DOS_DOT) that does not fit the current
+single-savepoint backtracker. It would require a dedicated `Win32GlobMatcher`
+plus a compile-time `TranslateWin32Expression` pre-pass. There is no concrete
+caller asking for it, and callers who need exact Windows matching today can
+call the BCL directly.
+
+**What replaces it.** Anyone needing Win32 / NT matching semantics calls
+[`System.IO.Enumeration.FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression)
+(net10 BCL) directly. `Touki.Io.Paths` already surfaces the
+`System.IO.Enumeration.MatchType.Win32` enumeration mode for the file-system
+enumerator. This is unrelated to `GlobDialect` and is not affected by the
+removal.
+
+**Bringing it back.** If a future caller needs it, re-add a `Win32` (and
+optionally `WinNT`) member to `GlobDialect`, add it to the
+`GlobSpecification.TryCompile` allowlist, and port the BCL `MatchPattern`
+algorithm (`useExtendedWildcards: true` branch) into a new
+`Win32GlobMatcher`. Oracle: cross-reference against
+`MatchesWin32Expression` (net10 only; the API is not on net472), and
+`RtlIsNameInExpression` P/Invoke on Windows. `Win32` defaults to
+case-insensitive (Unicode) matching - the historical D4 decision.
+
+- **Ref:** [FsRtlIsNameInExpression](https://learn.microsoft.com/windows-hardware/drivers/ddi/ntifs/nf-ntifs-fsrtlisnameinexpression),
+  [`FileSystemName.cs` source](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs).
+
+---
+
 ## Cross-cutting follow-ups
 
 ### Ignore-case customization (in
@@ -675,7 +798,6 @@ platform constraints for running it.
 | `PosixPath` | `fnmatch(3)` with `FNM_PATHNAME` flag set | Same P/Invoke; Python `pathlib.PurePath.match` is approximate, not exact | Linux/macOS native; WSL on Windows |
 | `Simple` | [`System.IO.Enumeration.FileSystemName.MatchesSimpleExpression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matchessimpleexpression) | Direct managed call | Any TFM net5+ - **net10 test project, cross-platform** |
 | `PowerShell` | [`System.Management.Automation.WildcardPattern`](https://learn.microsoft.com/dotnet/api/system.management.automation.wildcardpattern) | Reference `System.Management.Automation` (Windows PowerShell SDK / pwsh SDK), or subprocess to <c>pwsh -c</c> | SMA assembly is Windows-only by default; <c>pwsh</c> subprocess works cross-platform if PowerShell 7+ is installed |
-| `Win32` | [`System.IO.Enumeration.FileSystemName.MatchesWin32Expression`](https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression) | Direct managed call (algorithm is pure managed) | Any TFM net5+ - **net10 test project, cross-platform**. Cross-check against <c>RtlIsNameInExpression</c> P/Invoke on Windows-only |
 | `Bash` | <c>bash -O extglob -O globstar -c '[[ &quot;$input&quot; == $pattern ]] ; echo $?'</c> | Subprocess to <c>bash</c> on PATH | bash 4.0+ native on Linux/macOS; Git Bash or WSL on Windows |
 | `MSBuild` | [`Microsoft.Build.Globbing.MSBuildGlob.Parse(pattern).IsMatch(input)`](https://learn.microsoft.com/dotnet/api/microsoft.build.globbing.msbuildglob) | Direct managed call (NuGet: `Microsoft.Build`) | Any TFM net472+ - **already referenced via `FileMatcherWrapper` for the enumeration parity check** |
 | `FileSystemGlobbing` | [`Microsoft.Extensions.FileSystemGlobbing.Matcher`](https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher) | Direct managed call (NuGet: `Microsoft.Extensions.FileSystemGlobbing`) | Any TFM netstandard2.0+ - **cross-platform** |
@@ -692,9 +814,9 @@ platform constraints for running it.
   `System.IO.Enumeration.FileSystemName.MatchesSimpleExpression`, but its
   semantic differs (no `FNM_PERIOD`, no leading-dot rule), so it's only
   useful for a partial cross-check, not a full oracle.
-- **`Simple`** and **`Win32`** are the easiest oracles because the BCL ships
-  managed implementations on every supported TFM and platform. These should
-  be the first oracle suites stood up; they validate the matchers most users
+- **`Simple`** is among the easiest oracles because the BCL ships a managed
+  implementation on every supported TFM and platform. This should be one of
+  the first oracle suites stood up; it validates the matcher most users
   encounter via `Directory.EnumerateFiles`.
 - **`PowerShell`** has two oracle paths. The in-process path needs a
   reference to `System.Management.Automation`, which is a Windows-only
@@ -728,7 +850,7 @@ platform constraints for running it.
 
 | Oracle | Windows runner | Linux runner | macOS runner |
 |---|:-:|:-:|:-:|
-| BCL `Simple` / `Win32` | yes | yes | yes |
+| BCL `Simple` | yes | yes | yes |
 | `Microsoft.Build` MSBuild | yes | yes | yes |
 | `Microsoft.Extensions.FileSystemGlobbing` | yes | yes | yes |
 | `LibGit2Sharp` | yes | yes | yes |
@@ -738,7 +860,7 @@ platform constraints for running it.
 | `pwsh` subprocess | yes | yes (if installed) | yes (if installed) |
 | `System.Management.Automation` direct | yes (Windows PowerShell 5.1 referenced) | requires `Microsoft.PowerShell.SDK` | requires `Microsoft.PowerShell.SDK` |
 
-The first four rows cover six of nine dialects (`Simple`, `Win32`,
+The first four rows cover five of the eight dialects (`Simple`,
 `MSBuild`, `FileSystemGlobbing`, `Git`) without any platform gating and
 should be the first slice of oracle work. The remaining three dialects
 (`Posix`, `PosixPath`, `Bash`) inherently require Unix-family tools and
@@ -748,9 +870,9 @@ platforms via `Microsoft.PowerShell.SDK` if the test surface grows.
 
 ### Suggested oracle-suite slice order
 
-1. **`Simple` and `Win32` BCL oracles** (zero deps, cross-platform).
-   The `MatchesSimpleExpression` / `MatchesWin32Expression` algorithms are
-   already in the BCL, so the test class is a thin theory comparing
+1. **`Simple` BCL oracle** (zero deps, cross-platform).
+   The `MatchesSimpleExpression` algorithm is already in the BCL, so the
+   test class is a thin theory comparing
    `GlobMatcher.Compile(..., Simple).IsMatch(input)` against the BCL.
 2. **`MSBuild` oracle** via `MSBuildGlob.Parse` - complements the
    existing enumeration parity check by isolating the pattern-level match.
@@ -794,7 +916,7 @@ currently does.
 | `Git` | **Touki already agrees with `LibGit2Sharp`** - all 21 sequential-separator rows pass. Empirically, the gitignore evaluator treats embedded `//` as a literal empty segment that fails to match any normal path component, so most `a//b` / `**//*.cs` / `a//**//b` patterns simply never match real files. Touki produces the same verdicts. | Pinned via [`LibGit2Sharp.Repository.Ignore.IsPathIgnored`](https://github.com/libgit2/libgit2sharp). Cross-platform; oracle runs on every CI runner. |
 | `Posix`, `PosixPath` | **Not coalesced**: runs of `/` are preserved verbatim in the pattern; `fnmatch(3)` (with or without `FNM_PATHNAME`) treats each `/` as a literal. Validated against P/Invoke <c>fnmatch(3)</c> on Linux. | All rows green on Linux. Encapsulated in [`FnmatchInterop`](../touki.tests/Touki/Io/Globbing/FnmatchInterop.cs); the glibc/macOS `FNM_PATHNAME` bit difference is the only platform-specific detail. |
 | `Bash` (with `extglob` + `globstar`) | **Not coalesced**: bash's `[[ str == pat ]]` preserves runs of `/` in the pattern. Validated against <c>bash -O extglob -O globstar -c '[[ "$INPUT" == $PATTERN ]]'</c>, with pattern/input passed through env vars to side-step shell quoting. | All rows green on Linux native bash and Windows Git Bash. |
-| `PowerShell`, `Win32` | _TBD._ `Win32` is not implemented in touki's compile yet; oracle suite deferred. `PowerShell` requires `System.Management.Automation` (Windows-only in net481, `Microsoft.PowerShell.SDK` cross-platform on net10) - deferred to avoid bloating the test project until needed. | &nbsp; |
+| `PowerShell` | _TBD._ `PowerShell` requires `System.Management.Automation` (Windows-only in net481, `Microsoft.PowerShell.SDK` cross-platform on net10) - deferred to avoid bloating the test project until needed. | &nbsp; |
 
 **Implementation status vs. the contract above.** All compile-time
 normalization landed in `GlobMatcherFactory.TryNormalizeRuns` plus
@@ -817,7 +939,7 @@ green on Windows:
   down so any future engine change that drifts will fail fast.
 
 The Posix-family (Linux/macOS oracles via P/Invoke `fnmatch` and `bash`
-subprocess) and `PowerShell` / `Win32` rules will be added to the table
+subprocess) and `PowerShell` rules will be added to the table
 above once their oracle runs produce data - the Posix/PosixPath/Bash
 suites are checked in and ready, just skipped on Windows hosts.
 
@@ -837,7 +959,7 @@ with the 26 shared rows in [MultipleAsteriskRows.cs](../touki.tests/Touki/Io/Glo
 | `Git` | **`***`+ behaves like `**` (globstar across path components)** in `wildmatch`. `***` matches every file in the tree; `a/***` matches `a/b` and `a/b/c` but not `a/` alone; `a/***/b` matches every depth `a/.../b`. | **25 / 26 green, 1 documented divergence.** Compile-time `***`+ &rarr; `**` plus `DisallowEmptyInput = true`. The remaining row (`a/***` vs `a/`) is gitignore's "trailing globstar requires &ge;1 input segment" rule, which our engine's `GlobStar` opcode doesn't enforce. Skipped with reason; trivial engine fix when needed. |
 | `Bash` (with `extglob` + `globstar`) | **`***`+ behaves like `**` (globstar)** under `globstar`. Crosses path separators, with the standard globstar carve-out that a `**` enclosed by separators (e.g. `***/foo`) requires at least one path component on its globstar side. | **22 / 26 green, 4 documented divergences.** Compile-time `***`+ &rarr; `**`. The remaining four rows are the shell-glob vs `[[ == ]]` semantic split - touki models bash's *shell-glob* `**` (segment-bounded; `*` doesn't cross `/`); the oracle uses bash's *string-match* `[[ ]]` semantics. Closing these needs a per-context flag; deferred until a real user need. |
 | `Posix`, `PosixPath` | All 26 rows green on Linux against `fnmatch(3)` with and without `FNM_PATHNAME`. Compile-time `***`+ &rarr; `*` matches `fnmatch` exactly. Suites skip on Windows. | **26 / 26 green** (Linux). |
-| `PowerShell`, `Win32` | TBD - oracle not implemented (see notes above). | &nbsp; |
+| `PowerShell` | TBD - oracle not implemented (see notes above). | &nbsp; |
 
 Cross-dialect summary: **only `Bash` and `Git` give `***`+ a globstar
 meaning. Every other dialect treats it as either invalid (MSBuild) or as
@@ -932,7 +1054,7 @@ its documented default; the flag is consulted only when set explicitly.
 
 | Dialect | Globstar default |
 |---|---|
-| `Posix`, `Simple`, `PowerShell`, `Win32` | off (path-unaware) |
+| `Posix`, `Simple`, `PowerShell` | off (path-unaware) |
 | `PosixPath` | off (requires explicit opt-in per the POSIX `**` extension) |
 | `Bash` | off (matches `shopt -s globstar` being off by default) |
 | `Git`, `MSBuild`, `FileSystemGlobbing` | on (their documented behavior) |
@@ -967,7 +1089,6 @@ documents its expected default:
 | Dialect | Default separator |
 |---|---|
 | `PosixPath`, `Bash`, `Git`, `FileSystemGlobbing`, `MSBuild` | `ForwardSlash` |
-| `Win32` | `OSDefault` |
 
 `MSBuild` was originally specified as `OSDefault` to match how MSBuild
 evaluates `Include` / `Exclude` strings on the calling OS. The shipped
@@ -983,7 +1104,7 @@ consistently. Documented at the type level on `GlobMatcher.IsMatch` and on
 the new `GlobPathSeparator` enum.
 
 This replaces the earlier idea of accepting both separators on Windows for
-`MSBuild`/`FileSystemGlobbing`/`Win32`. If a consumer needs both, they
+`MSBuild`/`FileSystemGlobbing`. If a consumer needs both, they
 normalize first - usually a single `ReadOnlySpan<char>` walk with
 `string.Replace` or a `Touki.Buffers` helper.
 
@@ -1017,21 +1138,15 @@ for the broader integration contract with
 [`IEnumerationMatcher`](../touki/Touki/Io/IEnumerationMatcher.cs) and
 [`MatchEnumerator<TResult>`](../touki/Touki/Io/MatchEnumerator.cs).
 
-### D4. `Win32` dialect: IgnoreCase is the default
+### D4. `Win32` dialect: IgnoreCase is the default - **retired**
 
-Windows file matching is documented as case-insensitive throughout
-`FsRtlIsNameInExpression`, `FileSystemName.MatchesWin32Expression`, and the
-Windows file system itself. `Win32` therefore implies
-`IgnoreCaseKind.Unicode` whether or not the caller sets
-`GlobOptions.IgnoreCase`.
-
-A new flag may be added later to force case-sensitive `Win32` matching
-(`GlobOptions.Win32CaseSensitive`?) for code that consumes the dialect at a
-lower level than the OS; deferred until there's a concrete caller.
-
-Implementation: update `GlobDialectExtensions.DefaultIgnoreCaseKind` so
-`Win32` returns `IgnoreCaseKind.Unicode` regardless of the `IgnoreCase`
-flag, and document the deviation on `GlobDialect.Win32`.
+This decision applied to the `Win32` dialect, which is now
+[indefinitely postponed](#win32--winnt---indefinitely-postponed) and removed
+from `GlobDialect`. Recorded here for the record: Windows file matching is
+case-insensitive throughout `FsRtlIsNameInExpression`,
+`FileSystemName.MatchesWin32Expression`, and the Windows file system itself,
+so if `Win32` is ever reintroduced it should imply `IgnoreCaseKind.Unicode`
+regardless of `GlobOptions.IgnoreCase`.
 
 ### D5. Path-aware matching integrates via `IEnumerationMatcher`; sets compose via `MatchSet`
 

--- a/docs/globbing-feature-plan.md
+++ b/docs/globbing-feature-plan.md
@@ -90,9 +90,6 @@ self-time. Per workload iteration of the complex extglob, `MoveNext`
 - ~13% `Monitor.Enter_Slowpath` inside the BCL enumerator's own buffer/handle
   machinery (verified: no locks exist in the touki glob stack).
 
-SVGs: [scratch/extglob-single-flame.svg](../scratch/extglob-single-flame.svg)
-and [scratch/extglob-root-flame.svg](../scratch/extglob-root-flame.svg).
-
 **Root cause (verified in source).** `!(bin|obj)/**/*.cs` compiles to a
 program whose first opcode is `AltStart`, so
 `CompiledGlobStrategy.ComputeLiteralPathPrefix` returns an empty literal

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -1,0 +1,504 @@
+# Performance investigation guide
+
+How to gather performance data with BenchmarkDotNet and turn it into a
+concrete answer to "where is the time going, and what do I change?" This is a
+field manual written for AI coding agents working in `touki`, optimized for
+**effective, token-efficient** investigation: measure narrowly, read only the
+artifacts that carry signal, and stop once the data points at a fix.
+
+It complements three existing, more specific resources. Read this first to pick
+a tool; drop into them for the mechanics:
+
+- [`performance-testing`](../.agents/skills/performance-testing/SKILL.md) skill
+  - authoring/running BenchmarkDotNet, `[MemoryDiagnoser]`, reading the table.
+- [`framework-jit-optimization`](../.agents/skills/framework-jit-optimization/SKILL.md)
+  skill - what to *change* once a `net481` loop is shown to be slow.
+- [.github/instructions/perf.instructions.md](../.github/instructions/perf.instructions.md)
+  - the non-negotiable conventions (Release-only, JIT-naming rule, regression
+  threshold) every measurement in this repo must obey.
+- [dotnet-perf-discoveries.md](dotnet-perf-discoveries.md) and
+  [framework-span-performance.md](framework-span-performance.md) - the catalog
+  of measured BCL behaviors. **Check these before measuring** - the answer may
+  already be recorded.
+- [arraypool-performance.md](arraypool-performance.md) and the
+  [`scratch-buffer-strategy`](../.agents/skills/scratch-buffer-strategy/SKILL.md)
+  skill - choosing a scratch buffer (zeroed `stackalloc` vs `[SkipLocalsInit]`
+  vs `BufferScope<T>` vs an `ArrayPool` rental) and the net481/net10 size
+  crossovers. Use the skill for the quick decision; the doc for the backing data.
+
+---
+
+## 0. TL;DR decision tree
+
+```mermaid
+flowchart TD
+    A[Performance question] --> B{What kind?}
+    B -->|"Is impl A faster than B?"| C[BenchmarkDotNet A/B<br/>MemoryDiagnoser + Baseline]
+    B -->|"Does this allocate?"| D[BenchmarkDotNet<br/>MemoryDiagnoser - read Allocated]
+    B -->|"Which method eats the time<br/>in a whole operation?"| E[Profiler: EventPipeProfiler<br/>or dotnet-trace -> speedscope]
+    B -->|"Why is THIS loop slow<br/>on net481?"| F[DisassemblyDiagnoser<br/>compare net481 vs net10 asm]
+    B -->|"Branch mispredicts / cache?"| G[HardwareCounters<br/>Windows + admin]
+    C --> H[Read *.md report only]
+    D --> H
+    E --> I[Open trace: speedscope.app<br/>or VS / PerfView]
+    F --> J[Read *-asm.md / *-asm.html]
+    G --> H
+    H --> K{Signal clear?}
+    K -->|Yes| L[Apply fix, re-measure same filter]
+    K -->|No| E
+```
+
+Rule of thumb for picking the entry point:
+
+| Question shape | Tool | Cost |
+| --- | --- | --- |
+| "A vs B", "did my change regress?" | BenchmarkDotNet `[Benchmark]` + `Baseline` | low |
+| "Does X allocate? how much?" | BenchmarkDotNet `[MemoryDiagnoser]` | low |
+| "Where in a multi-method operation is the time?" | `[EventPipeProfiler]` or `dotnet-trace` | medium |
+| "Why does the JIT emit slow code here?" | `[DisassemblyDiagnoser]` | medium |
+| "Is it branch misprediction / cache misses?" | `[HardwareCounters]` (Win+admin) | medium |
+| "Does it leak / churn the GC over a long run?" | `dotnet-counters`, `dotnet-gcdump` | medium |
+
+---
+
+## 1. Token-efficient measurement protocol
+
+The single biggest waste in an agent perf loop is running the whole benchmark
+suite and pasting the whole console transcript back into context. Don't.
+
+1. **Check the catalog first.** Grep [dotnet-perf-discoveries.md](dotnet-perf-discoveries.md)
+   and [framework-span-performance.md](framework-span-performance.md) for the API
+   or pattern. Many "valleys" and crossover thresholds are already measured and
+   explained; re-deriving them burns tokens and CPU.
+2. **Filter to one class or method.** Always pass `--filter` so only the
+   relevant rows run. `--filter *MySubjectPerf*` for a class,
+   `--filter *MySubjectPerf.Variant` for one method.
+3. **Smoke first, then confirm.** Use `--job short` (or a `[ShortRunJob]`) for
+   the first pass to validate the benchmark is well-formed and the direction of
+   the result. Only drop `--job short` for the number you will quote.
+4. **Read the file, not the scrollback.** BenchmarkDotNet writes a
+   GitHub-flavored Markdown table to
+   `BenchmarkDotNet.Artifacts/results/*-report-github.md`. Read that file (it is
+   compact and already formatted) instead of scraping the console output. For an
+   even tighter read, `grep` the columns you care about.
+5. **Quote the minimum.** Report `Mean`, `Ratio`, and `Allocated` for the rows
+   that changed. Do not paste environment banners, warnings, or unrelated rows.
+6. **Re-measure with the identical filter** after a fix so the before/after is
+   apples-to-apples. Name the TFM and JIT in the writeup (see the JIT-naming
+   rule).
+
+### Output artifact map (where the signal lives)
+
+After any run, `BenchmarkDotNet.Artifacts/results/` contains:
+
+| File | When to read it |
+| --- | --- |
+| `*-report-github.md` | **Default read.** Compact table for A/B and allocations. |
+| `*-report.csv` | Diffing two runs programmatically. |
+| `*-report-full.json` | Raw per-measurement data; only for statistical disputes. |
+| `*-asm.md` / `*-asm.html` | `DisassemblyDiagnoser` output - the emitted asm. |
+| `*.nettrace` / `*.etl` / `*.speedscope.json` | Profiler output - open in a viewer, don't read raw. |
+
+Do **not** check these into git unless intentionally pinning a baseline
+(per perf.instructions.md).
+
+---
+
+## 2. Layer 1 - BenchmarkDotNet (the default tool)
+
+BenchmarkDotNet is the source of truth for every perf claim in this repo. The
+[`performance-testing`](../.agents/skills/performance-testing/SKILL.md) skill has
+the full authoring workflow; this section is the investigation-oriented summary.
+
+### Run commands (from repo root, PowerShell)
+
+```powershell
+# A/B on modern .NET, one class, full confidence
+dotnet run -c Release -f net10.0 --project touki.perf -- --filter *MySubjectPerf*
+
+# Same on .NET Framework 4.8.1 (ALWAYS run both for cross-TFM code)
+dotnet run -c Release -f net481 --project touki.perf -- --filter *MySubjectPerf*
+
+# Fast smoke pass while iterating
+dotnet run -c Release -f net10.0 --project touki.perf -- --filter *MySubjectPerf* --job short
+```
+
+`-c Release` is mandatory. `-f <tfm>` is mandatory (`touki.perf` multi-targets,
+the SDK will not pick one). A regression on one TFM and not the other is real
+signal, not noise.
+
+### What the columns mean for an investigation
+
+- **Mean** - the number you compare. **Median** is a sanity check; a large
+  Mean/Median spread means the benchmark is unstable - fix it before drawing
+  conclusions (usually a forgotten return value or per-call setup).
+- **Ratio** - appears when one method is `[Benchmark(Baseline = true)]`. This is
+  what you cite for "1.4x faster".
+- **Allocated** - per-op managed bytes. `-` or `0 B` means allocation-free. Any
+  new allocation in a documented hot path is a regression *regardless of
+  throughput*. Always run with `[MemoryDiagnoser]`.
+- **Gen0/1/2** - GC collections per 1000 ops. New Gen1/Gen2 promotion in a
+  steady-state bench is a red flag even when `Allocated` looks small.
+
+### The two failure modes that produce garbage numbers
+
+1. **Returning `void` or an invariant constant** - dead-code elimination wipes
+   the body. Symptoms: "optimized" variant slower than baseline, >50% StdDev,
+   near-zero timings. Return a value derived from the work (for buffer-mutating
+   APIs return `buffer[0]` or an XOR digest, never `buffer.Length`).
+2. **Helper-method indirection** between the `[Benchmark]` and the
+   system-under-test - the wrapper's call frame and type checks show up in the
+   measurement. Rename one overload while measuring, or split into two classes.
+
+### Regression threshold (from perf.instructions.md)
+
+> Judge a delta against the benchmark's **own run-to-run noise**, not a fixed
+> percentage. Establish the noise floor first (re-run the baseline, or read
+> `Error`/`StdDev` - a clean microbench is usually stable to ~1-2 %). A
+> *consistent* slowdown above that floor is a regression **even if it is under
+> 5 %** - 5 % is not a free budget. Any new allocation in a hot path is a
+> regression regardless of throughput. A **small throughput cost is acceptable
+> when it buys an allocation reduction**: per-op `Mean` does not capture the
+> amortized GC time the reclaimed bytes would have cost, so trading a few
+> percent of `Mean` for materially fewer `Allocated` bytes is usually a net win.
+> Always report the delta *and* the noise floor you measured it against, and
+> name the TFM/JIT.
+
+---
+
+## 3. Layer 2 - finding *where* the time goes (profilers)
+
+BenchmarkDotNet answers "how fast" and "how much allocated". When the operation
+spans many methods and you need to know **which one** dominates, attach a
+profiler. There are two paths: in-harness diagnosers and standalone tools.
+
+### Profiling is part of the iteration loop, not a one-off
+
+Treat a profile the way you treat the benchmark table: **capture it before and
+after every change you intend to keep.** A before/after pair is what proves a
+mitigation moved the bottleneck you thought it did - and, just as often, reveals
+that it didn't (the wall-clock dropped but the call-tree shape is unchanged, so
+the win came from somewhere other than your stated reason). The loop is:
+
+1. Profile the baseline. Save the trace under a `before/` folder.
+2. Apply one mitigation.
+3. Profile again with the **identical filter**. Save under `after/`.
+4. Diff the two flame graphs. Confirm the frame you targeted actually shrank.
+5. Only then write the claim, and cite the before/after flame graphs.
+
+Stash-and-reprofile is the cheap way to get a clean baseline when the change is
+already in the working tree: `git stash push -- <file>`, rebuild, profile into
+`before/`, `git stash pop`, rebuild, profile into `after/`.
+
+### Profiler support by TFM (validated in this repo)
+
+**The in-harness `EventPipeProfiler` / `--profiler EP` path is .NET-only.** It
+is built on EventPipe, which does not exist on .NET Framework. Confirmed on this
+repo: `dotnet run -f net481 ... --profiler EP` prints
+`UnresolvedDiagnoser ... install the latest BenchmarkDotNet.Diagnostics.Windows
+package` and produces **no** trace, while the same command on `-f net10.0`
+writes a `.speedscope.json` with no admin and no extra package.
+
+| Strategy | net10.0 | net481 |
+| --- | --- | --- |
+| `[EventPipeProfiler]` / `--profiler EP` | **Works, no admin, streamlined** | **Not supported** (EventPipe is Core-only) |
+| `[EtwProfiler]` (`--profiler ETW`) | Works (Windows, admin) | **Works** (Windows, admin) - the net481 elevation path |
+| `dotnet-trace` | Works (attaches via EventPipe) | Not supported (no EventPipe) |
+| `[DisassemblyDiagnoser]` | Works | Works (this is how the net481 codegen findings were captured) |
+| `[HardwareCounters]`, `InliningDiagnoser` | Works (Windows, admin) | Works (Windows, admin) |
+
+**Default to net10.0 for the call-tree question.** Its EventPipe path needs no
+admin, no extra package, and the structural answer (which method dominates,
+which subtree is hot) is almost always TFM-independent - the *shape* of the
+call tree is the algorithm, not the JIT. Use the net10.0 profile as the
+structural map, and confirm the magnitude of the win on net481 with the
+BenchmarkDotNet table (which **is** available on both TFMs).
+
+Only reach for the **net481 elevation path** when you need on-CPU attribution
+that the net10.0 shape cannot give you (e.g. you suspect the cost is
+net481-specific slow-span indexing inside one method, not a different call
+tree). That path is `[EtwProfiler]`:
+
+- add the `BenchmarkDotNet.Diagnostics.Windows` package and **consume one of its
+  public types** so MSBuild copies it to the output (or set
+  `<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>`) - without
+  this the diagnoser silently falls back to `UnresolvedDiagnoser`;
+- run the shell **as Administrator**;
+- open the resulting `.etl` in PerfView or WPA.
+
+For a pure net481 codegen question (the common case here), prefer
+`[DisassemblyDiagnoser]` (&sect;4) over ETW - it needs no admin and answers
+"why is this loop slow" directly.
+
+### 3a. In-harness: `EventPipeProfiler` (cross-platform, no admin)
+
+The lowest-friction way to get a call-tree for a benchmark. Add the attribute
+to the benchmark class:
+
+```c#
+using BenchmarkDotNet.Diagnosers;
+
+[MemoryDiagnoser]
+[EventPipeProfiler(EventPipeProfile.CpuSampling)] // also: GcVerbose, GcCollect, Jit
+public class MySubjectPerf
+{
+    [Benchmark]
+    public int Subject() => /* ... */;
+}
+```
+
+It writes a `.speedscope.json` (and `.nettrace`) under
+`BenchmarkDotNet.Artifacts/`. Open the speedscope file at
+<https://www.speedscope.app/> (drag-drop, nothing to install) to get a flame
+graph. Cross-platform, works on Linux/macOS/Windows, **no admin required**.
+
+> **Reading the BenchmarkDotNet speedscope export.** The trace it writes is an
+> *evented* profile whose leaf self-time is bucketed into a synthetic
+> `CPU_TIME` node, so a naive "top self-time" aggregation is useless - every
+> managed leaf reads as `0 ms`. The **inclusive call tree is the real signal**,
+> and it is exactly what a flame graph renders: read the inclusive percentages
+> per frame (`MatchCore` -> `RunEngine` -> `ProduceAlternative` ...) and follow
+> the widest path down. If you need a static, embeddable flame graph rather than
+> the interactive viewer, walk the evented `O`/`C` events maintaining an
+> open-frame stack, attribute each inter-event time delta to the full stack, and
+> emit folded stacks or an SVG. (`speedscope.app` does this internally; a small
+> script reproduces it for committing before/after images to a doc.)
+
+`EventPipeProfile` values worth knowing:
+
+- `CpuSampling` - "where is on-CPU time spent" (the usual first question).
+- `GcVerbose` - allocation call sites and GC pauses (pairs with a high
+  `Allocated` from the memory diagnoser to find *which* call allocates).
+- `Jit` - JIT compilation events.
+
+### 3b. In-harness: `EtwProfiler` (Windows, admin, richest data)
+
+```c#
+[EtwProfiler] // Windows only, requires running the shell as Administrator
+public class MySubjectPerf { /* ... */ }
+```
+
+Emits an `.etl` with full stacks plus GC/JIT/CLR events and the PDBs to resolve
+symbols. Open in **PerfView** or **Windows Performance Analyzer**. Use this when
+EventPipe's managed-only view is not enough (e.g. you suspect time in native
+runtime code). `NativeMemoryProfiler` and `ConcurrencyVisualizerProfiler` are
+built on the same ETW path.
+
+### 3c. Standalone: `dotnet-trace` (any process, no benchmark needed)
+
+When the hot path lives in a running app / test / sample rather than a
+benchmark, profile the live process. Install once:
+
+```powershell
+dotnet tool install --global dotnet-trace
+```
+
+Collect a CPU-sampled trace and convert to a flame graph:
+
+```powershell
+# List candidate processes
+dotnet-trace ps
+
+# Sample thread stacks for a running PID, write speedscope directly
+dotnet-trace collect --process-id <PID> --format Speedscope
+
+# Or launch + trace a self-contained app from startup
+dotnet-trace collect --format Speedscope -- dotnet exec MyApp.dll arg1
+```
+
+Notes from the current docs:
+
+- The default (no `--profile`) is `dotnet-common` + `dotnet-sampled-thread-time`.
+  The old `cpu-sampling` profile name was removed; for CPU hotspots use
+  `--profile dotnet-sampled-thread-time,dotnet-common`.
+- `--format Speedscope` -> open at <https://www.speedscope.app/>. On Windows you
+  can instead open the `.nettrace` directly in Visual Studio or PerfView.
+- `dotnet-trace report <file> topN --inclusive` prints the top-N methods by time
+  to stdout - a **token-cheap** way for an agent to get the hot methods without
+  opening a GUI.
+
+### 3d. Standalone: live counters and GC dumps
+
+- `dotnet-counters monitor --process-id <PID>` - live CPU, alloc rate, GC, JIT,
+  thread-pool, exception counters. Good for "is it allocating in steady state".
+- `dotnet-gcdump collect -p <PID>` - heap snapshot to diagnose what is retained
+  (open in Visual Studio or PerfView).
+- `dotnet-dump` - full process dump for post-mortem analysis with `dotnet dump
+  analyze` (SOS commands like `dumpheap -stat`).
+
+---
+
+## 4. Layer 3 - why the JIT emits slow code (disassembly)
+
+When a tight loop is slower than it "should" be - especially the recurring
+`net481` story - read the actual machine code.
+
+```c#
+using BenchmarkDotNet.Diagnosers;
+
+[DisassemblyDiagnoser(printSource: true, maxDepth: 3)]
+public class MySubjectPerf { /* ... */ }
+```
+
+Requirements and tips:
+
+- .NET Core disassembler works on Windows; target **AnyCPU**
+  (`<PlatformTarget>AnyCPU</PlatformTarget>`) to compare platforms.
+- For C#/IL interleaving set `<DebugType>pdbonly</DebugType>` and
+  `<DebugSymbols>true</DebugSymbols>`.
+- Output lands in `*-asm.md` / `*-asm.html`. Read the `.md`.
+- To get the asm **without** a long run, combine with `[DryJob]` - it runs once.
+
+This is the tool behind the discoveries in
+[framework-span-performance.md](framework-span-performance.md) (slow-span layout,
+the `cmp ecx, 0xFFFFFFFF` sign-extension foot-gun). When you suspect a
+`net481`-specific codegen issue, capture the asm on **both** TFMs and diff -
+the `framework-jit-optimization` skill explains what the differences mean and
+what to change.
+
+Related diagnosers (all Windows + `BenchmarkDotNet.Diagnostics.Windows`):
+
+- `InliningDiagnoser` - which calls were/weren't inlined (the net481 inliner is
+  conservative; this confirms a missing `[MethodImpl(AggressiveInlining)]`).
+- `TailCallDiagnoser`, `JitStatsDiagnoser` - JIT behavior detail.
+- `[HardwareCounters(HardwareCounter.BranchMispredictions, ...)]` - branch
+  misprediction / cache-miss counts; the canonical sorted-vs-unsorted branch
+  case. Windows 8+, admin, no Hyper-V.
+
+---
+
+## 5. IDE and editor tooling
+
+### Visual Studio (richest GUI, Windows)
+
+`Debug > Performance Profiler` (Alt+F2) bundles the tools an agent would
+otherwise wire up by hand:
+
+- **CPU Usage** - sampling profiler with a call tree and "hot path".
+- **.NET Object Allocation Tracking** - every allocation and its stack; the GUI
+  equivalent of `EventPipeProfile.GcVerbose`.
+- **Database**, **Instrumentation** (exact call counts), **GPU**, **Events**.
+- Opens `.nettrace`, `.etl`, and `.diagsession` files captured elsewhere.
+
+Best when a human is driving and wants to click through a flame graph. For an
+automated agent loop, the BenchmarkDotNet diagnosers and `dotnet-trace report
+topN` give the same answers in text.
+
+### VS Code
+
+There is **no built-in .NET sampling-profiler UI** in C# Dev Kit today. The
+practical VS Code workflow is:
+
+- Run `dotnet-trace` / `dotnet-counters` from the integrated terminal (sections
+  3c/3d) and open the resulting speedscope file in a browser.
+- Install the standalone tools as global dotnet tools; they need no extension.
+- For allocation/CPU GUIs, VS Code users typically hand the `.nettrace`/`.etl`
+  to Visual Studio or PerfView, or use the web speedscope viewer.
+
+### JetBrains (cross-platform, if available)
+
+- **dotTrace** - sampling/tracing/timeline CPU profiler.
+- **dotMemory** - allocation and retention profiler with snapshot diffing.
+
+Mention these as alternatives; they are not part of this repo's toolchain and
+require a license. Don't assume they're installed.
+
+### PerfView (free, Windows, deep)
+
+Microsoft's free ETW analyzer. The go-to for `.etl` from `EtwProfiler` and for
+GC-heavy investigations (GCStats, allocation-tick stacks). Steeper UI than VS
+but unmatched depth. Pairs with `dotnet-trace`'s `.nettrace` output too.
+
+---
+
+## 6. MCP servers and programmatic API access
+
+There is **no dedicated .NET profiling MCP server** in this workspace, and none
+is an industry standard at time of writing. Profiling is done with the CLI tools
+and diagnosers above. The MCP/API surfaces that *do* help an agent's perf work
+are research-oriented:
+
+- **Microsoft Learn MCP** (`microsoft_docs_search`, `microsoft_docs_fetch`) -
+  authoritative, current docs for `dotnet-trace`, `dotnet-counters`,
+  EventPipe, diagnosers, and runtime event providers. Use it to confirm flags
+  and profile names instead of guessing (they change between SDK versions - e.g.
+  the `cpu-sampling` profile rename).
+- **apisofdotnet MCP** (`mcp_apisofdotnet_*`) - which APIs exist on which TFM,
+  extension-method lookup, usage sources. Useful when deciding whether a faster
+  BCL primitive is even available on `net481`.
+- **GitHub MCP / PR tools** - pull prior benchmark numbers out of merged PR
+  descriptions in this repo to avoid re-measuring a known result.
+
+If you reach for an MCP "profiler", stop - there isn't one; use a diagnoser or
+`dotnet-trace`.
+
+---
+
+## 7. End-to-end investigation playbook
+
+A concrete, token-efficient loop an agent should follow:
+
+1. **Frame the question** as one of the rows in the &sect;0 table. If it's "A vs
+   B" or "does it allocate", you never leave Layer 1.
+2. **Search the catalog** ([dotnet-perf-discoveries.md](dotnet-perf-discoveries.md),
+   [framework-span-performance.md](framework-span-performance.md)) for the API or
+   pattern. Cite the existing measurement if found and stop.
+3. **Write or locate a benchmark** in `touki.perf/` (`<Subject>Perf` class,
+   `[MemoryDiagnoser]`, a `Baseline`, every method returns a real value).
+4. **Smoke** with `--job short --filter *<Subject>Perf*` on `net10.0`. Confirm
+   the benchmark is well-formed (stable Mean/Median, sane direction).
+5. **Confirm** on both TFMs without `--job short`. Read
+   `*-report-github.md`, quote only `Mean`/`Ratio`/`Allocated` for changed rows.
+6. **If the bottleneck is unclear**, attach `[EventPipeProfiler(CpuSampling)]`
+   (or run `dotnet-trace ... report topN`) on **net10.0** to find the dominant
+   method. Profiling is part of the loop: capture a `before/` trace, apply the
+   fix, capture an `after/` trace with the identical filter, and diff the flame
+   graphs to confirm the targeted frame shrank. EventPipe is net10.0-only; for
+   net481 on-CPU attribution use `[EtwProfiler]` (admin) - see the
+   per-TFM table in &sect;3.
+7. **If a specific loop is slow**, attach `[DisassemblyDiagnoser]` on both TFMs
+   and diff the asm; consult `framework-jit-optimization` for the fix.
+8. **Apply the fix, re-measure with the identical filter.** Name the TFM and
+   JIT ("modern .NET RyuJIT" / ".NET Framework 4.8.1 RyuJIT") in the writeup.
+9. **Record durable findings** in [dotnet-perf-discoveries.md](dotnet-perf-discoveries.md)
+   if the result is a reusable BCL/JIT behavior, so the next investigation skips
+   straight to step 2.
+
+### Anti-patterns (token and CPU waste)
+
+- Running the full suite when one `--filter` would do.
+- Pasting console banners/warnings/unrelated rows into context instead of
+  reading `*-report-github.md`.
+- Measuring in Debug (numbers are meaningless; BenchmarkDotNet warns).
+- Quoting an unqualified "RyuJIT" result - half the time it's wrong about which
+  JIT. Always name the TFM.
+- Reaching for a profiler before BenchmarkDotNet has even confirmed there's a
+  regression to chase.
+- Trusting a single noisy run with a large Mean/Median spread - fix the
+  benchmark first.
+
+---
+
+## 8. Quick reference card
+
+```text
+A/B + allocations ............ dotnet run -c Release -f <tfm> --project touki.perf -- --filter *X*
+Fast smoke ................... add --job short
+Read the result .............. BenchmarkDotNet.Artifacts/results/*-report-github.md
+Where's the time? (in-harness) [EventPipeProfiler(EventPipeProfile.CpuSampling)] -> speedscope.app
+                               net10.0 only (no admin); net481 needs [EtwProfiler] (admin) -> .etl
+                               Capture before/ AND after/ traces; diff the flame graphs.
+Where's the time? (live proc)  dotnet-trace collect -p <PID> --format Speedscope
+                               dotnet-trace report <file> topN --inclusive   (text, token-cheap)
+Why slow codegen? ............ [DisassemblyDiagnoser(printSource:true)] -> *-asm.md  (diff TFMs)
+Inlined or not? .............. [InliningDiagnoser]  (Windows pkg)
+Branch/cache? ................ [HardwareCounters(...)]  (Windows, admin)
+Live GC/alloc rate ........... dotnet-counters monitor -p <PID>
+Heap retention ............... dotnet-gcdump collect -p <PID>  (open in VS/PerfView)
+GUI flame graph .............. VS Performance Profiler (Alt+F2) | PerfView | speedscope.app
+Confirm a flag/profile ....... Microsoft Learn MCP (docs change between SDKs)
+```
+
+Remember the two hard rules from
+[perf.instructions.md](../.github/instructions/perf.instructions.md): **Release
+only**, and **name the JIT** in every claim.

--- a/tools/speedscope-to-flamegraph.ps1
+++ b/tools/speedscope-to-flamegraph.ps1
@@ -1,0 +1,156 @@
+<#
+.SYNOPSIS
+    Render an inclusive-time flame graph (SVG) from a BenchmarkDotNet
+    EventPipeProfiler speedscope trace.
+
+.DESCRIPTION
+    BenchmarkDotNet's EventPipeProfiler exports an "evented" speedscope file:
+    leaf self-time collapses into a synthetic CPU_TIME node, so the raw trace
+    is not directly usable as a flame graph. This script walks the open/close
+    events, attributes the wall-clock delta between consecutive events to the
+    full open-frame stack, and emits the inclusive-time call tree as a
+    standalone icicle SVG (root at top), which is exactly what a flame graph
+    visualizes.
+
+    Validated on net10.0 traces only. The EventPipeProfiler does not produce a
+    trace on net481 (it resolves to UnresolvedDiagnoser); use [EtwProfiler] for
+    Framework profiling instead.
+
+.PARAMETER Path
+    Path to the .speedscope.json file written to BenchmarkDotNet.Artifacts.
+
+.PARAMETER OutSvg
+    Destination path for the generated SVG.
+
+.PARAMETER RootFrame
+    Optional. A substring matched against frame names. When set, time is only
+    attributed to the subtree rooted at the first matching frame on each stack
+    (and that frame becomes the 100% root). Use this to exclude BenchmarkDotNet
+    warmup/pilot/JIT/overhead and scope the graph to just the measured workload,
+    e.g. -RootFrame 'WorkloadActionUnroll'.
+
+.EXAMPLE
+    ./tools/speedscope-to-flamegraph.ps1 `
+        -Path BenchmarkDotNet.Artifacts/MyBench.speedscope.json `
+        -OutSvg scratch/mybench.svg -Title "MyBench"
+#>
+param(
+    [Parameter(Mandatory)][string]$Path,
+    [Parameter(Mandatory)][string]$OutSvg,
+    [string]$Title = "Flame graph",
+    [string]$RootFrame = "",
+    [int]$Width = 1200,
+    [int]$RowHeight = 18,
+    [double]$MinPercent = 0.3
+)
+
+$j = Get-Content $Path -Raw | ConvertFrom-Json
+$frames = $j.shared.frames
+
+# node = @{ name; value; children = @{name->node} }
+$root = @{ name = "root"; value = 0.0; children = @{} }
+
+function Short([string]$n) {
+    # Trim the verbose CLR signatures to method identifiers for readability.
+    if ($n -match '!([^(]+)') { $n = $matches[1] }
+    $n = $n -replace 'value class ', '' -replace 'class ', ''
+    if ($n.Length -gt 90) { $n = $n.Substring(0, 87) + '...' }
+    return $n
+}
+
+foreach ($p in $j.profiles) {
+    if (-not $p.events -or $p.events.Count -eq 0) { continue }
+    $stack = [System.Collections.Generic.List[int]]::new()
+    $lastAt = $null
+    foreach ($e in $p.events) {
+        $at = [double]$e.at
+        if ($null -ne $lastAt -and $stack.Count -gt 0) {
+            $delta = $at - $lastAt
+            if ($delta -gt 0) {
+                # When -RootFrame is set, find the first matching frame on the
+                # stack and attribute only the subtree below it; otherwise use
+                # the whole stack from the process root.
+                $startIdx = 0
+                $include = $true
+                if ($RootFrame) {
+                    $include = $false
+                    for ($si = 0; $si -lt $stack.Count; $si++) {
+                        if ($frames[$stack[$si]].name -match [regex]::Escape($RootFrame)) {
+                            $startIdx = $si
+                            $include = $true
+                            break
+                        }
+                    }
+                }
+                if ($include) {
+                    $node = $root
+                    $node.value += $delta
+                    for ($fi = $startIdx; $fi -lt $stack.Count; $fi++) {
+                        $name = Short $frames[$stack[$fi]].name
+                        if (-not $node.children.ContainsKey($name)) {
+                            $node.children[$name] = @{ name = $name; value = 0.0; children = @{} }
+                        }
+                        $node = $node.children[$name]
+                        $node.value += $delta
+                    }
+                }
+            }
+        }
+        if ($e.type -eq 'O') { $stack.Add([int]$e.frame) }
+        elseif ($e.type -eq 'C') {
+            for ($k = $stack.Count - 1; $k -ge 0; $k--) {
+                if ($stack[$k] -eq [int]$e.frame) { $stack.RemoveAt($k); break }
+            }
+        }
+        $lastAt = $at
+    }
+}
+
+$total = $root.value
+if ($total -le 0) { Write-Error "No timed samples in $Path"; exit 1 }
+
+$rects = [System.Collections.Generic.List[object]]::new()
+$maxDepth = 0
+
+function Emit($node, $depth, $x0, $w) {
+    if ($w / $Width * 100.0 -lt $MinPercent) { return }
+    if ($depth -gt $script:maxDepth) { $script:maxDepth = $depth }
+    $pct = [math]::Round(100.0 * $node.value / $total, 1)
+    $script:rects.Add([pscustomobject]@{ x = $x0; depth = $depth; w = $w; name = $node.name; pct = $pct; ms = [math]::Round($node.value, 1) })
+    $childTotal = ($node.children.Values | Measure-Object -Property value -Sum).Sum
+    if (-not $childTotal) { return }
+    $cx = $x0
+    foreach ($c in ($node.children.Values | Sort-Object value -Descending)) {
+        $cw = $w * ($c.value / $node.value)
+        Emit $c ($depth + 1) $cx $cw
+        $cx += $cw
+    }
+}
+
+foreach ($c in ($root.children.Values | Sort-Object value -Descending)) {
+    Emit $c 0 0 ($Width * ($c.value / $total))
+}
+
+$height = ($maxDepth + 2) * $RowHeight + 40
+$palette = @('#e67e22', '#d35400', '#e74c3c', '#c0392b', '#f39c12', '#d68910', '#ca6f1e', '#ba4a00')
+
+$sb = [System.Text.StringBuilder]::new()
+[void]$sb.AppendLine("<svg xmlns='http://www.w3.org/2000/svg' width='$Width' height='$height' font-family='Consolas,monospace' font-size='11'>")
+[void]$sb.AppendLine("<rect width='$Width' height='$height' fill='#fafafa'/>")
+[void]$sb.AppendLine("<text x='8' y='20' font-size='14' font-weight='bold'>$([System.Security.SecurityElement]::Escape($Title))</text>")
+$i = 0
+foreach ($r in $rects) {
+    $y = 30 + $r.depth * $RowHeight
+    $fill = $palette[$i % $palette.Count]; $i++
+    $rw = [math]::Max($r.w, 0.5)
+    $esc = [System.Security.SecurityElement]::Escape("$($r.name)  ($($r.pct)% incl, $($r.ms) ms)")
+    [void]$sb.AppendLine("<g><title>$esc</title><rect x='$([math]::Round($r.x,2))' y='$y' width='$([math]::Round($rw,2))' height='$($RowHeight-1)' fill='$fill' stroke='#fff' stroke-width='0.5'/>")
+    if ($rw -gt 55) {
+        $label = [System.Security.SecurityElement]::Escape($r.name)
+        [void]$sb.AppendLine("<text x='$([math]::Round($r.x+2,2))' y='$($y+12)' fill='#000'>$label</text>")
+    }
+    [void]$sb.AppendLine("</g>")
+}
+[void]$sb.AppendLine("</svg>")
+Set-Content -Path $OutSvg -Value $sb.ToString() -Encoding UTF8
+Write-Host "Wrote $OutSvg  (total $([math]::Round($total,1)) ms, $($rects.Count) frames, depth $maxDepth)"

--- a/touki.perf/ArrayPoolCrossoverPerf.cs
+++ b/touki.perf/ArrayPoolCrossoverPerf.cs
@@ -1,0 +1,111 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace touki.perf;
+
+/// <summary>
+///  Finds the buffer size at which zero-initializing a <c>stackalloc</c> local
+///  becomes more expensive than renting an (uninitialized) array from
+///  <see cref="ArrayPool{T}"/>. The sweep is run for two rental shapes - a
+///  thread-local cache hit (the first rental of a bucket) and a per-core locked
+///  stack hit (the second rental of the same bucket while the first is still
+///  checked out) - on both target frameworks.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The zeroing path uses a dynamically sized <c>stackalloc byte[Size]</c> with
+///   the default <c>localsinit</c> flag, so the buffer is cleared on every call;
+///   its cost grows with <see cref="Size"/>. The rental path returns memory of at
+///   least the requested size without clearing it, so its cost is roughly flat
+///   across sizes (bucket math plus, for the locked path, a lock). The crossover
+///   is where the rising zeroing line meets the flat rental line.
+///  </para>
+///  <para>
+///   <see cref="RentTls"/> rents and returns one array; after warmup the bucket's
+///   one-deep thread-local slot is populated, so this is the fast path.
+///   <see cref="RentLocked"/> rents two same-bucket arrays before returning
+///   either: the first drains the thread-local slot, forcing the second onto the
+///   per-core locked stack. The marginal cost of that second rental is
+///   <c>RentLocked - RentTls</c>.
+///  </para>
+///  <para>
+///   Every buffer is routed through a <c>[NoInlining]</c> helper and a few slots
+///   are touched so neither the allocation nor the zeroing can be elided.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class ArrayPoolCrossoverPerf
+{
+    [Params(64, 128, 256, 512, 1024, 2048, 4096, 8192)]
+    public int Size { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Populate the thread-local slot for every bucket this sweep touches so
+        // RentTls measures a steady-state cache hit rather than a cold miss.
+        for (int i = 0; i < 64; i++)
+        {
+            RentOne(Size);
+            RentTwo(Size);
+        }
+    }
+
+    /// <summary>
+    ///  Zero-initialized <c>stackalloc</c> of <see cref="Size"/> bytes. The cost
+    ///  is the <c>localsinit</c> clear and scales with the byte count.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public int ZeroStack() => ZeroStackCore(Size);
+
+    /// <summary>
+    ///  Single rent plus return - the thread-local cache fast path.
+    /// </summary>
+    [Benchmark]
+    public int RentTls() => RentOne(Size);
+
+    /// <summary>
+    ///  Two same-bucket rentals before returning either, so the second falls to
+    ///  the per-core locked stack. The marginal second-rental cost is this row
+    ///  minus <see cref="RentTls"/>.
+    /// </summary>
+    [Benchmark]
+    public int RentLocked() => RentTwo(Size);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ZeroStackCore(int size)
+    {
+        Span<byte> buffer = stackalloc byte[size];
+        buffer[0] = 1;
+        buffer[size - 1] = 2;
+        return buffer[0] + buffer[size - 1];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int RentOne(int size)
+    {
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(size);
+        buffer[0] = 1;
+        buffer[size - 1] = 2;
+        int sum = buffer[0] + buffer[size - 1];
+        ArrayPool<byte>.Shared.Return(buffer);
+        return sum;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int RentTwo(int size)
+    {
+        byte[] first = ArrayPool<byte>.Shared.Rent(size);
+        byte[] second = ArrayPool<byte>.Shared.Rent(size);
+        first[0] = 1;
+        second[size - 1] = 2;
+        int sum = first[0] + second[size - 1];
+        ArrayPool<byte>.Shared.Return(second);
+        ArrayPool<byte>.Shared.Return(first);
+        return sum;
+    }
+}

--- a/touki.perf/ArrayPoolSeedRentPerf.cs
+++ b/touki.perf/ArrayPoolSeedRentPerf.cs
@@ -103,9 +103,10 @@ public class ArrayPoolSeedRentPerf
     }
 
     /// <summary>
-    ///  Zero-initialized <c>stackalloc</c> of the same five seed buffers. On
-    ///  net481 RyuJIT this pays a ~3.7 KB zeroing on entry that cannot be
-    ///  suppressed; on modern .NET RyuJIT the zeroing dominates this path.
+    ///  Zero-initialized <c>stackalloc</c> of the same five seed buffers. This
+    ///  path deliberately omits <c>[SkipLocalsInit]</c> so it measures the full
+    ///  ~3.7 KB zeroing both TFMs pay on entry; net481 RyuJIT would honor the
+    ///  attribute if applied. On modern .NET RyuJIT the zeroing dominates here.
     /// </summary>
     [Benchmark]
     public int StackAllocSeed()

--- a/touki.perf/ArrayPoolSeedRentPerf.cs
+++ b/touki.perf/ArrayPoolSeedRentPerf.cs
@@ -1,0 +1,131 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace touki.perf;
+
+/// <summary>
+///  Isolates the per-call cost of the extglob engine's five seed buffers when
+///  they are rented from <see cref="ArrayPool{T}"/> (uninitialized) versus
+///  <c>stackalloc</c> (zero-initialized). This is the variable behind the
+///  <c>RunEngine</c> seed swap: on .NET Framework 4.8.1 RyuJIT the pool path
+///  regressed every <c>GlobExtGlobMatchPerf</c> row, while modern .NET RyuJIT
+///  improved. The benchmark answers "why is the rental so expensive, and why
+///  doesn't warmup hide it" by measuring the rent/return sequence directly.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The buffer shapes mirror the engine seed exactly: a 28-byte frame struct
+///   times 32, a 16-byte range struct times 128, the same range struct times 32
+///   twice (the <c>work</c> and <c>rest</c> lists), and an int key buffer of 99.
+///   Element counts drive the <see cref="ArrayPool{T}"/> bucket selection, and
+///   the two same-sized range rentals deliberately hit the same bucket - the
+///   thread-local cache holds only one array per bucket, so the second rental
+///   misses the fast path and falls to the per-core locked stack.
+///  </para>
+///  <para>
+///   Three distinct element types (frame, range, int) reproduce the engine's
+///   three independent <c>ArrayPool&lt;T&gt;.Shared</c> instances. Total seed
+///   footprint is ~4.3 KB, matching the zero-init the stackalloc path pays on
+///   net481 unless the method is annotated with <c>[SkipLocalsInit]</c> (which
+///   the Framework JIT does honor).
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class ArrayPoolSeedRentPerf
+{
+    private const int SeedFrameCount = 32;
+    private const int SeedArenaCount = 128;
+    private const int MaxRangesDepth = 32;
+    private const int KeyLength = 3 + (MaxRangesDepth * 3);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FrameLike
+    {
+        public int A, B, C, D, E, F, G;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RangeLike
+    {
+        public int A, B, C, D;
+    }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Warm the pool exactly as a real workload would: rent and return each
+        // bucket once so the thread-local caches are populated before measuring.
+        for (int i = 0; i < 64; i++)
+        {
+            RentSeed();
+        }
+    }
+
+    /// <summary>
+    ///  Rents the five seed buffers, touches each once, and returns them. This is
+    ///  what the <c>RunEngine</c> BufferScope swap does on every match.
+    /// </summary>
+    [Benchmark(Baseline = true)]
+    public int PoolRent()
+    {
+        return RentSeed();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int RentSeed()
+    {
+        FrameLike[] frames = ArrayPool<FrameLike>.Shared.Rent(SeedFrameCount);
+        RangeLike[] arena = ArrayPool<RangeLike>.Shared.Rent(SeedArenaCount);
+        RangeLike[] work = ArrayPool<RangeLike>.Shared.Rent(MaxRangesDepth);
+        RangeLike[] rest = ArrayPool<RangeLike>.Shared.Rent(MaxRangesDepth);
+        int[] key = ArrayPool<int>.Shared.Rent(KeyLength);
+
+        // Touch a slot in each so the rentals cannot be optimized away.
+        frames[0].A = 1;
+        arena[0].A = 1;
+        work[0].A = 1;
+        rest[0].A = 1;
+        key[0] = 1;
+        int sum = frames[0].A + arena[0].A + work[0].A + rest[0].A + key[0];
+
+        ArrayPool<int>.Shared.Return(key);
+        ArrayPool<RangeLike>.Shared.Return(rest);
+        ArrayPool<RangeLike>.Shared.Return(work);
+        ArrayPool<RangeLike>.Shared.Return(arena);
+        ArrayPool<FrameLike>.Shared.Return(frames);
+        return sum;
+    }
+
+    /// <summary>
+    ///  Zero-initialized <c>stackalloc</c> of the same five seed buffers. On
+    ///  net481 RyuJIT this pays a ~4.3 KB zeroing on entry that cannot be
+    ///  suppressed; on modern .NET RyuJIT the zeroing dominates this path.
+    /// </summary>
+    [Benchmark]
+    public int StackAllocSeed()
+    {
+        return StackSeed();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int StackSeed()
+    {
+        Span<FrameLike> frames = stackalloc FrameLike[SeedFrameCount];
+        Span<RangeLike> arena = stackalloc RangeLike[SeedArenaCount];
+        Span<RangeLike> work = stackalloc RangeLike[MaxRangesDepth];
+        Span<RangeLike> rest = stackalloc RangeLike[MaxRangesDepth];
+        Span<int> key = stackalloc int[KeyLength];
+
+        frames[0].A = 1;
+        arena[0].A = 1;
+        work[0].A = 1;
+        rest[0].A = 1;
+        key[0] = 1;
+        return frames[0].A + arena[0].A + work[0].A + rest[0].A + key[0];
+    }
+}

--- a/touki.perf/ArrayPoolSeedRentPerf.cs
+++ b/touki.perf/ArrayPoolSeedRentPerf.cs
@@ -20,8 +20,8 @@ namespace touki.perf;
 /// <remarks>
 ///  <para>
 ///   The buffer shapes mirror the engine seed exactly: a 28-byte frame struct
-///   times 32, a 16-byte range struct times 128, the same range struct times 32
-///   twice (the <c>work</c> and <c>rest</c> lists), and an int key buffer of 99.
+///   times 32, a 16-byte range struct times 128, the same range struct times 18
+///   twice (the <c>work</c> and <c>rest</c> lists), and an int key buffer of 57.
 ///   Element counts drive the <see cref="ArrayPool{T}"/> bucket selection, and
 ///   the two same-sized range rentals deliberately hit the same bucket - the
 ///   thread-local cache holds only one array per bucket, so the second rental
@@ -30,7 +30,7 @@ namespace touki.perf;
 ///  <para>
 ///   Three distinct element types (frame, range, int) reproduce the engine's
 ///   three independent <c>ArrayPool&lt;T&gt;.Shared</c> instances. Total seed
-///   footprint is ~4.3 KB, matching the zero-init the stackalloc path pays on
+///   footprint is ~3.7 KB, matching the zero-init the stackalloc path pays on
 ///   net481 unless the method is annotated with <c>[SkipLocalsInit]</c> (which
 ///   the Framework JIT does honor).
 ///  </para>
@@ -40,7 +40,8 @@ public class ArrayPoolSeedRentPerf
 {
     private const int SeedFrameCount = 32;
     private const int SeedArenaCount = 128;
-    private const int MaxRangesDepth = 32;
+    // Mirrors CompiledGlobStrategy.MaxRangesDepth = (MaxExtGlobDepth * 2) + 2 = 18.
+    private const int MaxRangesDepth = 18;
     private const int KeyLength = 3 + (MaxRangesDepth * 3);
 
     [StructLayout(LayoutKind.Sequential)]
@@ -103,7 +104,7 @@ public class ArrayPoolSeedRentPerf
 
     /// <summary>
     ///  Zero-initialized <c>stackalloc</c> of the same five seed buffers. On
-    ///  net481 RyuJIT this pays a ~4.3 KB zeroing on entry that cannot be
+    ///  net481 RyuJIT this pays a ~3.7 KB zeroing on entry that cannot be
     ///  suppressed; on modern .NET RyuJIT the zeroing dominates this path.
     /// </summary>
     [Benchmark]

--- a/touki.perf/BufferScopeOverheadPerf.cs
+++ b/touki.perf/BufferScopeOverheadPerf.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using Touki.Buffers;
+
+namespace touki.perf;
+
+/// <summary>
+///  Measures the overhead of <see cref="BufferScope{T}"/> - the "start on a
+///  stack buffer, fall back to an <see cref="ArrayPool{T}"/> rental when more
+///  space is needed" pattern - against the hand-written equivalents on each
+///  path, and confirms that the wrapper does not interfere with
+///  <c>[SkipLocalsInit]</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="BufferScope{T}"/> is a <c>ref struct</c> that wraps a
+///   caller-supplied <c>stackalloc</c> span and only rents from the pool when
+///   the requested capacity exceeds the stack buffer. Because the
+///   <c>stackalloc</c> lives in the caller, the caller's <c>[SkipLocalsInit]</c>
+///   controls whether it is zeroed; the wrapper itself never clears memory.
+///  </para>
+///  <para>
+///   The benchmarks come in pairs so the wrapper overhead is the difference
+///   within each pair:
+///   <list type="bullet">
+///    <item><c>Direct_StackOnly</c> vs <c>Scope_StackOnly</c> - the stack-only
+///     fast path (no rental); isolates the cost of constructing and disposing
+///     the scope.</item>
+///    <item><c>Direct_Rent</c> vs <c>Scope_Rent</c> - the grow path where the
+///     requested size overflows the stack buffer and the scope rents.</item>
+///    <item><c>Scope_StackOnly_Zeroed</c> - identical to <c>Scope_StackOnly</c>
+///     but without <c>[SkipLocalsInit]</c>, so the delta to it shows the
+///     wrapper passes the localsinit decision straight through to the caller.
+///    </item>
+///   </list>
+///  </para>
+///  <para>
+///   Every method routes through a <c>[NoInlining]</c> helper so the wrapper
+///   cannot be folded into the harness and a few slots are touched so the
+///   buffer cannot be elided. The stack buffer is 256 bytes; the rented path
+///   asks for 1024 bytes so it always overflows it.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class BufferScopeOverheadPerf
+{
+    private const int StackSize = 256;
+    private const int RentSize = 1024;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Warm the bucket the rented path uses so Scope_Rent / Direct_Rent see a
+        // steady-state thread-local cache hit rather than a cold miss.
+        for (int i = 0; i < 64; i++)
+        {
+            byte[] warm = ArrayPool<byte>.Shared.Rent(RentSize);
+            ArrayPool<byte>.Shared.Return(warm);
+        }
+    }
+
+    // ---- Stack-only fast path (no rental) ----
+
+    [Benchmark(Baseline = true)]
+    [SkipLocalsInit]
+    public int Direct_StackOnly()
+    {
+        Span<byte> buffer = stackalloc byte[StackSize];
+        return Touch(buffer);
+    }
+
+    [Benchmark]
+    [SkipLocalsInit]
+    public int Scope_StackOnly()
+    {
+        using BufferScope<byte> scope = new(stackalloc byte[StackSize], StackSize);
+        return Touch(scope.AsSpan());
+    }
+
+    [Benchmark]
+    public int Scope_StackOnly_Zeroed()
+    {
+        using BufferScope<byte> scope = new(stackalloc byte[StackSize], StackSize);
+        return Touch(scope.AsSpan());
+    }
+
+    // ---- Grow path (stack buffer too small, scope rents) ----
+
+    [Benchmark]
+    public int Direct_Rent()
+    {
+        byte[] array = ArrayPool<byte>.Shared.Rent(RentSize);
+        int sum = Touch(array.AsSpan(0, RentSize));
+        ArrayPool<byte>.Shared.Return(array);
+        return sum;
+    }
+
+    [Benchmark]
+    [SkipLocalsInit]
+    public int Scope_Rent()
+    {
+        using BufferScope<byte> scope = new(stackalloc byte[StackSize], RentSize);
+        return Touch(scope.AsSpan());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int Touch(Span<byte> buffer)
+    {
+        buffer[0] = 1;
+        buffer[^1] = 2;
+        return buffer[0] + buffer[^1];
+    }
+}

--- a/touki.perf/StackZeroInitPerf.cs
+++ b/touki.perf/StackZeroInitPerf.cs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -10,9 +9,8 @@ namespace touki.perf;
 
 /// <summary>
 ///  Measures the cost of zero-initializing stack scratch buffers, how that cost
-///  scales with size and element type, and whether <c>[SkipLocalsInit]</c> and
-///  the fixed-buffer-plus-<see cref="Unsafe.SkipInit{T}"/> pattern actually
-///  suppress the zeroing on each target framework.
+///  scales with size and element type, and whether <c>[SkipLocalsInit]</c>
+///  actually suppresses the zeroing on each target framework.
 /// </summary>
 /// <remarks>
 ///  <para>
@@ -131,31 +129,5 @@ public class StackZeroInitPerf
         s[0] = 1;
         s[4095] = 2;
         return s[0] + s[4095];
-    }
-
-    // ---- Fixed-buffer ref struct + Unsafe.SkipInit (the no-zero scratch
-    // pattern). The struct carries a 4 KB inline fixed buffer; SkipInit leaves
-    // it uninitialized, and a scoped Span property exposes it. Available on both
-    // TFMs because Unsafe.SkipInit ships in the netstandard Unsafe surface. ----
-
-    [Benchmark]
-    public int FixedBufferSkipInit() => FixedBufferHelper();
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    private static int FixedBufferHelper()
-    {
-        Unsafe.SkipInit(out Scratch4K scratch);
-        Span<byte> s = scratch.AsSpan();
-        s[0] = 1;
-        s[4095] = 2;
-        return s[0] + s[4095];
-    }
-
-    private unsafe struct Scratch4K
-    {
-        public fixed byte Buffer[4096];
-
-        [UnscopedRef]
-        public Span<byte> AsSpan() => new(Unsafe.AsPointer(ref Buffer[0]), 4096);
     }
 }

--- a/touki.perf/StackZeroInitPerf.cs
+++ b/touki.perf/StackZeroInitPerf.cs
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace touki.perf;
+
+/// <summary>
+///  Measures the cost of zero-initializing stack scratch buffers, how that cost
+///  scales with size and element type, and whether <c>[SkipLocalsInit]</c> and
+///  the fixed-buffer-plus-<see cref="Unsafe.SkipInit{T}"/> pattern actually
+///  suppress the zeroing on each target framework.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is the evidence base for the ArrayPool-versus-zeroing decision guide.
+///   The headline comparison is ".NET Framework 4.8.1 RyuJIT" (no tiered JIT,
+///   weaker inlining, and - the question this benchmark answers - does it honor
+///   the absence of the <c>localsinit</c> flag?) against "modern .NET RyuJIT".
+///  </para>
+///  <para>
+///   Every method routes its <c>stackalloc</c> through a <c>[NoInlining]</c>
+///   helper so the allocation cannot be hoisted out or folded away, and returns
+///   a value derived from a few touched slots so dead-code elimination cannot
+///   delete the buffer.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class StackZeroInitPerf
+{
+    [StructLayout(LayoutKind.Sequential)]
+    private struct Range16
+    {
+        public int A, B, C, D;
+    }
+
+    // ---- Zeroing cost by size (default localsinit: the buffer is zeroed) ----
+
+    [Benchmark]
+    public int Zero_Byte_256() => TouchBytes256();
+
+    [Benchmark]
+    public int Zero_Byte_1024() => TouchBytes1024();
+
+    [Benchmark]
+    public int Zero_Byte_4096() => TouchBytes4096();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TouchBytes256()
+    {
+        Span<byte> s = stackalloc byte[256];
+        s[0] = 1;
+        s[255] = 2;
+        return s[0] + s[255];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TouchBytes1024()
+    {
+        Span<byte> s = stackalloc byte[1024];
+        s[0] = 1;
+        s[1023] = 2;
+        return s[0] + s[1023];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TouchBytes4096()
+    {
+        Span<byte> s = stackalloc byte[4096];
+        s[0] = 1;
+        s[4095] = 2;
+        return s[0] + s[4095];
+    }
+
+    // ---- Struct vs primitive at an equal ~4 KB byte size ----
+    // 4096 bytes as byte[4096], int[1024], and Range16[256]. If zeroing is a
+    // byte-wise memset the element type should not matter for equal byte size.
+
+    [Benchmark]
+    public int Zero_Int_1024() => TouchInts1024();
+
+    [Benchmark]
+    public int Zero_Struct16_256() => TouchStruct256();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TouchInts1024()
+    {
+        Span<int> s = stackalloc int[1024];
+        s[0] = 1;
+        s[1023] = 2;
+        return s[0] + s[1023];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int TouchStruct256()
+    {
+        Span<Range16> s = stackalloc Range16[256];
+        s[0].A = 1;
+        s[255].D = 2;
+        return s[0].A + s[255].D;
+    }
+
+    // ---- [SkipLocalsInit] effect at 4 KB ----
+    // Same 4 KB stackalloc with and without the localsinit flag. On modern .NET
+    // RyuJIT the SkipInit variant drops the zeroing; whether net481 RyuJIT does
+    // is exactly what this pair measures.
+
+    [Benchmark]
+    public int Zeroed_4096() => ZeroedHelper();
+
+    [Benchmark]
+    public int SkipInit_4096() => SkipInitHelper();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int ZeroedHelper()
+    {
+        Span<byte> s = stackalloc byte[4096];
+        s[0] = 1;
+        s[4095] = 2;
+        return s[0] + s[4095];
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [SkipLocalsInit]
+    private static int SkipInitHelper()
+    {
+        Span<byte> s = stackalloc byte[4096];
+        s[0] = 1;
+        s[4095] = 2;
+        return s[0] + s[4095];
+    }
+
+    // ---- Fixed-buffer ref struct + Unsafe.SkipInit (the no-zero scratch
+    // pattern). The struct carries a 4 KB inline fixed buffer; SkipInit leaves
+    // it uninitialized, and a scoped Span property exposes it. Available on both
+    // TFMs because Unsafe.SkipInit ships in the netstandard Unsafe surface. ----
+
+    [Benchmark]
+    public int FixedBufferSkipInit() => FixedBufferHelper();
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static int FixedBufferHelper()
+    {
+        Unsafe.SkipInit(out Scratch4K scratch);
+        Span<byte> s = scratch.AsSpan();
+        s[0] = 1;
+        s[4095] = 2;
+        return s[0] + s[4095];
+    }
+
+    private unsafe struct Scratch4K
+    {
+        public fixed byte Buffer[4096];
+
+        [UnscopedRef]
+        public Span<byte> AsSpan() => new(Unsafe.AsPointer(ref Buffer[0]), 4096);
+    }
+}

--- a/touki.tests/Touki/Io/Globbing/ExtGlobNegationMatchTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobNegationMatchTests.cs
@@ -87,6 +87,87 @@ public class ExtGlobNegationMatchTests
     public void Match_NegationNested(string pattern, string input, bool expected) =>
         Match(pattern, input).Should().Be(expected);
 
+    [Fact]
+    public void Match_MaxDepthNegationNesting_DoesNotTripRecursionGuard()
+    {
+        // The encoder accepts up to GlobSpecification.MaxExtGlobDepth nested
+        // extglob constructs. Negation re-entry is the engine's only native
+        // recursion, so the deepest legal pattern - that many nested !(...) -
+        // drives the recursion-depth guard to its budget. This pins that the
+        // budget accommodates the real maximum and never trips on valid input.
+        int depth = GlobSpecification.MaxExtGlobDepth;
+        string pattern = string.Concat(Enumerable.Repeat("!(", depth)) + "x" + new string(')', depth);
+
+        // !(P) matches s exactly when P does not match s, so wrapping x in an
+        // even number of negations is equivalent to matching "x", and an odd
+        // number is equivalent to "not x".
+        bool matchesLiteral = (depth & 1) == 0;
+
+        Func<bool> act = () => Match(pattern, "x");
+        act.Should().NotThrow();
+        act().Should().Be(matchesLiteral);
+        Match(pattern, "abcd").Should().Be(!matchesLiteral);
+    }
+
+    [Fact]
+    public void MatchCore_OverBudgetNegationNesting_TripsRecursionGuard()
+    {
+        // Companion to Match_MaxDepthNegationNesting_DoesNotTripRecursionGuard:
+        // that test proves the guard never trips at the deepest LEGAL nesting;
+        // this one proves the guard actually fires when nesting exceeds the
+        // budget. The encoder (GlobSpecification.Factory) rejects patterns nested
+        // deeper than MaxExtGlobDepth, so a normally compiled pattern can never
+        // reach the guard. To exercise the safety net we hand-craft an over-deep
+        // bytecode program directly - the shape an encoder bug would have to
+        // produce for the guard to matter - and run it through the engine.
+        //
+        // Each !(...) wraps a body in the AltStart bytecode block. The innermost
+        // body is the literal "x". A literal alternative is matched without an
+        // engine re-entry, so only the outer negations (whose body is itself a
+        // negation) recurse: N nested negations drive the native recursion to
+        // depth N. MaxExtGlobDepth + 2 is comfortably past the guard's budget.
+        int depth = GlobSpecification.MaxExtGlobDepth + 2;
+        string program = BuildNestedNegationProgram(depth);
+
+        CompiledGlobStrategy strategy = new(
+            program,
+            nfaProgramLength: program.Length,
+            tailStart: -1,
+            tailLength: 0,
+            hasGlobStar: false,
+            hasExtGlob: true,
+            GlobDialect.Bash,
+            GlobOptions.AllowGlobStar | GlobOptions.AllowExtGlob);
+
+        Action act = () => _ = strategy.MatchCore(default, "x".AsSpan());
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*recursion exceeded*");
+    }
+
+    // Builds a hand-crafted bytecode program of `depth` nested !(...) constructs
+    // wrapping the literal "x". The AltStart header layout (see
+    // CompiledGlobStrategy.ExtGlob) is
+    // [AltStart][kind][blockLength][altCount][off_0] followed by the single
+    // alternative body and a closing AltEnd. blockLength is the inclusive char
+    // count from AltStart through AltEnd; off_0 is the body start relative to the
+    // AltStart (always 5 for a single-alternative block: the 5-char header).
+    private static string BuildNestedNegationProgram(int depth)
+    {
+        // Innermost body: a Literal opcode carrying the single character 'x'.
+        string program = $"{GlobOpCodes.Literal}{(char)1}x";
+
+        for (int i = 0; i < depth; i++)
+        {
+            int blockLength = 5 + program.Length + 1;
+            program =
+                $"{GlobOpCodes.AltStart}!{(char)blockLength}{(char)1}{(char)5}"
+                + program
+                + GlobOpCodes.AltEnd;
+        }
+
+        return program;
+    }
+
     // -- Path-aware: negation can't cross the separator ------------------------------
 
     [Theory]

--- a/touki.tests/Touki/Io/Globbing/ExtGlobNegationMatchTests.cs
+++ b/touki.tests/Touki/Io/Globbing/ExtGlobNegationMatchTests.cs
@@ -93,8 +93,13 @@ public class ExtGlobNegationMatchTests
         // The encoder accepts up to GlobSpecification.MaxExtGlobDepth nested
         // extglob constructs. Negation re-entry is the engine's only native
         // recursion, so the deepest legal pattern - that many nested !(...) -
-        // drives the recursion-depth guard to its budget. This pins that the
+        // drives the recursion to depth MaxExtGlobDepth (the innermost !(x)
+        // body is a literal, matched inline without re-entry). That is the
+        // deepest level any valid input can reach; it sits one frame below the
+        // guard's MaxExtGlobDepth + 1 budget by design. This pins that the
         // budget accommodates the real maximum and never trips on valid input.
+        // (MatchCore_OverBudgetNegationNesting_TripsRecursionGuard covers the
+        // over-budget trip with hand-crafted bytecode.)
         int depth = GlobSpecification.MaxExtGlobDepth;
         string pattern = string.Concat(Enumerable.Repeat("!(", depth)) + "x" + new string(')', depth);
 

--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
@@ -236,9 +236,9 @@ public partial class GlobSpecificationTests
     [Fact]
     public void Compile_UnsupportedDialect_Throws()
     {
-#pragma warning disable CS0618 // GlobDialect.Win32 is obsolete; this test pins its not-implemented behavior.
-        Action act = () => GlobSpecification.Compile("*", GlobDialect.Win32);
-#pragma warning restore CS0618
+        // No GlobDialect value is unimplemented today; cast an out-of-range value to
+        // exercise the defensive FeatureNotEnabled branch in TryCompile.
+        Action act = () => GlobSpecification.Compile("*", (GlobDialect)999);
         act.Should().Throw<GlobFormatException>()
             .Which.Error.Code.Should().Be(GlobCompileErrorCode.FeatureNotEnabled);
     }

--- a/touki.tests/Touki/Io/Globbing/IgnoreCaseKindTests.cs
+++ b/touki.tests/Touki/Io/Globbing/IgnoreCaseKindTests.cs
@@ -2,12 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-// GlobDialect.Win32 is reserved-but-unimplemented and marked [Obsolete] for external
-// callers. These tests pin down its metadata-level mappings (default kind, escape,
-// separator, leading-dot, path-aware) so future drift is caught, and have to reference
-// the obsolete member by name.
-#pragma warning disable CS0618 // GlobDialect.Win32 is obsolete
-
 namespace Touki.Io.Globbing;
 
 /// <summary>
@@ -24,7 +18,6 @@ public class IgnoreCaseKindTests
     [InlineData(GlobDialect.Bash)]
     [InlineData(GlobDialect.Git)]
     [InlineData(GlobDialect.FileSystemGlobbing)]
-    [InlineData(GlobDialect.Win32)]
     [InlineData(GlobDialect.Simple)]
     [InlineData(GlobDialect.PowerShell)]
     public void DefaultIgnoreCaseKind_OptionsNone_ReturnsOff(GlobDialect dialect) =>
@@ -48,10 +41,9 @@ public class IgnoreCaseKindTests
         dialect.DefaultIgnoreCaseKind(GlobOptions.IgnoreCase).Should().Be(IgnoreCaseKind.Ascii);
 
     [Theory]
-    // .NET / Windows-native dialects default to full Unicode ordinal case folding.
+    // .NET-native dialects default to full Unicode ordinal case folding.
     [InlineData(GlobDialect.MSBuild)]
     [InlineData(GlobDialect.FileSystemGlobbing)]
-    [InlineData(GlobDialect.Win32)]
     [InlineData(GlobDialect.Simple)]
     [InlineData(GlobDialect.PowerShell)]
     public void DefaultIgnoreCaseKind_DotNetNative_ReturnsUnicode(GlobDialect dialect) =>
@@ -92,7 +84,6 @@ public class IgnoreCaseKindTests
     [InlineData(GlobDialect.Git, GlobOptions.None, '\\')]
     [InlineData(GlobDialect.MSBuild, GlobOptions.None, '\0')]
     [InlineData(GlobDialect.FileSystemGlobbing, GlobOptions.None, '\0')]
-    [InlineData(GlobDialect.Win32, GlobOptions.None, '\\')]
     [InlineData(GlobDialect.PowerShell, GlobOptions.None, '`')]
     [InlineData(GlobDialect.PowerShell, GlobOptions.NoEscape, '\0')]
     // Simple has no escape character regardless of options.
@@ -112,7 +103,6 @@ public class IgnoreCaseKindTests
     // Other dialects don't restrict leading dots.
     [InlineData(GlobDialect.MSBuild, true)]
     [InlineData(GlobDialect.FileSystemGlobbing, true)]
-    [InlineData(GlobDialect.Win32, true)]
     [InlineData(GlobDialect.Simple, true)]
     [InlineData(GlobDialect.PowerShell, true)]
     public void MatchesLeadingDotByDefault_PerDialect(GlobDialect dialect, bool expected) =>
@@ -131,7 +121,6 @@ public class IgnoreCaseKindTests
     [InlineData(GlobDialect.Posix, false)]
     [InlineData(GlobDialect.Simple, false)]
     [InlineData(GlobDialect.PowerShell, false)]
-    [InlineData(GlobDialect.Win32, false)]
     public void IsPathAware_PerDialect(GlobDialect dialect, bool expected) =>
         dialect.IsPathAware().Should().Be(expected);
 
@@ -148,7 +137,6 @@ public class IgnoreCaseKindTests
     [InlineData(GlobDialect.Posix, '\0')]
     [InlineData(GlobDialect.Simple, '\0')]
     [InlineData(GlobDialect.PowerShell, '\0')]
-    [InlineData(GlobDialect.Win32, '\0')]
     public void DefaultSeparator_PerDialect(GlobDialect dialect, char expected) =>
         dialect.DefaultSeparator().Should().Be(expected);
 

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
@@ -296,7 +296,7 @@ internal sealed partial class CompiledGlobStrategy
     ///   the engine writes every frame, range, and key slot before reading it
     ///   (high-water-mark counters bound every read to a written region), so it
     ///   does not depend on zero-init. This removes the per-call zero-fill of the
-    ///   roughly 4.3 KB seed - on net481 RyuJIT (unvectorized memset) that clear
+    ///   roughly 3.7 KB seed - on net481 RyuJIT (unvectorized memset) that clear
     ///   dominated the top-level match cost.
     ///  </para>
     /// </remarks>
@@ -1061,17 +1061,25 @@ internal sealed partial class CompiledGlobStrategy
                             // them for every later candidate/alternative.
                             if (!probeReady)
                             {
+                                int keyLength = KeyHeaderLength + (MaxRangesDepth * RangeKeyLength);
                                 probeFramesScope.EnsureCapacity(SeedFrameCount);
                                 probeArenaScope.EnsureCapacity(SeedArenaCount);
                                 probeWorkScope.EnsureCapacity(MaxRangesDepth);
                                 probeRestScope.EnsureCapacity(MaxRangesDepth);
-                                probeKeyScope.EnsureCapacity(KeyHeaderLength + (MaxRangesDepth * RangeKeyLength));
+                                probeKeyScope.EnsureCapacity(keyLength);
+
+                                // EnsureCapacity can hand back an oversized pool
+                                // bucket, so slice each span back to its logical
+                                // seed length. This keeps the probe path under the
+                                // same MaxRangesDepth/key-size ceiling as the
+                                // stack-backed top-level path, so it can never build
+                                // a state the key buffer was not sized to serialize.
                                 probeScratch = new(
-                                    probeFramesScope.AsSpan(),
-                                    probeArenaScope.AsSpan(),
-                                    probeWorkScope.AsSpan(),
-                                    probeRestScope.AsSpan(),
-                                    probeKeyScope.AsSpan());
+                                    probeFramesScope.AsSpan()[..SeedFrameCount],
+                                    probeArenaScope.AsSpan()[..SeedArenaCount],
+                                    probeWorkScope.AsSpan()[..MaxRangesDepth],
+                                    probeRestScope.AsSpan()[..MaxRangesDepth],
+                                    probeKeyScope.AsSpan()[..keyLength]);
                                 probeInputs = new(_first, _second, _program, _separator, _kind);
                                 probeReady = true;
                             }

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
@@ -54,7 +54,37 @@ namespace Touki.Io.Globbing;
 /// </remarks>
 internal sealed partial class CompiledGlobStrategy
 {
-    private const int MaxRangesDepth = 32;
+    /// <summary>
+    ///  Hard cap on the number of program ranges a single match configuration may
+    ///  hold at once. A "range list" is the ordered set of program slices the engine
+    ///  is matching in sequence (the active <c>Work</c> list and the <c>Rest</c>
+    ///  scratch list an alternative is built into); it also sizes the failure-memo
+    ///  <c>Key</c>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is a correctness ceiling, not a growable seed:
+    ///   <see cref="BuildRangesWithAlternative"/> and
+    ///   <see cref="BuildRangesWithAlternativeAndBlock"/> return
+    ///   <see langword="false"/> (failing the match arm) rather than spilling to a
+    ///   larger buffer when a list would exceed it, so it must stay at or above the
+    ///   worst case any pattern the encoder accepts can reach.
+    ///  </para>
+    ///  <para>
+    ///   The count grows only when an extglob alternative expands into the program:
+    ///   entering a construct prepends the alternative body and, for a repeating
+    ///   <c>+(...)</c> / <c>*(...)</c> block, a re-entry slice plus the post-block
+    ///   tail. That is at most two persistent ranges per enclosing construct, so the
+    ///   worst case scales with extglob <em>nesting depth</em> - not with input
+    ///   length (<see cref="CompactEmptyRanges"/> stops a repeating construct from
+    ///   accumulating one range per iteration). The encoder caps that nesting at
+    ///   <see cref="GlobSpecification.MaxExtGlobDepth"/>, so the bound is derived from
+    ///   it directly: two ranges per level, plus the initial whole-program range and
+    ///   one slot of slack. Raising <see cref="GlobSpecification.MaxExtGlobDepth"/>
+    ///   widens this in lock-step; do not hard-code a smaller literal.
+    ///  </para>
+    /// </remarks>
+    private const int MaxRangesDepth = (GlobSpecification.MaxExtGlobDepth * 2) + 2;
 
     // Failure-memo key layout: [inputIndex, totalLength, rangeCount] followed by
     // (Start, End, KindOverride) for each range.
@@ -219,6 +249,7 @@ internal sealed partial class CompiledGlobStrategy
     ///  Entry point used by <see cref="MatchCore"/> when the program contains
     ///  one or more <see cref="GlobOpCodes.AltStart"/> opcodes.
     /// </summary>
+    [SkipLocalsInit]
     private static bool MatchExtGlob(
         ReadOnlySpan<char> first,
         ReadOnlySpan<char> second,
@@ -256,12 +287,20 @@ internal sealed partial class CompiledGlobStrategy
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   This is the only native recursion point: the negation handler re-enters
-    ///   here with a clipped <paramref name="totalLength"/> to probe whether an
-    ///   alternative consumes exactly a candidate number of characters. Recursion
-    ///   depth is bounded by the encoder's maximum negation nesting.
+    ///   Runs once per top-level extglob match. The negation handler does not
+    ///   re-enter here - it re-enters <see cref="RunEngineCore"/> directly,
+    ///   reusing a single set of probe buffers across all of its bounded probes.
+    ///  </para>
+    ///  <para>
+    ///   The five seed buffers are left uninitialized (<see cref="SkipLocalsInitAttribute"/>):
+    ///   the engine writes every frame, range, and key slot before reading it
+    ///   (high-water-mark counters bound every read to a written region), so it
+    ///   does not depend on zero-init. This removes the per-call zero-fill of the
+    ///   roughly 4.3 KB seed - on net481 RyuJIT (unvectorized memset) that clear
+    ///   dominated the top-level match cost.
     ///  </para>
     /// </remarks>
+    [SkipLocalsInit]
     private static bool RunEngine(
         in EngineInputs inputs,
         ReadOnlySpan<ProgramRange> startRanges,
@@ -293,6 +332,10 @@ internal sealed partial class CompiledGlobStrategy
         in EngineScratch scratch,
         ref ExtGlobMatchState state)
     {
+        // Guard the native recursion depth (negation re-entry is the only native
+        // recursion). Throws before recursing past the budget so an encoder/logic
+        // regression fails fast instead of overflowing the stack.
+        state.EnterRecursion();
         ExtGlobEngine engine = new(in inputs, totalLength, in scratch);
         startRanges.CopyTo(scratch.Work);
         engine.WorkCount = startRanges.Length;
@@ -305,6 +348,7 @@ internal sealed partial class CompiledGlobStrategy
         finally
         {
             engine.ReturnRented();
+            state.ExitRecursion();
         }
     }
 
@@ -722,19 +766,24 @@ internal sealed partial class CompiledGlobStrategy
         // working configuration. Returns false when the frame is exhausted.
         private bool ProduceAlternative(int frameIdx, ref ExtGlobMatchState state)
         {
-            char k = _frames[frameIdx].Kind;
-            int snapOffset = _frames[frameIdx].SnapshotOffset;
-            int snapCount = _frames[frameIdx].SnapshotCount;
-            int savedInput = _frames[frameIdx].SavedInput;
-            int programIndex = _frames[frameIdx].ProgramIndex;
+            // Bind the frame once by reference. The body reads and writes its
+            // fields many times across the per-kind loops below; a single ref
+            // local avoids re-indexing the (bounds-checked) frame span on every
+            // access, which is a measurable cost on the net481 RyuJIT.
+            ref Frame frame = ref _frames[frameIdx];
+            char k = frame.Kind;
+            int snapOffset = frame.SnapshotOffset;
+            int snapCount = frame.SnapshotCount;
+            int savedInput = frame.SavedInput;
+            int programIndex = frame.ProgramIndex;
             ReadOnlySpan<ProgramRange> snap = _arena.Slice(snapOffset, snapCount);
 
             if (k == GlobOpCodes.AnyRun)
             {
                 // Alternatives are consumed lengths 0, 1, ... up to the cached
                 // separator-bounded limit.
-                int consumed = _frames[frameIdx].Cursor;
-                int limit = _frames[frameIdx].Aux;
+                int consumed = frame.Cursor;
+                int limit = frame.Aux;
                 if (savedInput + consumed > limit)
                 {
                     return false;
@@ -745,7 +794,7 @@ internal sealed partial class CompiledGlobStrategy
                 Head = 0;
                 _work[0].Start = programIndex + 1;
                 WorkInput = savedInput + consumed;
-                _frames[frameIdx].Cursor = consumed + 1;
+                frame.Cursor = consumed + 1;
                 return true;
             }
 
@@ -754,9 +803,9 @@ internal sealed partial class CompiledGlobStrategy
                 // Alternatives are the valid absorbed lengths in increasing
                 // order; the run stops once a length would exceed the input.
                 int flags = _program[programIndex + 1];
-                int absorbed = _frames[frameIdx].Cursor == 0
+                int absorbed = frame.Cursor == 0
                     ? FirstValidGlobStarLength(_first, _second, savedInput, flags, _separator)
-                    : NextValidGlobStarLength(_first, _second, savedInput, _frames[frameIdx].Aux, flags, _separator);
+                    : NextValidGlobStarLength(_first, _second, savedInput, frame.Aux, flags, _separator);
 
                 if (absorbed < 0 || savedInput + absorbed > _totalLength)
                 {
@@ -768,8 +817,8 @@ internal sealed partial class CompiledGlobStrategy
                 Head = 0;
                 _work[0].Start = programIndex + 2;
                 WorkInput = savedInput + absorbed;
-                _frames[frameIdx].Aux = absorbed;
-                _frames[frameIdx].Cursor = 1;
+                frame.Aux = absorbed;
+                frame.Cursor = 1;
                 return true;
             }
 
@@ -784,24 +833,22 @@ internal sealed partial class CompiledGlobStrategy
             int altEndIndex = afterEnd - 1;
             int altCount = _program[programIndex + 3];
 
-            // The encoder caps alternatives at GlobSpecification.MaxExtGlobAlternatives
-            // (the single source of truth) and bakes that many offset slots, so
-            // altCount is guaranteed to fit this fixed compile-time buffer.
-            Span<int> altStarts = stackalloc int[GlobSpecification.MaxExtGlobAlternatives];
-            for (int a = 0; a < altCount; a++)
-            {
-                altStarts[a] = programIndex + _program[programIndex + 4 + a];
-            }
+            // The per-alternative body offsets live in the AltStart header at
+            // [programIndex + 4 + j]. They are read inline at each use site
+            // (AltBodyStart) rather than expanded into a scratch buffer: the
+            // computation is a single program read, so materializing a table
+            // would only add a stack zero and fill loop on every production.
+            int altOffsetBase = programIndex + 4;
 
             switch (k)
             {
                 case '@':
-                    while (_frames[frameIdx].Cursor < altCount)
+                    while (frame.Cursor < altCount)
                     {
-                        int j = _frames[frameIdx].Cursor;
-                        _frames[frameIdx].Cursor = j + 1;
-                        int altBodyStart = altStarts[j];
-                        int altBodyEnd = (j + 1 < altCount) ? altStarts[j + 1] - 1 : altEndIndex;
+                        int j = frame.Cursor;
+                        frame.Cursor = j + 1;
+                        int altBodyStart = programIndex + _program[altOffsetBase + j];
+                        int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
                         snap.CopyTo(_rest);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
@@ -816,12 +863,12 @@ internal sealed partial class CompiledGlobStrategy
                     return false;
 
                 case '?':
-                    while (_frames[frameIdx].Cursor < altCount)
+                    while (frame.Cursor < altCount)
                     {
-                        int j = _frames[frameIdx].Cursor;
-                        _frames[frameIdx].Cursor = j + 1;
-                        int altBodyStart = altStarts[j];
-                        int altBodyEnd = (j + 1 < altCount) ? altStarts[j + 1] - 1 : altEndIndex;
+                        int j = frame.Cursor;
+                        frame.Cursor = j + 1;
+                        int altBodyStart = programIndex + _program[altOffsetBase + j];
+                        int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
                         snap.CopyTo(_rest);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
@@ -833,10 +880,10 @@ internal sealed partial class CompiledGlobStrategy
                         }
                     }
 
-                    if (_frames[frameIdx].Cursor == altCount)
+                    if (frame.Cursor == altCount)
                     {
                         // Zero-consume: skip the entire alternation block.
-                        _frames[frameIdx].Cursor = altCount + 1;
+                        frame.Cursor = altCount + 1;
                         snap.CopyTo(_work);
                         WorkCount = snapCount;
                         Head = 0;
@@ -849,12 +896,12 @@ internal sealed partial class CompiledGlobStrategy
                     return false;
 
                 case '+':
-                    while (_frames[frameIdx].Cursor < altCount)
+                    while (frame.Cursor < altCount)
                     {
-                        int j = _frames[frameIdx].Cursor;
-                        _frames[frameIdx].Cursor = j + 1;
-                        int altBodyStart = altStarts[j];
-                        int altBodyEnd = (j + 1 < altCount) ? altStarts[j + 1] - 1 : altEndIndex;
+                        int j = frame.Cursor;
+                        frame.Cursor = j + 1;
+                        int altBodyStart = programIndex + _program[altOffsetBase + j];
+                        int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
                         snap.CopyTo(_rest);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
@@ -884,12 +931,12 @@ internal sealed partial class CompiledGlobStrategy
                     return false;
 
                 case '*':
-                    while (_frames[frameIdx].Cursor < altCount)
+                    while (frame.Cursor < altCount)
                     {
-                        int j = _frames[frameIdx].Cursor;
-                        _frames[frameIdx].Cursor = j + 1;
-                        int altBodyStart = altStarts[j];
-                        int altBodyEnd = (j + 1 < altCount) ? altStarts[j + 1] - 1 : altEndIndex;
+                        int j = frame.Cursor;
+                        frame.Cursor = j + 1;
+                        int altBodyStart = programIndex + _program[altOffsetBase + j];
+                        int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
                         snap.CopyTo(_rest);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
@@ -913,10 +960,10 @@ internal sealed partial class CompiledGlobStrategy
                         }
                     }
 
-                    if (_frames[frameIdx].Cursor == altCount)
+                    if (frame.Cursor == altCount)
                     {
                         // Zero iterations: skip the entire alternation block.
-                        _frames[frameIdx].Cursor = altCount + 1;
+                        frame.Cursor = altCount + 1;
                         snap.CopyTo(_work);
                         WorkCount = snapCount;
                         Head = 0;
@@ -953,42 +1000,48 @@ internal sealed partial class CompiledGlobStrategy
                     // needed.
                     Span<ProgramRange> altRange = stackalloc ProgramRange[1];
 
-                    // Seed buffers for the bounded re-entry probes. Allocated once
-                    // per negation production and reused across every candidate
-                    // length and alternative, rather than re-seeding a fresh (and
-                    // zeroed) set inside each probe call. Only the non-literal
-                    // alternatives actually re-enter the engine; single-literal
-                    // alternatives take the cheap comparison path below.
-                    Span<Frame> probeFrames = stackalloc Frame[SeedFrameCount];
-                    Span<ProgramRange> probeArena = stackalloc ProgramRange[SeedArenaCount];
-                    Span<ProgramRange> probeWork = stackalloc ProgramRange[MaxRangesDepth];
-                    Span<ProgramRange> probeRest = stackalloc ProgramRange[MaxRangesDepth];
-                    Span<int> probeKey = stackalloc int[KeyHeaderLength + (MaxRangesDepth * RangeKeyLength)];
-                    EngineScratch probeScratch = new(probeFrames, probeArena, probeWork, probeRest, probeKey);
-                    EngineInputs probeInputs = new(_first, _second, _program, _separator, _kind);
+                    // Probe scratch is consumed only by the non-literal re-entry
+                    // path. Rather than zero-filling ~4 KB of stackalloc on every
+                    // negation production (the dominant cost in the negation flame
+                    // graphs - System.Buffer.ZeroMemoryInternal), the seed buffers
+                    // stay unallocated until the candidate loop actually reaches a
+                    // non-literal alternative. The common negation shape - every
+                    // alternative a single literal, e.g. !(bin|obj) - takes only
+                    // the cheap comparison path below and never allocates. When a
+                    // non-literal alternative is first encountered the seed buffers
+                    // are grown once from the pool (uninitialized: the engine writes
+                    // every frame, range, and key slot before reading it, so it does
+                    // not depend on zero-init) and reused for every later probe. The
+                    // using declarations return each rental to the pool on exit; a
+                    // default BufferScope that was never grown disposes as a no-op.
+                    using BufferScope<Frame> probeFramesScope = default;
+                    using BufferScope<ProgramRange> probeArenaScope = default;
+                    using BufferScope<ProgramRange> probeWorkScope = default;
+                    using BufferScope<ProgramRange> probeRestScope = default;
+                    using BufferScope<int> probeKeyScope = default;
+                    EngineScratch probeScratch = default;
+                    EngineInputs probeInputs = default;
+                    bool probeReady = false;
 
-                    while (_frames[frameIdx].Cursor <= maxL)
+                    while (frame.Cursor <= maxL)
                     {
-                        int candidate = _frames[frameIdx].Cursor;
-                        _frames[frameIdx].Cursor = candidate + 1;
+                        int candidate = frame.Cursor;
+                        frame.Cursor = candidate + 1;
 
                         bool anyAltMatches = false;
                         for (int j = 0; j < altCount; j++)
                         {
-                            int altBodyStart = altStarts[j];
-                            int altBodyEnd = (j + 1 < altCount) ? altStarts[j + 1] - 1 : altEndIndex;
+                            int altBodyStart = programIndex + _program[altOffsetBase + j];
+                            int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
 
                             // Fast path for a single-literal alternative: its shape
                             // is already encoded in the program (a Literal opcode
-                            // plus length char spanning the whole body), so detect
-                            // it by reading those bytes directly - no parallel
-                            // per-alternative table, no runtime-sized stackalloc. It
-                            // matches exactly 'candidate' characters only when the
-                            // lengths agree and the literal compares equal at the
-                            // cursor.
-                            if (altBodyStart < altBodyEnd
-                                && _program[altBodyStart] == GlobOpCodes.Literal
-                                && altBodyStart + 2 + _program[altBodyStart + 1] == altBodyEnd)
+                            // plus length char spanning the whole body), so detect it
+                            // by reading those bytes directly - no parallel
+                            // per-alternative table, no engine re-entry. It matches
+                            // exactly 'candidate' characters only when the lengths
+                            // agree and the literal compares equal at the cursor.
+                            if (IsSingleLiteralAlternative(_program, altBodyStart, altBodyEnd))
                             {
                                 int litLen = _program[altBodyStart + 1];
                                 if (litLen == candidate
@@ -1002,6 +1055,26 @@ internal sealed partial class CompiledGlobStrategy
                             }
 
                             altRange[0] = new ProgramRange { Start = altBodyStart, End = altBodyEnd };
+
+                            // First non-literal alternative on this production: grow
+                            // the probe seed buffers once from the pool and reuse
+                            // them for every later candidate/alternative.
+                            if (!probeReady)
+                            {
+                                probeFramesScope.EnsureCapacity(SeedFrameCount);
+                                probeArenaScope.EnsureCapacity(SeedArenaCount);
+                                probeWorkScope.EnsureCapacity(MaxRangesDepth);
+                                probeRestScope.EnsureCapacity(MaxRangesDepth);
+                                probeKeyScope.EnsureCapacity(KeyHeaderLength + (MaxRangesDepth * RangeKeyLength));
+                                probeScratch = new(
+                                    probeFramesScope.AsSpan(),
+                                    probeArenaScope.AsSpan(),
+                                    probeWorkScope.AsSpan(),
+                                    probeRestScope.AsSpan(),
+                                    probeKeyScope.AsSpan());
+                                probeInputs = new(_first, _second, _program, _separator, _kind);
+                                probeReady = true;
+                            }
 
                             // Bounded re-entry: probes whether the alternative
                             // consumes exactly 'candidate' characters. Native
@@ -1042,6 +1115,18 @@ internal sealed partial class CompiledGlobStrategy
                     return false;
             }
         }
+
+        /// <summary>
+        ///  Returns <see langword="true"/> when the alternative body
+        ///  <c>[bodyStart, bodyEnd)</c> is a single <see cref="GlobOpCodes.Literal"/>
+        ///  opcode spanning the whole body. Such alternatives are matched by a
+        ///  direct length-and-compare against each negation candidate length, so
+        ///  they never re-enter the engine and need no probe scratch.
+        /// </summary>
+        private static bool IsSingleLiteralAlternative(ReadOnlySpan<char> program, int bodyStart, int bodyEnd) =>
+            bodyStart < bodyEnd
+                && program[bodyStart] == GlobOpCodes.Literal
+                && bodyStart + 2 + program[bodyStart + 1] == bodyEnd;
     }
 
     /// <summary>
@@ -1214,13 +1299,66 @@ internal sealed partial class CompiledGlobStrategy
         // crafted input. Once reached, recording stops (still correct).
         private const int MaxEntries = 1 << 20;
 
+        /// <summary>
+        ///  Hard ceiling on the native recursion depth of the engine. Negation
+        ///  (<c>!(...)</c>) re-entry is the engine's only native recursion: each
+        ///  enclosing negation re-enters <see cref="RunEngineCore"/> one level
+        ///  deeper, and the encoder caps extglob nesting at
+        ///  <see cref="GlobSpecification.MaxExtGlobDepth"/>, so a validly compiled
+        ///  program reaches at most that many re-entries plus the one top-level
+        ///  entry. A program that exceeds this could only come from an encoder bug
+        ///  that let through deeper nesting, so the guard exists purely to convert
+        ///  such a regression into a deterministic, catchable failure instead of a
+        ///  stack overflow.
+        /// </summary>
+        private const int MaxRecursionDepth = GlobSpecification.MaxExtGlobDepth + 1;
+
+        /// <summary>
+        ///  Running count of choice-point visits in the current match. Compared
+        ///  against <see cref="EngageThreshold"/> to decide when to engage the
+        ///  failure memo; never reset within a match.
+        /// </summary>
         public long Steps;
+
+        // Current native recursion depth (number of live RunEngineCore frames).
+        // Incremented on entry and decremented on exit by EnterRecursion /
+        // ExitRecursion; guarded against MaxRecursionDepth.
+        private int _depth;
 
         // Failure memo. Non-null exactly when engaged; lazily created so benign
         // inputs that never cross the threshold pay no allocation.
         private SequenceSet<int>? _failures;
 
+        /// <summary>
+        ///  <see langword="true"/> once the failure memo has been created - that is,
+        ///  once the walk has crossed <see cref="EngageThreshold"/> steps. Before
+        ///  then the common-case path pays no memo allocation or lookup cost.
+        /// </summary>
         public readonly bool Engaged => _failures is not null;
+
+        /// <summary>
+        ///  Records entry into a <see cref="RunEngineCore"/> frame and throws when
+        ///  the native recursion depth would exceed <see cref="MaxRecursionDepth"/>.
+        ///  Unreachable for any validly compiled program (the encoder caps nesting
+        ///  at <see cref="GlobSpecification.MaxExtGlobDepth"/>); it fires only if a
+        ///  logic change breaks that invariant, failing fast and deterministically
+        ///  rather than overflowing the stack.
+        /// </summary>
+        public void EnterRecursion()
+        {
+            if (++_depth > MaxRecursionDepth)
+            {
+                throw new InvalidOperationException(
+                    $"Extended-glob match recursion exceeded the depth budget of {MaxRecursionDepth}. "
+                        + $"The encoder should reject patterns nested deeper than {GlobSpecification.MaxExtGlobDepth} before matching.");
+            }
+        }
+
+        /// <summary>
+        ///  Records exit from a <see cref="RunEngineCore"/> frame, balancing a
+        ///  prior <see cref="EnterRecursion"/>.
+        /// </summary>
+        public void ExitRecursion() => _depth--;
 
         /// <summary>
         ///  Creates the failure memo. Called once when the step counter first

--- a/touki/Touki/Io/Globbing/GlobDialect.cs
+++ b/touki/Touki/Io/Globbing/GlobDialect.cs
@@ -80,25 +80,6 @@ public enum GlobDialect
     FileSystemGlobbing,
 
     /// <summary>
-    ///  Win32 <c>FsRtlIsNameInExpression</c> semantics including the DOS metacharacters
-    ///  <c>&lt;</c>, <c>&gt;</c>, and <c>"</c>.
-    /// </summary>
-    /// <remarks>
-    ///  <para>
-    ///   See <see href="https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matcheswin32expression">
-    ///   <c>FileSystemName.MatchesWin32Expression</c></see>.
-    ///  </para>
-    ///  <para>
-    ///   <b>Not yet implemented.</b> Reserved for a future release; passing this value
-    ///   to <see cref="GlobSpecification.Compile(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>
-    ///   throws <see cref="GlobFormatException"/> with
-    ///   <see cref="GlobCompileErrorCode.FeatureNotEnabled"/>.
-    ///  </para>
-    /// </remarks>
-    [Obsolete("GlobDialect.Win32 is reserved but not yet implemented. Compiling with this value throws GlobFormatException.", error: false)]
-    Win32,
-
-    /// <summary>
     ///  Simple file-name expression matching (<c>*</c> and <c>?</c> only).
     /// </summary>
     /// <remarks>

--- a/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
+++ b/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
@@ -24,9 +24,9 @@ internal static class GlobDialectExtensions
     ///   POSIX/C locale.
     ///  </para>
     ///  <para>
-    ///   .NET-native and Windows-native dialects
+    ///   .NET-native dialects
     ///   (<see cref="GlobDialect.MSBuild"/>, <see cref="GlobDialect.FileSystemGlobbing"/>,
-    ///   <see cref="GlobDialect.Win32"/>, <see cref="GlobDialect.Simple"/>,
+    ///   <see cref="GlobDialect.Simple"/>,
     ///   <see cref="GlobDialect.PowerShell"/>) default to <see cref="IgnoreCaseKind.Unicode"/>
     ///   because their documented implementations use
     ///   <see cref="StringComparison.OrdinalIgnoreCase"/> or the Windows kernel
@@ -63,7 +63,7 @@ internal static class GlobDialectExtensions
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   POSIX-family, MSBuild, FileSystemGlobbing, and Win32 dialects use backslash
+    ///   POSIX-family, MSBuild, and FileSystemGlobbing dialects use backslash
     ///   (<c>\</c>) as the escape character. PowerShell <c>WildcardPattern</c> /
     ///   <c>-like</c> uses backtick (<c>`</c>) per
     ///   <see href="https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_wildcards">
@@ -100,7 +100,7 @@ internal static class GlobDialectExtensions
     ///   <see cref="GlobDialect.PosixPath"/>, <see cref="GlobDialect.Bash"/>,
     ///   <see cref="GlobDialect.Git"/>) treat a leading <c>.</c> as a "hidden" marker
     ///   per <c>fnmatch</c>'s <c>FNM_PERIOD</c> rule, requiring a literal <c>.</c>
-    ///   in the pattern. All other dialects - including PowerShell, Win32,
+    ///   in the pattern. All other dialects - including PowerShell,
     ///   Simple, MSBuild, FileSystemGlobbing - do not.
     ///  </para>
     /// </remarks>

--- a/touki/Touki/Io/Globbing/GlobOptions.cs
+++ b/touki/Touki/Io/Globbing/GlobOptions.cs
@@ -86,14 +86,12 @@ public enum GlobOptions
     ///    <item>
     ///     <description>
     ///      <see cref="GlobDialect.MSBuild"/>, <see cref="GlobDialect.FileSystemGlobbing"/>,
-    ///      <see cref="GlobDialect.Win32"/>, <see cref="GlobDialect.Simple"/>, and
+    ///      <see cref="GlobDialect.Simple"/>, and
     ///      <see cref="GlobDialect.PowerShell"/> use <b>full Unicode</b> ordinal case
     ///      folding equivalent to <see cref="StringComparison.OrdinalIgnoreCase"/>. This
     ///      matches the documented behavior of
     ///      <see href="https://learn.microsoft.com/dotnet/api/microsoft.extensions.filesystemglobbing.matcher"><c>Microsoft.Extensions.FileSystemGlobbing.Matcher</c></see>,
     ///      <see href="https://learn.microsoft.com/dotnet/api/system.io.enumeration.filesystemname.matchessimpleexpression"><c>FileSystemName.MatchesSimpleExpression</c></see>,
-    ///      Win32
-    ///      <see href="https://learn.microsoft.com/windows-hardware/drivers/ddi/ntifs/nf-ntifs-fsrtlisnameinexpression"><c>FsRtlIsNameInExpression</c></see>,
     ///      and PowerShell
     ///      <see href="https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_wildcards"><c>-like</c></see>.
     ///     </description>

--- a/touki/Touki/Io/Globbing/GlobPathSeparator.cs
+++ b/touki/Touki/Io/Globbing/GlobPathSeparator.cs
@@ -17,8 +17,7 @@ namespace Touki.Io.Globbing;
 ///   Each path-aware dialect documents a default separator
 ///   (<see cref="GlobDialect.PosixPath"/>, <see cref="GlobDialect.Bash"/>,
 ///   <see cref="GlobDialect.Git"/>, <see cref="GlobDialect.MSBuild"/>, and
-///   <see cref="GlobDialect.FileSystemGlobbing"/> default to forward-slash;
-///   <see cref="GlobDialect.Win32"/> defaults to the OS separator). Passing this enum
+///   <see cref="GlobDialect.FileSystemGlobbing"/> default to forward-slash). Passing this enum
 ///   to <see cref="GlobSpecification.Compile(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>
 ///   overrides that default; <see cref="DialectDefault"/> keeps it.
 ///  </para>

--- a/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.Factory.cs
@@ -23,6 +23,24 @@ public sealed partial class GlobSpecification
     internal const int MaxExtGlobAlternatives = 32;
 
     /// <summary>
+    ///  Maximum nesting depth of extended-glob constructs (<c>?(…)</c>, <c>*(…)</c>,
+    ///  <c>+(…)</c>, <c>@(…)</c>, <c>!(…)</c>). Exceeding this raises
+    ///  <see cref="GlobCompileErrorCode.FeatureLimitExceeded"/>. The cap exists so
+    ///  the interpreter's stack-allocated savepoint buffer stays bounded: with
+    ///  this depth and the per-construct alternative cap, simultaneous savepoints
+    ///  are guaranteed to fit in the fixed runtime budget.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is the single source of truth for the nesting cap. The encoder
+    ///   enforces it; the matcher derives its fixed range-list ceiling
+    ///   (<see cref="CompiledGlobStrategy"/>'s <c>MaxRangesDepth</c>) from it so the
+    ///   two sides can never drift.
+    ///  </para>
+    /// </remarks>
+    internal const int MaxExtGlobDepth = 8;
+
+    /// <summary>
     ///  Classifies a source pattern and constructs the cheapest <see cref="GlobStrategy"/>
     ///  implementation that can evaluate it.
     /// </summary>
@@ -52,16 +70,6 @@ public sealed partial class GlobSpecification
         ///  <see cref="GlobCompileErrorCode.PatternTooLarge"/>.
         /// </summary>
         internal const int MaxOpcodeBodyLength = char.MaxValue;
-
-        /// <summary>
-        ///  Maximum nesting depth of extended-glob constructs (<c>?(…)</c>, <c>*(…)</c>,
-        ///  <c>+(…)</c>, <c>@(…)</c>, <c>!(…)</c>). Exceeding this raises
-        ///  <see cref="GlobCompileErrorCode.FeatureLimitExceeded"/>. The cap exists so
-        ///  the interpreter's stack-allocated savepoint buffer stays bounded: with
-        ///  this depth and the per-construct alternative cap, simultaneous savepoints
-        ///  are guaranteed to fit in the fixed runtime budget.
-        /// </summary>
-        internal const int MaxExtGlobDepth = 8;
 
         /// <summary>
         ///  Default upper bound (in characters) applied by the

--- a/touki/Touki/Io/Globbing/IgnoreCaseKind.cs
+++ b/touki/Touki/Io/Globbing/IgnoreCaseKind.cs
@@ -41,8 +41,7 @@ internal enum IgnoreCaseKind
     /// <summary>
     ///  Full Unicode ordinal case fold matching <see cref="StringComparison.OrdinalIgnoreCase"/>.
     ///  Implements the behavior of MSBuild item globs, <c>Microsoft.Extensions.FileSystemGlobbing.Matcher</c>,
-    ///  Win32 <c>FsRtlIsNameInExpression</c> with <c>IgnoreCase</c>, the .NET
-    ///  <c>FileSystemName.MatchesSimpleExpression</c>, and PowerShell's <c>-like</c> operator.
+    ///  the .NET <c>FileSystemName.MatchesSimpleExpression</c>, and PowerShell's <c>-like</c> operator.
     /// </summary>
     /// <remarks>
     ///  <para>


### PR DESCRIPTION
## Globbing

- Remove the Win32 dialect path from `GlobDialect` and simplify the dialect / options / separator surface and the factory accordingly.
- Rewrite `docs/globbing-feature-plan.md` to match the trimmed surface.
- Add `MatchCore_OverBudgetNegationNesting_TripsRecursionGuard`: proves the extglob engine's native recursion-depth guard (`EnterRecursion`) actually fires when negation nesting exceeds the budget. The encoder caps nesting at `MaxExtGlobDepth`, so the guard is unreachable from a normally compiled pattern; the test hand-crafts an over-deep bytecode program (the shape an encoder bug would produce) and feeds it straight to `CompiledGlobStrategy`. Complements the existing `Match_MaxDepthNegationNesting_DoesNotTripRecursionGuard`, which pins that the guard never trips at the deepest legal nesting.

## Performance investigation

- Add `docs/arraypool-performance.md` and `docs/performance-investigation.md` capturing the `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope` vs `ArrayPool` crossover measurements (net481 / net10).
- Add the `scratch-buffer-strategy` skill plus the `AGENTS.md` / instructions references that point to it.
- Add supporting BenchmarkDotNet projects (`ArrayPoolCrossoverPerf`, `ArrayPoolSeedRentPerf`, `BufferScopeOverheadPerf`, `StackZeroInitPerf`) and `tools/speedscope-to-flamegraph.ps1`.

## Validation

- `dotnet build touki.slnx -c Release` — clean.
- `dotnet test touki.tests -c Release` — green on both TFMs (net481 7922 passed, net10 6577 passed).
