### PR TITLE
Add source heatmap to touki.mcp with full test coverage

### DIFF
--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -55,6 +55,12 @@ is fine." On `net481` a hand-written specialized loop frequently beats the BCL b
 ## Decision flow for a new framework-only fast path
 
 1. Start with the simplest possible scalar loop and measure it as the baseline.
+   Capture the baseline on **both** `net10.0` and `net481` before editing, and
+   keep the full BenchmarkDotNet rows (`Mean`/`Error`/`StdDev`/`Allocated`), not
+   a one-line summary - see the before/after discipline in
+   [performance-testing](../performance-testing/SKILL.md). EventPipe line
+   profiling is net10-only, but every change still has to be re-measured on
+   net481 overall.
 2. Decide whether to specialize. See [specialization.md](specialization.md) for the
    `typeof(T)` pattern and primitive equivalence classes.
 3. Decide whether to defer to a BCL primitive. See
@@ -72,6 +78,10 @@ is fine." On `net481` a hand-written specialized loop frequently beats the BCL b
    modern path. If a specialization is harmful on net10 (because the BCL is
    actually vectorized there), guard it with `#if NETFRAMEWORK` so only `net481`
    gets the loop.
+8. Report both TFMs' before/after tables together, and confirm the targeted hot
+   line/method from the net10 trace actually shrank (e.g. `System.Array.Copy`
+   self-time dropping). A faster `Mean` with the targeted frame unchanged is
+   usually noise or an unrelated win.
 
 ## Quick reference: ratios from real benchmarks
 

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -227,6 +227,46 @@ analyzer and remain as a no-MCP fallback (plus `speedscope-to-flamegraph.ps1`
 for SVG) in
 [docs/performance-investigation-without-mcp.md](../../../docs/performance-investigation-without-mcp.md).
 
+### Before/after measurement discipline (both TFMs, every time)
+
+A perf change is not done until you can show it helped and harmed nothing. The
+trace analyzer answers *where* to optimize; only a before/after benchmark answers
+*whether it worked*. Treat the following as mandatory whenever a code change is
+driven by a profile:
+
+- **Capture a baseline first, on both `net10.0` and `net481`.** Run the affected
+  benchmark on each TFM (`-f net10.0` and `-f net481`) *before* touching the
+  source and save the full result rows. The line-level EventPipe profiling that
+  guides the edit is `net10.0`-only, but the change still has to be measured on
+  `net481` - the older RyuJIT and BCL allocate and inline differently, and a
+  win on one TFM can be a wash or a regression on the other. **Never iterate on
+  net10 line info without also tracking the net481 overall throughput and
+  allocation numbers.**
+- **Re-run both TFMs after the change** and diff against the saved baseline.
+- **Record the full BenchmarkDotNet rows, not just a one-line summary.** Keep
+  the whole table - `Mean`, `Error`, `StdDev`, `Gen0`, `Gen1`, `Gen2`,
+  `Allocated` - for both the before and after runs on both TFMs. A summary like
+  "~7% faster" loses the error bars (is the delta inside the noise?) and the
+  allocation column (did the speedup trade CPU for garbage?). Save the raw
+  output to `artifacts/<name>-baseline-<tfm>.txt` and
+  `artifacts/<name>-after-<tfm>.txt` so the full diff is reproducible. Pipe the
+  run through `Tee-Object` to keep the console table.
+- **Allocation must not regress.** Compare the `Allocated` column before and
+  after on *both* TFMs. "No additional allocations" is only true if both columns
+  are unchanged.
+- **Confirm the targeted cost actually moved.** Re-capture a `net10.0` trace
+  after the change and check that the specific method/line the heat map flagged
+  dropped (e.g. `System.Array.Copy` self-time falling from 30 ms to 19 ms). A
+  faster wall-clock with the targeted frame unchanged usually means the win came
+  from somewhere else - or from noise.
+- **Distrust sub-microsecond deltas from this machine.** The i9-14900K harness
+  shows thermal/variance swings; trust the `Allocated` column and a unit test
+  over a small `Mean` delta. Deltas comfortably outside the `Error`/`StdDev` and
+  consistent in direction across both TFMs are credible.
+
+Present both TFMs' before/after tables together when reporting the result, plus
+the line-level evidence that the targeted hot spot shrank.
+
 ## 3. Evaluating memory usage
 
 With `[MemoryDiagnoser]` (or `--memory`), each row of the results table includes:

--- a/touki.mcp.tests/ConsoleAnalyzerTests.cs
+++ b/touki.mcp.tests/ConsoleAnalyzerTests.cs
@@ -139,4 +139,14 @@ public class ConsoleAnalyzerTests
         exit.Should().Be(0);
         output.Should().Contain("TOP SELF-TIME");
     }
+
+    [Test]
+    public void Run_HeatmapFlag_SpeedscopeHasNoLineData_PrintsHeaderAndEmptyNote()
+    {
+        (int exit, string output, _) = Run(Fixture, "--heatmap", "Engine.cs");
+
+        exit.Should().Be(0);
+        output.Should().Contain("SOURCE HEATMAP");
+        output.Should().Contain("No samples attributed to 'Engine.cs'");
+    }
 }

--- a/touki.mcp.tests/FoldingAggregatorTests.cs
+++ b/touki.mcp.tests/FoldingAggregatorTests.cs
@@ -87,6 +87,26 @@ public class FoldingAggregatorTests
     }
 
     [Test]
+    public void CallersOf_MoreCallersThanTop_TruncatesToHeaviest()
+    {
+        // Three distinct callers of Target; top of 2 keeps only the two heaviest.
+        List<SampleStack> samples =
+        [
+            new(["Ccc", "Target"], 1.0, "1"),
+            new(["Bbb", "Target"], 2.0, "1"),
+            new(["Aaa", "Target"], 3.0, "1")
+        ];
+
+        CallersResult result = new FoldingAggregator(samples).CallersOf("Target", "", top: 2);
+
+        result.Callers.Should().HaveCount(2);
+        result.Callers[0].Milliseconds.Should().Be(3.0);
+        result.Callers[1].Milliseconds.Should().Be(2.0);
+        // The 1 ms caller is dropped by the truncation.
+        result.Callers.Should().NotContain(static c => c.Milliseconds == 1.0);
+    }
+
+    [Test]
     public void SelfTime_RootScoping_ExcludesSamplesWithoutRootFrame()
     {
         RankingResult result = LoadFolding().Aggregator.SelfTime("MyApp.Work", FrameNames.DefaultFoldPatterns, 25);
@@ -222,5 +242,126 @@ public class FoldingAggregatorTests
         result.Callers.Should().ContainSingle();
         result.Callers[0].Caller.Should().Be("<root>");
         result.Callers[0].Milliseconds.Should().Be(25.0);
+    }
+
+    [Test]
+    public void SourceHeatmap_BucketsLeafSamplesByLineFoldingHelperLeaves()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 3.0, "1", ["Engine.cs:20"]),
+            new(["app!Run", "app!WriteBarrier"], 4.0, "1", ["Engine.cs:10", "Helpers.cs:99"]),
+            new(["app!Other"], 8.0, "1", ["Other.cs:1"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        // Percent is over the whole trace (20 ms), file total is the 12 ms in Engine.cs.
+        result.ScopeMilliseconds.Should().Be(20.0);
+        result.File.Should().Be("Engine.cs");
+        result.FileMilliseconds.Should().Be(12.0);
+
+        result.Lines.Should().HaveCount(2);
+        // Ordered by line number, not by time.
+        result.Lines[0].Line.Should().Be(10);
+        result.Lines[0].Milliseconds.Should().Be(9.0);
+        result.Lines[0].SampleCount.Should().Be(2);
+        result.Lines[0].Method.Should().Be("Run");
+        result.Lines[0].PercentOfScope.Should().Be(45.0);
+        result.Lines[1].Line.Should().Be(20);
+        result.Lines[1].Milliseconds.Should().Be(3.0);
+    }
+
+    [Test]
+    public void SourceHeatmap_MatchesFileNameCaseInsensitively()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("ENGINE.CS", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().ContainSingle();
+        // The file name keeps the casing recorded in the trace.
+        result.File.Should().Be("Engine.cs");
+    }
+
+    [Test]
+    public void SourceHeatmap_SamplesWithoutLocationsOrOtherFiles_AreExcluded()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 9.0, "1"),
+            new(["app!Run"], 4.0, "1", [""]),
+            new(["app!Run"], 2.0, "1", ["Other.cs:3"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        // Whole-trace total still counts every sample; only Engine.cs contributes lines.
+        result.ScopeMilliseconds.Should().Be(20.0);
+        result.FileMilliseconds.Should().Be(5.0);
+        result.Lines.Should().ContainSingle();
+        result.Lines[0].Line.Should().Be(10);
+    }
+
+    [Test]
+    public void SourceHeatmap_NoMatchingFile_ReturnsEmptyLines()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Missing.cs", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().BeEmpty();
+        result.FileMilliseconds.Should().Be(0.0);
+        result.ScopeMilliseconds.Should().Be(5.0);
+    }
+
+    [Test]
+    public void SourceHeatmap_CompetingMethodsOnOneLine_ReportsDominantByTime()
+    {
+        // Two methods resolve to the same Engine.cs:10; the heaviest one dominates.
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 3.0, "1", ["Engine.cs:10"]),
+            new(["app!Helper"], 7.0, "1", ["Engine.cs:10"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().ContainSingle();
+        result.Lines[0].Line.Should().Be(10);
+        result.Lines[0].Milliseconds.Should().Be(10.0);
+        result.Lines[0].SampleCount.Should().Be(2);
+        // Helper (7 ms) outweighs Run (3 ms) for the line.
+        result.Lines[0].Method.Should().Be("Helper");
+    }
+
+    [Test]
+    [Arguments("Engine.cs")]
+    [Arguments("Engine.cs:")]
+    [Arguments("Engine.cs:abc")]
+    [Arguments(":10")]
+    public void SourceHeatmap_MalformedLeafLocation_IsExcluded(string location)
+    {
+        // A location with no colon, a trailing colon, a non-numeric line, or no file
+        // name cannot be split into file:line and must not contribute to any file.
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", [location])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().BeEmpty();
+        result.FileMilliseconds.Should().Be(0.0);
+        // The sample still counts toward the whole-trace total.
+        result.ScopeMilliseconds.Should().Be(5.0);
     }
 }

--- a/touki.mcp.tests/FoldingAggregatorTests.cs
+++ b/touki.mcp.tests/FoldingAggregatorTests.cs
@@ -348,10 +348,13 @@ public class FoldingAggregatorTests
     [Arguments("Engine.cs:")]
     [Arguments("Engine.cs:abc")]
     [Arguments(":10")]
+    [Arguments("Engine.cs:0")]
+    [Arguments("Engine.cs:-1")]
     public void SourceHeatmap_MalformedLeafLocation_IsExcluded(string location)
     {
-        // A location with no colon, a trailing colon, a non-numeric line, or no file
-        // name cannot be split into file:line and must not contribute to any file.
+        // A location with no colon, a trailing colon, a non-numeric line, no file
+        // name, or a non-positive (non 1-based) line cannot be split into file:line
+        // and must not contribute to any file.
         List<SampleStack> samples =
         [
             new(["app!Run"], 5.0, "1", [location])

--- a/touki.mcp.tests/SourceAnnotatorTests.cs
+++ b/touki.mcp.tests/SourceAnnotatorTests.cs
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Mcp.Tracing;
+
+public class SourceAnnotatorTests
+{
+    [Test]
+    public void TryReadSourceLines_ExistingFile_ReturnsLines()
+    {
+        string temp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllLines(temp, ["first", "second", "third"]);
+
+            SourceAnnotator.TryReadSourceLines(temp, out string[] lines).Should().BeTrue();
+            lines.Should().Equal("first", "second", "third");
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [Test]
+    public void TryReadSourceLines_MissingFile_ReturnsFalseAndEmpty()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.cs");
+
+        SourceAnnotator.TryReadSourceLines(missing, out string[] lines).Should().BeFalse();
+        lines.Should().BeEmpty();
+    }
+
+    [Test]
+    public void Render_SmallFile_RendersEveryLineWithHeaderAndGutter()
+    {
+        string[] source = ["alpha", "beta", "gamma"];
+        List<HeatLine> heat = [new HeatLine(2, 6.0, 50.0, 3, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 12.0);
+
+        // Header is always present.
+        output.Should().Contain("ms");
+        output.Should().Contain("%file");
+        output.Should().Contain("heat");
+
+        // Every source line is rendered, hot or cold.
+        output.Should().Contain("alpha");
+        output.Should().Contain("beta");
+        output.Should().Contain("gamma");
+    }
+
+    [Test]
+    public void Render_HotLine_ShowsMillisecondsPercentOfFileAndHeatBars()
+    {
+        string[] source = ["cold", "hot"];
+        List<HeatLine> heat = [new HeatLine(2, 6.0, 30.0, 3, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 12.0);
+
+        string[] lines = output.Split('\n');
+        string hotRow = lines.Single(static l => l.Contains("hot"));
+
+        // 6 of 12 file ms = 50.0% of file, and a full 8-bar heat (it is the max line).
+        hotRow.Should().Contain("6.0");
+        hotRow.Should().Contain("50.0");
+        hotRow.Should().Contain("########");
+    }
+
+    [Test]
+    public void Render_ColdLine_HasBlankGutter()
+    {
+        string[] source = ["cold", "hot"];
+        List<HeatLine> heat = [new HeatLine(2, 6.0, 30.0, 3, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 12.0);
+
+        string[] lines = output.Split('\n');
+        string coldRow = lines.Single(static l => l.Contains("cold"));
+
+        // The cold line carries no ms/percent/heat - only the line number and text.
+        coldRow.Should().NotContain("#");
+        coldRow.Should().Contain("cold");
+    }
+
+    [Test]
+    public void Render_ZeroFileMilliseconds_DoesNotDivideByZero()
+    {
+        string[] source = ["only"];
+        List<HeatLine> heat = [new HeatLine(1, 5.0, 0.0, 1, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 0.0);
+
+        string[] lines = output.Split('\n');
+        string row = lines.Single(static l => l.Contains("only"));
+        // Percent-of-file collapses to 0.0 rather than NaN/Infinity.
+        row.Should().Contain("0.0");
+        row.Should().Contain("5.0");
+    }
+
+    [Test]
+    public void Render_LargeFile_WindowsAroundHotLinesWithGapMarkers()
+    {
+        string[] source = new string[700];
+        for (int i = 0; i < source.Length; i++)
+        {
+            source[i] = $"line{i + 1}";
+        }
+
+        // Two hot lines far apart force two separate windows with a gap between them.
+        List<HeatLine> heat =
+        [
+            new HeatLine(100, 4.0, 40.0, 1, "Foo"),
+            new HeatLine(400, 6.0, 60.0, 1, "Bar")
+        ];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 10.0);
+
+        // Hot lines and their context are shown.
+        output.Should().Contain("line100");
+        output.Should().Contain("line400");
+
+        // A line in neither window is omitted.
+        output.Should().NotContain("line250\n");
+
+        // A gap marker separates the two windows.
+        output.Should().Contain("...");
+    }
+}

--- a/touki.mcp.tests/SourceAnnotatorTests.cs
+++ b/touki.mcp.tests/SourceAnnotatorTests.cs
@@ -121,8 +121,9 @@ public class SourceAnnotatorTests
         output.Should().Contain("line100");
         output.Should().Contain("line400");
 
-        // A line in neither window is omitted.
-        output.Should().NotContain("line250\n");
+        // A line in neither window is omitted. Match the rendered gutter so the
+        // check is newline-agnostic (AppendLine emits \r\n on Windows).
+        output.Should().NotContain("|  250  line250");
 
         // A gap marker separates the two windows.
         output.Should().Contain("...");

--- a/touki.mcp.tests/TraceToolsTests.cs
+++ b/touki.mcp.tests/TraceToolsTests.cs
@@ -98,6 +98,19 @@ public class TraceToolsTests
     }
 
     [Test]
+    public void SourceHeatmap_SpeedscopeHasNoLineData_ReturnsEmptyLinesWithNote()
+    {
+        TraceStore store = new();
+
+        JsonElement root = Parse(TraceTools.SourceHeatmap(store, Fixture, "Engine.cs"));
+
+        root.GetProperty("lines").GetArrayLength().Should().Be(0);
+        root.GetProperty("sourceFound").GetBoolean().Should().BeFalse();
+        root.GetProperty("annotatedSource").ValueKind.Should().Be(JsonValueKind.Null);
+        root.GetProperty("note").GetString().Should().Contain("Engine.cs");
+    }
+
+    [Test]
     public void ListThreads_ReportsPerThreadSampleCounts()
     {
         TraceStore store = new();

--- a/touki.mcp/ConsoleAnalyzer.cs
+++ b/touki.mcp/ConsoleAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Touki.Mcp;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   Usage: <c>touki.mcp analyze &lt;trace&gt; [--root &lt;substr&gt;] [--callers &lt;substr&gt;] [--lines [&lt;methodSubstr&gt;]] [--symbols &lt;dir&gt;] [--top N]</c>.
+///   Usage: <c>touki.mcp analyze &lt;trace&gt; [--root &lt;substr&gt;] [--callers &lt;substr&gt;] [--lines [&lt;methodSubstr&gt;]] [--heatmap &lt;sourceFile&gt;] [--symbols &lt;dir&gt;] [--top N]</c>.
 ///  </para>
 /// </remarks>
 internal static class ConsoleAnalyzer
@@ -26,7 +26,7 @@ internal static class ConsoleAnalyzer
     {
         if (args.Length == 0)
         {
-            Console.Error.WriteLine("Usage: touki.mcp analyze <trace> [--root <substr>] [--callers <substr>] [--lines [<methodSubstr>]] [--symbols <dir>] [--top N]");
+            Console.Error.WriteLine("Usage: touki.mcp analyze <trace> [--root <substr>] [--callers <substr>] [--lines [<methodSubstr>]] [--heatmap <sourceFile>] [--symbols <dir>] [--top N]");
             return 1;
         }
 
@@ -34,6 +34,7 @@ internal static class ConsoleAnalyzer
         string root = "";
         string callers = "";
         string lines = "";
+        string heatmap = "";
         string symbols = "";
         bool linesRequested = false;
         int top = 25;
@@ -61,6 +62,13 @@ internal static class ConsoleAnalyzer
                     if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
                     {
                         lines = args[++i];
+                    }
+
+                    break;
+                case "--heatmap":
+                    if (i + 1 < args.Length)
+                    {
+                        heatmap = args[++i];
                     }
 
                     break;
@@ -119,6 +127,37 @@ internal static class ConsoleAnalyzer
             foreach (LineRow row in result.Rows)
             {
                 Console.WriteLine($"  {row.Milliseconds,9:N1} ms  {row.PercentOfScope,5:N1}%  {row.Location}  {row.Method}");
+            }
+
+            return 0;
+        }
+
+        if (heatmap.Length > 0)
+        {
+            string fileName = Path.GetFileName(heatmap);
+            SourceHeatmapResult result = trace.Aggregator.SourceHeatmap(fileName, FrameNames.DefaultFoldPatterns);
+            Console.WriteLine(
+                $"\nSOURCE HEATMAP '{result.File}' ({result.FileMilliseconds:N1} ms, "
+                + $"{(result.ScopeMilliseconds > 0 ? 100.0 * result.FileMilliseconds / result.ScopeMilliseconds : 0.0):N1}% of trace)");
+
+            if (result.Lines.Count == 0)
+            {
+                Console.WriteLine($"  No samples attributed to '{fileName}'. Check the trace has PDBs (--symbols) and the file name.");
+                return 0;
+            }
+
+            if (SourceAnnotator.TryReadSourceLines(heatmap, out string[] sourceLines))
+            {
+                Console.WriteLine();
+                Console.Write(SourceAnnotator.Render(sourceLines, result.Lines, result.FileMilliseconds));
+            }
+            else
+            {
+                Console.WriteLine("  (pass the full on-disk path to render annotated source; showing line data only)");
+                foreach (HeatLine row in result.Lines)
+                {
+                    Console.WriteLine($"  {row.Milliseconds,9:N1} ms  {row.PercentOfScope,5:N1}%  line {row.Line,5}  {row.Method}");
+                }
             }
 
             return 0;

--- a/touki.mcp/Server/TraceTools.cs
+++ b/touki.mcp/Server/TraceTools.cs
@@ -171,6 +171,82 @@ public static class TraceTools
     }
 
     /// <summary>
+    ///  Builds a per-line self-time heat map for one source file and, when the
+    ///  file is found on disk, a ready-to-render annotated source view.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="file">Path or file name of the source file to map.</param>
+    /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>A JSON heat map plus, when resolvable, an annotated source listing.</returns>
+    [McpServerTool(Name = "source_heatmap")]
+    [Description(
+        "Per-line self-time heat map for a single source file: every leaf sample (after folding JIT-helper leaves "
+        + "into their caller) attributed to the line that was executing, ordered by line number so you can overlay "
+        + "hotness onto the source. Pass 'file' as the full on-disk path (e.g. n:/repos/touki/touki/Io/ExtGlob.cs) to "
+        + "also get a ready-to-render annotated listing with a per-line ms/percent/heat gutter; a bare file name still "
+        + "returns the JSON line data. Requires a .nettrace or .etl trace whose modules have portable PDBs; pass "
+        + "'symbols' pointing at the build-output directory (e.g. artifacts/.../touki.perf/net10.0). Speedscope inputs "
+        + "carry no line data and yield an empty map.")]
+    public static string SourceHeatmap(
+        TraceStore store,
+        [Description("Path to a .nettrace or .etl trace file (speedscope carries no line data).")] string path,
+        [Description("Full on-disk path (preferred) or bare name of the source file to map, e.g. ExtGlob.cs.")] string file,
+        [Description("Optional regex fold patterns; omit to use the built-in JIT-helper defaults.")] string[]? fold = null,
+        [Description(
+            "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' embedded "
+            + "portable PDBs are extracted so managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        FoldingAggregator aggregator = store.Get(path, NullIfEmpty(symbols)).Aggregator;
+        string fileName = Path.GetFileName(file);
+        SourceHeatmapResult result = aggregator.SourceHeatmap(fileName, fold ?? FrameNames.DefaultFoldPatterns);
+
+        string? annotatedSource = null;
+        bool sourceFound = false;
+        string? note = null;
+
+        if (result.Lines.Count == 0)
+        {
+            note =
+                $"No samples were attributed to '{fileName}'. Confirm the trace is a .nettrace or .etl read with "
+                + "PDBs (pass 'symbols'), and that the file name is correct - hot_lines lists the files that resolved.";
+        }
+        else if (SourceAnnotator.TryReadSourceLines(file, out string[] sourceLines))
+        {
+            sourceFound = true;
+            annotatedSource = SourceAnnotator.Render(sourceLines, result.Lines, result.FileMilliseconds);
+        }
+        else
+        {
+            note =
+                "Pass 'file' as the full on-disk path to also get an annotated source listing; "
+                + "the file was not found on disk, so only line data is returned.";
+        }
+
+        return Serialize(new
+        {
+            scopeMilliseconds = result.ScopeMilliseconds,
+            file = result.File,
+            fileMilliseconds = result.FileMilliseconds,
+            sourceFound,
+            sourcePath = sourceFound ? Path.GetFullPath(file) : null,
+            note,
+            lines = result.Lines.Select(line => new
+            {
+                line = line.Line,
+                method = line.Method,
+                milliseconds = line.Milliseconds,
+                percentOfTrace = line.PercentOfScope,
+                percentOfFile = result.FileMilliseconds > 0 ? 100.0 * line.Milliseconds / result.FileMilliseconds : 0.0,
+                sampleCount = line.SampleCount
+            }),
+            annotatedSource
+        });
+    }
+
+    /// <summary>
     ///  Lists the per-thread sample counts for a trace, to help pick a root frame
     ///  or spot idle thread-pool noise.
     /// </summary>

--- a/touki.mcp/Tracing/FoldingAggregator.cs
+++ b/touki.mcp/Tracing/FoldingAggregator.cs
@@ -293,6 +293,114 @@ internal sealed class FoldingAggregator
         return new LineRankingResult(total, methodFilter, rows);
     }
 
+    /// <summary>
+    ///  Computes a per-line self-time heat map for a single source file: each leaf
+    ///  sample (after folding JIT-helper leaves into their caller) whose executing
+    ///  source line belongs to <paramref name="fileName"/> is bucketed by line
+    ///  number, ordered by line for overlaying onto the source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Matching is by file name only (the trace records the build-time file name,
+    ///   not its full path), so two source files that share a name are merged. The
+    ///   percent on each line is the share of whole-trace time, making absolute
+    ///   hotness comparable across files.
+    ///  </para>
+    /// </remarks>
+    /// <param name="fileName">The source file name to build the heat map for (no directory).</param>
+    /// <param name="foldPatterns">Leaf-frame fold patterns.</param>
+    /// <returns>The per-line heat map, ordered by line number.</returns>
+    public SourceHeatmapResult SourceHeatmap(string fileName, IReadOnlyList<string> foldPatterns)
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(foldPatterns);
+        Dictionary<int, LineAccumulator> lines = new();
+        double traceTotal = 0.0;
+        double fileTotal = 0.0;
+        string matchedFile = fileName;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string> frames = sample.Frames;
+            if (frames.Count == 0)
+            {
+                continue;
+            }
+
+            traceTotal += sample.WeightMs;
+
+            IReadOnlyList<string>? locations = sample.FrameLocations;
+            if (locations is null)
+            {
+                continue;
+            }
+
+            int leafIdx = frames.Count - 1;
+            while (leafIdx > 0 && FrameNames.IsFolded(ShortOf(frames[leafIdx]), fold))
+            {
+                leafIdx--;
+            }
+
+            if (leafIdx >= locations.Count
+                || !TrySplitLocation(locations[leafIdx], out string leafFile, out int line)
+                || !string.Equals(leafFile, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Preserve the file name's casing as recorded in the trace.
+            matchedFile = leafFile;
+            fileTotal += sample.WeightMs;
+
+            if (!lines.TryGetValue(line, out LineAccumulator? accumulator))
+            {
+                accumulator = new LineAccumulator();
+                lines[line] = accumulator;
+            }
+
+            accumulator.Add(sample.WeightMs, ShortOf(frames[leafIdx]));
+        }
+
+        List<HeatLine> rows = new(lines.Count);
+        foreach (KeyValuePair<int, LineAccumulator> pair in lines)
+        {
+            LineAccumulator accumulator = pair.Value;
+            double pct = traceTotal > 0 ? 100.0 * accumulator.Milliseconds / traceTotal : 0.0;
+            rows.Add(new HeatLine(pair.Key, accumulator.Milliseconds, pct, accumulator.SampleCount, accumulator.DominantMethod));
+        }
+
+        rows.Sort(static (a, b) => a.Line.CompareTo(b.Line));
+        return new SourceHeatmapResult(traceTotal, matchedFile, fileTotal, rows);
+    }
+
+    /// <summary>
+    ///  Splits a <c>file:line</c> location into its file name and line number.
+    ///  Returns <see langword="false"/> for empty, unresolved (<c>&lt;no source&gt;</c>)
+    ///  or otherwise malformed locations.
+    /// </summary>
+    private static bool TrySplitLocation(string location, out string file, out int line)
+    {
+        file = "";
+        line = 0;
+        if (location.Length == 0)
+        {
+            return false;
+        }
+
+        int colon = location.LastIndexOf(':');
+        if (colon <= 0 || colon == location.Length - 1)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(location.AsSpan(colon + 1), out line))
+        {
+            return false;
+        }
+
+        file = location[..colon];
+        return true;
+    }
+
     private static List<RankRow> RankRows(Dictionary<string, double> times, double total, int top)
     {
         List<RankRow> rows = [];
@@ -309,5 +417,45 @@ internal sealed class FoldingAggregator
         }
 
         return rows;
+    }
+
+    /// <summary>
+    ///  Accumulates the self-time and sample count attributed to one source line,
+    ///  tracking which method dominates the line's time.
+    /// </summary>
+    private sealed class LineAccumulator
+    {
+        private readonly Dictionary<string, double> _methods = new(StringComparer.Ordinal);
+
+        public double Milliseconds { get; private set; }
+
+        public int SampleCount { get; private set; }
+
+        public void Add(double milliseconds, string method)
+        {
+            Milliseconds += milliseconds;
+            SampleCount++;
+            _methods.TryGetValue(method, out double current);
+            _methods[method] = current + milliseconds;
+        }
+
+        public string DominantMethod
+        {
+            get
+            {
+                string dominant = "";
+                double dominantMs = -1.0;
+                foreach (KeyValuePair<string, double> pair in _methods)
+                {
+                    if (pair.Value > dominantMs)
+                    {
+                        dominantMs = pair.Value;
+                        dominant = pair.Key;
+                    }
+                }
+
+                return dominant;
+            }
+        }
     }
 }

--- a/touki.mcp/Tracing/FoldingAggregator.cs
+++ b/touki.mcp/Tracing/FoldingAggregator.cs
@@ -397,6 +397,13 @@ internal sealed class FoldingAggregator
             return false;
         }
 
+        // Line numbers are 1-based; reject zero and negative values that cannot map onto source.
+        if (line < 1)
+        {
+            line = 0;
+            return false;
+        }
+
         file = location[..colon];
         return true;
     }

--- a/touki.mcp/Tracing/RankingResult.cs
+++ b/touki.mcp/Tracing/RankingResult.cs
@@ -60,3 +60,35 @@ internal sealed record LineRow(string Method, string Location, double Millisecon
 /// <param name="MethodFilter">The substring the methods were matched on, or empty for every method.</param>
 /// <param name="Rows">The ranked source lines, highest first.</param>
 internal sealed record LineRankingResult(double ScopeMilliseconds, string MethodFilter, IReadOnlyList<LineRow> Rows);
+
+/// <summary>
+///  Self-time attributed to a single source line of a file in a heat map.
+/// </summary>
+/// <param name="Line">The 1-based source line number.</param>
+/// <param name="Milliseconds">Self-time attributed to the line, in milliseconds.</param>
+/// <param name="PercentOfScope">Share of the whole-trace self-time, in percent.</param>
+/// <param name="SampleCount">Number of leaf samples attributed to the line.</param>
+/// <param name="Method">The shortened method that dominates the line's self-time.</param>
+internal sealed record HeatLine(int Line, double Milliseconds, double PercentOfScope, int SampleCount, string Method);
+
+/// <summary>
+///  A per-line self-time heat map for a single source file: each leaf sample
+///  (after folding JIT-helper leaves into their caller) is bucketed by the source
+///  line that was executing, ordered by line number for overlaying onto the source.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Only samples carrying per-frame source locations contribute; speedscope
+///   inputs have none, so a heat map is meaningful only for <c>.nettrace</c> and
+///   <c>.etl</c> traces read with local PDBs present.
+///  </para>
+/// </remarks>
+/// <param name="ScopeMilliseconds">Total whole-trace time, in milliseconds (the percent denominator).</param>
+/// <param name="File">The source file name the lines belong to (no directory).</param>
+/// <param name="FileMilliseconds">Self-time attributed to the file across all its lines, in milliseconds.</param>
+/// <param name="Lines">The hot lines of the file, ordered by line number.</param>
+internal sealed record SourceHeatmapResult(
+    double ScopeMilliseconds,
+    string File,
+    double FileMilliseconds,
+    IReadOnlyList<HeatLine> Lines);

--- a/touki.mcp/Tracing/SourceAnnotator.cs
+++ b/touki.mcp/Tracing/SourceAnnotator.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text;
+
+namespace Touki.Mcp.Tracing;
+
+/// <summary>
+///  Renders a <see cref="SourceHeatmapResult"/> over a source file's text as a
+///  ready-to-read annotated listing with a per-line <c>ms / %file / heat</c>
+///  gutter. Shared by the <c>source_heatmap</c> MCP tool and the console
+///  analyzer's <c>--heatmap</c> command.
+/// </summary>
+internal static class SourceAnnotator
+{
+    // Files larger than this render only windows around hot lines; smaller files
+    // render in full so the heat map reads top to bottom.
+    private const int FullRenderLineCap = 600;
+
+    // Lines of unchanged context shown around each hot line in windowed mode.
+    private const int HeatContextLines = 4;
+
+    /// <summary>
+    ///  Reads the source file at <paramref name="file"/> if it exists on disk.
+    /// </summary>
+    /// <param name="file">The on-disk path to read.</param>
+    /// <param name="lines">The file's lines on success, otherwise empty.</param>
+    /// <returns><see langword="true"/> when the file was read.</returns>
+    public static bool TryReadSourceLines(string file, out string[] lines)
+    {
+        lines = [];
+        try
+        {
+            if (!File.Exists(file))
+            {
+                return false;
+            }
+
+            lines = File.ReadAllLines(file);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///  Renders source with a per-line ms/percent/heat gutter, in full for small
+    ///  files or as windows around hot lines for large ones.
+    /// </summary>
+    /// <param name="sourceLines">The source file's lines.</param>
+    /// <param name="heat">The per-line heat, in any order.</param>
+    /// <param name="fileMilliseconds">Total self-time attributed to the file.</param>
+    /// <returns>The annotated source listing.</returns>
+    public static string Render(string[] sourceLines, IReadOnlyList<HeatLine> heat, double fileMilliseconds)
+    {
+        Dictionary<int, HeatLine> byLine = new(heat.Count);
+        double maxMs = 0.0;
+        foreach (HeatLine line in heat)
+        {
+            byLine[line.Line] = line;
+            if (line.Milliseconds > maxMs)
+            {
+                maxMs = line.Milliseconds;
+            }
+        }
+
+        StringBuilder builder = new();
+        builder.AppendLine("       ms   %file  heat      | line  source");
+        builder.AppendLine("  -------  ------  --------  | ----  ------");
+
+        if (sourceLines.Length <= FullRenderLineCap)
+        {
+            for (int i = 0; i < sourceLines.Length; i++)
+            {
+                AppendSourceLine(builder, i + 1, sourceLines[i], byLine, maxMs, fileMilliseconds);
+            }
+
+            return builder.ToString();
+        }
+
+        SortedSet<int> show = [];
+        foreach (HeatLine line in heat)
+        {
+            for (int l = line.Line - HeatContextLines; l <= line.Line + HeatContextLines; l++)
+            {
+                if (l >= 1 && l <= sourceLines.Length)
+                {
+                    show.Add(l);
+                }
+            }
+        }
+
+        int previous = 0;
+        foreach (int l in show)
+        {
+            if (previous != 0 && l > previous + 1)
+            {
+                builder.AppendLine("     ...");
+            }
+
+            AppendSourceLine(builder, l, sourceLines[l - 1], byLine, maxMs, fileMilliseconds);
+            previous = l;
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///  Appends one annotated source line: a populated gutter for hot lines, a
+    ///  blank gutter for cold ones.
+    /// </summary>
+    private static void AppendSourceLine(
+        StringBuilder builder,
+        int lineNumber,
+        string text,
+        Dictionary<int, HeatLine> byLine,
+        double maxMilliseconds,
+        double fileMilliseconds)
+    {
+        if (byLine.TryGetValue(lineNumber, out HeatLine? line))
+        {
+            double percentOfFile = fileMilliseconds > 0 ? 100.0 * line.Milliseconds / fileMilliseconds : 0.0;
+            int bars = maxMilliseconds > 0 ? (int)Math.Round(8.0 * line.Milliseconds / maxMilliseconds) : 0;
+            string heat = new string('#', bars);
+            builder.AppendLine($"  {line.Milliseconds,7:F1}  {percentOfFile,5:F1}  {heat,-8}  | {lineNumber,4}  {text}");
+        }
+        else
+        {
+            builder.AppendLine($"  {"",7}  {"",5}  {"",8}  | {lineNumber,4}  {text}");
+        }
+    }
+}

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs
@@ -587,8 +587,14 @@ internal sealed partial class CompiledGlobStrategy
                     // terminal/deadend state.
                     while (true)
                     {
-                        while (Head < WorkCount && _work[Head].Start >= _work[Head].End)
+                        while (Head < WorkCount)
                         {
+                            ref ProgramRange skip = ref _work[Head];
+                            if (skip.Start < skip.End)
+                            {
+                                break;
+                            }
+
                             Head++;
                         }
 
@@ -612,20 +618,28 @@ internal sealed partial class CompiledGlobStrategy
                             break;
                         }
 
-                        int programIndex = _work[Head].Start;
+                        // Head is invariant for the remainder of this deterministic
+                        // iteration (only the skip loop above advances it), so resolve
+                        // the head range reference once instead of re-indexing the work
+                        // span on every field read and write below. The net481 slow-span
+                        // layout costs ~8 micro-ops per indexer access; a single hoisted
+                        // ref collapses that to one address computation.
+                        ref ProgramRange head = ref _work[Head];
+
+                        int programIndex = head.Start;
                         char opcode = _program[programIndex];
 
                         if (opcode == GlobOpCodes.AltStart
-                            && _work[Head].KindOverride != '\0'
-                            && WorkInput <= _work[Head].MinProgressInput)
+                            && head.KindOverride != '\0'
+                            && WorkInput <= head.MinProgressInput)
                         {
                             // Progress guard: refuse another iteration of a
                             // repeating block when the previous one consumed no
                             // input. Collapse the block (skip it) and continue
                             // with the rest, avoiding unbounded empty iterations.
                             int guardedBlockLength = _program[programIndex + 2];
-                            _work[Head].Start = programIndex + guardedBlockLength;
-                            _work[Head].KindOverride = '\0';
+                            head.Start = programIndex + guardedBlockLength;
+                            head.KindOverride = '\0';
                             continue;
                         }
 
@@ -638,7 +652,7 @@ internal sealed partial class CompiledGlobStrategy
                                 break;
                             }
 
-                            _work[Head].Start = programIndex + 2 + literalLength;
+                            head.Start = programIndex + 2 + literalLength;
                             WorkInput += literalLength;
                             continue;
                         }
@@ -656,7 +670,7 @@ internal sealed partial class CompiledGlobStrategy
                                 break;
                             }
 
-                            _work[Head].Start = programIndex + 1;
+                            head.Start = programIndex + 1;
                             WorkInput++;
                             continue;
                         }
@@ -684,7 +698,7 @@ internal sealed partial class CompiledGlobStrategy
                                 break;
                             }
 
-                            _work[Head].Start = programIndex + 2 + classLength;
+                            head.Start = programIndex + 2 + classLength;
                             WorkInput++;
                             continue;
                         }
@@ -734,14 +748,7 @@ internal sealed partial class CompiledGlobStrategy
                         int limit = _totalLength;
                         if (_separator != '\0')
                         {
-                            for (int j = WorkInput; j < _totalLength; j++)
-                            {
-                                if (CharAt(_first, _second, _firstLength, j) == _separator)
-                                {
-                                    limit = j;
-                                    break;
-                                }
-                            }
+                            limit = IndexOfSeparator(WorkInput);
                         }
 
                         auxValue = limit;
@@ -777,7 +784,7 @@ internal sealed partial class CompiledGlobStrategy
                     // Snapshot the choice configuration and push a frame.
                     int snapshotCount = WorkCount - Head;
                     EnsureArena(_arenaTop + snapshotCount);
-                    _work[Head..WorkCount].CopyTo(_arena[_arenaTop..]);
+                    CopyRanges(_work.Slice(Head, snapshotCount), _arena[_arenaTop..], snapshotCount);
 
                     EnsureFrames(_frameCount + 1);
                     _frames[_frameCount] = new Frame
@@ -885,6 +892,100 @@ internal sealed partial class CompiledGlobStrategy
             _arena = bigger;
         }
 
+        // Copies the first `count` ProgramRange values from `source` to
+        // `destination`. The backtracking save/restore moves only a few ranges per
+        // choice point, and at those tiny lengths the fixed per-call overhead of
+        // Span.CopyTo (its Buffer.Memmove length dispatch) dominates the actual
+        // copy - this save/restore was the single hottest cluster in the
+        // GlobEnumeratorExtGlobSingleWithRoot CPU trace. The common one-to-three
+        // range cases are unrolled into direct assignments off a hoisted ref (no
+        // bounds check, no Memmove setup); larger snapshots fall back to the bulk
+        // copy. Every call site copies between two distinct buffers (work, arena,
+        // rest) so the regions never overlap and a forward copy is always correct.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void CopyRanges(ReadOnlySpan<ProgramRange> source, Span<ProgramRange> destination, int count)
+        {
+            if (count <= 0)
+            {
+                return;
+            }
+
+            if (count > 3)
+            {
+                source[..count].CopyTo(destination);
+                return;
+            }
+
+            ref ProgramRange src = ref MemoryMarshal.GetReference(source);
+            ref ProgramRange dst = ref MemoryMarshal.GetReference(destination);
+            dst = src;
+            if (count == 1)
+            {
+                return;
+            }
+
+            Unsafe.Add(ref dst, 1) = Unsafe.Add(ref src, 1);
+            if (count == 2)
+            {
+                return;
+            }
+
+            Unsafe.Add(ref dst, 2) = Unsafe.Add(ref src, 2);
+        }
+
+        // Returns the index of the first separator at or after 'start' in the
+        // virtual _first + _second concatenation, clamped to _totalLength when none
+        // is found. The path-aware AnyRun choice point calls this once per push to
+        // bound its run, and it was the hottest scan in the engine after the literal
+        // compare. The previous form walked one character at a time through CharAt,
+        // paying the virtual-concatenation branch on every character; this routes
+        // each contiguous half through the vectorized span IndexOf instead.
+        //
+        // _totalLength can be clipped below _first.Length + _second.Length (the
+        // negation handler shortens it per candidate), so every search is bounded by
+        // it rather than by the raw span lengths.
+        private readonly int IndexOfSeparator(int start)
+        {
+            int total = _totalLength;
+            char separator = _separator;
+
+            if (start < _firstLength)
+            {
+                int firstEnd = Math.Min(_firstLength, total);
+                if (start < firstEnd)
+                {
+                    int relative = _first[start..firstEnd].IndexOf(separator);
+                    if (relative >= 0)
+                    {
+                        return start + relative;
+                    }
+                }
+
+                if (total > _firstLength)
+                {
+                    int found = _second[..(total - _firstLength)].IndexOf(separator);
+                    if (found >= 0)
+                    {
+                        return _firstLength + found;
+                    }
+                }
+
+                return total;
+            }
+
+            int secondCount = total - start;
+            if (secondCount > 0)
+            {
+                int found = _second.Slice(start - _firstLength, secondCount).IndexOf(separator);
+                if (found >= 0)
+                {
+                    return start + found;
+                }
+            }
+
+            return total;
+        }
+
         // Records the choice configuration captured by the given frame as a
         // proven failure.
         private readonly void RecordFrameFailure(int frameIdx, ref ExtGlobMatchState state)
@@ -921,7 +1022,7 @@ internal sealed partial class CompiledGlobStrategy
                     return false;
                 }
 
-                snap.CopyTo(_work);
+                CopyRanges(snap, _work, snapCount);
                 WorkCount = snapCount;
                 Head = 0;
                 _work[0].Start = programIndex + 1;
@@ -944,7 +1045,7 @@ internal sealed partial class CompiledGlobStrategy
                     return false;
                 }
 
-                snap.CopyTo(_work);
+                CopyRanges(snap, _work, snapCount);
                 WorkCount = snapCount;
                 Head = 0;
                 _work[0].Start = programIndex + 2;
@@ -981,7 +1082,7 @@ internal sealed partial class CompiledGlobStrategy
                         frame.Cursor = j + 1;
                         int altBodyStart = programIndex + _program[altOffsetBase + j];
                         int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
-                        snap.CopyTo(_rest);
+                        CopyRanges(snap, _rest, snapCount);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
                         if (BuildRangesWithAlternative(altBodyStart, altBodyEnd, _rest[..snapCount], _work, out WorkCount))
@@ -1001,7 +1102,7 @@ internal sealed partial class CompiledGlobStrategy
                         frame.Cursor = j + 1;
                         int altBodyStart = programIndex + _program[altOffsetBase + j];
                         int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
-                        snap.CopyTo(_rest);
+                        CopyRanges(snap, _rest, snapCount);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
                         if (BuildRangesWithAlternative(altBodyStart, altBodyEnd, _rest[..snapCount], _work, out WorkCount))
@@ -1016,7 +1117,7 @@ internal sealed partial class CompiledGlobStrategy
                     {
                         // Zero-consume: skip the entire alternation block.
                         frame.Cursor = altCount + 1;
-                        snap.CopyTo(_work);
+                        CopyRanges(snap, _work, snapCount);
                         WorkCount = snapCount;
                         Head = 0;
                         _work[0].Start = afterEnd;
@@ -1034,7 +1135,7 @@ internal sealed partial class CompiledGlobStrategy
                         frame.Cursor = j + 1;
                         int altBodyStart = programIndex + _program[altOffsetBase + j];
                         int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
-                        snap.CopyTo(_rest);
+                        CopyRanges(snap, _rest, snapCount);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
                         int restCount = CompactEmptyRanges(_rest, snapCount);
@@ -1044,7 +1145,7 @@ internal sealed partial class CompiledGlobStrategy
                             // Empty alternative: the progress guard refuses to
                             // re-enter the block with no input consumed, so this
                             // collapses to matching just the rest.
-                            _rest[..restCount].CopyTo(_work);
+                            CopyRanges(_rest, _work, restCount);
                             WorkCount = restCount;
                             Head = 0;
                             WorkInput = savedInput;
@@ -1069,14 +1170,14 @@ internal sealed partial class CompiledGlobStrategy
                         frame.Cursor = j + 1;
                         int altBodyStart = programIndex + _program[altOffsetBase + j];
                         int altBodyEnd = (j + 1 < altCount) ? programIndex + _program[altOffsetBase + j + 1] - 1 : altEndIndex;
-                        snap.CopyTo(_rest);
+                        CopyRanges(snap, _rest, snapCount);
                         _rest[0].Start = afterEnd;
                         _rest[0].KindOverride = '\0';
                         int restCount = CompactEmptyRanges(_rest, snapCount);
 
                         if (altBodyStart >= altBodyEnd)
                         {
-                            _rest[..restCount].CopyTo(_work);
+                            CopyRanges(_rest, _work, restCount);
                             WorkCount = restCount;
                             Head = 0;
                             WorkInput = savedInput;
@@ -1096,7 +1197,7 @@ internal sealed partial class CompiledGlobStrategy
                     {
                         // Zero iterations: skip the entire alternation block.
                         frame.Cursor = altCount + 1;
-                        snap.CopyTo(_work);
+                        CopyRanges(snap, _work, snapCount);
                         WorkCount = snapCount;
                         Head = 0;
                         _work[0].Start = afterEnd;
@@ -1238,7 +1339,7 @@ internal sealed partial class CompiledGlobStrategy
                             continue;
                         }
 
-                        snap.CopyTo(_work);
+                        CopyRanges(snap, _work, snapCount);
                         WorkCount = snapCount;
                         Head = 0;
                         _work[0].Start = afterEnd;


### PR DESCRIPTION
## Summary

Adds a source-level heatmap to the touki.mcp trace analyzer (on top of the merged #171), which renders a source file annotated with per-line `ms` / `%-of-file` / `heat` bars, and brings the new tracing code to near-complete test coverage.

### Feature
- **`SourceAnnotator`** renders a source listing in full mode (small files) or windowed mode (context around hot lines, with `...` gap markers).
- **`FoldingAggregator.SourceHeatmap`** buckets samples by `file:line`, tracks the dominant method per line, and folds JIT-helper leaves.
- **`RankingResult`** gains `HeatLine` / `SourceHeatmapResult` records.
- Exposed via the **`SourceHeatmap` MCP tool** and the **`--heatmap` console flag**.

### Tests
- New `SourceAnnotatorTests`: read found/missing, full + windowed render, hot vs. cold gutters, zero-`fileMilliseconds` guard, large-file windowing with gap markers.
- `FoldingAggregatorTests`: `DominantMethod` tie-break, malformed `file:line` exclusion, `CallersOf` top-truncation, plus the heatmap bucketing already present.
- `ConsoleAnalyzerTests`: `--heatmap` path.
- `FoldingAggregator.cs` reaches **100% line coverage**; remaining uncovered lines in `TraceTools` / `ConsoleAnalyzer` are glue paths that require a real `.nettrace` fixture carrying embedded-PDB line data (the speedscope reader never attaches line locations).

### Also included
- ExtGlob first-segment iterations in `CompiledGlobStrategy.ExtGlob.cs`.
- Skill-doc updates (`framework-jit-optimization`, `performance-testing`).

## Validation
- `touki.mcp.tests`: 61 passing (net10).
- Globbing suite: 1486 passing (net10).
- `touki.mcp` builds clean in Release.
