### PR TITLE
Refactor agent skills into thin cores; add portability metadata

### DIFF
--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -40,7 +40,11 @@ This repo also uses two optional fields:
 - `metadata.portability` - one of `portable`, `semi-portable`, or
   `repo-specific`, mirrored in the [README.md](./README.md) inventory. Records
   how much a skill's content would need to change to be reused in another repo.
-  The validator ignores nested `metadata` keys, so this is additive.
+  This is documentation only: `tools/Validate-AgentFiles.ps1` validates just
+  `name` and `description`, and its hand-rolled frontmatter parser does not
+  read nested `metadata` keys at all (an indented `portability:` line is
+  skipped, not parsed), so the field is neither read nor machine-validated.
+  Keep it in sync with the README by hand.
 
 ## Thin core plus sibling files
 

--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -32,6 +32,28 @@ relative Markdown links, e.g. `[template](./template.cs)`.
 Optional frontmatter fields: `argument-hint`, `user-invocable`,
 `disable-model-invocation`, `context` (`inline` or `fork`).
 
+This repo also uses two optional fields:
+
+- `compatibility` - free-text environment requirements (the Agent Skills spec
+  field). Used to declare an MCP-server dependency, e.g. "Uses the
+  microsoft-learn MCP server when available; falls back to web docs otherwise".
+- `metadata.portability` - one of `portable`, `semi-portable`, or
+  `repo-specific`, mirrored in the [README.md](./README.md) inventory. Records
+  how much a skill's content would need to change to be reused in another repo.
+  The validator ignores nested `metadata` keys, so this is additive.
+
+## Thin core plus sibling files
+
+Keep each `SKILL.md` body small (the whole body loads on every trigger; sibling
+files load only when referenced). When a skill grows past roughly 150 lines,
+split the deep detail into sibling `*.md` files in the same directory and leave
+the core as an overview that links to them. See
+[framework-jit-optimization](./framework-jit-optimization/SKILL.md),
+[performance-testing](./performance-testing/SKILL.md), and
+[security-review](./security-review/SKILL.md) for the pattern. Sibling links are
+plain relative Markdown (`[authoring.md](authoring.md)`); the directory depth is
+unchanged, so links to repo files keep the same `../../../` prefix as the core.
+
 ## Discovery
 
 Vendor-neutral location for [Agent Skills](https://agentskills.io/). Discovered

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -10,20 +10,26 @@ The "Disambiguation" section below records every known overlap.
 
 ## Inventory
 
-| Skill | Trigger phrasing | Cross-references |
-| ----- | ---------------- | ---------------- |
-| [polyfill-dotnet-api](./polyfill-dotnet-api/SKILL.md) | "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", missing-on-net472-present-on-net10 | `pre-pr-self-review`, `performance-testing`, `framework-jit-optimization`, `create-pr` |
-| [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | hot-path tuning for `net481` in `touki/Framework/`, generic specialization, scalar/unrolled vs BCL delegation, net481 RyuJIT regressions | `performance-testing` |
-| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations | `framework-jit-optimization`, `scratch-buffer-strategy` |
-| [scratch-buffer-strategy](./scratch-buffer-strategy/SKILL.md) | choosing a scratch-buffer strategy (zeroed `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs `ArrayPool` rental), "should I rent or stackalloc?", net481/net10 size crossovers, weighing `[SkipLocalsInit]` | `performance-testing`, `framework-jit-optimization` |
-| [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review checklist before opening or pushing a PR; missing tests, unchecked length sums, empty-span foot-guns, TFM phrasing | `create-pr`, `polyfill-dotnet-api` |
-| [security-review](./security-review/SKILL.md) | "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling"; any member accepting caller-supplied data, any use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, or any BCL API whose name or doc says "unsafe" / "caller must" - abusive-input handling, length / integer overflow, allocation and algorithmic DoS, caller-validated preconditions, argument validation | `pre-pr-self-review`, `performance-testing` |
-| [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", "publish for review" - **initial** publish | `pre-pr-self-review` |
-| [address-pr-feedback](./address-pr-feedback/SKILL.md) | "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure" - **post-PR** review-cycle work | `pre-pr-self-review` |
-| [agent-files-review](./agent-files-review/SKILL.md) | reviewing/validating agent-customization files (`AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, validator, CI workflow); fixing `agent-files.yml` failures | - |
-| [run-tests-on-wsl](./run-tests-on-wsl/SKILL.md) | "run tests on Linux", "run the Posix/PosixPath/Bash oracles", "iterate Unix tests locally"; WSL Ubuntu bootstrap, the `~/repos/touki` Linux-native mirror that sidesteps the `/mnt/` DrvFs NuGet trap, the `DOTNET_ROOT` apphost requirement, and the `iconv` UTF-16 log trick | `performance-testing`, `pre-pr-self-review` |
-| [fuzz-testing](./fuzz-testing/SKILL.md) | "add a fuzz target", "run the fuzzer", "install fuzzing prereqs", "fuzz SpanReader/SpanWriter", coverage-guided SharpFuzz runs on net10/net481, promoting a crash into a regression | `security-review`, `pre-pr-self-review`, `run-tests-on-wsl` |
-| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" - choosing the right `Major.Minor.Patch`, alpha/beta/rc/stable channel, tag stream (`v*` vs `ts-v*`), and GitHub release notes | `pre-pr-self-review` |
+| Skill | Trigger phrasing | Portability | Cross-references |
+| ----- | ---------------- | ----------- | ---------------- |
+| [polyfill-dotnet-api](./polyfill-dotnet-api/SKILL.md) | "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", missing-on-net472-present-on-net10 | repo-specific | `pre-pr-self-review`, `performance-testing`, `framework-jit-optimization`, `create-pr` |
+| [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | hot-path tuning for `net481` in `touki/Framework/`, generic specialization, scalar/unrolled vs BCL delegation, net481 RyuJIT regressions | semi-portable | `performance-testing` |
+| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations | semi-portable | `framework-jit-optimization`, `scratch-buffer-strategy` |
+| [scratch-buffer-strategy](./scratch-buffer-strategy/SKILL.md) | choosing a scratch-buffer strategy (zeroed `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs `ArrayPool` rental), "should I rent or stackalloc?", net481/net10 size crossovers, weighing `[SkipLocalsInit]` | semi-portable | `performance-testing`, `framework-jit-optimization` |
+| [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review checklist before opening or pushing a PR; missing tests, unchecked length sums, empty-span foot-guns, TFM phrasing | semi-portable | `create-pr`, `polyfill-dotnet-api` |
+| [security-review](./security-review/SKILL.md) | "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling"; any member accepting caller-supplied data, any use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, or any BCL API whose name or doc says "unsafe" / "caller must" - abusive-input handling, length / integer overflow, allocation and algorithmic DoS, caller-validated preconditions, argument validation | semi-portable | `pre-pr-self-review`, `performance-testing` |
+| [create-pr](./create-pr/SKILL.md) | "make a PR", "open a pull request", "push and PR", "publish for review" - **initial** publish | semi-portable | `pre-pr-self-review` |
+| [address-pr-feedback](./address-pr-feedback/SKILL.md) | "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure" - **post-PR** review-cycle work | repo-specific | `pre-pr-self-review` |
+| [agent-files-review](./agent-files-review/SKILL.md) | reviewing/validating agent-customization files (`AGENTS.md`, `*.instructions.md`, `*.prompt.md`, `*.agent.md`, `SKILL.md`, validator, CI workflow); fixing `agent-files.yml` failures | semi-portable | - |
+| [run-tests-on-wsl](./run-tests-on-wsl/SKILL.md) | "run tests on Linux", "run the Posix/PosixPath/Bash oracles", "iterate Unix tests locally"; WSL Ubuntu bootstrap, the `~/repos/touki` Linux-native mirror that sidesteps the `/mnt/` DrvFs NuGet trap, the `DOTNET_ROOT` apphost requirement, and the `iconv` UTF-16 log trick | repo-specific | `performance-testing`, `pre-pr-self-review` |
+| [fuzz-testing](./fuzz-testing/SKILL.md) | "add a fuzz target", "run the fuzzer", "install fuzzing prereqs", "fuzz SpanReader/SpanWriter", coverage-guided SharpFuzz runs on net10/net481, promoting a crash into a regression | semi-portable | `security-review`, `pre-pr-self-review`, `run-tests-on-wsl` |
+| [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" - choosing the right `Major.Minor.Patch`, alpha/beta/rc/stable channel, tag stream (`v*` vs `ts-v*`), and GitHub release notes | repo-specific | `pre-pr-self-review` |
+
+**Portability** (mirrored from each skill's `metadata.portability`) marks how much
+a skill would need to change to be reused in another repo: `portable` (generic),
+`semi-portable` (general pattern with touki paths / conventions to edit out), or
+`repo-specific` (tied to touki's structure). See the sharing roadmap in
+[docs/skills-improvement-plan.md](../../docs/skills-improvement-plan.md).
 
 ## Disambiguation
 

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: address-pr-feedback
 description: Address feedback on an existing pull request - review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
+metadata:
+  portability: repo-specific
 ---
 
 # Address PR feedback

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: agent-files-review
 description: Review changes to AI-agent customization files in this repo (AGENTS.md, .github/copilot-instructions.md, *.instructions.md, *.prompt.md, *.agent.md, SKILL.md, validator, CI workflow). Use when asked to review or validate agent-file changes, fix CI failures from agent-files.yml, or audit a draft of any of these files.
+metadata:
+  portability: semi-portable
 ---
 
 # Agent customization files - review checklist

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-pr
 description: Create a pull request for the current changes. Use when asked to "make a PR", "open a pull request", "push and PR", or otherwise publish in-progress work for review. Ensures changes are on a non-`main` branch, commits are made and pushed, and the PR targets `upstream/main` when an `upstream` remote exists, otherwise `origin/main`.
+metadata:
+  portability: semi-portable
 ---
 
 # Create a pull request

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: framework-jit-optimization
 description: Optimize hot-path code for the `net481` target in `touki/Framework/`. Use when writing or reviewing performance-sensitive loops, deciding whether to specialize a generic method for primitive types, choosing between scalar/unrolled/BCL-delegating implementations, or diagnosing why a net481 micro-benchmark regresses on the older RyuJIT. For BenchmarkDotNet harness mechanics (authoring/running benchmarks, evaluating allocations) see the `performance-testing` skill.
+metadata:
+  portability: semi-portable
 ---
 
 # .NET Framework 4.8.1 JIT optimization
@@ -14,9 +16,9 @@ This skill captures decisions distilled from real benchmarks under
 [performance-testing](../performance-testing/SKILL.md) skill workflow before
 committing a change. Run the
 [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist before
-opening a PR - in particular &sect;5 (allocation-free over raw speed)
-and &sect;7 (perf claims must name the JIT and be measured) apply directly
-to changes guided by this skill.
+opening a PR - in particular its polyfill / framework-correctness items
+(allocation-free over raw speed; perf claims must name the JIT and be
+measured) apply directly to changes guided by this skill.
 
 For the broader "how do I polyfill API X for net472?" question (which
 packages to prefer, when to hand-roll), see the

--- a/.agents/skills/fuzz-testing/SKILL.md
+++ b/.agents/skills/fuzz-testing/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: fuzz-testing
 description: Author and run SharpFuzz coverage-guided fuzz targets in the `touki.fuzz` project. Use when adding a new fuzz target, running the fuzzer locally on net10 or net481, installing the fuzzing prerequisites, or promoting a crashing input into a `touki.tests` regression. Covers the cross-TFM harness, the libFuzzer driver workflow, and the crash-to-regression loop.
+metadata:
+  portability: semi-portable
 ---
 
 # Fuzz testing in `touki.fuzz`

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: performance-testing
 description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `touki.mcp` trace analyzer), or evaluating allocations / memory usage for code in the `touki` library.
+metadata:
+  portability: semi-portable
 ---
 
 # Performance testing in `touki.perf`
@@ -30,284 +32,30 @@ References to those types from a benchmark must be guarded with `#if NETFRAMEWOR
   in `touki.perf/` (or an explicit "not measured" note) for any perf claim that
   drives a code change in `touki/Framework/`.
 
-## 1. Authoring a benchmark
+## The rules that always apply
 
-### File and class layout
+Five rules cover most benchmark work; the sub-pages hold the rest.
 
-- One benchmark class per file, file named after the class
-  (e.g. [StoreInteger.cs](../../../touki.perf/StoreInteger.cs)).
-- Namespace is always `touki.perf`.
-- Class is `public` (BenchmarkDotNet requires this) and contains one or more methods
-  marked `[Benchmark]`.
-- Use the standard repo file header.
-- Follow the repo coding style (no `var`, target-typed `new()`, C# keyword type names,
-  `is null` / `is not null`, indented XML docs, etc.). See
-  [AGENTS.md](../../../AGENTS.md).
-
-### Globals already imported
-
-[GlobalUsings.cs](../../../touki.perf/GlobalUsings.cs) already provides:
-
-- `BenchmarkDotNet.Attributes` - `[Benchmark]`, `[MemoryDiagnoser]`, `[Params]`,
-  `[GlobalSetup]`, etc.
-- `BenchmarkDotNet.Jobs` - `RuntimeMoniker`, `[SimpleJob]`.
-- `Touki` - the library root namespace.
-- `Microsoft.IO` (on NETFRAMEWORK) or `System.IO` otherwise.
-
-Do not re-import these.
-
-### Required attributes for memory evaluation
-
-Always annotate every benchmark class with `[MemoryDiagnoser]`, regardless of
-its purpose. This adds three columns to the results table:
-**Gen0 / Gen1 / Gen2** (collections per 1000 ops) and **Allocated** (bytes
-per op). Without it you only get timings.
-
-```c#
-[MemoryDiagnoser]
-public class StringFormatting
-{
-    [Benchmark(Baseline = true)]
-    public string StringFormat() => string.Format("The answer is {0}.", _value);
-
-    [Benchmark]
-    public string StringsFormat() => string.FormatValue("The answer is {0}.", _value);
-}
-```
-
-Mark one method `[Benchmark(Baseline = true)]` whenever you are comparing
-alternative implementations - the report adds a **Ratio** and
-**RatioSD** column relative to that baseline.
-
-### Optional attributes
-
-- `[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]`
-  - cuts run time when iterating on a benchmark. Use only while developing; remove
-  (or revert to defaults) before checking in stable measurements. See
-  [StoreInteger.cs](../../../touki.perf/StoreInteger.cs) for an example.
-- `[Params(...)]` on a public field/property to run the benchmark for each value.
-- `[GlobalSetup]` for one-time setup outside the measured region.
-- `[Arguments(...)]` to pass per-method parameters.
-
-### What a benchmark method must do
-
-- **Return a value derived from the measured work, even when measuring
-  `void`-returning APIs.** Returning `void` (or a constant the JIT can
-  prove invariant) lets dead-code elimination wipe the body, producing
-  meaningless near-zero or wildly inconsistent timings. BenchmarkDotNet
-  consumes the return value to prevent that. For buffer-mutating APIs
-  (`Span<T>.Replace`, `Random.NextBytes`, `Encoding.GetBytes`) return
-  `buffer[0]`, the last element, or an XOR/sum digest of the buffer
-  - not `buffer.Length` or any other value invariant of execution.
-  Symptoms of forgetting: "optimized" variants slower than the baseline
-  (because the baseline got eliminated), >50% StdDev between runs,
-  near-zero timings for non-trivial work. See
-  [BenchmarkDotNet good practices](https://benchmarkdotnet.org/articles/guides/good-practices.html).
-- Be cheap to call repeatedly - BenchmarkDotNet invokes it millions of times.
-- Avoid per-call setup; move setup into `[GlobalSetup]` or readonly fields.
-- Avoid wrapping the system-under-test in a helper method just to satisfy
-  overload resolution - the helper's call frame, type check, and
-  generic instantiation show up in the measurement. Either rename one
-  overload temporarily while measuring, or split into two benchmark classes.
-- Ref structs cannot be returned from `[Benchmark]` methods; consume them
-  inside the method and return a representative scalar (length or hash).
-
-## 2. Running benchmarks
-
-The project's `Program.Main` uses `BenchmarkSwitcher.FromAssembly(...)` so all CLI
-arguments are forwarded to BenchmarkDotNet. Run from the repo root in PowerShell.
-
-### Specifying the target framework is required
-
-Because `touki.perf` is multi-targeted, **`dotnet run` requires `-f <tfm>`** -
-the SDK will not pick one for you and the run fails with NETSDK1005 or an ambiguous
-target error if you omit it. Always pass `-f net10.0` or `-f net481` (or whatever
-`$(DotNetCoreVersion)` currently resolves to).
+1. **Pass `-f <tfm>`.** `touki.perf` is multi-targeted, so `dotnet run` fails
+   without an explicit `-f net10.0` or `-f net481`.
+2. **`-c Release` is mandatory.** Debug runs are not representative.
+3. **`[MemoryDiagnoser]` on every class.** It adds the `Allocated` column, which
+   is usually the point.
+4. **Every `[Benchmark]` method returns a value derived from the work**, never
+   `void` - otherwise dead-code elimination wipes the body and the numbers are
+   meaningless. See [authoring.md](authoring.md).
+5. **Run both TFMs** for any code that compiles for both. Results diverge: the
+   modern runtime has vectorized BCL APIs net481 lacks.
 
 ```powershell
-# Modern .NET
+# The canonical run, one TFM. Repeat with -f net481.
 dotnet run -c Release -f net10.0 --project touki.perf -- --filter *StoreInteger*
-
-# .NET Framework 4.8.1
-dotnet run -c Release -f net481 --project touki.perf -- --filter *StoreInteger*
 ```
 
-`-c Release` is **mandatory**. Debug builds are not representative and BenchmarkDotNet
-will warn loudly.
-
-When a change touches code that compiles for both targets, **run both TFMs**. The
-results often differ dramatically - the modern runtime has vectorized BCL APIs
-that .NET Framework lacks, so a hand-tuned net481 fast path may look identical to the
-generic path on net10.
-
-### Run a single class or method
-
-```powershell
-# All benchmarks in StoreInteger
-dotnet run -c Release -f net10.0 --project touki.perf -- --filter *StoreInteger*
-
-# A single method
-dotnet run -c Release -f net10.0 --project touki.perf -- --filter *StoreInteger.As
-```
-
-### Interactive picker
-
-```powershell
-dotnet run -c Release --project touki.perf
-```
-
-With no `--filter`, BenchmarkSwitcher prints a numbered menu. Useful when exploring.
-
-### Useful extra switches
-
-- `--job short` - very fast, low-confidence run; good for smoke-testing a new
-  benchmark before committing to a full run.
-- `--memory` - enables the memory diagnoser for this run even if the class is not
-  decorated. Prefer the attribute.
-- `--exporters github` - emits a GitHub-flavored Markdown report alongside the
-  default outputs.
-
-### Profiling a benchmark: from operation to method to line
-
-To find where a benchmark spends its time - optimizing a hot path or chasing a
-regression - capture an EventPipe CPU trace on `net10.0`, then drill it with the
-in-workspace [touki.mcp](../../../touki.mcp/touki.mcp.csproj) analyzer. It reads
-the trace through TraceEvent, folds the JIT-helper sampling artifacts, and ranks
-by method or by source `file:line`. One capture serves both:
-
-```powershell
-# Capture once. --keepFiles preserves BDN's build so its PDB GUID survives for
-# the line ranking below.
-dotnet run -c Release -f net10.0 --project touki.perf -- `
-    --filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' -p EP --keepFiles
-
-$trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
-    -Filter '*GlobEnumeratorExtGlobSingleWithRoot*.nettrace' |
-    Sort-Object LastWriteTime | Select-Object -Last 1).FullName
-# The exact build BDN profiled - its PDB GUID matches the trace:
-$sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
-
-# Method ranking, scoped to a workload frame (which method owns the self-time).
-dotnet run --project touki.mcp -c Release -- analyze $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
-
-# Line ranking inside the dominant method (which lines of its hot loop dominate).
-dotnet run --project touki.mcp -c Release -- analyze $trace --lines RunEngine --symbols $sym --top 30
-
-# Who calls a folded JIT-helper artifact, to confirm what it's attributable to.
-dotnet run --project touki.mcp -c Release -- analyze $trace --callers 'BulkMoveWithWriteBarrier'
-```
-
-An agent that speaks MCP calls the equivalent tools directly (`hotspots_self`,
-`hotspots_inclusive`, `hot_lines`, `callers_of`, `load_trace`, `list_threads`).
-
-Things that bite, kept short - full rationale in
-[docs/performance-investigation.md](../../../docs/performance-investigation.md)
-sections 3a (methods) and 3f (lines):
-
-- **EventPipe is net10.0-only** - net481 needs `[EtwProfiler]` + admin.
-- **Fold the artifacts.** A raw self-time view shows `0 ms` per method (the leaf
-  is a synthetic `CPU_TIME` marker), and the managed-only walker mislabels
-  JIT-helper thunks (`BulkMoveWithWriteBarrier`, `Thread.PollGCWorker`,
-  `Buffer.Memmove`) as the hotspot. The analyzer folds both by default; a
-  `BulkMoveWithWriteBarrier` over a GC-ref-free struct is always an artifact.
-- **`--root` must be a frame inside the workload**, not the benchmark method
-  name (that also matches BDN's `Activity Benchmark(...)` wrapper and pulls in
-  idle threadpool threads).
-- **Line ranking needs `--symbols` pointing at BDN's `...-DefaultJob-N/bin/...`
-  build** - `touki.dll` ships its PDB embedded, and the symbols build's GUID
-  must match the trace (hence `--keepFiles`). A wrong dir resolves frames to
-  `<no source>` or is rejected with a GUID mismatch.
-- **Line attribution stops at inlined boundaries** - a fully-inlined callee
-  collapses onto its caller's call-site line. If the ranking piles onto one or
-  two call-site lines, scope `--lines` to the callee (`--lines ExtGlobEngine`)
-  or add a temporary `[MethodImpl(MethodImplOptions.NoInlining)]`.
-
-The older `Profile-Benchmark.ps1` / `Get-TraceHotspots.ps1` scripts predate the
-analyzer and remain as a no-MCP fallback (plus `speedscope-to-flamegraph.ps1`
-for SVG) in
-[docs/performance-investigation-without-mcp.md](../../../docs/performance-investigation-without-mcp.md).
-
-### Before/after measurement discipline (both TFMs, every time)
-
-A perf change is not done until you can show it helped and harmed nothing. The
-trace analyzer answers *where* to optimize; only a before/after benchmark answers
-*whether it worked*. Treat the following as mandatory whenever a code change is
-driven by a profile:
-
-- **Capture a baseline first, on both `net10.0` and `net481`.** Run the affected
-  benchmark on each TFM (`-f net10.0` and `-f net481`) *before* touching the
-  source and save the full result rows. The line-level EventPipe profiling that
-  guides the edit is `net10.0`-only, but the change still has to be measured on
-  `net481` - the older RyuJIT and BCL allocate and inline differently, and a
-  win on one TFM can be a wash or a regression on the other. **Never iterate on
-  net10 line info without also tracking the net481 overall throughput and
-  allocation numbers.**
-- **Re-run both TFMs after the change** and diff against the saved baseline.
-- **Record the full BenchmarkDotNet rows, not just a one-line summary.** Keep
-  the whole table - `Mean`, `Error`, `StdDev`, `Gen0`, `Gen1`, `Gen2`,
-  `Allocated` - for both the before and after runs on both TFMs. A summary like
-  "~7% faster" loses the error bars (is the delta inside the noise?) and the
-  allocation column (did the speedup trade CPU for garbage?). Save the raw
-  output to `artifacts/<name>-baseline-<tfm>.txt` and
-  `artifacts/<name>-after-<tfm>.txt` so the full diff is reproducible. Pipe the
-  run through `Tee-Object` to keep the console table.
-- **Allocation must not regress.** Compare the `Allocated` column before and
-  after on *both* TFMs. "No additional allocations" is only true if both columns
-  are unchanged.
-- **Confirm the targeted cost actually moved.** Re-capture a `net10.0` trace
-  after the change and check that the specific method/line the heat map flagged
-  dropped (e.g. `System.Array.Copy` self-time falling from 30 ms to 19 ms). A
-  faster wall-clock with the targeted frame unchanged usually means the win came
-  from somewhere else - or from noise.
-- **Distrust sub-microsecond deltas from this machine.** The i9-14900K harness
-  shows thermal/variance swings; trust the `Allocated` column and a unit test
-  over a small `Mean` delta. Deltas comfortably outside the `Error`/`StdDev` and
-  consistent in direction across both TFMs are credible.
-
-Present both TFMs' before/after tables together when reporting the result, plus
-the line-level evidence that the targeted hot spot shrank.
-
-## 3. Evaluating memory usage
-
-With `[MemoryDiagnoser]` (or `--memory`), each row of the results table includes:
-
-| Column      | Meaning                                                      |
-| ----------- | ------------------------------------------------------------ |
-| `Gen0`      | Gen0 collections per 1000 operations.                        |
-| `Gen1`      | Gen1 collections per 1000 operations.                        |
-| `Gen2`      | Gen2 collections per 1000 operations.                        |
-| `Allocated` | Managed bytes allocated per single operation.                |
-
-### Reading the numbers
-
-- **`Allocated` is the primary signal.** A method that should be allocation-free must
-  report `-` or `0 B`. Anything else is a regression.
-- A `Ratio` column appears when one method is `Baseline = true`. Use it together with
-  `Allocated` to confirm a perf change is not just trading CPU for allocations (or
-  vice versa).
-- `Gen0` ticking up while `Allocated` stays flat usually means you allocated a lot of
-  short-lived objects on previous iterations - recheck `[GlobalSetup]`.
-- Stack-only types (`Span<T>`, `ref struct`s, `stackalloc`) do not contribute to
-  `Allocated`. Boxing of value types does - watch for accidental boxing through
-  `object`, non-generic interfaces, or `string.Format`.
-- On `net481` the JIT and BCL allocate differently than on the modern .NET target
-  (`net10.0`). Always run both before declaring a win.
-
-### Where the report lives
-
-After each run BenchmarkDotNet writes artifacts under
-`BenchmarkDotNet.Artifacts/results/` next to the executable, including:
-
-- `*.md` - GitHub-friendly Markdown table (paste this into PR descriptions).
-- `*.csv` and `*.html` - for spreadsheets / browser viewing.
-- `*-report-full.json` - raw measurements; useful for diffing two runs
-  programmatically.
-
-The same table is also printed to the console at the end of the run.
-
-## 4. Workflow checklist for a new benchmark
+## Workflow checklist for a new benchmark
 
 1. Add a `<Name>.cs` file under `touki.perf/` with a `public` class in `touki.perf`.
+   See [authoring.md](authoring.md) for layout, globals, and attributes.
 2. Decorate the class with `[MemoryDiagnoser]`.
 3. Add `[Benchmark(Baseline = true)]` to the reference implementation and `[Benchmark]`
    to each variant.
@@ -317,14 +65,18 @@ The same table is also printed to the console at the end of the run.
    measuring, then revert.
 6. Build Release: `dotnet build -c Release touki.perf`.
 7. Smoke-test with `--job short --filter *<Name>*` on each target framework
-   individually using `-f net10.0` and `-f net481`.
+   individually using `-f net10.0` and `-f net481`. See [running.md](running.md).
 8. Run the full benchmark on both target frameworks (drop `--job short`).
 9. Inspect `Allocated` and `Ratio` columns; copy the Markdown report into the PR.
+   See [interpreting-results.md](interpreting-results.md).
 10. If one method dominates and you need to know which - or which *line* inside
-    it - profile it; see *Profiling a benchmark: from operation to method to
-    line* in &sect;2.
+    it - profile it. See [profiling.md](profiling.md).
 
-## 5. Codegen-level optimization rules
+When the change is driven by a profile, follow the before/after discipline in
+[interpreting-results.md](interpreting-results.md) (baseline both TFMs, re-run
+both, keep full rows, confirm the targeted frame moved).
+
+## Codegen-level optimization rules
 
 For decisions about *how to write* a hot path - whether to specialize a
 generic for primitives, choose between scalar/unrolled forms, defer to BCL
@@ -335,36 +87,13 @@ That skill is the right entry point for "this loop is slow on `net481`, what
 should I try?" questions, while this one is about authoring and running the
 benchmarks themselves.
 
-## 6. Tuple-swap on .NET Core hot paths
+## Sub-pages
 
-`IDE0180` ("use tuple to swap values") is disabled globally in
-[.editorconfig](../../../.editorconfig) because the auto-fix is unsafe on
-`net481` - see [SpanSwapPerf.cs](../../../touki.perf/SpanSwapPerf.cs)
-for the measurements. The summary is:
-
-| Form | net481 RyuJIT | .NET 10 RyuJIT |
-| --- | --- | --- |
-| Plain-local `(a, b) = (b, a)` | ~23% slower | equivalent |
-| Paired `Span<T>` indexed deconstruction | ~9% slower | ~13% **faster** |
-| Single `Span<T>` indexed or `ref` local deconstruction | equivalent | equivalent |
-
-That means a `#if NET` (modern-only) hot path that performs paired indexed
-swaps is one of the few cases where tuple swap is genuinely worth it. If a
-benchmark in `touki.perf/` confirms the win for a specific call site, opt in
-with a localized pragma rather than re-enabling the rule globally:
-
-```c#
-#if NET
-#pragma warning disable IDE0180 // Tuple swap measured faster on .NET 10 RyuJIT
-        (keys[i], keys[j], items[i], items[j]) =
-            (keys[j], keys[i], items[j], items[i]);
-#pragma warning restore IDE0180
-#else
-        TKey tk = keys[i]; keys[i] = keys[j]; keys[j] = tk;
-        TValue tv = items[i]; items[i] = items[j]; items[j] = tv;
-#endif
-```
-
-Do **not** apply this to code under `touki/Framework/` (compiled only for
-.NET Framework) or to code shared across both targets without a
-`#if NET` / `#else` split - the .NET Framework branch will regress.
+- [authoring.md](authoring.md) - file/class layout, the imported globals, the
+  required and optional attributes, and what a benchmark method must do.
+- [running.md](running.md) - the `-f <tfm>` requirement, filtering to a class or
+  method, the interactive picker, and useful switches.
+- [profiling.md](profiling.md) - capturing an EventPipe trace and drilling it
+  with the `touki.mcp` analyzer from operation to method to line.
+- [interpreting-results.md](interpreting-results.md) - before/after discipline on
+  both TFMs, reading the memory columns, and the tuple-swap exception.

--- a/.agents/skills/performance-testing/authoring.md
+++ b/.agents/skills/performance-testing/authoring.md
@@ -1,0 +1,85 @@
+# Authoring a benchmark
+
+Detail for the [performance-testing](SKILL.md) skill. Covers file/class layout,
+the globals already imported, the required and optional attributes, and what a
+benchmark method must do.
+
+## File and class layout
+
+- One benchmark class per file, file named after the class
+  (e.g. [StoreInteger.cs](../../../touki.perf/StoreInteger.cs)).
+- Namespace is always `touki.perf`.
+- Class is `public` (BenchmarkDotNet requires this) and contains one or more methods
+  marked `[Benchmark]`.
+- Use the standard repo file header.
+- Follow the repo coding style (no `var`, target-typed `new()`, C# keyword type names,
+  `is null` / `is not null`, indented XML docs, etc.). See
+  [AGENTS.md](../../../AGENTS.md).
+
+## Globals already imported
+
+[GlobalUsings.cs](../../../touki.perf/GlobalUsings.cs) already provides:
+
+- `BenchmarkDotNet.Attributes` - `[Benchmark]`, `[MemoryDiagnoser]`, `[Params]`,
+  `[GlobalSetup]`, etc.
+- `BenchmarkDotNet.Jobs` - `RuntimeMoniker`, `[SimpleJob]`.
+- `Touki` - the library root namespace.
+- `Microsoft.IO` (on NETFRAMEWORK) or `System.IO` otherwise.
+
+Do not re-import these.
+
+## Required attributes for memory evaluation
+
+Always annotate every benchmark class with `[MemoryDiagnoser]`, regardless of
+its purpose. This adds three columns to the results table:
+**Gen0 / Gen1 / Gen2** (collections per 1000 ops) and **Allocated** (bytes
+per op). Without it you only get timings.
+
+```c#
+[MemoryDiagnoser]
+public class StringFormatting
+{
+    [Benchmark(Baseline = true)]
+    public string StringFormat() => string.Format("The answer is {0}.", _value);
+
+    [Benchmark]
+    public string StringsFormat() => string.FormatValue("The answer is {0}.", _value);
+}
+```
+
+Mark one method `[Benchmark(Baseline = true)]` whenever you are comparing
+alternative implementations - the report adds a **Ratio** and
+**RatioSD** column relative to that baseline.
+
+## Optional attributes
+
+- `[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]`
+  - cuts run time when iterating on a benchmark. Use only while developing; remove
+  (or revert to defaults) before checking in stable measurements. See
+  [StoreInteger.cs](../../../touki.perf/StoreInteger.cs) for an example.
+- `[Params(...)]` on a public field/property to run the benchmark for each value.
+- `[GlobalSetup]` for one-time setup outside the measured region.
+- `[Arguments(...)]` to pass per-method parameters.
+
+## What a benchmark method must do
+
+- **Return a value derived from the measured work, even when measuring
+  `void`-returning APIs.** Returning `void` (or a constant the JIT can
+  prove invariant) lets dead-code elimination wipe the body, producing
+  meaningless near-zero or wildly inconsistent timings. BenchmarkDotNet
+  consumes the return value to prevent that. For buffer-mutating APIs
+  (`Span<T>.Replace`, `Random.NextBytes`, `Encoding.GetBytes`) return
+  `buffer[0]`, the last element, or an XOR/sum digest of the buffer
+  - not `buffer.Length` or any other value invariant of execution.
+  Symptoms of forgetting: "optimized" variants slower than the baseline
+  (because the baseline got eliminated), >50% StdDev between runs,
+  near-zero timings for non-trivial work. See
+  [BenchmarkDotNet good practices](https://benchmarkdotnet.org/articles/guides/good-practices.html).
+- Be cheap to call repeatedly - BenchmarkDotNet invokes it millions of times.
+- Avoid per-call setup; move setup into `[GlobalSetup]` or readonly fields.
+- Avoid wrapping the system-under-test in a helper method just to satisfy
+  overload resolution - the helper's call frame, type check, and
+  generic instantiation show up in the measurement. Either rename one
+  overload temporarily while measuring, or split into two benchmark classes.
+- Ref structs cannot be returned from `[Benchmark]` methods; consume them
+  inside the method and return a representative scalar (length or hash).

--- a/.agents/skills/performance-testing/interpreting-results.md
+++ b/.agents/skills/performance-testing/interpreting-results.md
@@ -1,0 +1,117 @@
+# Interpreting results
+
+Detail for the [performance-testing](SKILL.md) skill. Covers the before/after
+measurement discipline, reading the memory columns, and the one .NET Core hot
+path where tuple swap is worth it.
+
+## Before/after measurement discipline (both TFMs, every time)
+
+A perf change is not done until you can show it helped and harmed nothing. The
+trace analyzer answers *where* to optimize (see [profiling.md](profiling.md));
+only a before/after benchmark answers *whether it worked*. Treat the following as
+mandatory whenever a code change is driven by a profile:
+
+- **Capture a baseline first, on both `net10.0` and `net481`.** Run the affected
+  benchmark on each TFM (`-f net10.0` and `-f net481`) *before* touching the
+  source and save the full result rows. The line-level EventPipe profiling that
+  guides the edit is `net10.0`-only, but the change still has to be measured on
+  `net481` - the older RyuJIT and BCL allocate and inline differently, and a
+  win on one TFM can be a wash or a regression on the other. **Never iterate on
+  net10 line info without also tracking the net481 overall throughput and
+  allocation numbers.**
+- **Re-run both TFMs after the change** and diff against the saved baseline.
+- **Record the full BenchmarkDotNet rows, not just a one-line summary.** Keep
+  the whole table - `Mean`, `Error`, `StdDev`, `Gen0`, `Gen1`, `Gen2`,
+  `Allocated` - for both the before and after runs on both TFMs. A summary like
+  "~7% faster" loses the error bars (is the delta inside the noise?) and the
+  allocation column (did the speedup trade CPU for garbage?). Save the raw
+  output to `artifacts/<name>-baseline-<tfm>.txt` and
+  `artifacts/<name>-after-<tfm>.txt` so the full diff is reproducible. Pipe the
+  run through `Tee-Object` to keep the console table.
+- **Allocation must not regress.** Compare the `Allocated` column before and
+  after on *both* TFMs. "No additional allocations" is only true if both columns
+  are unchanged.
+- **Confirm the targeted cost actually moved.** Re-capture a `net10.0` trace
+  after the change and check that the specific method/line the heat map flagged
+  dropped (e.g. `System.Array.Copy` self-time falling from 30 ms to 19 ms). A
+  faster wall-clock with the targeted frame unchanged usually means the win came
+  from somewhere else - or from noise.
+- **Distrust sub-microsecond deltas from this machine.** The i9-14900K harness
+  shows thermal/variance swings; trust the `Allocated` column and a unit test
+  over a small `Mean` delta. Deltas comfortably outside the `Error`/`StdDev` and
+  consistent in direction across both TFMs are credible.
+
+Present both TFMs' before/after tables together when reporting the result, plus
+the line-level evidence that the targeted hot spot shrank.
+
+## Evaluating memory usage
+
+With `[MemoryDiagnoser]` (or `--memory`), each row of the results table includes:
+
+| Column      | Meaning                                                      |
+| ----------- | ------------------------------------------------------------ |
+| `Gen0`      | Gen0 collections per 1000 operations.                        |
+| `Gen1`      | Gen1 collections per 1000 operations.                        |
+| `Gen2`      | Gen2 collections per 1000 operations.                        |
+| `Allocated` | Managed bytes allocated per single operation.                |
+
+### Reading the numbers
+
+- **`Allocated` is the primary signal.** A method that should be allocation-free must
+  report `-` or `0 B`. Anything else is a regression.
+- A `Ratio` column appears when one method is `Baseline = true`. Use it together with
+  `Allocated` to confirm a perf change is not just trading CPU for allocations (or
+  vice versa).
+- `Gen0` ticking up while `Allocated` stays flat usually means you allocated a lot of
+  short-lived objects on previous iterations - recheck `[GlobalSetup]`.
+- Stack-only types (`Span<T>`, `ref struct`s, `stackalloc`) do not contribute to
+  `Allocated`. Boxing of value types does - watch for accidental boxing through
+  `object`, non-generic interfaces, or `string.Format`.
+- On `net481` the JIT and BCL allocate differently than on the modern .NET target
+  (`net10.0`). Always run both before declaring a win.
+
+### Where the report lives
+
+After each run BenchmarkDotNet writes artifacts under
+`BenchmarkDotNet.Artifacts/results/` next to the executable, including:
+
+- `*.md` - GitHub-friendly Markdown table (paste this into PR descriptions).
+- `*.csv` and `*.html` - for spreadsheets / browser viewing.
+- `*-report-full.json` - raw measurements; useful for diffing two runs
+  programmatically.
+
+The same table is also printed to the console at the end of the run.
+
+## Tuple-swap on .NET Core hot paths
+
+`IDE0180` ("use tuple to swap values") is disabled globally in
+[.editorconfig](../../../.editorconfig) because the auto-fix is unsafe on
+`net481` - see [SpanSwapPerf.cs](../../../touki.perf/SpanSwapPerf.cs)
+for the measurements. The summary is:
+
+| Form | net481 RyuJIT | .NET 10 RyuJIT |
+| --- | --- | --- |
+| Plain-local `(a, b) = (b, a)` | ~23% slower | equivalent |
+| Paired `Span<T>` indexed deconstruction | ~9% slower | ~13% **faster** |
+| Single `Span<T>` indexed or `ref` local deconstruction | equivalent | equivalent |
+
+That means a `#if NET` (modern-only) hot path that performs paired indexed
+swaps is one of the few cases where tuple swap is genuinely worth it. If a
+benchmark in `touki.perf/` confirms the win for a specific call site, opt in
+with a localized pragma rather than re-enabling the rule globally:
+
+```c#
+#if NET
+#pragma warning disable IDE0180 // Tuple swap measured faster on .NET 10 RyuJIT
+        (keys[i], keys[j], items[i], items[j]) =
+            (keys[j], keys[i], items[j], items[i]);
+#pragma warning restore IDE0180
+#else
+        TKey tk = keys[i]; keys[i] = keys[j]; keys[j] = tk;
+        TValue tv = items[i]; items[i] = items[j]; items[j] = tv;
+#endif
+```
+
+Do **not** apply this to code under `touki/Framework/` (compiled only for
+.NET Framework) or to code shared across both targets without a
+`#if NET` / `#else` split - the .NET Framework branch will regress.

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -1,0 +1,61 @@
+# Profiling a benchmark: from operation to method to line
+
+Detail for the [performance-testing](SKILL.md) skill.
+
+To find where a benchmark spends its time - optimizing a hot path or chasing a
+regression - capture an EventPipe CPU trace on `net10.0`, then drill it with the
+in-workspace [touki.mcp](../../../touki.mcp/touki.mcp.csproj) analyzer. It reads
+the trace through TraceEvent, folds the JIT-helper sampling artifacts, and ranks
+by method or by source `file:line`. One capture serves both:
+
+```powershell
+# Capture once. --keepFiles preserves BDN's build so its PDB GUID survives for
+# the line ranking below.
+dotnet run -c Release -f net10.0 --project touki.perf -- `
+    --filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' -p EP --keepFiles
+
+$trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
+    -Filter '*GlobEnumeratorExtGlobSingleWithRoot*.nettrace' |
+    Sort-Object LastWriteTime | Select-Object -Last 1).FullName
+# The exact build BDN profiled - its PDB GUID matches the trace:
+$sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
+
+# Method ranking, scoped to a workload frame (which method owns the self-time).
+dotnet run --project touki.mcp -c Release -- analyze $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+
+# Line ranking inside the dominant method (which lines of its hot loop dominate).
+dotnet run --project touki.mcp -c Release -- analyze $trace --lines RunEngine --symbols $sym --top 30
+
+# Who calls a folded JIT-helper artifact, to confirm what it's attributable to.
+dotnet run --project touki.mcp -c Release -- analyze $trace --callers 'BulkMoveWithWriteBarrier'
+```
+
+An agent that speaks MCP calls the equivalent tools directly (`hotspots_self`,
+`hotspots_inclusive`, `hot_lines`, `callers_of`, `load_trace`, `list_threads`).
+
+Things that bite, kept short - full rationale in
+[docs/performance-investigation.md](../../../docs/performance-investigation.md)
+sections 3a (methods) and 3f (lines):
+
+- **EventPipe is net10.0-only** - net481 needs `[EtwProfiler]` + admin.
+- **Fold the artifacts.** A raw self-time view shows `0 ms` per method (the leaf
+  is a synthetic `CPU_TIME` marker), and the managed-only walker mislabels
+  JIT-helper thunks (`BulkMoveWithWriteBarrier`, `Thread.PollGCWorker`,
+  `Buffer.Memmove`) as the hotspot. The analyzer folds both by default; a
+  `BulkMoveWithWriteBarrier` over a GC-ref-free struct is always an artifact.
+- **`--root` must be a frame inside the workload**, not the benchmark method
+  name (that also matches BDN's `Activity Benchmark(...)` wrapper and pulls in
+  idle threadpool threads).
+- **Line ranking needs `--symbols` pointing at BDN's `...-DefaultJob-N/bin/...`
+  build** - `touki.dll` ships its PDB embedded, and the symbols build's GUID
+  must match the trace (hence `--keepFiles`). A wrong dir resolves frames to
+  `<no source>` or is rejected with a GUID mismatch.
+- **Line attribution stops at inlined boundaries** - a fully-inlined callee
+  collapses onto its caller's call-site line. If the ranking piles onto one or
+  two call-site lines, scope `--lines` to the callee (`--lines ExtGlobEngine`)
+  or add a temporary `[MethodImpl(MethodImplOptions.NoInlining)]`.
+
+The older `Profile-Benchmark.ps1` / `Get-TraceHotspots.ps1` scripts predate the
+analyzer and remain as a no-MCP fallback (plus `speedscope-to-flamegraph.ps1`
+for SVG) in
+[docs/performance-investigation-without-mcp.md](../../../docs/performance-investigation-without-mcp.md).

--- a/.agents/skills/performance-testing/running.md
+++ b/.agents/skills/performance-testing/running.md
@@ -1,0 +1,59 @@
+# Running benchmarks
+
+Detail for the [performance-testing](SKILL.md) skill. The project's
+`Program.Main` uses `BenchmarkSwitcher.FromAssembly(...)` so all CLI arguments
+are forwarded to BenchmarkDotNet. Run from the repo root in PowerShell.
+
+For drilling a benchmark down to the hot method or source line, see
+[profiling.md](profiling.md). For before/after discipline and reading the
+result columns, see [interpreting-results.md](interpreting-results.md).
+
+## Specifying the target framework is required
+
+Because `touki.perf` is multi-targeted, **`dotnet run` requires `-f <tfm>`** -
+the SDK will not pick one for you and the run fails with NETSDK1005 or an ambiguous
+target error if you omit it. Always pass `-f net10.0` or `-f net481` (or whatever
+`$(DotNetCoreVersion)` currently resolves to).
+
+```powershell
+# Modern .NET
+dotnet run -c Release -f net10.0 --project touki.perf -- --filter *StoreInteger*
+
+# .NET Framework 4.8.1
+dotnet run -c Release -f net481 --project touki.perf -- --filter *StoreInteger*
+```
+
+`-c Release` is **mandatory**. Debug builds are not representative and BenchmarkDotNet
+will warn loudly.
+
+When a change touches code that compiles for both targets, **run both TFMs**. The
+results often differ dramatically - the modern runtime has vectorized BCL APIs
+that .NET Framework lacks, so a hand-tuned net481 fast path may look identical to the
+generic path on net10.
+
+## Run a single class or method
+
+```powershell
+# All benchmarks in StoreInteger
+dotnet run -c Release -f net10.0 --project touki.perf -- --filter *StoreInteger*
+
+# A single method
+dotnet run -c Release -f net10.0 --project touki.perf -- --filter *StoreInteger.As
+```
+
+## Interactive picker
+
+```powershell
+dotnet run -c Release --project touki.perf
+```
+
+With no `--filter`, BenchmarkSwitcher prints a numbered menu. Useful when exploring.
+
+## Useful extra switches
+
+- `--job short` - very fast, low-confidence run; good for smoke-testing a new
+  benchmark before committing to a full run.
+- `--memory` - enables the memory diagnoser for this run even if the class is not
+  decorated. Prefer the attribute.
+- `--exporters github` - emits a GitHub-flavored Markdown report alongside the
+  default outputs.

--- a/.agents/skills/polyfill-dotnet-api/SKILL.md
+++ b/.agents/skills/polyfill-dotnet-api/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: polyfill-dotnet-api
 description: Polyfill a modern .NET BCL API for .NET Framework. Use when asked to "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", or any time a member is missing on net472 and present on net10. Picks the right source (Microsoft-shipped package vs PolySharp source-gen vs hand-rolled `touki/Framework/` polyfill) and captures the recurring design gotchas.
+compatibility: Uses the microsoft-learn MCP server to confirm modern BCL API shapes and edge cases when available; falls back to fetching learn.microsoft.com and the dotnet/runtime reference source otherwise.
+metadata:
+  portability: repo-specific
 ---
 
 # Polyfill a .NET API for .NET Framework
@@ -12,258 +15,77 @@ description: Polyfill a modern .NET BCL API for .NET Framework. Use when asked t
 [touki.csproj](../../../touki/touki.csproj)). Tests run on `net481` but
 exercise the `net472` polyfill assembly.
 
-Work the source list below in order; stop at the first hit. Don't add a
-hand polyfill for something a Microsoft package or PolySharp already
-ships.
-
 **Related skills:**
 [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) (this skill feeds
-into &sect;5 / &sect;6 / &sect;7 there),
+into its tests / allocation / parity items),
 [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
 (net481 RyuJIT shape once hand-rolling),
 [`performance-testing`](../performance-testing/SKILL.md) (benchmark
 required for any perf trade-off).
 
-## Source preference order
+## Source preference order (stop at the first hit)
 
-### 1. Microsoft-shipped NuGet packages
+Don't add a hand polyfill for something a Microsoft package or PolySharp
+already ships. Full detail - the package table, the PolySharp attribute
+list, and the hand-rolled folder/namespace rules - is in
+[source-selection.md](source-selection.md).
 
-Probe before polyfilling: write a tiny `#if NETFRAMEWORK` snippet in
-`touki.tests/Framework/` that calls the candidate API and try a `net472`
-build. If it compiles, a referenced package already supplies the member;
-delete the probe.
+1. **Microsoft-shipped NuGet package.** Probe first: write a tiny
+   `#if NETFRAMEWORK` snippet in `touki.tests/Framework/`, build `net472`,
+   and if it compiles a referenced package already supplies the member.
+   `System.Memory`, `Microsoft.Bcl.Memory`, `Microsoft.Bcl.HashCode`, and
+   `Microsoft.IO.Redist` are already referenced.
+2. **PolySharp source-gen** for compiler / language *attributes*
+   (`IsExternalInit`, `CallerArgumentExpression`, `SkipLocalsInit`, the
+   nullable attributes). Never hand-write these.
+3. **Hand-rolled polyfill** under
+   `touki/Framework/Polyfills/<BclNamespace>/`, only when a real caller
+   needs a runtime member no package or attribute supplies. Folder = BCL
+   namespace dotted; `namespace` matches the folder; use C# 14 `extension`
+   blocks; no `#if NETFRAMEWORK` inside the already-framework-only tree.
 
-| Package | Covers | Referenced |
-| --- | --- | --- |
-| `System.Memory` | `Span<T>` / `ReadOnlySpan<T>` / `Memory<T>`, base `MemoryExtensions`, `MemoryMarshal`, `Unsafe`, `BinaryPrimitives`, `ArrayPool<T>` | yes |
-| `Microsoft.Bcl.Memory` | `Range`, `Index`, newer `MemoryExtensions` (`Count`, `CommonPrefixLength`, `ContainsAnyExcept`, `IsWhiteSpace`) | yes |
-| `Microsoft.Bcl.HashCode` | `HashCode` | yes |
-| `Microsoft.IO.Redist` | .NET 6 `System.IO` (via `global using Microsoft.IO;`) | yes |
-| `Microsoft.Bcl.AsyncInterfaces` | `IAsyncEnumerable<T>`, `IAsyncDisposable`, async-returning interfaces | not yet |
-| `Microsoft.Bcl.TimeProvider` | `TimeProvider`, `ITimer` | not yet |
-| `Microsoft.Bcl.Numerics` | `Half`, `BigInteger` additions | not yet |
+## Design rules for a hand polyfill
 
-When adding a new package, place the `<PackageReference>` inside the
-`Condition="'$(TargetFramework)' == '$(DotNetFrameworkVersion)'"`
-ItemGroup - never unconditional.
-
-### 2. PolySharp source-generated polyfills
-
-[PolySharp](https://github.com/Sergio0694/PolySharp) (referenced for the
-.NET Framework target only) supplies **language / compiler attributes**,
-not runtime types. Use it for `IsExternalInit`, `RequiredMember`,
-`CompilerFeatureRequired`, `CallerArgumentExpression`,
-`ModuleInitializerAttribute`, `SkipLocalsInit`, and the nullable
-attributes (`NotNullWhen`, `MaybeNullWhen`, `MemberNotNull`,
-`DoesNotReturn`, ...).
-
-The repo enables:
-
-```xml
-<PolySharpUsePublicAccessibilityForGeneratedTypes>true</PolySharpUsePublicAccessibilityForGeneratedTypes>
-<PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
-```
-
-Don't hand-write attribute polyfills; PolySharp generates them.
-
-### 3. Hand-rolled polyfill in `touki/Framework/Polyfills/<BclNamespace>/`
-
-Last resort, when a runtime member (instance method, static helper,
-ctor) isn't supplied by a package and isn't an attribute. Polyfill only
-when there's a real caller; "completeness" polyfills bloat the surface.
-
-- **Folder = BCL namespace, dotted.** `System.Convert` &rarr;
-  `touki/Framework/Polyfills/System/ConvertExtensions.cs`.
-  `System.Text.Encoding` &rarr;
-  `touki/Framework/Polyfills/System.Text/EncodingExtensions.cs`.
-  `System.Security.Cryptography.CryptographicOperations` &rarr;
-  `touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs`.
-- **`namespace` matches the folder.** `Polyfills/System/Foo.cs` declares
-  `namespace System;`, `Polyfills/System.Text/Foo.cs` declares
-  `namespace System.Text;`. Callers reach the polyfill through the same
-  `using` they already had for the BCL type.
-- **Use C# 14 `extension` blocks** (e.g. `extension(Encoding encoding) { ... }`)
-  rather than static-class extension methods. Lookup picks the BCL
-  member on modern .NET and the polyfill on net472. See
-  [ConvertExtensions.cs](../../../touki/Framework/Polyfills/System/ConvertExtensions.cs).
-- **Don't `#if NETFRAMEWORK` inside `touki/Framework/`** - the
-  whole folder is already framework-only.
-- **Touki-specific helpers (not polyfills)** live in
-  `touki/Framework/Touki/...` with `Touki.*` namespaces. If your file
-  isn't shadowing a public modern .NET BCL member, it doesn't go under
-  `Polyfills/`.
-
-## Design rules every hand polyfill must satisfy
-
-### Behavior parity
-
-- Match the BCL exception type **and** message family
-  (`ArgumentNullException` vs `NullReferenceException` is an observable
-  diff; same for span "destination too short" cases).
-- Read modern .NET docs / reference source for edge cases
-  (empty / null / zero-length-destination / overflow inputs).
-- For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
-  only take a fast path when `typeof(BaseType) == obj.GetType()`;
-  subclasses dispatch through the virtual member. See
-  [RandomExtensions.NextBytes](../../../touki/Framework/Polyfills/System/RandomExtensions.cs).
-- Stateful types (`HashCode`, `Random`): match the documented contract,
-  not observable cross-runtime output. `HashCode` is process-local.
-
-### Allocations
-
-The point of a span overload is to skip the array overload's
-allocation. Allocating a temp `T[]` to delegate to the BCL throws that
-benefit away. **Default allocation-free even at 5-15% throughput
-cost**; document the trade-off in `<remarks>`. Use existing helpers
-before inventing new ones:
-
-- **`stackalloc` + [`BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs)**
-  for small bounded buffers that may grow into `ArrayPool<T>`.
-- **`ArrayPool<T>.Shared.Rent` / `Return`** for unbounded buffers
-  (clear on return only when `T` contains references); see
-  [`ArrayPoolList<T>`](../../../touki/Touki/Collections/ArrayPoolList.cs).
-- **Pinned write into `new string('\0', length)`** for `string`-returning
-  methods (`Convert.ToHexString`, `string.Concat(ROS<char>...)`).
-- **Pinned `unsafe` pass-through to BCL `T*` overloads** when no span
-  variant exists; see
-  [EncodingExtensions](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
-  Watch the empty-span null-pinnable foot-gun (Gotchas &sect;1).
-- **`MemoryMarshal.AsBytes` / `AsRef` / `GetReference`** for zero-copy
-  reinterpretation.
-
-### Reflecting into BCL internals
-
-**Last-resort tool. Never write reflection-based polyfill code without
-explicit user approval.** The default answer is "allocate instead."
-
-Consider asking only when both hold:
-
-- Win is **substantial** (order of magnitude, or removes a per-call
-  allocation from a documented hot path).
-- No supported alternative exists (no Microsoft package, no
-  `MemoryMarshal`/`Unsafe` route, no `extension`-blockable surface).
-
-When asking, surface: which BCL member, the perf/alloc delta vs the
-supported alternative, the fragility (private members can change in
-servicing updates), and any security/trust implications. If approved,
-isolate in one internal helper, cache `MethodInfo`/`FieldInfo` once,
-and comment which BCL surface is targeted and why.
-
-### Argument validation
-
-- `ArgumentNullException.ThrowIfNull(arg)` - the polyfill at
-  [`ArgumentNullExtensions`](../../../touki/Framework/Polyfills/System/ArgumentNullExtensions.cs)
-  covers net472.
-- `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when available;
-  fall back to `(uint)x > (uint)max`.
-- Mirror the BCL exception type. Don't introduce custom exception types.
-
-### Length / overflow
-
-Wrap any sum of input lengths used to size an allocation in `checked()`.
-Unchecked overflow allocates the wrong-sized buffer and surfaces failure
-later from `CopyTo`.
-[`StringExtensions.Concat`](../../../touki/Framework/Polyfills/System/StringExtensions.cs)
-is the reference pattern.
-
-### Coexistence with future BCL polyfills
-
-C# 14 `extension` blocks add members to an existing type, not new types.
-A future Microsoft `Convert.ToHexString` on net472 wins lookup over the
-extension; the polyfill goes silently inert. No `extern alias` needed.
-
-The exception is when the polyfill defines a **new type** in `System.*`
-(e.g.
-[CryptographicOperations](../../../touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs)).
-A future Microsoft polyfill for that exact type collides (CS0436/CS0433)
-and callers need `extern alias`. The recipe and the list of new-type
-polyfills lives in
-[docs/polyfill-layout.md](../../../docs/polyfill-layout.md). Prefer
-extension members over new `System.*` types when feasible.
-
-Touki's stated commitment is to **defer to Microsoft-shipped polyfills
-when they ship**: a future Touki release will reference the official
-package and remove (or thin-forward) the duplicate type, so callers
-upgrade automatically. See
-[docs/polyfill-layout.md](../../../docs/polyfill-layout.md) for the
-user-facing version of that policy.
-
-## Gotchas seen in past PRs
-
-The [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist
-enforces these; this section explains *why*.
-
-1. **Empty-span pinning yields `null`.**
-   `MemoryMarshal.GetReference(default(ROS<T>))` is a null ref, so
-   `fixed (T* p = ...)` produces a null pointer, and net481 BCL `T*`
-   overloads typically throw `ArgumentNullException` instead of the
-   canonical "destination too short". Handle empty source / empty
-   destination separately before pinning. See
-   [EncodingExtensions.GetBytes](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
-
-2. **`[AggressiveInlining]` + `Unsafe.As<T, narrower>(ref param)`
-   compares against the wrong constant on net481.** When the caller
-   passes a literal of a *signed* primitive narrower than `int`
-   (`sbyte`, `short`), C# `int`-promotion sign-extends it (`(sbyte)-1`
-   becomes `0xFFFFFFFF`). If the called method is
-   `[AggressiveInlining]` and reinterprets the parameter via
-   `Unsafe.As<T, byte>(ref oldValue)` to compare against bytes loaded
-   with `movzx`, RyuJIT propagates the *int-promoted* constant into
-   the compare immediate (`cmp ecx, 0xFFFFFFFF`) instead of the
-   requested byte (`0xFF`). The `movzx`-loaded byte is in `[0, 0xFF]`
-   so the compare is *unconditionally false* - the loop runs
-   silently doing nothing in Release. Debug passes (no inlining).
-   Confirmed by disassembly in
-   [ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs).
-
-   **Fix:** explicitly mask in the int domain so RyuJIT must fold the
-   high bits to zero. The cast alone is not enough - the JIT's
-   constant tracker doesn't model the `conv.u1` IL op as truncating
-   to `[0, 0xFF]` here. Use:
-
-   ```csharp
-   byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
-   ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
-   ```
-
-   See [SpanExtensions.Replace.cs](../../../touki/Framework/Polyfills/System/SpanExtensions.Replace.cs)
-   for the in-place version, and the
-   [ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs)
-   benchmark for the disassembly proof. The unsigned cases (`byte`,
-   `ushort`, `char`) are unaffected because their int-promoted form
-   already has the upper bits zero. Tests on signed inputs are
-   essential - symmetric tests that only use `byte`/`char` will
-   not catch this.
-
-3. **`Random.NextBytes(byte[])` is native on net481; the obvious
-   managed span loop is slower per byte** (loses to `byte[]` + copy by
-   ~1.2&times; on big buffers despite saving the alloc). Use a pinned
-   pointer loop and only on the type-exact fast path; subclasses go
-   through the array overload. See
-   [RandomExtensions](../../../touki/Framework/Polyfills/System/RandomExtensions.cs).
-
-4. **`HashCode` is process-local.** No cross-runtime parity contract;
-   only assert within-process determinism.
-
-5. **`net472` vs `net481` phrasing.** Polyfill assembly TFM is `net472`
-   (`$(DotNetFrameworkVersion)`); test TFM is `net481` for richer GC
-   APIs but consumes the `net472` polyfill. Don't call the polyfill
-   "net481-only" in commits or PR descriptions.
+When step 3 applies, the polyfill must satisfy the rules in
+[design-rules.md](design-rules.md): behavior parity (exception type *and*
+message family, edge cases, type-exact fast paths), **allocation-free by
+default even at a 5-15% throughput cost**, `checked()` on any length sum
+that sizes an allocation, standard throw helpers (no custom exception
+types), no reflection into BCL internals without explicit user approval,
+and coexistence with a future Microsoft polyfill (prefer `extension`
+members over new `System.*` types). The recurring net481 / empty-span /
+TFM-phrasing foot-guns are in [gotchas.md](gotchas.md).
 
 ## Workflow
 
-1. Probe to confirm the API is missing; pick the highest source from
-   the order above that supplies it.
-2. If hand-rolling, place under `touki/Framework/<BclNamespace>/` using
-   `extension(...)` blocks (only declare a new type when the BCL
-   surface itself is a brand-new type).
-3. Add tests under [`touki.tests/`](../../../touki.tests/) running on
-   both TFMs. Identical observable behavior to modern BCL for matching
-   inputs.
-4. Consult [`dotnet/runtime`](https://github.com/dotnet/runtime) tests
-   for additional edge cases. Location pattern is `src/libraries/<AreaName>/tests/...`.
-5. Run [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) and get user approval before
-   invoking [`create-pr`](../create-pr/SKILL.md).
+1. **Confirm the API is missing and learn its exact shape.** When the
+   microsoft-learn MCP server is available, query it for the modern API
+   signature, exception contract, and edge-case behavior; otherwise fetch
+   the learn.microsoft.com page and the
+   [`dotnet/runtime`](https://github.com/dotnet/runtime) reference source
+   (`src/libraries/<AreaName>/...`). Pick the highest source from the
+   order above that supplies it.
+2. If hand-rolling, place under `touki/Framework/Polyfills/<BclNamespace>/`
+   using `extension(...)` blocks (only declare a new type when the BCL
+   surface itself is a brand-new type). Apply [design-rules.md](design-rules.md).
+3. Add tests under [`touki.tests/`](../../../touki.tests/) running on both
+   TFMs. Identical observable behavior to the modern BCL for matching
+   inputs. Consult `dotnet/runtime` tests (`src/libraries/<AreaName>/tests/...`)
+   for additional edge cases - via the microsoft-learn MCP server when
+   available, otherwise the GitHub source.
+4. Run [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) and get user
+   approval before invoking [`create-pr`](../create-pr/SKILL.md).
+
+## Sub-pages
+
+- [source-selection.md](source-selection.md) - the package table, the
+  PolySharp attribute list, and the hand-rolled folder / namespace rules.
+- [design-rules.md](design-rules.md) - behavior parity, allocation
+  strategies, argument validation, `checked()` sums, reflection policy,
+  and coexistence with future BCL polyfills.
+- [gotchas.md](gotchas.md) - empty-span pinning, the net481 `Unsafe.As`
+  sign-extension bug, native `Random.NextBytes`, process-local `HashCode`,
+  and net472-vs-net481 phrasing.
 
 ## Examples in this repo
 

--- a/.agents/skills/polyfill-dotnet-api/design-rules.md
+++ b/.agents/skills/polyfill-dotnet-api/design-rules.md
@@ -1,0 +1,98 @@
+# Design rules every hand polyfill must satisfy
+
+Detail for the [polyfill-dotnet-api](SKILL.md) skill. Applies once the
+[source-selection.md](source-selection.md) order has landed you on a
+hand-rolled polyfill under `touki/Framework/Polyfills/`.
+
+## Behavior parity
+
+- Match the BCL exception type **and** message family
+  (`ArgumentNullException` vs `NullReferenceException` is an observable
+  diff; same for span "destination too short" cases).
+- Read modern .NET docs / reference source for edge cases
+  (empty / null / zero-length-destination / overflow inputs).
+- For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
+  only take a fast path when `typeof(BaseType) == obj.GetType()`;
+  subclasses dispatch through the virtual member. See
+  [RandomExtensions.NextBytes](../../../touki/Framework/Polyfills/System/RandomExtensions.cs).
+- Stateful types (`HashCode`, `Random`): match the documented contract,
+  not observable cross-runtime output. `HashCode` is process-local.
+
+## Allocations
+
+The point of a span overload is to skip the array overload's
+allocation. Allocating a temp `T[]` to delegate to the BCL throws that
+benefit away. **Default allocation-free even at 5-15% throughput
+cost**; document the trade-off in `<remarks>`. Use existing helpers
+before inventing new ones:
+
+- **`stackalloc` + [`BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs)**
+  for small bounded buffers that may grow into `ArrayPool<T>`.
+- **`ArrayPool<T>.Shared.Rent` / `Return`** for unbounded buffers
+  (clear on return only when `T` contains references); see
+  [`ArrayPoolList<T>`](../../../touki/Touki/Collections/ArrayPoolList.cs).
+- **Pinned write into `new string('\0', length)`** for `string`-returning
+  methods (`Convert.ToHexString`, `string.Concat(ROS<char>...)`).
+- **Pinned `unsafe` pass-through to BCL `T*` overloads** when no span
+  variant exists; see
+  [EncodingExtensions](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
+  Watch the empty-span null-pinnable foot-gun ([gotchas.md](gotchas.md) &sect;1).
+- **`MemoryMarshal.AsBytes` / `AsRef` / `GetReference`** for zero-copy
+  reinterpretation.
+
+## Reflecting into BCL internals
+
+**Last-resort tool. Never write reflection-based polyfill code without
+explicit user approval.** The default answer is "allocate instead."
+
+Consider asking only when both hold:
+
+- Win is **substantial** (order of magnitude, or removes a per-call
+  allocation from a documented hot path).
+- No supported alternative exists (no Microsoft package, no
+  `MemoryMarshal`/`Unsafe` route, no `extension`-blockable surface).
+
+When asking, surface: which BCL member, the perf/alloc delta vs the
+supported alternative, the fragility (private members can change in
+servicing updates), and any security/trust implications. If approved,
+isolate in one internal helper, cache `MethodInfo`/`FieldInfo` once,
+and comment which BCL surface is targeted and why.
+
+## Argument validation
+
+- `ArgumentNullException.ThrowIfNull(arg)` - the polyfill at
+  [`ArgumentNullExtensions`](../../../touki/Framework/Polyfills/System/ArgumentNullExtensions.cs)
+  covers net472.
+- `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when available;
+  fall back to `(uint)x > (uint)max`.
+- Mirror the BCL exception type. Don't introduce custom exception types.
+
+## Length / overflow
+
+Wrap any sum of input lengths used to size an allocation in `checked()`.
+Unchecked overflow allocates the wrong-sized buffer and surfaces failure
+later from `CopyTo`.
+[`StringExtensions.Concat`](../../../touki/Framework/Polyfills/System/StringExtensions.cs)
+is the reference pattern.
+
+## Coexistence with future BCL polyfills
+
+C# 14 `extension` blocks add members to an existing type, not new types.
+A future Microsoft `Convert.ToHexString` on net472 wins lookup over the
+extension; the polyfill goes silently inert. No `extern alias` needed.
+
+The exception is when the polyfill defines a **new type** in `System.*`
+(e.g.
+[CryptographicOperations](../../../touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs)).
+A future Microsoft polyfill for that exact type collides (CS0436/CS0433)
+and callers need `extern alias`. The recipe and the list of new-type
+polyfills lives in
+[docs/polyfill-layout.md](../../../docs/polyfill-layout.md). Prefer
+extension members over new `System.*` types when feasible.
+
+Touki's stated commitment is to **defer to Microsoft-shipped polyfills
+when they ship**: a future Touki release will reference the official
+package and remove (or thin-forward) the duplicate type, so callers
+upgrade automatically. See
+[docs/polyfill-layout.md](../../../docs/polyfill-layout.md) for the
+user-facing version of that policy.

--- a/.agents/skills/polyfill-dotnet-api/gotchas.md
+++ b/.agents/skills/polyfill-dotnet-api/gotchas.md
@@ -1,0 +1,63 @@
+# Gotchas seen in past PRs
+
+Detail for the [polyfill-dotnet-api](SKILL.md) skill. The
+[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist enforces these;
+this page explains *why*.
+
+## 1. Empty-span pinning yields `null`
+
+`MemoryMarshal.GetReference(default(ROS<T>))` is a null ref, so
+`fixed (T* p = ...)` produces a null pointer, and net481 BCL `T*`
+overloads typically throw `ArgumentNullException` instead of the
+canonical "destination too short". Handle empty source / empty
+destination separately before pinning. See
+[EncodingExtensions.GetBytes](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
+
+## 2. `[AggressiveInlining]` + `Unsafe.As<T, narrower>(ref param)` compares against the wrong constant on net481
+
+When the caller passes a literal of a *signed* primitive narrower than
+`int` (`sbyte`, `short`), C# `int`-promotion sign-extends it (`(sbyte)-1`
+becomes `0xFFFFFFFF`). If the called method is `[AggressiveInlining]` and
+reinterprets the parameter via `Unsafe.As<T, byte>(ref oldValue)` to
+compare against bytes loaded with `movzx`, RyuJIT propagates the
+*int-promoted* constant into the compare immediate (`cmp ecx, 0xFFFFFFFF`)
+instead of the requested byte (`0xFF`). The `movzx`-loaded byte is in
+`[0, 0xFF]` so the compare is *unconditionally false* - the loop runs
+silently doing nothing in Release. Debug passes (no inlining). Confirmed
+by disassembly in
+[ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs).
+
+**Fix:** explicitly mask in the int domain so RyuJIT must fold the high
+bits to zero. The cast alone is not enough - the JIT's constant tracker
+doesn't model the `conv.u1` IL op as truncating to `[0, 0xFF]` here. Use:
+
+```csharp
+byte oldByte = (byte)(Unsafe.As<T, byte>(ref oldValue) & 0xFF);
+ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
+```
+
+See [SpanExtensions.Replace.cs](../../../touki/Framework/Polyfills/System/SpanExtensions.Replace.cs)
+for the in-place version, and the
+[ReplaceUnsafeAsPerf](../../../touki.perf/ReplaceUnsafeAsPerf.cs)
+benchmark for the disassembly proof. The unsigned cases (`byte`,
+`ushort`, `char`) are unaffected because their int-promoted form already
+has the upper bits zero. Tests on signed inputs are essential - symmetric
+tests that only use `byte`/`char` will not catch this.
+
+## 3. `Random.NextBytes(byte[])` is native on net481
+
+The obvious managed span loop is slower per byte (loses to `byte[]` + copy
+by ~1.2&times; on big buffers despite saving the alloc). Use a pinned
+pointer loop and only on the type-exact fast path; subclasses go through
+the array overload. See
+[RandomExtensions](../../../touki/Framework/Polyfills/System/RandomExtensions.cs).
+
+## 4. `HashCode` is process-local
+
+No cross-runtime parity contract; only assert within-process determinism.
+
+## 5. `net472` vs `net481` phrasing
+
+Polyfill assembly TFM is `net472` (`$(DotNetFrameworkVersion)`); test TFM
+is `net481` for richer GC APIs but consumes the `net472` polyfill. Don't
+call the polyfill "net481-only" in commits or PR descriptions.

--- a/.agents/skills/polyfill-dotnet-api/source-selection.md
+++ b/.agents/skills/polyfill-dotnet-api/source-selection.md
@@ -1,0 +1,72 @@
+# Source preference order
+
+Detail for the [polyfill-dotnet-api](SKILL.md) skill. Work the list below in
+order; stop at the first hit. Don't add a hand polyfill for something a
+Microsoft package or PolySharp already ships.
+
+## 1. Microsoft-shipped NuGet packages
+
+Probe before polyfilling: write a tiny `#if NETFRAMEWORK` snippet in
+`touki.tests/Framework/` that calls the candidate API and try a `net472`
+build. If it compiles, a referenced package already supplies the member;
+delete the probe.
+
+| Package | Covers | Referenced |
+| --- | --- | --- |
+| `System.Memory` | `Span<T>` / `ReadOnlySpan<T>` / `Memory<T>`, base `MemoryExtensions`, `MemoryMarshal`, `Unsafe`, `BinaryPrimitives`, `ArrayPool<T>` | yes |
+| `Microsoft.Bcl.Memory` | `Range`, `Index`, newer `MemoryExtensions` (`Count`, `CommonPrefixLength`, `ContainsAnyExcept`, `IsWhiteSpace`) | yes |
+| `Microsoft.Bcl.HashCode` | `HashCode` | yes |
+| `Microsoft.IO.Redist` | .NET 6 `System.IO` (via `global using Microsoft.IO;`) | yes |
+| `Microsoft.Bcl.AsyncInterfaces` | `IAsyncEnumerable<T>`, `IAsyncDisposable`, async-returning interfaces | not yet |
+| `Microsoft.Bcl.TimeProvider` | `TimeProvider`, `ITimer` | not yet |
+| `Microsoft.Bcl.Numerics` | `Half`, `BigInteger` additions | not yet |
+
+When adding a new package, place the `<PackageReference>` inside the
+`Condition="'$(TargetFramework)' == '$(DotNetFrameworkVersion)'"`
+ItemGroup - never unconditional.
+
+## 2. PolySharp source-generated polyfills
+
+[PolySharp](https://github.com/Sergio0694/PolySharp) (referenced for the
+.NET Framework target only) supplies **language / compiler attributes**,
+not runtime types. Use it for `IsExternalInit`, `RequiredMember`,
+`CompilerFeatureRequired`, `CallerArgumentExpression`,
+`ModuleInitializerAttribute`, `SkipLocalsInit`, and the nullable
+attributes (`NotNullWhen`, `MaybeNullWhen`, `MemberNotNull`,
+`DoesNotReturn`, ...).
+
+The repo enables:
+
+```xml
+<PolySharpUsePublicAccessibilityForGeneratedTypes>true</PolySharpUsePublicAccessibilityForGeneratedTypes>
+<PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
+```
+
+Don't hand-write attribute polyfills; PolySharp generates them.
+
+## 3. Hand-rolled polyfill in `touki/Framework/Polyfills/<BclNamespace>/`
+
+Last resort, when a runtime member (instance method, static helper,
+ctor) isn't supplied by a package and isn't an attribute. Polyfill only
+when there's a real caller; "completeness" polyfills bloat the surface.
+
+- **Folder = BCL namespace, dotted.** `System.Convert` &rarr;
+  `touki/Framework/Polyfills/System/ConvertExtensions.cs`.
+  `System.Text.Encoding` &rarr;
+  `touki/Framework/Polyfills/System.Text/EncodingExtensions.cs`.
+  `System.Security.Cryptography.CryptographicOperations` &rarr;
+  `touki/Framework/Polyfills/System.Security.Cryptography/CryptographicOperations.cs`.
+- **`namespace` matches the folder.** `Polyfills/System/Foo.cs` declares
+  `namespace System;`, `Polyfills/System.Text/Foo.cs` declares
+  `namespace System.Text;`. Callers reach the polyfill through the same
+  `using` they already had for the BCL type.
+- **Use C# 14 `extension` blocks** (e.g. `extension(Encoding encoding) { ... }`)
+  rather than static-class extension methods. Lookup picks the BCL
+  member on modern .NET and the polyfill on net472. See
+  [ConvertExtensions.cs](../../../touki/Framework/Polyfills/System/ConvertExtensions.cs).
+- **Don't `#if NETFRAMEWORK` inside `touki/Framework/`** - the
+  whole folder is already framework-only.
+- **Touki-specific helpers (not polyfills)** live in
+  `touki/Framework/Touki/...` with `Touki.*` namespaces. If your file
+  isn't shadowing a public modern .NET BCL member, it doesn't go under
+  `Polyfills/`.

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pre-pr-self-review
 description: Self-review checklist before opening a PR. Use before invoking `create-pr`, when reviewing your own draft, or when a reviewer flags issues that should have been caught earlier. Codifies recurring mistakes from this repo's polyfill work: missing tests for new public surface, unchecked length sums, null-pointer foot-guns from `MemoryMarshal.GetReference` on empty spans, drift from `ArgumentNullException.ThrowIfNull` and `checked()` conventions, TFM phrasing errors, and stale PR descriptions.
+metadata:
+  portability: semi-portable
 ---
 
 # Pre-PR self-review
@@ -19,9 +21,9 @@ the skill whenever a reviewer flags something not yet listed.
 - [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - the
   follow-up workflow that re-runs this checklist after review comments.
 - [`performance-testing`](../performance-testing/SKILL.md) - benchmark
-  authoring required by &sect;7 when a perf claim drives a code change.
+  authoring required when a perf claim drives a code change.
 - [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
-  - net481 RyuJIT tradeoffs cited in &sect;5 and &sect;7.
+  - net481 RyuJIT tradeoffs cited in the polyfill-correctness items.
 - [`agent-files-review`](../agent-files-review/SKILL.md) - for any
   changes under `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`.
 - [`security-review`](../security-review/SKILL.md) - the
@@ -52,7 +54,7 @@ For each new `public` (or `InternalsVisibleTo`-internal) member:
   differing-content, length mismatch, both empty, one empty, and a long
   span where only the last byte differs.
 - Allocating APIs (`Concat`, `ToHexString`): include an
-  `OverflowException` test on the length sum (see &sect;3).
+  `OverflowException` test on the length sum.
 
 Test hygiene for the tests themselves - the recurring miss list
 that costs the most review rounds on coverage-only PRs:
@@ -76,115 +78,25 @@ that costs the most review rounds on coverage-only PRs:
   See the "Culture-sensitive assertions" section in
   `tests.instructions.md`.
 
-## 2. Empty / null spans before `unsafe` interop
+## 2. Polyfill / framework correctness
 
-`MemoryMarshal.GetReference(default(ReadOnlySpan<T>))` is a null ref.
-`fixed (T* p = &nullRef)` produces a null pointer, and BCL `T*` overloads
-on net481 typically throw `ArgumentNullException` instead of the canonical
-"destination too short" / "source empty" exception the modern span
-overloads produce.
+For any change under `touki/Framework/`, walk the
+[polyfill-correctness.md](polyfill-correctness.md) items:
 
-Before pinning:
+- Empty / null spans handled before `unsafe` interop (empty source,
+  empty destination, both empty; exception type cross-checked).
+- Multi-input length sums wrapped in `checked()`.
+- Throw helpers use the standard BCL exceptions, not custom types.
+- Span overloads stay allocation-free by default (document any
+  trade-off in `<remarks>`).
+- Behavior parity with the modern BCL (exception type and message
+  family, edge cases, type-exact fast paths).
+- Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT)
+  and are measured or explicitly marked unmeasured.
 
-- Both empty &rarr; return the zero-length result without pinning.
-- Source non-empty, destination empty &rarr; pass a stack-allocated
-  non-null pointer with length 0
-  (`byte stack = 0; return Foo(src, &stack, 0);`).
-- Source empty &rarr; return the empty result without pinning.
-- Cross-check the resulting exception type against the modern BCL.
+If the change is not under `touki/Framework/`, skip to &sect;3.
 
-## 3. Multi-input length sums are `checked()`
-
-Any public API summing lengths before allocating wraps the sum in
-`checked()`. Unchecked overflow allocates the wrong-sized buffer and
-fails later from `CopyTo`. See
-[touki.tests/System/StringExtensionsConcatTests.cs](../../../touki.tests/System/StringExtensionsConcatTests.cs)
-for the canonical `OverflowException` test pattern.
-
-## 4. Throw helpers
-
-- Null guards use `ArgumentNullException.ThrowIfNull(arg)` - the
-  polyfill at
-  [touki/Framework/Polyfills/System/ArgumentNullExtensions.cs](../../../touki/Framework/Polyfills/System/ArgumentNullExtensions.cs)
-  covers net472.
-- Range checks use `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when
-  available; fall back to `(uint)x > (uint)max`.
-- Match the BCL exception type for parity. New custom exception types
-  are almost never the right answer in a polyfill.
-
-## 5. Span overloads prefer fewer allocations over raw speed
-
-The whole reason callers reach for a span overload is to avoid the
-allocation the array overload makes. A polyfill that allocates a temp
-`T[]` to delegate to the BCL has thrown that benefit away.
-
-**Default to allocation-free, even if 5-15% slower.** Document
-the trade-off in `<remarks>` so callers understand the choice.
-
-Strategies used elsewhere in this repo (look here before inventing a
-new one):
-
-- **`stackalloc` for small bounded buffers.** Always pair with
-  [`Touki.Buffers.BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs)
-  so the buffer transparently grows into an `ArrayPool<T>` rental if it
-  doesn't fit. Usage: `using BufferScope<char> buffer = new(stackalloc char[64]);`
-- **`ArrayPool<T>.Shared.Rent` / `Return`** for unbounded buffers. See
-  [`Touki.Collections.ArrayPoolList<T>`](../../../touki/Touki/Collections/ArrayPoolList.cs)
-  for the rental + clear-on-return pattern (clear only when `T` contains
-  references).
-- **Pinned write into `new string('\0', length)`.** Allocates one final
-  string with no temp `char[]`; see
-  [`StringExtensions.Concat`](../../../touki/Framework/Polyfills/System/StringExtensions.cs)
-  and `Convert.ToHexString` for the `fixed (char* p = result)` pattern.
-- **Pinned `unsafe` pass-through to BCL `T*` overloads** when the BCL
-  doesn't expose a span variant. See
-  [`EncodingExtensions`](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
-- **`MemoryMarshal.AsBytes` / `AsRef` / `GetArrayDataReference`** to
-  reinterpret without copying.
-- **Type-exact runtime check + inline path for the base type**, with
-  fallback through the virtual member for subclasses (see
-  [`RandomExtensions.NextBytes`](../../../touki/Framework/Polyfills/System/RandomExtensions.cs)).
-- **`InternalsVisibleTo` to the test project** so you can test
-  internal helpers directly without exposing them in the public API.
-
-If the only way to be allocation-free is to call an `internal` BCL API,
-allocate - do not reflect into the BCL.
-
-## 6. Behavior parity with the modern BCL
-
-- Read modern .NET docs / reference source for edge cases (empty / null
-  inputs, length-zero destination, exception types and message family).
-- Mirror the BCL exception type and message family for observable cases.
-- For stateful types (`HashCode`, `Random`), document any deviation in
-  `<remarks>`. `HashCode` is process-local in the BCL too -
-  within-process determinism is the only contract.
-- For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
-  the polyfill's fast path applies only when
-  `typeof(T) == obj.GetType()`; subclasses must dispatch through the
-  virtual member.
-
-## 7. Performance claims name the JIT and are measured
-
-State which JIT - **net481 RyuJIT** (no tiered JIT, no PGO, no
-`EqualityComparer<T>.Default` intrinsic, weaker inlining) vs **modern
-.NET RyuJIT** (.NET 6+, tiered, PGO, devirtualizes
-`EqualityComparer<T>.Default`). Unqualified "RyuJIT does X" claims are
-wrong about half the time on this repo. The
-[`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
-skill catalogues which optimizations actually win on net481.
-
-For code changes in `touki/Framework/` driven by a perf claim:
-
-- Add a benchmark in `touki.perf/` per the
-  [`performance-testing`](../performance-testing/SKILL.md) skill, *or*
-- Include a statement in the commit message, the PR description, or the
-  method's `<remarks>` explicitly indicating that no performance
-  measurements were conducted.
-
-If a polyfill is slower than the array-taking BCL it shadows, quantify
-the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
-
-## 8. PR description matches reality
+## 3. PR description matches reality
 
 - TFM phrasing: the polyfill TFM is `$(DotNetFrameworkVersion)` =
   `net472`. The test project's `net481` TFM is just where it runs. Do
@@ -201,7 +113,7 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
 - "Deliberately deferred" entries match what's actually absent from
   the working tree.
 
-## 9. Final audit before staging
+## 4. Final audit before staging
 
 - `git status --short` - delete leftover probe / scratch files;
   confirm every listed file belongs in the change set.
@@ -226,13 +138,13 @@ the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.
   (`cmp ecx, 0xFFFFFFFF` instead of `cmp ecx, 0xFF`) for negative
   signed-primitive inputs on net481, but only in Release. Mask
   explicitly with `& 0xFF` / `& 0xFFFF`. See
-  [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) &sect;Gotchas
-  and [`framework-jit-optimization/specialization.md`](../framework-jit-optimization/specialization.md).
+  [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) and
+  [`polyfill-correctness.md`](polyfill-correctness.md).
 - Stage **by path**, never `git add -A` / `git add .` when the working
   tree spans more than one logical change. If topics are intermingled,
   ask before staging.
 
-## 10. Failing CI is a stop, not a sprint
+## 5. Failing CI is a stop, not a sprint
 
 When a build / test / CI run fails on a PR:
 
@@ -244,9 +156,16 @@ When a build / test / CI run fails on a PR:
 Stacked rapid-fire fix commits are how perf regressions and unrelated
 sweep-ups get into history.
 
-## 11. Update this skill
+## 6. Update this skill
 
 If a reviewer flags something not in this checklist, add it. If the
 review touched `.agents/` files, also update via the
 [`agent-files-review`](../agent-files-review/SKILL.md) workflow so the
 validator and CI mirror stay in sync.
+
+## Sub-pages
+
+- [polyfill-correctness.md](polyfill-correctness.md) - the deep
+  per-item detail for &sect;2 (empty-span pinning, `checked()` sums,
+  throw helpers, allocation-free strategies, BCL parity, JIT-naming),
+  with the code patterns and reference files.

--- a/.agents/skills/pre-pr-self-review/polyfill-correctness.md
+++ b/.agents/skills/pre-pr-self-review/polyfill-correctness.md
@@ -1,0 +1,114 @@
+# Polyfill correctness items
+
+Detail for the [pre-pr-self-review](SKILL.md) checklist. These items apply to
+any change under `touki/Framework/` (a polyfill or a framework-only fast path).
+The [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) skill sets the
+design rules; this page is the pre-PR verification of them.
+
+## Empty / null spans before `unsafe` interop
+
+`MemoryMarshal.GetReference(default(ReadOnlySpan<T>))` is a null ref.
+`fixed (T* p = &nullRef)` produces a null pointer, and BCL `T*` overloads
+on net481 typically throw `ArgumentNullException` instead of the canonical
+"destination too short" / "source empty" exception the modern span
+overloads produce.
+
+Before pinning:
+
+- Both empty &rarr; return the zero-length result without pinning.
+- Source non-empty, destination empty &rarr; pass a stack-allocated
+  non-null pointer with length 0
+  (`byte stack = 0; return Foo(src, &stack, 0);`).
+- Source empty &rarr; return the empty result without pinning.
+- Cross-check the resulting exception type against the modern BCL.
+
+## Multi-input length sums are `checked()`
+
+Any public API summing lengths before allocating wraps the sum in
+`checked()`. Unchecked overflow allocates the wrong-sized buffer and
+fails later from `CopyTo`. See
+[touki.tests/System/StringExtensionsConcatTests.cs](../../../touki.tests/System/StringExtensionsConcatTests.cs)
+for the canonical `OverflowException` test pattern.
+
+## Throw helpers
+
+- Null guards use `ArgumentNullException.ThrowIfNull(arg)` - the
+  polyfill at
+  [touki/Framework/Polyfills/System/ArgumentNullExtensions.cs](../../../touki/Framework/Polyfills/System/ArgumentNullExtensions.cs)
+  covers net472.
+- Range checks use `ThrowIfNegative` / `ThrowIfGreaterThan` / etc. when
+  available; fall back to `(uint)x > (uint)max`.
+- Match the BCL exception type for parity. New custom exception types
+  are almost never the right answer in a polyfill.
+
+## Span overloads prefer fewer allocations over raw speed
+
+The whole reason callers reach for a span overload is to avoid the
+allocation the array overload makes. A polyfill that allocates a temp
+`T[]` to delegate to the BCL has thrown that benefit away.
+
+**Default to allocation-free, even if 5-15% slower.** Document
+the trade-off in `<remarks>` so callers understand the choice.
+
+Strategies used elsewhere in this repo (look here before inventing a
+new one):
+
+- **`stackalloc` for small bounded buffers.** Always pair with
+  [`Touki.Buffers.BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs)
+  so the buffer transparently grows into an `ArrayPool<T>` rental if it
+  doesn't fit. Usage: `using BufferScope<char> buffer = new(stackalloc char[64]);`
+- **`ArrayPool<T>.Shared.Rent` / `Return`** for unbounded buffers. See
+  [`Touki.Collections.ArrayPoolList<T>`](../../../touki/Touki/Collections/ArrayPoolList.cs)
+  for the rental + clear-on-return pattern (clear only when `T` contains
+  references).
+- **Pinned write into `new string('\0', length)`.** Allocates one final
+  string with no temp `char[]`; see
+  [`StringExtensions.Concat`](../../../touki/Framework/Polyfills/System/StringExtensions.cs)
+  and `Convert.ToHexString` for the `fixed (char* p = result)` pattern.
+- **Pinned `unsafe` pass-through to BCL `T*` overloads** when the BCL
+  doesn't expose a span variant. See
+  [`EncodingExtensions`](../../../touki/Framework/Polyfills/System.Text/EncodingExtensions.cs).
+- **`MemoryMarshal.AsBytes` / `AsRef` / `GetArrayDataReference`** to
+  reinterpret without copying.
+- **Type-exact runtime check + inline path for the base type**, with
+  fallback through the virtual member for subclasses (see
+  [`RandomExtensions.NextBytes`](../../../touki/Framework/Polyfills/System/RandomExtensions.cs)).
+- **`InternalsVisibleTo` to the test project** so you can test
+  internal helpers directly without exposing them in the public API.
+
+If the only way to be allocation-free is to call an `internal` BCL API,
+allocate - do not reflect into the BCL.
+
+## Behavior parity with the modern BCL
+
+- Read modern .NET docs / reference source for edge cases (empty / null
+  inputs, length-zero destination, exception types and message family).
+- Mirror the BCL exception type and message family for observable cases.
+- For stateful types (`HashCode`, `Random`), document any deviation in
+  `<remarks>`. `HashCode` is process-local in the BCL too -
+  within-process determinism is the only contract.
+- For overridable members (`Random.NextBytes`, `Encoding.GetBytes`),
+  the polyfill's fast path applies only when
+  `typeof(T) == obj.GetType()`; subclasses must dispatch through the
+  virtual member.
+
+## Performance claims name the JIT and are measured
+
+State which JIT - **net481 RyuJIT** (no tiered JIT, no PGO, no
+`EqualityComparer<T>.Default` intrinsic, weaker inlining) vs **modern
+.NET RyuJIT** (.NET 6+, tiered, PGO, devirtualizes
+`EqualityComparer<T>.Default`). Unqualified "RyuJIT does X" claims are
+wrong about half the time on this repo. The
+[`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
+skill catalogues which optimizations actually win on net481.
+
+For code changes in `touki/Framework/` driven by a perf claim:
+
+- Add a benchmark in `touki.perf/` per the
+  [`performance-testing`](../performance-testing/SKILL.md) skill, *or*
+- Include a statement in the commit message, the PR description, or the
+  method's `<remarks>` explicitly indicating that no performance
+  measurements were conducted.
+
+If a polyfill is slower than the array-taking BCL it shadows, quantify
+the overhead in `<remarks>` and keep the benchmark file in `touki.perf/`.

--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: publish-release
 description: Publish a new version of `KlutzyNinja.Touki` or `KlutzyNinja.Touki.TestSupport` to NuGet by cutting a release tag. Use when asked to "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", or "tag and publish". Walks the user through choosing the right `Major.Minor.Patch` bump, deciding whether to stay in `alpha` / `beta` / `rc` / stable, picking the correct tag stream (`v*` vs `ts-v*`), pushing the tag, and creating the matching GitHub release. Vets when an `AssemblyVersion`-changing bump is required (binary breaking changes vs additive/bugfix work).
+metadata:
+  portability: repo-specific
 ---
 
 # Publish a release
@@ -25,8 +27,20 @@ typo) before any pack/push runs.
 
 **Approval scope.** "Publish a release" authorizes preparing the tag and
 release notes. It does **not** authorize the tag push. The
-**Approval checkpoint** in step 6 is the gate. See AGENTS.md
+**Approval checkpoint** below is the gate. See AGENTS.md
 § "Working with the user on changes" for the canonical rule.
+
+## Steps overview
+
+1. **Inspect repo state and confirm the package** (below).
+2. Establish the prior version on the stream - see [versioning.md](versioning.md).
+3. Decide the prerelease channel (alpha / beta / rc / stable) - [versioning.md](versioning.md).
+4. Decide `Major.Minor.Patch` and check the `AssemblyVersion` gotcha - [versioning.md](versioning.md).
+5. Compose and validate the tag against the workflow regex - [versioning.md](versioning.md).
+6. **Approval checkpoint** (below) - stop and wait for an explicit publish verb.
+7. Create and push the tag, then watch the workflow - see [release-steps.md](release-steps.md).
+8. Create the GitHub release from the notes template - [release-steps.md](release-steps.md).
+9. Aftercare (sample version bump, TestSupport lockstep) - [release-steps.md](release-steps.md).
 
 ## 1. Inspect repo state and confirm the package
 
@@ -51,149 +65,10 @@ Ask the user **which package** if not already obvious from the request:
 Use `vscode_askQuestions` only if ambiguous; if the user said "publish
 TestSupport" or similar, skip the prompt.
 
-## 2. Establish the prior version on this stream
+Then work through steps 2-5 in [versioning.md](versioning.md) to land on a
+validated tag.
 
-Different streams have different prior tags. List the most recent five tags
-on the relevant prefix:
-
-```pwsh
-# Main package
-git tag --list 'v*' --sort=-creatordate | Select-Object -First 5
-
-# TestSupport
-git tag --list 'ts-v*' --sort=-creatordate | Select-Object -First 5
-```
-
-Cross-check against nuget.org so you don't accidentally re-publish a version
-that's already live (publishing is idempotent thanks to `--skip-duplicate`,
-but choosing a duplicate is almost always a mistake):
-
-- <https://www.nuget.org/packages/KlutzyNinja.Touki>
-- <https://www.nuget.org/packages/KlutzyNinja.Touki.TestSupport>
-
-Record the prior version (e.g. `0.1.0-alpha.12` for the main package).
-
-If TestSupport has **no** `ts-v*` tags yet, the next published version becomes
-the bootstrap of that stream. The previously-published version on nuget.org
-under the old scheme was `0.1.0-alpha.8.11`; pick a `ts-v` tag that sorts
-strictly higher (e.g. `ts-v0.1.0-alpha.9` or higher).
-
-## 3. Decide the prerelease channel (alpha / beta / rc / stable)
-
-Before picking numbers, decide what *kind* of release this is. **Always
-prompt** the user with the current state explicit:
-
-> "The last release was an **alpha** (`v0.1.0-alpha.12`). Should this also
-> be an alpha release, or are you promoting to beta / rc / stable?"
-
-Use `vscode_askQuestions` with these options (mark the matching-prior option
-as `recommended: true`):
-
-- `Stay in alpha` - bug fixes / additive work during early development.
-- `Promote to beta` - feature-complete for the upcoming Minor; only
-  stabilization work expected.
-- `Promote to rc` - release candidate; only blocker bug fixes.
-- `Promote to stable` - drop the prerelease label entirely.
-- `Use a different label` - free-form.
-
-Channel rules of thumb:
-
-- Don't *skip* channels casually. `alpha → beta → rc → stable` is the
-  normal path. Going `alpha → stable` is allowed but should be deliberate.
-- Once you ship a stable `Major.Minor.Patch`, the next prerelease must
-  bump *something* (`0.1.0` → `0.1.1-alpha.1` or `0.2.0-alpha.1`); you
-  cannot ship `0.1.0-alpha.2` after `0.1.0` stable.
-- Do **not** mix channels backwards (no going from `beta` back to `alpha`
-  for the same Major.Minor.Patch). If a beta turned out to need more
-  churn, bump the underlying version: `0.2.0-beta.3` → `0.3.0-alpha.1`.
-
-## 4. Decide `Major.Minor.Patch`
-
-Apply [SemVer 2.0.0](https://semver.org) rules. The package is currently
-pre-1.0, so the rules below describe the **target stable** semantics; while
-the prior tag is itself a prerelease, the same bump table applies to the
-underlying `Major.Minor.Patch` portion.
-
-| Change shipped since the last tag | Bump |
-| --- | --- |
-| Binary breaking change to public API of `touki.dll` (removed/renamed type or member, signature change, return-type change, base-type change, broken inheritance, removed `[Obsolete]`'d API) | **Major** |
-| Behavioral break that compiles but changes observable runtime contract (different exception type, different default, different ordering, different threading guarantee) | **Major** unless the user explicitly accepts shipping it as Minor with a release-note callout |
-| Net-new public API, new overload, new optional parameter, new public type, new TFM | **Minor** |
-| Bug fix only, no new public surface, no observable contract change for non-buggy callers | **Patch** |
-| Internal-only refactor, perf, doc, comment, build, CI | **Patch** (or no release at all) |
-
-For pre-1.0, the user may treat **Major** and **Minor** as both "Minor"
-during alpha/beta. That is fine; just confirm the call out loud:
-
-> "This change adds a public type but you're still in 0.1.x alpha - bump
-> to 0.2.0-alpha.1 (treating it as Minor) or stay at 0.1.0-alpha.13?"
-
-### When `AssemblyVersion` changes - and why it matters
-
-MinVer's defaults (used as-is in this repo, no overrides) produce:
-
-- `Version` / `PackageVersion` / `InformationalVersion` = full SemVer
-  (e.g. `0.1.0-alpha.13`).
-- `FileVersion` = `Major.Minor.Patch.0` (e.g. `0.1.0.0`).
-- **`AssemblyVersion` = `Major.0.0.0`** (e.g. `0.0.0.0` for any `0.x.y`).
-
-Only a **Major** bump changes `AssemblyVersion`. That has real consequences:
-
-- A change in `AssemblyVersion` forces every consumer that has the assembly
-  in their build graph to either rebuild against the new identity or use
-  binding redirects (on .NET Framework). Strong-named assemblies make this
-  stricter, and `touki.dll` is strong-named.
-- A change in `Version`/`FileVersion` *without* `AssemblyVersion` changing
-  is binary-compatible - consumers can drop the new DLL into an existing
-  bin folder and it just works.
-
-**Therefore:** any binary breaking change *must* bump `Major`, even during
-0.x. Refusing to bump `Major` on a binary break - to "stay at 0.1.x" -
-silently keeps `AssemblyVersion = 0.0.0.0` across an incompatible
-boundary, which is a real foot-gun for downstream binders.
-
-When `Major` does bump, also note in the release that `AssemblyVersion`
-moved (`0.0.0.0` → `1.0.0.0`).
-
-## 5. Compose the tag
-
-Format (enforced by the regex guard in each workflow):
-
-```text
-v<Major>.<Minor>.<Patch>[-<prerelease>]          # main package
-ts-v<Major>.<Minor>.<Patch>[-<prerelease>]       # TestSupport
-```
-
-Prerelease segment uses dot-separated identifiers, e.g. `alpha.13`,
-`beta.2`, `rc.1`. Numeric identifiers are SemVer-sorted as numbers, so
-`alpha.10` correctly sorts above `alpha.9` (no leading zeros).
-
-Examples (good):
-
-- `v0.1.0-alpha.13`
-- `v0.2.0-beta.1`
-- `v0.2.0-rc.1`
-- `v0.2.0`
-- `v1.0.0-rc.1`
-- `ts-v0.1.0-alpha.9`
-
-Examples (rejected by guard):
-
-- `v.0.1.0-alpha.11` - stray `.` after `v`. The historical 9/10/11 tags
-  hit this; do not recreate it.
-- `0.1.0-alpha.13` - missing `v` prefix.
-- `v0.1.0.alpha.13` - `.` instead of `-` before prerelease.
-- `v0.1` - missing patch component.
-- `v01.02.03` - leading zeros in numeric identifiers.
-
-The regex used by the workflow guards (must match):
-
-```text
-^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
-^ts-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
-```
-
-## 6. Approval checkpoint
+## Approval checkpoint
 
 **Stop here.** Show the user:
 
@@ -209,120 +84,17 @@ Wait for an explicit publishing verb (`tag`, `push the tag`, `ship it`,
 `publish`). Do **not** infer approval from the original "publish a release"
 request - that authorized the *preparation*, not the push. See AGENTS.md.
 
-## 7. Create and push the tag
+After approval, follow [release-steps.md](release-steps.md) to push the tag,
+watch the workflow, and create the GitHub release.
 
-Use an annotated tag with a short message:
+## Sub-pages
 
-```pwsh
-git tag -a v0.1.0-alpha.13 -m "v0.1.0-alpha.13"
-git push origin v0.1.0-alpha.13
-```
-
-Do **not** use lightweight tags - annotated tags carry the tagger and date
-that show up in GitHub releases.
-
-Pushing the tag triggers the publish workflow. Watch the run:
-
-- <https://github.com/JeremyKuhne/touki/actions/workflows/publish.yml>
-- <https://github.com/JeremyKuhne/touki/actions/workflows/publishtestsupport.yml>
-
-The workflow validates the tag format, packs, OIDC-logs into NuGet, and
-pushes with `--skip-duplicate`. The main publish workflow filters out
-`KlutzyNinja.Touki.TestSupport.*` from its glob, and TestSupport's workflow
-fires only on `ts-v*` - they will not stomp each other.
-
-If the workflow fails, treat it like any CI failure: do **not** delete and
-re-push the tag without explicit user approval - that's destructive and the
-nuget.org publish is irreversible. Fix forward with the next tag in the
-stream.
-
-### Re-running the publish for an existing tag (`workflow_dispatch`)
-
-If a transient failure (NuGet outage, OIDC blip) leaves a tag pushed but
-not published, both workflows accept a `workflow_dispatch` with a
-required `tag` input. Provide the **exact existing tag name** (e.g.
-`v0.1.0-alpha.13` or `ts-v0.1.0-alpha.9`); the workflow checks out that
-ref, runs the same tag-format guard, and publishes. Do **not** dispatch
-without a tag input - the workflow will fail validation rather than
-publish a `0.0.0-alpha.0.<height>` MinVer fallback.
-
-## 8. Create the GitHub release
-
-Once the workflow has succeeded and the package is visible on nuget.org,
-create the matching GitHub release. This is what users actually read.
-
-Use `mcp_io_github_git_get_latest_release` first to find the prior release
-on the same stream, so the new release notes can reference it. Then create
-via the GitHub UI or `gh release create` (preferred when available):
-
-```pwsh
-gh release create v0.1.0-alpha.13 `
-  --title "v0.1.0-alpha.13" `
-  --notes-file release-notes.md `
-  --prerelease   # omit for a stable release
-```
-
-If `gh` is not available, use the GitHub web UI (Releases → Draft a new
-release → choose the existing tag).
-
-### Release notes template
-
-````markdown
-## Changes
-
-<!-- One-sentence headline of the most important change. -->
-
-### Added
-- ...
-
-### Changed
-- ...
-
-### Fixed
-- ...
-
-### Breaking changes
-<!-- Only present on Major bumps. AssemblyVersion changed from
-     0.0.0.0 → 1.0.0.0; consumers must rebuild. -->
-- ...
-
-## Compatibility
-
-- Targets: `net10.0`, `net472`.
-- AssemblyVersion: `<old>` → `<new>` (note **changed** or **unchanged**).
-
-## Install
-
-```bash
-dotnet add package KlutzyNinja.Touki --version 0.1.0-alpha.13
-```
-
-**Full changelog:** <https://github.com/JeremyKuhne/touki/compare/v0.1.0-alpha.12...v0.1.0-alpha.13>
-````
-
-Notes on the template:
-
-- Use the **same** `--prerelease` flag iff the SemVer has a prerelease label.
-  GitHub displays prereleases differently (latest indicator stays on the
-  most recent stable). Skipping `--prerelease` on an alpha is a real bug.
-- `compare/<prior>...<new>` works across both streams (just substitute
-  `ts-v...` for TestSupport).
-- For TestSupport releases, also call out the Touki version this build was
-  produced against (look at the resolved `<dependency>` in the published
-  `.nuspec`); that's what consumers will transitively pull.
-
-## 9. Aftercare
-
-- If you bumped `KlutzyNinja.Touki`, consider whether the sample's pinned
-  version in [Directory.Packages.props](../../../Directory.Packages.props)
-  should advance. The sample dog-foods the released package; leaving it
-  stale defeats the purpose. (Open as a follow-up PR - not part of the
-  release commit/tag.)
-- If you bumped `Major` (binary break), also bump `Major` of TestSupport
-  on its next release. They don't have to march in lockstep but TestSupport
-  cannot consume an incompatible Touki.
-- Update [touki.testsupport/README.md](../../../touki.testsupport/README.md)
-  if the supported targets or AOT story changed.
+- [versioning.md](versioning.md) - establishing the prior version, the
+  prerelease channel decision, the `Major.Minor.Patch` bump table, the
+  `AssemblyVersion` gotcha, and the exact tag format with its regex guard.
+- [release-steps.md](release-steps.md) - creating and pushing the annotated
+  tag, `workflow_dispatch` recovery, the GitHub release notes template, and
+  aftercare.
 
 ## Cross-references
 
@@ -331,7 +103,7 @@ Notes on the template:
 - [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - used to land
   the changes that this skill then ships.
 - AGENTS.md § "Working with the user on changes" - publish-boundary rule
-  governing the approval checkpoint in step 6.
+  governing the approval checkpoint.
 - [Directory.Build.targets](../../../Directory.Build.targets) - central
   MinVer wiring.
 - [.github/workflows/publish.yml](../../../.github/workflows/publish.yml),

--- a/.agents/skills/publish-release/release-steps.md
+++ b/.agents/skills/publish-release/release-steps.md
@@ -50,10 +50,11 @@ on the same stream, so the new release notes can reference it. Then create
 via the GitHub UI or `gh release create` (preferred when available):
 
 ```pwsh
+# Drop the --prerelease flag for a stable release.
 gh release create v0.1.0-alpha.13 `
   --title "v0.1.0-alpha.13" `
   --notes-file release-notes.md `
-  --prerelease   # omit for a stable release
+  --prerelease
 ```
 
 If `gh` is not available, use the GitHub web UI (Releases → Draft a new

--- a/.agents/skills/publish-release/release-steps.md
+++ b/.agents/skills/publish-release/release-steps.md
@@ -1,0 +1,119 @@
+# Tag, publish, and aftercare
+
+Detail for the [publish-release](SKILL.md) skill. These steps run **only after**
+the approval checkpoint in the core has passed.
+
+## 1. Create and push the tag
+
+Use an annotated tag with a short message:
+
+```pwsh
+git tag -a v0.1.0-alpha.13 -m "v0.1.0-alpha.13"
+git push origin v0.1.0-alpha.13
+```
+
+Do **not** use lightweight tags - annotated tags carry the tagger and date
+that show up in GitHub releases.
+
+Pushing the tag triggers the publish workflow. Watch the run:
+
+- <https://github.com/JeremyKuhne/touki/actions/workflows/publish.yml>
+- <https://github.com/JeremyKuhne/touki/actions/workflows/publishtestsupport.yml>
+
+The workflow validates the tag format, packs, OIDC-logs into NuGet, and
+pushes with `--skip-duplicate`. The main publish workflow filters out
+`KlutzyNinja.Touki.TestSupport.*` from its glob, and TestSupport's workflow
+fires only on `ts-v*` - they will not stomp each other.
+
+If the workflow fails, treat it like any CI failure: do **not** delete and
+re-push the tag without explicit user approval - that's destructive and the
+nuget.org publish is irreversible. Fix forward with the next tag in the
+stream.
+
+### Re-running the publish for an existing tag (`workflow_dispatch`)
+
+If a transient failure (NuGet outage, OIDC blip) leaves a tag pushed but
+not published, both workflows accept a `workflow_dispatch` with a
+required `tag` input. Provide the **exact existing tag name** (e.g.
+`v0.1.0-alpha.13` or `ts-v0.1.0-alpha.9`); the workflow checks out that
+ref, runs the same tag-format guard, and publishes. Do **not** dispatch
+without a tag input - the workflow will fail validation rather than
+publish a `0.0.0-alpha.0.<height>` MinVer fallback.
+
+## 2. Create the GitHub release
+
+Once the workflow has succeeded and the package is visible on nuget.org,
+create the matching GitHub release. This is what users actually read.
+
+Use `mcp_io_github_git_get_latest_release` first to find the prior release
+on the same stream, so the new release notes can reference it. Then create
+via the GitHub UI or `gh release create` (preferred when available):
+
+```pwsh
+gh release create v0.1.0-alpha.13 `
+  --title "v0.1.0-alpha.13" `
+  --notes-file release-notes.md `
+  --prerelease   # omit for a stable release
+```
+
+If `gh` is not available, use the GitHub web UI (Releases → Draft a new
+release → choose the existing tag).
+
+### Release notes template
+
+````markdown
+## Changes
+
+<!-- One-sentence headline of the most important change. -->
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+### Breaking changes
+<!-- Only present on Major bumps. AssemblyVersion changed from
+     0.0.0.0 → 1.0.0.0; consumers must rebuild. -->
+- ...
+
+## Compatibility
+
+- Targets: `net10.0`, `net472`.
+- AssemblyVersion: `<old>` → `<new>` (note **changed** or **unchanged**).
+
+## Install
+
+```bash
+dotnet add package KlutzyNinja.Touki --version 0.1.0-alpha.13
+```
+
+**Full changelog:** <https://github.com/JeremyKuhne/touki/compare/v0.1.0-alpha.12...v0.1.0-alpha.13>
+````
+
+Notes on the template:
+
+- Use the **same** `--prerelease` flag iff the SemVer has a prerelease label.
+  GitHub displays prereleases differently (latest indicator stays on the
+  most recent stable). Skipping `--prerelease` on an alpha is a real bug.
+- `compare/<prior>...<new>` works across both streams (just substitute
+  `ts-v...` for TestSupport).
+- For TestSupport releases, also call out the Touki version this build was
+  produced against (look at the resolved `<dependency>` in the published
+  `.nuspec`); that's what consumers will transitively pull.
+
+## 3. Aftercare
+
+- If you bumped `KlutzyNinja.Touki`, consider whether the sample's pinned
+  version in [Directory.Packages.props](../../../Directory.Packages.props)
+  should advance. The sample dog-foods the released package; leaving it
+  stale defeats the purpose. (Open as a follow-up PR - not part of the
+  release commit/tag.)
+- If you bumped `Major` (binary break), also bump `Major` of TestSupport
+  on its next release. They don't have to march in lockstep but TestSupport
+  cannot consume an incompatible Touki.
+- Update [touki.testsupport/README.md](../../../touki.testsupport/README.md)
+  if the supported targets or AOT story changed.

--- a/.agents/skills/publish-release/versioning.md
+++ b/.agents/skills/publish-release/versioning.md
@@ -1,0 +1,147 @@
+# Choosing the version and composing the tag
+
+Detail for the [publish-release](SKILL.md) skill. Covers establishing the prior
+version, the prerelease channel decision, the `Major.Minor.Patch` bump, the
+`AssemblyVersion` gotcha, and the exact tag format.
+
+## 1. Establish the prior version on this stream
+
+Different streams have different prior tags. List the most recent five tags
+on the relevant prefix:
+
+```pwsh
+# Main package
+git tag --list 'v*' --sort=-creatordate | Select-Object -First 5
+
+# TestSupport
+git tag --list 'ts-v*' --sort=-creatordate | Select-Object -First 5
+```
+
+Cross-check against nuget.org so you don't accidentally re-publish a version
+that's already live (publishing is idempotent thanks to `--skip-duplicate`,
+but choosing a duplicate is almost always a mistake):
+
+- <https://www.nuget.org/packages/KlutzyNinja.Touki>
+- <https://www.nuget.org/packages/KlutzyNinja.Touki.TestSupport>
+
+Record the prior version (e.g. `0.1.0-alpha.12` for the main package).
+
+If TestSupport has **no** `ts-v*` tags yet, the next published version becomes
+the bootstrap of that stream. The previously-published version on nuget.org
+under the old scheme was `0.1.0-alpha.8.11`; pick a `ts-v` tag that sorts
+strictly higher (e.g. `ts-v0.1.0-alpha.9` or higher).
+
+## 2. Decide the prerelease channel (alpha / beta / rc / stable)
+
+Before picking numbers, decide what *kind* of release this is. **Always
+prompt** the user with the current state explicit:
+
+> "The last release was an **alpha** (`v0.1.0-alpha.12`). Should this also
+> be an alpha release, or are you promoting to beta / rc / stable?"
+
+Use `vscode_askQuestions` with these options (mark the matching-prior option
+as `recommended: true`):
+
+- `Stay in alpha` - bug fixes / additive work during early development.
+- `Promote to beta` - feature-complete for the upcoming Minor; only
+  stabilization work expected.
+- `Promote to rc` - release candidate; only blocker bug fixes.
+- `Promote to stable` - drop the prerelease label entirely.
+- `Use a different label` - free-form.
+
+Channel rules of thumb:
+
+- Don't *skip* channels casually. `alpha → beta → rc → stable` is the
+  normal path. Going `alpha → stable` is allowed but should be deliberate.
+- Once you ship a stable `Major.Minor.Patch`, the next prerelease must
+  bump *something* (`0.1.0` → `0.1.1-alpha.1` or `0.2.0-alpha.1`); you
+  cannot ship `0.1.0-alpha.2` after `0.1.0` stable.
+- Do **not** mix channels backwards (no going from `beta` back to `alpha`
+  for the same Major.Minor.Patch). If a beta turned out to need more
+  churn, bump the underlying version: `0.2.0-beta.3` → `0.3.0-alpha.1`.
+
+## 3. Decide `Major.Minor.Patch`
+
+Apply [SemVer 2.0.0](https://semver.org) rules. The package is currently
+pre-1.0, so the rules below describe the **target stable** semantics; while
+the prior tag is itself a prerelease, the same bump table applies to the
+underlying `Major.Minor.Patch` portion.
+
+| Change shipped since the last tag | Bump |
+| --- | --- |
+| Binary breaking change to public API of `touki.dll` (removed/renamed type or member, signature change, return-type change, base-type change, broken inheritance, removed `[Obsolete]`'d API) | **Major** |
+| Behavioral break that compiles but changes observable runtime contract (different exception type, different default, different ordering, different threading guarantee) | **Major** unless the user explicitly accepts shipping it as Minor with a release-note callout |
+| Net-new public API, new overload, new optional parameter, new public type, new TFM | **Minor** |
+| Bug fix only, no new public surface, no observable contract change for non-buggy callers | **Patch** |
+| Internal-only refactor, perf, doc, comment, build, CI | **Patch** (or no release at all) |
+
+For pre-1.0, the user may treat **Major** and **Minor** as both "Minor"
+during alpha/beta. That is fine; just confirm the call out loud:
+
+> "This change adds a public type but you're still in 0.1.x alpha - bump
+> to 0.2.0-alpha.1 (treating it as Minor) or stay at 0.1.0-alpha.13?"
+
+### When `AssemblyVersion` changes - and why it matters
+
+MinVer's defaults (used as-is in this repo, no overrides) produce:
+
+- `Version` / `PackageVersion` / `InformationalVersion` = full SemVer
+  (e.g. `0.1.0-alpha.13`).
+- `FileVersion` = `Major.Minor.Patch.0` (e.g. `0.1.0.0`).
+- **`AssemblyVersion` = `Major.0.0.0`** (e.g. `0.0.0.0` for any `0.x.y`).
+
+Only a **Major** bump changes `AssemblyVersion`. That has real consequences:
+
+- A change in `AssemblyVersion` forces every consumer that has the assembly
+  in their build graph to either rebuild against the new identity or use
+  binding redirects (on .NET Framework). Strong-named assemblies make this
+  stricter, and `touki.dll` is strong-named.
+- A change in `Version`/`FileVersion` *without* `AssemblyVersion` changing
+  is binary-compatible - consumers can drop the new DLL into an existing
+  bin folder and it just works.
+
+**Therefore:** any binary breaking change *must* bump `Major`, even during
+0.x. Refusing to bump `Major` on a binary break - to "stay at 0.1.x" -
+silently keeps `AssemblyVersion = 0.0.0.0` across an incompatible
+boundary, which is a real foot-gun for downstream binders.
+
+When `Major` does bump, also note in the release that `AssemblyVersion`
+moved (`0.0.0.0` → `1.0.0.0`).
+
+## 4. Compose the tag
+
+Format (enforced by the regex guard in each workflow):
+
+```text
+v<Major>.<Minor>.<Patch>[-<prerelease>]          # main package
+ts-v<Major>.<Minor>.<Patch>[-<prerelease>]       # TestSupport
+```
+
+Prerelease segment uses dot-separated identifiers, e.g. `alpha.13`,
+`beta.2`, `rc.1`. Numeric identifiers are SemVer-sorted as numbers, so
+`alpha.10` correctly sorts above `alpha.9` (no leading zeros).
+
+Examples (good):
+
+- `v0.1.0-alpha.13`
+- `v0.2.0-beta.1`
+- `v0.2.0-rc.1`
+- `v0.2.0`
+- `v1.0.0-rc.1`
+- `ts-v0.1.0-alpha.9`
+
+Examples (rejected by guard):
+
+- `v.0.1.0-alpha.11` - stray `.` after `v`. The historical 9/10/11 tags
+  hit this; do not recreate it.
+- `0.1.0-alpha.13` - missing `v` prefix.
+- `v0.1.0.alpha.13` - `.` instead of `-` before prerelease.
+- `v0.1` - missing patch component.
+- `v01.02.03` - leading zeros in numeric identifiers.
+
+The regex used by the workflow guards (must match):
+
+```text
+^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
+^ts-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
+```

--- a/.agents/skills/run-tests-on-wsl/SKILL.md
+++ b/.agents/skills/run-tests-on-wsl/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: run-tests-on-wsl
 description: Run touki tests - especially the Unix-only oracle suites under `touki.tests/Touki/Io/Globbing/` - inside WSL Ubuntu on Windows. Use when the user asks to "run tests on Linux", "run the Posix/PosixPath/Bash oracles", or "iterate Unix tests locally", and for any fix that needs Linux verification before pushing.
+metadata:
+  portability: repo-specific
 ---
 
 # Running tests inside WSL Ubuntu

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: scratch-buffer-strategy
 description: Choose how a hot path gets a short-lived scratch buffer - zeroed `stackalloc`, `[SkipLocalsInit]` + `stackalloc`, `BufferScope<T>` (stack with pool fallback), or an `ArrayPool<T>.Shared` rental - and apply the net481/net10 size crossovers. Use when designing or reviewing a performance-sensitive path that needs a temporary buffer, when deciding "should I rent or stackalloc?", when weighing `[SkipLocalsInit]`, or when evaluating buffer/allocation cost. Defers the backing measurements and full reasoning to `docs/arraypool-performance.md`.
+metadata:
+  portability: semi-portable
 ---
 
 # Scratch buffer strategy (net481 + net10)

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: security-review
 description: Security-focused review of pending changes. Audit any change that could affect safety or correctness under abusive input or unchecked preconditions - oversized values, malformed structures, integer/length overflow, catastrophic backtracking, allocation pressure, other denial-of-service shapes, and any use of `unsafe` code or the `Unsafe` / `MemoryMarshal` / `Marshal` static helpers (which trade compiler safety guarantees for speed and need extra scrutiny). Add regression tests that pin safe behavior even when the current implementation already handles the input correctly. Use when asked to "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling", or before publishing any change that adds or modifies code that parses, decodes, encodes, compiles, marshals, or reinterprets memory.
+metadata:
+  portability: semi-portable
 ---
 
 # Security review
@@ -29,265 +31,50 @@ APIs** (everything the C# compiler doesn't check for you).
   preconditions drift across refactors.
 - A CVE in a comparable library prompts "do we have the same shape?".
 
-## Core principles
+## The discipline in one paragraph
 
-1. **Test safe properties, even when current code is already
-   correct.** A safe property = the method terminates within a stated
-   bound, returns a defined error for malformed input, returns the
-   documented default for empty input, doesn't read/write past the
-   buffer, or doesn't crash. These tests must pass against current
-   code; commit them as the regression lock.
-2. **Never write a test that pins observable wrong output.** A test
-   asserting "this silently truncates" locks the bug in. If current
-   code is wrong, skip the test until the fix lands and pin the
-   *corrected* output then.
-3. **Test the shape, not the specific exploit.** "Input at the
-   declared limit" lasts forever; "exact pattern that triggered CVE-X"
-   decays.
-4. **Boundary tests come in pairs.** One at the limit (succeeds), one
-   just over (fails in a defined way).
-5. **Surface findings before patching production code.** When a
-   finding needs a production change, output the options report,
-   **end your turn, and do not produce the patch or any failing test
-   on that turn**. Resume after the user replies with an approval
-   verb (`go`, `apply A`, `fix it`). Passing safe-property tests
-   (principle 1) may ship on the same turn as the report; failing
-   tests may not.
-
-### Severity rubric
-
-Label every finding before the report.
-
-- **High** - memory corruption, OOB read/write, type confusion,
-  lifetime escape, RCE, disclosure of secrets/addresses, auth bypass.
-  Fix on the same PR.
-- **Medium** - DoS (CPU, memory, stack, FDs), crashing unhandled
-  exception, parser accepting malformed input as valid, ambiguous
-  parsing that smuggles a different shape past validation. Usually
-  fix on the same PR; deferral needs a documented mitigation.
-- **Low** - silent truncation still bounded by a downstream BCL
-  slice check, documented contract violations on edge cases,
-  non-sensitive error-message leakage. Safe to defer; still pin the
-  *corrected* behavior with a regression test once the fix lands.
-
-## Audit checklist
-
-Walk every new/modified member through the categories below. The
-question is whether the *input shape* or *unchecked precondition*
-could push the code into the failure mode, not whether it currently
-does.
-
-When attention is limited, allocate it by tier:
-
-- **Critical (never skip):** &sect;1, &sect;4, &sect;7.
-- **Standard (every member):** &sect;2, &sect;5, &sect;9.
-- **Conditional (when the code shape matches):** &sect;3 (allocates
-  proportional to input), &sect;6 (encoder uses in-band sentinels),
-  &sect;8 (path-handling API).
-
-### 1. Length / size of inputs
-
-- Is there an upper bound? What stops a caller from passing a
-  multi-MB / multi-GB value?
-- Is the bound at the API boundary, not buried in a helper?
-- For composed inputs (list of strings, stream of records), is the
-  **total** size bounded, not just per-element?
-- Is the default safe for untrusted callers, with an opt-out for
-  trusted ones? See `DefaultMaxPatternLength` / `maxPatternLength`
-  in [touki/Touki/Io/Globbing/GlobSpecification.Factory.cs](../../../touki/Touki/Io/Globbing/GlobSpecification.Factory.cs).
-
-**Tests:** at-limit success, over-limit failure with documented
-error, opt-out (e.g. `-1`) disables the check.
-
-### 2. Integer / length-field overflow
-
-- Are length sums (`a.Length + b.Length`, `count * elementSize`)
-  protected by `checked()` where crafted input can overflow?
-- Are running lengths cast to a narrower type (`(char)len`,
-  `(byte)count`)? Silent truncation lets oversized fields slip
-  through and be re-read as smaller values, misdecoding downstream
-  data as structural metadata. Check the counter *before* the cast.
-
-**Tests:** boundary inside the representable range plus boundary
-outside. Specialized fast paths often bypass the affected code
-- pick an input shape that **forces the general path**.
-
-### 3. Allocation pressure / memory DoS
-
-- Does work allocate proportional to (or worse than) input size?
-- Is the worst case bounded by an explicit cap (&sect;1) or only by
-  available memory?
-- Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
-  per call (acceptable if bounded), or grow without limit (red flag)?
-
-**Tests:** a "large but legitimate" input completes within a
-`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
-Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
-allocation count.
-
-### 4. Computational complexity / algorithmic DoS
-
-- Worst-case runtime: linear, polynomial, or exponential?
-- ReDoS shape: matcher with multiple wildcards (`*`, `**`, `?(...)`,
-  alternation) that retries every wildcard on mismatch. Safe shape:
-  **fixed savepoint slots** (each new wildcard overwrites the
-  previous slot of the same kind), bounding the worst case to
-  O(n&middot;m).
-- Hashtable attacks: are user-controlled keys hashed with a
-  randomized hash (modern .NET `string.GetHashCode()` and
-  `Dictionary<,>` are per-process randomized), or a deterministic one
-  a caller could pre-image into a single bucket?
-
-**Tests** (pin the safe property):
-
-```csharp
-[Fact]
-public void Method_PathologicalInput_TerminatesPromptly()
-{
-    /* construct adversarial pattern + input */
-
-    Stopwatch sw = Stopwatch.StartNew();
-    bool result = m.IsMatch(input);
-    sw.Stop();
-
-    result.Should().Be(/* expected */);
-    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
-}
-```
-
-Add one per "we use the safe algorithm" claim; the property is
-invisible to refactors, the test is the lock.
-
-### 5. Malformed structure / parser robustness
-
-- Truncated input handled gracefully (no `IndexOutOfRangeException`
-  past the end)?
-- Unmatched opens (`[`, `{`, `(`, dangling `\\` / `%`) produce a
-  defined error, not an unrelated runtime exception?
-
-**Tests:** one per malformed shape asserting the exact error type;
-empty, single-character, and "exactly the sentinel" inputs (`""`,
-`"["`, `"\\"`).
-
-### 6. Sentinel / in-band markers colliding with input
-
-- Encoder uses in-band sentinel values (opcode chars, length prefix
-  bytes, control chars)? If user input contains those same values,
-  are they distinguishable from real structure (escaping, length
-  framing, reserved noncharacter code points)?
-
-**Test:** input containing every sentinel value used as ordinary
-data; the member treats them as data.
-
-### 7. `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, and other caller-validated APIs
-
-Mandatory whenever a PR touches one of these. The compiler offloads
-safety to you; the review *is* the safety check.
-
-For each use site answer:
-
-1. What precondition does the API require? (Read the XML doc.)
-2. Where in the calling code is it established? If it's a *different*
-   method, what stops a future refactor from desyncing them?
-3. Is the precondition still satisfied when the input is empty,
-   `null`, zero-length, or `default`? (Empty is the most common
-   blow-up.)
-
-Walk every use site against this table; rows are independent.
-
-| API pattern | Precondition (compiler does NOT check) | Failure mode if violated | Required test shape |
-| ----------- | -------------------------------------- | ------------------------ | ------------------- |
-| `MemoryMarshal.GetReference(span)` / `GetPinnableReference` / `Unsafe.AsPointer(ref span[0])` / `GetArrayDataReference` | Returned `ref` only valid when `span.Length > 0`; empty span yields the managed-null sentinel. | Crash or wild read at null. | `Method_EmptyInput_DoesNotDereferenceNullReference` returns documented default with no exception. |
-| `Unsafe.Add(ref T, int)` | Index `< span.Length` (or backing buffer element count). | OOB read leaks adjacent-page memory; OOB write corrupts heap. | One test at the last in-range index (loop guard's last iteration is the off-by-one site). |
-| `Unsafe.ReadUnaligned<T>` / `WriteUnaligned<T>` | `ref byte` points at `sizeof(T)` valid bytes; alignment is your problem. | OOB read or torn write. | Boundary tests at exactly `sizeof(T)` bytes and one less. |
-| `Unsafe.As<TFrom, TTo>(ref TFrom)` / `Unsafe.As<T>(object)` | `sizeof(TTo) <= sizeof(TFrom)`; GC reference layout matches. | Reads garbage past source; corrupts GC heap if reference layout differs. **net481 RyuJIT pitfall:** `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates the caller's int-promoted negative value into the comparison immediate. See [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md). | One test per primitive width including signed/negative values; mask with `& 0xFF` / `& 0xFFFF` if needed. |
-| `Unsafe.SkipInit<T>(out T)` | Caller fully initializes every reachable field before any read. | Stale-pointer foot-gun for ref fields; uninitialized read otherwise. | Test every code path that reads from the skip-init local. |
-| `MemoryMarshal.Cast<TFrom, TTo>` / `AsBytes` | Result length is `source.Length * sizeof(TFrom) / sizeof(TTo)`; partial elements vanish silently. | Caller treats a truncated result as the full payload. | Partial-element case (source length doesn't divide evenly). |
-| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime &le; referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
-| `fixed (T* p = ...)` | `p` valid only inside the `fixed` block. | Dangling pointer after GC relocates. | Manual review: `p` not stashed in a field, passed to `async`/iterator continuations, or returned. |
-| `stackalloc T[n]` | `n` small and bounded. | Stack-overflow DoS if `n` comes from input. | Max-allowed size succeeds; one element more is rejected before `stackalloc` runs. Use [`BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs) when input could exceed the stack budget. |
-| `[DllImport]` / `LibraryImport` | Marshaller attrs (`[MarshalAs]`, `SizeConst`, `string` vs `IntPtr`) silently change buffer sizes / ownership. | Buffer overrun, double-free, type confusion across the managed/native boundary. | Cross-check signature against native docs; re-verify on every TFM. |
-| Any BCL API whose XML doc contains "unsafe" or "caller must" | Whatever the doc specifies. | Whatever the doc warns about. | Edge case where the precondition *almost* holds (one byte short, off-by-one alignment). |
-
-### 8. Path traversal / sandbox escape
-
-- API takes a root + relative input and returns paths - results
-  stay inside the root? Symlink behavior is the caller's documented
-  choice, not silently re-enabled?
-- Caller-supplied fragments concatenated without normalization?
-  `Path.Combine` honors absolute inner segments, which is a foot-gun.
-
-**Tests:** inputs with `..` segments, absolute paths, alternate
-separators, and symlink-style names; enumerator stays inside the
-configured root.
-
-### 9. Argument validation at the boundary
-
-- `ArgumentNullException.ThrowIfNull` on every reference-type
-  parameter the contract forbids `null` for.
-- `ArgumentOutOfRangeException.ThrowIfNegative` / `ThrowIfGreaterThan`
-  on numeric range checks.
-- Enum parameters: validated against the declared range, or
-  documented to accept any underlying value with explicit defaulting.
-
-**Test:** one per parameter for each forbidden violation mode. Don't
-trust the downstream BCL primitive to throw - the contract is
-yours.
+Write tests that pin the **safe property** (terminates within a bound,
+returns a defined error for malformed input, never reads/writes past the
+buffer) - and make them pass against *current* code as a regression lock.
+Never pin observable wrong output; that locks the bug in. Test the input
+*shape*, not a specific exploit pattern. Boundary tests come in pairs (at
+the limit, just over). When a finding needs a production change, surface
+the options report and **end your turn** before patching. The full
+principles and the High/Medium/Low rubric are in [principles.md](principles.md).
 
 ## Review procedure
 
-1. **Inventory.** `git status --short` and read every new/modified
-   file. Tag each member that takes external input or uses a
-   caller-validated API.
-2. **Walk each tagged member through the tiered categories.** The
-   test you'd write to prove it's fine is the deliverable.
-3. **Place tests in `<TypeName>.Security.cs` partial-class files**
-   beside the production type. Create one if it doesn't exist.
-4. **Add safe-property tests now (principle 1); commit failing /
-   wrong-output tests only with the fix.**
-5. **If a test fails against current code, stop and report.** Don't
-   patch without surfacing first.
-6. **Run tests on every TFM.** Timing bounds and allocation behavior
+1. **Inventory.** `git status --short`; tag each new/modified member that
+   takes external input or uses a caller-validated API.
+2. **Walk each tagged member** through the [checklist.md](checklist.md)
+   categories. The largest category - `unsafe` / `Unsafe.*` /
+   `MemoryMarshal.*` and other caller-validated APIs - has its own
+   per-API table in [unsafe-apis.md](unsafe-apis.md).
+3. **Place tests in `<TypeName>.Security.cs`** beside the production type.
+4. **Add safe-property tests now; report findings that need a production
+   change before patching.** See [reporting.md](reporting.md) for the
+   options-report format and the don'ts.
+5. **Run tests on every TFM** - timing bounds and allocation behavior
    differ across BCL versions.
 
-## Options report format
+When attention is limited, allocate it by tier (detail in
+[checklist.md](checklist.md)):
 
-When the report contains any finding that requires a production-code
-change: output the report and **end your turn**. Don't produce the
-patch, don't produce a failing test, don't run further tool calls
-beyond what's needed to classify the finding. Resume only after the
-user replies with an approval verb (`go`, `apply Option A`, `fix it`,
-or similar). Passing safe-property tests (principle 1) may be added
-on the same turn; they don't change production behavior.
+- **Critical (never skip):** length/size bounds, algorithmic complexity,
+  and the caller-validated-API audit.
+- **Standard (every member):** integer overflow, malformed structure,
+  argument validation.
+- **Conditional (when the shape matches):** allocation DoS, in-band
+  sentinels, path traversal.
 
-```text
-### Finding #N -- <one-line summary>
+## Sub-pages
 
-<which file(s), which lines, what the failure mode is>
-**Severity:** High / Medium / Low (per rubric)
-
-**Option A -- <approach>**
-- <change shape, ~LoC>
-- Pro: ...
-- Con: ...
-
-**Option B -- ...**
-
-**My recommendation:** <one of the above, with rationale.>
-```
-
-Low-severity findings can be deferred entirely; Medium/High deferrals
-need an explicit reason in the PR body.
-
-## Don'ts
-
-- **Don't patch production code without surfacing the finding first.**
-- **Don't pin observable wrong output in a test.** That locks the bug
-  in. Either ship the corrected-behavior test *alongside* the fix, or
-  skip the test until the fix lands. Safe-property tests (principle 1)
-  are not this case.
-- **Don't claim "safe by construction" without a regression test.**
-  The safe property is invisible to a future refactor.
-- **Don't assume `internal` / `InternalsVisibleTo` members are out of
-  scope.** Tests reach them; refactors promote them. Audit them on
-  the same basis as `public`.
+- [principles.md](principles.md) - the five core principles and the
+  High / Medium / Low severity rubric.
+- [checklist.md](checklist.md) - the nine audit categories with the test
+  shape each one demands.
+- [unsafe-apis.md](unsafe-apis.md) - the per-API precondition / failure /
+  test-shape table for `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, `fixed`,
+  `stackalloc`, and `[DllImport]`.
+- [reporting.md](reporting.md) - the review procedure, the options-report
+  format, and the don'ts that keep tests from pinning bugs.

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -1,0 +1,143 @@
+# Audit checklist
+
+Detail for the [security-review](SKILL.md) skill. Walk every new/modified
+member through the categories below. The question is whether the *input shape*
+or *unchecked precondition* could push the code into the failure mode, not
+whether it currently does.
+
+The largest category - `unsafe` / `Unsafe.*` / `MemoryMarshal.*` and other
+caller-validated APIs (&sect;7) - lives in [unsafe-apis.md](unsafe-apis.md).
+
+When attention is limited, allocate it by tier:
+
+- **Critical (never skip):** &sect;1, &sect;4, [unsafe-apis.md](unsafe-apis.md).
+- **Standard (every member):** &sect;2, &sect;5, &sect;9.
+- **Conditional (when the code shape matches):** &sect;3 (allocates
+  proportional to input), &sect;6 (encoder uses in-band sentinels),
+  &sect;8 (path-handling API).
+
+## 1. Length / size of inputs
+
+- Is there an upper bound? What stops a caller from passing a
+  multi-MB / multi-GB value?
+- Is the bound at the API boundary, not buried in a helper?
+- For composed inputs (list of strings, stream of records), is the
+  **total** size bounded, not just per-element?
+- Is the default safe for untrusted callers, with an opt-out for
+  trusted ones? See `DefaultMaxPatternLength` / `maxPatternLength`
+  in [touki/Touki/Io/Globbing/GlobSpecification.Factory.cs](../../../touki/Touki/Io/Globbing/GlobSpecification.Factory.cs).
+
+**Tests:** at-limit success, over-limit failure with documented
+error, opt-out (e.g. `-1`) disables the check.
+
+## 2. Integer / length-field overflow
+
+- Are length sums (`a.Length + b.Length`, `count * elementSize`)
+  protected by `checked()` where crafted input can overflow?
+- Are running lengths cast to a narrower type (`(char)len`,
+  `(byte)count`)? Silent truncation lets oversized fields slip
+  through and be re-read as smaller values, misdecoding downstream
+  data as structural metadata. Check the counter *before* the cast.
+
+**Tests:** boundary inside the representable range plus boundary
+outside. Specialized fast paths often bypass the affected code
+- pick an input shape that **forces the general path**.
+
+## 3. Allocation pressure / memory DoS
+
+- Does work allocate proportional to (or worse than) input size?
+- Is the worst case bounded by an explicit cap (&sect;1) or only by
+  available memory?
+- Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
+  per call (acceptable if bounded), or grow without limit (red flag)?
+
+**Tests:** a "large but legitimate" input completes within a
+`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
+Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
+allocation count.
+
+## 4. Computational complexity / algorithmic DoS
+
+- Worst-case runtime: linear, polynomial, or exponential?
+- ReDoS shape: matcher with multiple wildcards (`*`, `**`, `?(...)`,
+  alternation) that retries every wildcard on mismatch. Safe shape:
+  **fixed savepoint slots** (each new wildcard overwrites the
+  previous slot of the same kind), bounding the worst case to
+  O(n&middot;m).
+- Hashtable attacks: are user-controlled keys hashed with a
+  randomized hash (modern .NET `string.GetHashCode()` and
+  `Dictionary<,>` are per-process randomized), or a deterministic one
+  a caller could pre-image into a single bucket?
+
+**Tests** (pin the safe property):
+
+```csharp
+[Fact]
+public void Method_PathologicalInput_TerminatesPromptly()
+{
+    /* construct adversarial pattern + input */
+
+    Stopwatch sw = Stopwatch.StartNew();
+    bool result = m.IsMatch(input);
+    sw.Stop();
+
+    result.Should().Be(/* expected */);
+    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+}
+```
+
+Add one per "we use the safe algorithm" claim; the property is
+invisible to refactors, the test is the lock.
+
+## 5. Malformed structure / parser robustness
+
+- Truncated input handled gracefully (no `IndexOutOfRangeException`
+  past the end)?
+- Unmatched opens (`[`, `{`, `(`, dangling `\\` / `%`) produce a
+  defined error, not an unrelated runtime exception?
+
+**Tests:** one per malformed shape asserting the exact error type;
+empty, single-character, and "exactly the sentinel" inputs (`""`,
+`"["`, `"\\"`).
+
+## 6. Sentinel / in-band markers colliding with input
+
+- Encoder uses in-band sentinel values (opcode chars, length prefix
+  bytes, control chars)? If user input contains those same values,
+  are they distinguishable from real structure (escaping, length
+  framing, reserved noncharacter code points)?
+
+**Test:** input containing every sentinel value used as ordinary
+data; the member treats them as data.
+
+## 7. `unsafe`, `Unsafe.*`, `MemoryMarshal.*`, and other caller-validated APIs
+
+Mandatory whenever a PR touches one of these. The compiler offloads
+safety to you; the review *is* the safety check. The per-API table
+(precondition, failure mode, required test shape) lives in
+[unsafe-apis.md](unsafe-apis.md).
+
+## 8. Path traversal / sandbox escape
+
+- API takes a root + relative input and returns paths - results
+  stay inside the root? Symlink behavior is the caller's documented
+  choice, not silently re-enabled?
+- Caller-supplied fragments concatenated without normalization?
+  `Path.Combine` honors absolute inner segments, which is a foot-gun.
+
+**Tests:** inputs with `..` segments, absolute paths, alternate
+separators, and symlink-style names; enumerator stays inside the
+configured root.
+
+## 9. Argument validation at the boundary
+
+- `ArgumentNullException.ThrowIfNull` on every reference-type
+  parameter the contract forbids `null` for.
+- `ArgumentOutOfRangeException.ThrowIfNegative` / `ThrowIfGreaterThan`
+  on numeric range checks.
+- Enum parameters: validated against the declared range, or
+  documented to accept any underlying value with explicit defaulting.
+
+**Test:** one per parameter for each forbidden violation mode. Don't
+trust the downstream BCL primitive to throw - the contract is
+yours.

--- a/.agents/skills/security-review/principles.md
+++ b/.agents/skills/security-review/principles.md
@@ -1,0 +1,44 @@
+# Core principles and severity
+
+Detail for the [security-review](SKILL.md) skill.
+
+## Core principles
+
+1. **Test safe properties, even when current code is already
+   correct.** A safe property = the method terminates within a stated
+   bound, returns a defined error for malformed input, returns the
+   documented default for empty input, doesn't read/write past the
+   buffer, or doesn't crash. These tests must pass against current
+   code; commit them as the regression lock.
+2. **Never write a test that pins observable wrong output.** A test
+   asserting "this silently truncates" locks the bug in. If current
+   code is wrong, skip the test until the fix lands and pin the
+   *corrected* output then.
+3. **Test the shape, not the specific exploit.** "Input at the
+   declared limit" lasts forever; "exact pattern that triggered CVE-X"
+   decays.
+4. **Boundary tests come in pairs.** One at the limit (succeeds), one
+   just over (fails in a defined way).
+5. **Surface findings before patching production code.** When a
+   finding needs a production change, output the options report,
+   **end your turn, and do not produce the patch or any failing test
+   on that turn**. Resume after the user replies with an approval
+   verb (`go`, `apply A`, `fix it`). Passing safe-property tests
+   (principle 1) may ship on the same turn as the report; failing
+   tests may not.
+
+## Severity rubric
+
+Label every finding before the report.
+
+- **High** - memory corruption, OOB read/write, type confusion,
+  lifetime escape, RCE, disclosure of secrets/addresses, auth bypass.
+  Fix on the same PR.
+- **Medium** - DoS (CPU, memory, stack, FDs), crashing unhandled
+  exception, parser accepting malformed input as valid, ambiguous
+  parsing that smuggles a different shape past validation. Usually
+  fix on the same PR; deferral needs a documented mitigation.
+- **Low** - silent truncation still bounded by a downstream BCL
+  slice check, documented contract violations on edge cases,
+  non-sensitive error-message leakage. Safe to defer; still pin the
+  *corrected* behavior with a regression test once the fix lands.

--- a/.agents/skills/security-review/reporting.md
+++ b/.agents/skills/security-review/reporting.md
@@ -1,0 +1,62 @@
+# Review procedure and reporting
+
+Detail for the [security-review](SKILL.md) skill.
+
+## Review procedure
+
+1. **Inventory.** `git status --short` and read every new/modified
+   file. Tag each member that takes external input or uses a
+   caller-validated API.
+2. **Walk each tagged member through the tiered categories** in
+   [checklist.md](checklist.md). The test you'd write to prove it's
+   fine is the deliverable.
+3. **Place tests in `<TypeName>.Security.cs` partial-class files**
+   beside the production type. Create one if it doesn't exist.
+4. **Add safe-property tests now (principle 1); commit failing /
+   wrong-output tests only with the fix.**
+5. **If a test fails against current code, stop and report.** Don't
+   patch without surfacing first.
+6. **Run tests on every TFM.** Timing bounds and allocation behavior
+   differ across BCL versions.
+
+## Options report format
+
+When the report contains any finding that requires a production-code
+change: output the report and **end your turn**. Don't produce the
+patch, don't produce a failing test, don't run further tool calls
+beyond what's needed to classify the finding. Resume only after the
+user replies with an approval verb (`go`, `apply Option A`, `fix it`,
+or similar). Passing safe-property tests (principle 1) may be added
+on the same turn; they don't change production behavior.
+
+```text
+### Finding #N -- <one-line summary>
+
+<which file(s), which lines, what the failure mode is>
+**Severity:** High / Medium / Low (per rubric)
+
+**Option A -- <approach>**
+- <change shape, ~LoC>
+- Pro: ...
+- Con: ...
+
+**Option B -- ...**
+
+**My recommendation:** <one of the above, with rationale.>
+```
+
+Low-severity findings can be deferred entirely; Medium/High deferrals
+need an explicit reason in the PR body.
+
+## Don'ts
+
+- **Don't patch production code without surfacing the finding first.**
+- **Don't pin observable wrong output in a test.** That locks the bug
+  in. Either ship the corrected-behavior test *alongside* the fix, or
+  skip the test until the fix lands. Safe-property tests (principle 1)
+  are not this case.
+- **Don't claim "safe by construction" without a regression test.**
+  The safe property is invisible to a future refactor.
+- **Don't assume `internal` / `InternalsVisibleTo` members are out of
+  scope.** Tests reach them; refactors promote them. Audit them on
+  the same basis as `public`.

--- a/.agents/skills/security-review/unsafe-apis.md
+++ b/.agents/skills/security-review/unsafe-apis.md
@@ -1,0 +1,30 @@
+# Caller-validated APIs (`unsafe`, `Unsafe.*`, `MemoryMarshal.*`)
+
+Detail for &sect;7 of the [security-review](SKILL.md) audit
+[checklist.md](checklist.md). Mandatory whenever a PR touches one of these.
+The compiler offloads safety to you; the review *is* the safety check.
+
+For each use site answer:
+
+1. What precondition does the API require? (Read the XML doc.)
+2. Where in the calling code is it established? If it's a *different*
+   method, what stops a future refactor from desyncing them?
+3. Is the precondition still satisfied when the input is empty,
+   `null`, zero-length, or `default`? (Empty is the most common
+   blow-up.)
+
+Walk every use site against this table; rows are independent.
+
+| API pattern | Precondition (compiler does NOT check) | Failure mode if violated | Required test shape |
+| ----------- | -------------------------------------- | ------------------------ | ------------------- |
+| `MemoryMarshal.GetReference(span)` / `GetPinnableReference` / `Unsafe.AsPointer(ref span[0])` / `GetArrayDataReference` | Returned `ref` only valid when `span.Length > 0`; empty span yields the managed-null sentinel. | Crash or wild read at null. | `Method_EmptyInput_DoesNotDereferenceNullReference` returns documented default with no exception. |
+| `Unsafe.Add(ref T, int)` | Index `< span.Length` (or backing buffer element count). | OOB read leaks adjacent-page memory; OOB write corrupts heap. | One test at the last in-range index (loop guard's last iteration is the off-by-one site). |
+| `Unsafe.ReadUnaligned<T>` / `WriteUnaligned<T>` | `ref byte` points at `sizeof(T)` valid bytes; alignment is your problem. | OOB read or torn write. | Boundary tests at exactly `sizeof(T)` bytes and one less. |
+| `Unsafe.As<TFrom, TTo>(ref TFrom)` / `Unsafe.As<T>(object)` | `sizeof(TTo) <= sizeof(TFrom)`; GC reference layout matches. | Reads garbage past source; corrupts GC heap if reference layout differs. **net481 RyuJIT pitfall:** `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates the caller's int-promoted negative value into the comparison immediate. See [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md). | One test per primitive width including signed/negative values; mask with `& 0xFF` / `& 0xFFFF` if needed. |
+| `Unsafe.SkipInit<T>(out T)` | Caller fully initializes every reachable field before any read. | Stale-pointer foot-gun for ref fields; uninitialized read otherwise. | Test every code path that reads from the skip-init local. |
+| `MemoryMarshal.Cast<TFrom, TTo>` / `AsBytes` | Result length is `source.Length * sizeof(TFrom) / sizeof(TTo)`; partial elements vanish silently. | Caller treats a truncated result as the full payload. | Partial-element case (source length doesn't divide evenly). |
+| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime &le; referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
+| `fixed (T* p = ...)` | `p` valid only inside the `fixed` block. | Dangling pointer after GC relocates. | Manual review: `p` not stashed in a field, passed to `async`/iterator continuations, or returned. |
+| `stackalloc T[n]` | `n` small and bounded. | Stack-overflow DoS if `n` comes from input. | Max-allowed size succeeds; one element more is rejected before `stackalloc` runs. Use [`BufferScope<T>`](../../../touki/Touki/Buffers/BufferScope.cs) when input could exceed the stack budget. |
+| `[DllImport]` / `LibraryImport` | Marshaller attrs (`[MarshalAs]`, `SizeConst`, `string` vs `IntPtr`) silently change buffer sizes / ownership. | Buffer overrun, double-free, type confusion across the managed/native boundary. | Cross-check signature against native docs; re-verify on every TFM. |
+| Any BCL API whose XML doc contains "unsafe" or "caller must" | Whatever the doc specifies. | Whatever the doc warns about. | Edge case where the precondition *almost* holds (one byte short, off-by-one alignment). |

--- a/.github/agents/touki-reviewer.agent.md
+++ b/.github/agents/touki-reviewer.agent.md
@@ -38,50 +38,49 @@ checked. Do not pad.
 
 ## What to check (in priority order)
 
+The normative rules live in the path-specific instructions and skills cited
+below - they are the single source of truth. Don't restate them here; confirm
+the diff complies and cite the owning file in each finding. Your value is
+catching what the build cannot: cross-TFM behavior, sibling parity, missing
+tests, and API design.
+
 1. **Cross-TFM correctness.** All code must compile and behave on both .NET 10
-   and .NET Framework 4.7.2. Flag any modern C# / BCL usage not gated for the
-   older target. Flag missing `#if NET` where required. Note: code under
-   `touki/Framework/` already targets only the framework, so `#if NETFRAMEWORK`
-   inside that tree is dead - see
+   and .NET Framework 4.7.2. Flag modern C# / BCL usage not gated for the older
+   target, and missing `#if NET`. Code under `touki/Framework/` is
+   framework-only, so `#if NETFRAMEWORK` there is dead - see
    [.github/instructions/polyfills.instructions.md](../instructions/polyfills.instructions.md).
 
-2. **Polyfill conventions.** For files under `touki/Framework/Polyfills/`:
-   - Namespace must equal the BCL namespace being polyfilled (e.g.
-     `Polyfills/System/Foo.cs` &rarr; `namespace System;`).
-   - No `#if NETFRAMEWORK` directives.
-   - Hand-rolled is a last resort; flag any new file if a Microsoft package
-     or PolySharp source-gen would have worked. Reference the
-     [`polyfill-dotnet-api`](../../.agents/skills/polyfill-dotnet-api/SKILL.md)
-     skill in the finding.
+2. **Polyfill conventions** (`touki/Framework/Polyfills/`). Verify the diff
+   against [.github/instructions/polyfills.instructions.md](../instructions/polyfills.instructions.md)
+   and the [`polyfill-dotnet-api`](../../.agents/skills/polyfill-dotnet-api/SKILL.md)
+   skill (namespace = BCL namespace, no `#if NETFRAMEWORK`, hand-rolled only
+   when no Microsoft package or PolySharp source-gen would have worked). Cite
+   the owning file in the finding.
 
-3. **JIT-naming rule.** Performance claims in code comments, PR descriptions,
-   or commit messages must say either ".NET Framework 4.8.1 RyuJIT" or
-   "modern .NET RyuJIT". Unqualified "RyuJIT" claims are a finding. Flag
-   `[MethodImpl(MethodImplOptions.AggressiveInlining)]` methods that take a
-   generic `T` and call `Unsafe.As<T, byte/sbyte/short/ushort>(ref param)`
-   without masking - this is the documented net481 codegen bug. See
+3. **JIT-naming rule and the net481 `Unsafe.As` foot-gun.** Perf claims must
+   carry the JIT qualifier required by
+   [.github/instructions/perf.instructions.md](../instructions/perf.instructions.md)
+   (".NET Framework 4.8.1 RyuJIT" or "modern .NET RyuJIT"); unqualified claims
+   are a finding. Separately, flag any
+   `[MethodImpl(MethodImplOptions.AggressiveInlining)]` method that takes a
+   generic `T` and calls `Unsafe.As<T, byte/sbyte/short/ushort>(ref param)`
+   without masking - the documented net481 codegen bug, pinned by
    [touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs](../../touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs).
 
-4. **Public API additions.**
-   - XML doc comments on every new public type, method, property.
-   - At least one test in `touki.tests/` covering the new surface.
-   - If the addition is a polyfill, the `Examples` table in the polyfill
-     skill is updated.
+4. **Public API additions.** XML doc comments on every new public member; at
+   least one test in `touki.tests/` covering the new surface; if the addition is
+   a polyfill, the `Examples` table in the
+   [`polyfill-dotnet-api`](../../.agents/skills/polyfill-dotnet-api/SKILL.md)
+   skill is updated.
 
-5. **Test conventions.** See
-   [.github/instructions/tests.instructions.md](../instructions/tests.instructions.md).
-   Common findings:
-   - Test name not in `MethodName_StateUnderTest_ExpectedBehavior` form.
-   - "Arrange / Act / Assert" comments present.
-   - New `using` for `FluentAssertions` or `Xunit` (already global).
-   - Reflection used instead of `TestAccessor` for private members.
-   - Ref-struct under test exercised inside a lambda.
+5. **Test conventions.** Check the diff against
+   [.github/instructions/tests.instructions.md](../instructions/tests.instructions.md);
+   the [`pre-pr-self-review`](../../.agents/skills/pre-pr-self-review/SKILL.md)
+   skill lists the recurring misses (test-name form, stray "Arrange / Act /
+   Assert" comments, redundant `FluentAssertions` / `Xunit` usings, reflection
+   instead of `TestAccessor`, ref-struct exercised inside a lambda).
 
-6. **Whitespace and formatting.** Trailing whitespace; tabs in Markdown;
-   missing blank line between methods; lines exceeding 150 characters
-   without a break before 120.
-
-7. **Approval-verb hygiene** (for PR descriptions only). The PR description
+6. **Approval-verb hygiene** (for PR descriptions only). The PR description
    should not assume publish authority from "open a PR" / "address the
    review" / similar non-publishing verbs. See "Working with the user on
    changes" in [AGENTS.md](../../AGENTS.md).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -261,18 +261,13 @@ catch a mistake.
   `IsOnlyOneFlagSet`, `SetFlags`, `ClearFlags` inline to the same
   instructions as `&`/`|`/`==` on both TFMs and avoid the `Enum.HasFlag`
   boxing penalty on net472/net481 (~20&times; faster, zero alloc).
-- **When optimizing span-walking helpers, read
-  [docs/framework-span-performance.md](../docs/framework-span-performance.md)
-  first.** On net472/net481 the `ReadOnlySpan<T>` indexer costs ~8 µops
-  per element (slow-span layout) versus ~1 µop on net10. Hoist
-  `ref T = MemoryMarshal.GetReference(span)` outside the loop and walk
-  with `Unsafe.Add<T>(ref, i)` for a 19-44% Framework win at no
-  `unsafe`-keyword cost. Prefer a single simple implementation when it
-  measures within ~5% of any Framework-tuned variant on net10 so the
-  simple source keeps accruing future RyuJIT improvements; split with
-  `#if NET` / `#else` only when net10 regresses measurably, and prefer
-  `fixed` over `Unsafe.AsPointer` tricks when the Framework path needs
-  raw pointers.
+- **When optimizing span-walking helpers**, read
+  [docs/framework-span-performance.md](../docs/framework-span-performance.md) and the
+  [`framework-jit-optimization`](../.agents/skills/framework-jit-optimization/SKILL.md)
+  skill first. The headline rule: on net472/net481 hoist
+  `ref T = MemoryMarshal.GetReference(span)` out of the loop and walk with
+  `Unsafe.Add<T>(ref, i)` for a 19-44% Framework win at no `unsafe`-keyword cost,
+  and prefer one simple implementation unless net10 regresses measurably.
 - **Prefer Touki utility types over their BCL counterparts** when building
   strings, buffers, or collections in production library code. They are
   designed to avoid managed allocation on the hot path:
@@ -292,27 +287,19 @@ catch a mistake.
     `SingleOptimizedList`, `EmptyList`) instead of `List<T>` /
     `Dictionary<,>` when the lifetime is bounded.
 - **When choosing how a hot path gets a short-lived scratch buffer** (zeroed
-  `stackalloc` vs `[SkipLocalsInit]` + `stackalloc` vs `BufferScope<T>` vs an
+  `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs an
   `ArrayPool<T>.Shared` rental), follow the
   [`scratch-buffer-strategy`](../.agents/skills/scratch-buffer-strategy/SKILL.md)
-  skill for the decision tree and the net481/net10 size crossovers, and
-  [docs/arraypool-performance.md](../docs/arraypool-performance.md) for the backing
-  measurements. Key facts: net481 *does* honor `[SkipLocalsInit]`; a warm
-  `ArrayPool` still has a per-call floor warmup cannot remove; and below the
-  crossover (roughly 190 B net10 / 1.3 KB net481 vs a warm rental) a zeroed
-  `stackalloc` beats renting.
+  skill for the decision tree and the net481/net10 size crossovers, backed by
+  [docs/arraypool-performance.md](../docs/arraypool-performance.md).
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
-  prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,
-  `Microsoft.IO.Redist`), then PolySharp source-gen for compiler attributes,
-  and only hand-roll under `touki/Framework/Polyfills/<BclNamespace>/` as a
-  last resort. Hand-rolled polyfills declare the BCL namespace they're
-  polyfilling (`Polyfills/System/Foo.cs` &rarr; `namespace System;`,
-  `Polyfills/System.Text/Foo.cs` &rarr; `namespace System.Text;`).
-  Touki-specific code that does not polyfill a modern .NET API stays under
-  `touki/Framework/Touki/...` with `Touki.*` namespaces. See
-  [docs/polyfill-layout.md](../docs/polyfill-layout.md) for the user-facing
-  description and the `extern alias` recipe for type-name conflicts.
+  prefer Microsoft-shipped packages, then PolySharp source-gen for compiler
+  attributes, and only hand-roll under
+  `touki/Framework/Polyfills/<BclNamespace>/` as a last resort. See
+  [docs/polyfill-layout.md](../docs/polyfill-layout.md) for the layout rules
+  (namespace = BCL namespace; Touki-specific code stays under
+  `touki/Framework/Touki/...`) and the `extern alias` recipe.
 
 ## Path-specific instructions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -287,7 +287,7 @@ catch a mistake.
     `SingleOptimizedList`, `EmptyList`) instead of `List<T>` /
     `Dictionary<,>` when the lifetime is bounded.
 - **When choosing how a hot path gets a short-lived scratch buffer** (zeroed
-  `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs an
+  `stackalloc` vs `[SkipLocalsInit]` + `stackalloc` vs `BufferScope<T>` vs an
   `ArrayPool<T>.Shared` rental), follow the
   [`scratch-buffer-strategy`](../.agents/skills/scratch-buffer-strategy/SKILL.md)
   skill for the decision tree and the net481/net10 size crossovers, backed by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,7 +286,7 @@ catch a mistake.
     `SingleOptimizedList`, `EmptyList`) instead of `List<T>` /
     `Dictionary<,>` when the lifetime is bounded.
 - **When choosing how a hot path gets a short-lived scratch buffer** (zeroed
-  `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs an
+  `stackalloc` vs `[SkipLocalsInit]` + `stackalloc` vs `BufferScope<T>` vs an
   `ArrayPool<T>.Shared` rental), follow the
   [`scratch-buffer-strategy`](.agents/skills/scratch-buffer-strategy/SKILL.md)
   skill for the decision tree and the net481/net10 size crossovers, backed by

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -260,18 +260,13 @@ catch a mistake.
   `IsOnlyOneFlagSet`, `SetFlags`, `ClearFlags` inline to the same
   instructions as `&`/`|`/`==` on both TFMs and avoid the `Enum.HasFlag`
   boxing penalty on net472/net481 (~20&times; faster, zero alloc).
-- **When optimizing span-walking helpers, read
-  [docs/framework-span-performance.md](docs/framework-span-performance.md)
-  first.** On net472/net481 the `ReadOnlySpan<T>` indexer costs ~8 µops
-  per element (slow-span layout) versus ~1 µop on net10. Hoist
-  `ref T = MemoryMarshal.GetReference(span)` outside the loop and walk
-  with `Unsafe.Add<T>(ref, i)` for a 19-44% Framework win at no
-  `unsafe`-keyword cost. Prefer a single simple implementation when it
-  measures within ~5% of any Framework-tuned variant on net10 so the
-  simple source keeps accruing future RyuJIT improvements; split with
-  `#if NET` / `#else` only when net10 regresses measurably, and prefer
-  `fixed` over `Unsafe.AsPointer` tricks when the Framework path needs
-  raw pointers.
+- **When optimizing span-walking helpers**, read
+  [docs/framework-span-performance.md](docs/framework-span-performance.md) and the
+  [`framework-jit-optimization`](.agents/skills/framework-jit-optimization/SKILL.md)
+  skill first. The headline rule: on net472/net481 hoist
+  `ref T = MemoryMarshal.GetReference(span)` out of the loop and walk with
+  `Unsafe.Add<T>(ref, i)` for a 19-44% Framework win at no `unsafe`-keyword cost,
+  and prefer one simple implementation unless net10 regresses measurably.
 - **Prefer Touki utility types over their BCL counterparts** when building
   strings, buffers, or collections in production library code. They are
   designed to avoid managed allocation on the hot path:
@@ -291,27 +286,19 @@ catch a mistake.
     `SingleOptimizedList`, `EmptyList`) instead of `List<T>` /
     `Dictionary<,>` when the lifetime is bounded.
 - **When choosing how a hot path gets a short-lived scratch buffer** (zeroed
-  `stackalloc` vs `[SkipLocalsInit]` + `stackalloc` vs `BufferScope<T>` vs an
+  `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs an
   `ArrayPool<T>.Shared` rental), follow the
   [`scratch-buffer-strategy`](.agents/skills/scratch-buffer-strategy/SKILL.md)
-  skill for the decision tree and the net481/net10 size crossovers, and
-  [docs/arraypool-performance.md](docs/arraypool-performance.md) for the backing
-  measurements. Key facts: net481 *does* honor `[SkipLocalsInit]`; a warm
-  `ArrayPool` still has a per-call floor warmup cannot remove; and below the
-  crossover (roughly 190 B net10 / 1.3 KB net481 vs a warm rental) a zeroed
-  `stackalloc` beats renting.
+  skill for the decision tree and the net481/net10 size crossovers, backed by
+  [docs/arraypool-performance.md](docs/arraypool-performance.md).
 - When adding a polyfill for a modern .NET API on .NET Framework, follow the
   [`polyfill-dotnet-api`](.agents/skills/polyfill-dotnet-api/SKILL.md) skill:
-  prefer Microsoft-shipped packages (`System.Memory`, `Microsoft.Bcl.*`,
-  `Microsoft.IO.Redist`), then PolySharp source-gen for compiler attributes,
-  and only hand-roll under `touki/Framework/Polyfills/<BclNamespace>/` as a
-  last resort. Hand-rolled polyfills declare the BCL namespace they're
-  polyfilling (`Polyfills/System/Foo.cs` &rarr; `namespace System;`,
-  `Polyfills/System.Text/Foo.cs` &rarr; `namespace System.Text;`).
-  Touki-specific code that does not polyfill a modern .NET API stays under
-  `touki/Framework/Touki/...` with `Touki.*` namespaces. See
-  [docs/polyfill-layout.md](docs/polyfill-layout.md) for the user-facing
-  description and the `extern alias` recipe for type-name conflicts.
+  prefer Microsoft-shipped packages, then PolySharp source-gen for compiler
+  attributes, and only hand-roll under
+  `touki/Framework/Polyfills/<BclNamespace>/` as a last resort. See
+  [docs/polyfill-layout.md](docs/polyfill-layout.md) for the layout rules
+  (namespace = BCL namespace; Touki-specific code stays under
+  `touki/Framework/Touki/...`) and the `extern alias` recipe.
 
 ## Path-specific instructions
 

--- a/docs/skills-improvement-plan.md
+++ b/docs/skills-improvement-plan.md
@@ -1,0 +1,313 @@
+# Skills improvement plan
+
+Status: draft roadmap (no skill files changed yet). Authored 2026-06-04.
+
+This plan answers three questions about the agent skills under
+[.agents/skills/](../.agents/skills/):
+
+1. Are the skills appropriately factored?
+2. Should some skills be a different file type?
+3. Which skills are portable to other repos, and how should they be shared?
+
+It is scoped to the design intent captured from the maintainer: the only sharing
+audience is **other personal repos (`JeremyKuhne/*`)**; the target hosts are
+**Copilot in VS Code, the Copilot CLI, and the Copilot cloud agent** (not Claude
+Code or other agents); and the preferred distribution is **a dedicated skills repo
+consumed via `gh skill` that also doubles as a Copilot/Claude plugin marketplace**.
+
+For the format reference and the existing catalog see
+[.agents/skills/FORMAT.md](../.agents/skills/FORMAT.md) and
+[.agents/skills/README.md](../.agents/skills/README.md). For the layer-selection
+matrix see [docs/agent-customization.md](agent-customization.md).
+
+## TL;DR answers
+
+1. **Factoring is good but five skills break the repo's own size budget.** The
+   structure (vendor-neutral location, cross-reference catalog, disambiguation
+   table, CI freshness checks) is sound. The defect is that the largest
+   reference-style skills load 12-18 KB of body on every trigger when only a
+   fraction is usually relevant. Split them into a thin core plus sibling files,
+   the way [framework-jit-optimization](../.agents/skills/framework-jit-optimization/SKILL.md)
+   already does.
+2. **The file-type assignments are correct; do not convert skills to prompts or
+   agents.** Prompt files are not read by the Copilot CLI or cloud agent, so the
+   PR/release workflows must stay skills. The fix is the opposite direction: trim
+   the deep "when doing X" bullets in [AGENTS.md](../AGENTS.md) (now 66 % over
+   budget) down to one-line pointers at the skills that already own that
+   knowledge, and make [touki-reviewer.agent.md](../.github/agents/touki-reviewer.agent.md)
+   a thin persona that references the checklist skills instead of restating them.
+3. **Most skills have a portable core wrapped around a touki-specific overlay.**
+   Share the cores from one `JeremyKuhne/agent-skills` repo that is both a
+   `gh skill` source and a plugin marketplace; vendor pinned, provenance-stamped
+   copies back into each consuming repo (required, because the cloud agent only
+   sees committed repo-level files). Keep the touki overlays in touki.
+
+## 1. Current-state assessment
+
+### What is already right
+
+- Skills live in the vendor-neutral [.agents/skills/](../.agents/skills/)
+  location, which all three target Copilot surfaces read.
+- [.agents/skills/README.md](../.agents/skills/README.md) is a real catalog with
+  a disambiguation section for skills whose descriptions compete for
+  auto-invocation - this is the single highest-value piece of the setup and most
+  repos do not have it.
+- Descriptions are written "pushy", with explicit trigger phrasing, which is what
+  drives correct auto-invocation.
+- CI freshness (90-day, git-history-derived) and the
+  [Validate-AgentFiles.ps1](../tools/Validate-AgentFiles.ps1) frontmatter checks
+  already exist.
+- [framework-jit-optimization](../.agents/skills/framework-jit-optimization/SKILL.md)
+  is the model for progressive disclosure: a 121-line core plus four sibling docs
+  (`specialization.md`, `bcl-tradeoffs.md`, `antipatterns.md`, `unrolling.md`)
+  that load only when referenced.
+
+### The factoring defect: size-budget violations
+
+Measured 2026-06-04 against the budgets in
+[docs/agent-customization.md](agent-customization.md) (SKILL.md body <= 15 KB,
+AGENTS.md <= 10 KB, each `*.instructions.md` <= 8 KB):
+
+| File | Size | Budget | Over? |
+| ---- | ---- | ------ | ----- |
+| `performance-testing/SKILL.md` | 18.5 KB / 370 lines | 15 KB | yes |
+| `security-review/SKILL.md` | 15.4 KB / 293 lines | 15 KB | yes |
+| `publish-release/SKILL.md` | 14.4 KB / 339 lines | 15 KB | close |
+| `polyfill-dotnet-api/SKILL.md` | 14.4 KB / 281 lines | 15 KB | close |
+| `pre-pr-self-review/SKILL.md` | 12.7 KB / 252 lines | 15 KB | close |
+| `AGENTS.md` | 16.6 KB / 328 lines | 10 KB | yes (66 %) |
+| `msbuild.instructions.md` | 9.4 KB / 168 lines | 8 KB | yes (minor) |
+
+A skill body loads in full the moment the skill triggers; only sibling files
+load lazily. A 370-line `performance-testing` body therefore costs its whole
+weight even when the user only wants the one-line "always pass `-f <tfm>`" rule.
+Splitting reclaims that budget and - usefully - the split boundary is the same
+boundary as the portable-core / touki-overlay boundary in section 3.
+
+### The duplication defect: AGENTS.md restates skill content
+
+The "General guidance" section of [AGENTS.md](../AGENTS.md) carries multi-line
+bullets on span performance, scratch buffers, and polyfills that restate what
+[framework-jit-optimization](../.agents/skills/framework-jit-optimization/SKILL.md),
+[scratch-buffer-strategy](../.agents/skills/scratch-buffer-strategy/SKILL.md), and
+[polyfill-dotnet-api](../.agents/skills/polyfill-dotnet-api/SKILL.md) already own
+in depth (and which the `docs/` files back with measurements). That deep prose is
+always-on overhead. The always-true one-liner should stay in AGENTS.md; the depth
+belongs in the skill it points at.
+
+## 2. Are skills the right file type?
+
+The repo already documents the decision matrix
+([docs/agent-customization.md](agent-customization.md)). Applying it to the
+target hosts (VS Code + CLI + cloud agent), the type assignments hold:
+
+| Skill group | Current type | Verdict |
+| ----------- | ------------ | ------- |
+| Workflows (`create-pr`, `address-pr-feedback`, `publish-release`) | skill | **Keep.** Prompt files are not read by the CLI or cloud agent, so a workflow that must run there cannot be a `*.prompt.md`. Skills are the only portable home. |
+| Checklists (`pre-pr-self-review`, `security-review`, `agent-files-review`) | skill | **Keep as skills.** A skill is invocable by the user, auto-loaded by the model, and referenceable by any agent persona. Converting to agents would narrow host support (agents load unevenly across VS Code / CLI / cloud). |
+| Reference (`framework-jit-optimization`, `polyfill-dotnet-api`, `scratch-buffer-strategy`) | skill | **Keep.** "Knowledge that loads when relevant" is the definition of a skill. |
+
+Two refinements (not type changes):
+
+- **Trim AGENTS.md to pointers** (section 1) so the always-on layer stops
+  duplicating the on-demand layer.
+- **Make `touki-reviewer` a thin persona.** Today
+  [touki-reviewer.agent.md](../.github/agents/touki-reviewer.agent.md) restates
+  the JIT-naming rule, polyfill conventions, and test conventions that
+  [security-review](../.agents/skills/security-review/SKILL.md),
+  [polyfill-dotnet-api](../.agents/skills/polyfill-dotnet-api/SKILL.md), and
+  [tests.instructions.md](../.github/instructions/tests.instructions.md) already
+  own. Replace the restatements with references so there is a single source of
+  truth and no drift. The persona keeps only what is unique to it: the read-only
+  stance, the findings-table format, and the "review for what the build will not
+  catch" framing.
+
+Recommendation on the delegated "review skills vs agent" question: **keep the
+review knowledge in skills, keep one thin reviewer persona that points at them.**
+Optionally mark the review/checklist skills with `context: fork` (VS Code only,
+ignored elsewhere) so a heavy review runs in a subagent and only its conclusion
+returns to the main session.
+
+## 3. Portability and the core-plus-overlay model
+
+Portability is rarely all-or-nothing. The right shape (author once against the
+open spec, keep host-specific or repo-specific material additive) is a **generic
+core plus a touki overlay**. The split boundary from section 1 is exactly this
+boundary, so the refactor and the extraction are one piece of work.
+
+| Skill | Tier | Portable core | Touki overlay |
+| ----- | ---- | ------------- | ------------- |
+| `security-review` | core extractable | audit checklist: length/size bounds, integer overflow, allocation DoS, complexity / ReDoS, malformed input, the unsafe-API table | touki examples, cross-TFM timing notes, `<Name>.Security.cs` convention |
+| `pre-pr-self-review` | core extractable | generic pre-PR checklist: tests per branch, empty/null spans, `checked()` sums, standard throw helpers, "PR description matches the diff" | polyfill conventions, net472/net481 test splits, JIT-naming, the net481 `Unsafe.As` pitfall |
+| `performance-testing` | core extractable | BenchmarkDotNet authoring/running, `[MemoryDiagnoser]`, dead-code-elimination discipline | multi-TFM `-f net481/net10`, the `touki.mcp` analyzer, before/after on both TFMs |
+| `framework-jit-optimization` | already split | older-RyuJIT optimization knowledge | net481/net10 crossovers, `touki.perf` data |
+| `scratch-buffer-strategy` | core extractable | `stackalloc` vs `[SkipLocalsInit]` vs pool decision tree | `BufferScope<T>`, net481/net10 crossovers |
+| `fuzz-testing` | core extractable | SharpFuzz target authoring + crash-to-regression loop | `touki.fuzz` layout, cross-TFM build tricks |
+| `create-pr` | core extractable | git/PR open workflow + approval gate | branch naming, `dotnet test -c Release`, fork/upstream |
+| `agent-files-review` | core extractable | reviewing agent-customization files generally | `Validate-AgentFiles.ps1`, the mirror generator, `agent-files.yml` |
+| `polyfill-dotnet-api` | repo-specific (small core) | the "MS package -> PolySharp -> hand-roll" decision tree | `touki/Framework/` layout, namespace rules, extension-block coexistence |
+| `address-pr-feedback` | repo-specific | thin approval-gate restatement | touki approval phrasing bank |
+| `publish-release` | repo-specific | none meaningful | MinVer dual tag streams, package names |
+| `run-tests-on-wsl` | repo-specific | the WSL DrvFs / NuGet trap workaround | oracle suite names, `touki.tests` paths |
+
+### Sharing architecture
+
+Stand up one repo - working name `JeremyKuhne/agent-skills` - that is
+simultaneously:
+
+- a **`gh skill` source**: portable skill cores under the standard skill
+  directory, each with a clean `name` + `description` and no host-specific
+  frontmatter in the core;
+- a **plugin marketplace**: a `plugin.json` bundling the skills plus portable
+  agent personas plus an `.mcp.json` (the `microsoft-learn` server, and the
+  NuGet MCP server for package intelligence), and a `marketplace.json` so
+  `copilot plugin marketplace add JeremyKuhne/agent-skills` works. The plugin
+  format is the Copilot CLI's and is Claude-compatible, so the same repo serves
+  the CLI bundle path and any future Claude use at no extra cost.
+
+Consumption model (the load-bearing constraint):
+
+> The cloud agent has **no user level** - it sees only committed, repo-level
+> files. Shared skills therefore cannot be referenced; they must be **vendored as
+> committed copies** into each consuming repo.
+
+So the shared repo is the source of truth, and each repo (touki included) holds
+**pinned, provenance-stamped copies**:
+
+- `gh skill install JeremyKuhne/agent-skills <skill> --pin vX.Y.Z` vendors a copy
+  into `.agents/skills/` and writes the source repo + ref + tree SHA into the
+  copy's frontmatter. Commit it.
+- `gh skill update` later compares tree SHAs and surfaces upstream drift as a
+  normal diff; `--pin` excludes a skill from bulk updates until you re-pin.
+- The touki overlay skills stay in touki and reference the vendored cores.
+
+Constraint to resolve first: the GitHub CLI (`gh` >= 2.90, which provides
+`gh skill`) is **not installed on the maintainer's machine**. Either install it
+(CI runners already have it) or use the manual-vendor fallback: copy the core
+folder in, record the source ref in frontmatter by hand, and run a small
+tree-SHA drift script in CI instead of `gh skill update`.
+
+### Expressing the skill -> MCP dependency
+
+[polyfill-dotnet-api](../.agents/skills/polyfill-dotnet-api/SKILL.md) uses the
+`microsoft-learn` MCP server to confirm modern BCL shapes. The spec has no
+machine-enforced dependency field, so use the layered convention:
+
+- add a `compatibility:` frontmatter line: "Uses the microsoft-learn MCP server
+  to verify modern BCL API shapes when available; falls back to fetched web docs
+  otherwise";
+- write the body defensively: "if the microsoft-learn tools are available, use
+  them; otherwise fetch the docs page" (graceful degradation works on every
+  host);
+- in the shared plugin, list `microsoft-learn` in the bundle's `.mcp.json` so
+  installing the plugin wires the server - the only path that actually installs
+  the dependency with the skill;
+- if polyfill work ever runs on the **cloud agent**, add `microsoft-learn` (with
+  a `tools` allowlist) to the repo's cloud-agent MCP configuration, since that
+  surface does not read `.vscode/mcp.json`.
+
+### Portability metadata
+
+The spec has no portability field, so record the tier in the sanctioned
+`metadata` map plus the catalog:
+
+```yaml
+metadata:
+  portability: repo-specific          # portable | semi-portable | repo-specific
+  shared-source: JeremyKuhne/agent-skills@v1.2.0   # only on vendored copies
+```
+
+Add a matching column to [.agents/skills/README.md](../.agents/skills/README.md).
+Verify [Validate-AgentFiles.ps1](../tools/Validate-AgentFiles.ps1) tolerates the
+extra frontmatter key before rolling it out (it currently checks only `name` and
+`description`).
+
+## 4. Phased execution plan
+
+Each phase is independently reviewable and reversible. Phase 0 is entirely
+in-repo and unblocks the rest.
+
+### Phase 0 - in-repo refactor (no external repo, low risk)
+
+- [ ] Split `performance-testing`, `security-review`, `polyfill-dotnet-api`,
+      `pre-pr-self-review`, and `publish-release` into a thin core SKILL.md plus
+      sibling reference files, mirroring `framework-jit-optimization`. Target
+      every core under ~150 lines; push tables, examples, and measured data into
+      siblings. The core/sibling cut follows the core/overlay column in section 3.
+- [ ] Trim the AGENTS.md "General guidance" deep bullets (span performance,
+      scratch buffers, polyfills) to one-line pointers; regenerate the mirror with
+      `pwsh tools/Validate-AgentFiles.ps1 -Fix`. Re-measure to confirm AGENTS.md
+      is back under 10 KB.
+- [ ] Thin [touki-reviewer.agent.md](../.github/agents/touki-reviewer.agent.md):
+      replace restated rules with references to the owning skills/instructions.
+- [ ] Add the `compatibility:` line and graceful-degradation prose to
+      `polyfill-dotnet-api`.
+- [ ] Add `metadata.portability` to every skill and the catalog column; confirm
+      the validator passes.
+- [ ] Optional: add `context: fork` to the review/checklist skills.
+- Validation: `pwsh tools/Validate-AgentFiles.ps1`; re-run the size measurement;
+      confirm every catalog cross-reference still resolves.
+
+### Phase 1 - stand up the shared repo
+
+- [ ] Create `JeremyKuhne/agent-skills` (confirm the name first).
+- [ ] Move the portable cores in; keep their descriptions host-neutral.
+- [ ] Add portable agent personas (the generic reviewer), `plugin.json`,
+      `marketplace.json`, and `.mcp.json` (`microsoft-learn`, NuGet MCP).
+- [ ] Tag `v0.1.0`.
+- Validation: install the plugin into a scratch checkout via the CLI; confirm the
+      skills appear and the MCP servers start.
+
+### Phase 2 - re-consume into touki
+
+- [ ] Vendor the pinned cores back into touki's `.agents/skills/` (via
+      `gh skill install --pin`, or manual-vendor if `gh` is not installed).
+- [ ] Keep the touki overlays in touki, referencing the vendored cores.
+- [ ] Update the catalog with the `shared-source` provenance.
+- Validation: full `Validate-AgentFiles.ps1`; spot-check that a vendored core plus
+      its overlay still reads as one coherent skill.
+
+### Phase 3 - roll out to the next personal repo
+
+- [ ] Install the plugin (or vendor the skills) into one other `JeremyKuhne/*`
+      repo end to end as the real cross-repo test.
+- [ ] Capture anything that needed per-repo editing; fold genuinely generic bits
+      back into the cores.
+
+### Phase 4 - freshness and CI automation
+
+- [ ] Add a report-only `gh skill update --all` drift job (or the tree-SHA script
+      fallback) that opens a PR when a vendored core diverges from upstream.
+- [ ] Optionally add `skills-ref validate` over `.agents/skills/**` to the
+      existing [agent-files.yml](../.github/workflows/agent-files.yml).
+- [ ] Keep the existing 90-day freshness warning.
+
+## 5. Open decisions
+
+- **Shared repo name** - `JeremyKuhne/agent-skills` vs `dotnet-agent-skills` vs
+  other.
+- **`gh` adoption** - install the GitHub CLI locally for `gh skill`, or use the
+  manual-vendor + drift-script fallback.
+- **Portable agent personas** - worth publishing given uneven agent-host support,
+  or keep agents touki-local for now and share only skills + MCP.
+- **Cloud-agent MCP** - only needed if polyfill work runs on the cloud agent;
+  defer until that happens.
+- **msbuild.instructions.md (9.4 KB)** - out of scope here, but it is over its
+  8 KB budget and is a candidate for a later split.
+
+## 6. Per-skill disposition (appendix)
+
+| Skill | Phase 0 action | Tier | Where the core lives after sharing |
+| ----- | -------------- | ---- | ---------------------------------- |
+| `performance-testing` | split | core extractable | shared (mechanics) + touki overlay (TFM/mcp) |
+| `security-review` | split | core extractable | shared (checklist) + touki overlay |
+| `polyfill-dotnet-api` | split + add `compatibility:` | repo-specific (small core) | shared (decision tree) + touki overlay (layout) |
+| `pre-pr-self-review` | split | core extractable | shared (checklist) + touki overlay |
+| `publish-release` | split | repo-specific | touki only |
+| `framework-jit-optimization` | none (already split) | core extractable | shared (RyuJIT knowledge) + touki overlay (data) |
+| `scratch-buffer-strategy` | metadata only | core extractable | shared (decision tree) + touki overlay |
+| `fuzz-testing` | metadata only | core extractable | shared (harness) + touki overlay (project) |
+| `create-pr` | metadata only | core extractable | shared (workflow) + touki overlay |
+| `agent-files-review` | metadata only | core extractable | shared (checklist) + touki overlay (tooling) |
+| `address-pr-feedback` | metadata only | repo-specific | touki only |
+| `run-tests-on-wsl` | metadata only | repo-specific | touki only (WSL trap note may generalize) |

--- a/docs/skills-improvement-plan.md
+++ b/docs/skills-improvement-plan.md
@@ -1,6 +1,8 @@
 # Skills improvement plan
 
-Status: draft roadmap (no skill files changed yet). Authored 2026-06-04.
+Status: roadmap. Phase 0 (the in-repo refactor described below) is implemented
+in the same change that adds this document; later phases are not started.
+Authored 2026-06-04.
 
 This plan answers three questions about the agent skills under
 [.agents/skills/](../.agents/skills/):


### PR DESCRIPTION
## Summary

Phase 0 of the agent-skills improvement roadmap ([docs/skills-improvement-plan.md](docs/skills-improvement-plan.md)). Refactors the skills under `.agents/skills/` so each `SKILL.md` body stays within the repo's own size budget, removes duplicated depth from the always-on layer, and adds portability metadata as the foundation for sharing skills across personal repos.

No production code is touched - this is entirely agent-customization files plus one new doc.

## What changed

**Five oversized skills split into a thin core + sibling files** (the whole body loads on every trigger; siblings load only when referenced):

| Skill | Core before -> after | New siblings |
| --- | --- | --- |
| `performance-testing` | 18.5 -> 5.4 KB | authoring, running, profiling, interpreting-results |
| `security-review` | 15.4 -> 4.3 KB | principles, checklist, unsafe-apis, reporting |
| `publish-release` | 14.4 -> 5.7 KB | versioning, release-steps |
| `polyfill-dotnet-api` | 14.4 -> 6.2 KB | source-selection, design-rules, gotchas |
| `pre-pr-self-review` | 12.7 -> 8.5 KB | polyfill-correctness |

Every core is now well under the 15 KB `SKILL.md` budget. Content was moved verbatim; sibling links are plain relative Markdown at the same directory depth, so repo-file links keep their existing `../../../` prefix.

**AGENTS.md trimmed** (16.6 -> 15.8 KB): the span-performance, scratch-buffer, and polyfill bullets in "General guidance" duplicated depth that already lives in the skills/docs they reference, so they were collapsed to pointers. The `.github/copilot-instructions.md` mirror was regenerated with `Validate-AgentFiles.ps1 -Fix`.

**`touki-reviewer` agent thinned**: it now references the owning `*.instructions.md` and skills instead of restating the JIT-naming, polyfill, and test-convention rules - single source of truth, no drift. The redundant whitespace-review item (already covered by "don't flag what CI catches") was dropped.

**Portability + MCP metadata**:
- `metadata.portability` (`portable` / `semi-portable` / `repo-specific`) on all 12 skills, mirrored as a new column + legend in [.agents/skills/README.md](.agents/skills/README.md).
- [.agents/skills/FORMAT.md](.agents/skills/FORMAT.md) documents the `metadata` and `compatibility` fields and the thin-core pattern.
- `polyfill-dotnet-api` gains a `compatibility:` line and graceful-degradation prose for the `microsoft-learn` MCP server.

**New doc**: [docs/skills-improvement-plan.md](docs/skills-improvement-plan.md) - the phased roadmap (Phase 0 here; later phases stand up a shared `gh skill` / plugin source repo and vendor pinned cores back).

## Validation

- `pwsh tools/Validate-AgentFiles.ps1` - passes (frontmatter, mirror sync, whitespace).
- `pwsh tools/Test-AgentFileLinks.ps1` - all relative links resolve (43 files scanned).

## Known limitation

`AGENTS.md` is 15.8 KB against the doc's 10 KB target. The remaining bulk is the load-bearing, append-only "Working with the user on changes" approval section (~8 KB of safety rules). The genuine duplication is removed; trimming further would mean cutting safety content, which is left as a separate decision rather than done here.