### PR TITLE
Vendor pre-pr-self-review and resequence Phase 4 around traceq

### DIFF
--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -1,47 +1,42 @@
 ---
-name: pre-pr-self-review
-description: Self-review checklist before opening a PR. Use before invoking `create-pr`, when reviewing your own draft, or when a reviewer flags issues that should have been caught earlier. Codifies recurring mistakes from this repo's polyfill work: missing tests for new public surface, unchecked length sums, null-pointer foot-guns from `MemoryMarshal.GetReference` on empty spans, drift from `ArgumentNullException.ThrowIfNull` and `checked()` conventions, TFM phrasing errors, and stale PR descriptions.
+description: Self-review checklist before opening a PR. Use before invoking `create-pr`, when reviewing your own draft, or when a reviewer flags issues that should have been caught earlier. Codifies recurring mistakes from multi-targeted polyfill work - missing tests for new public surface, unchecked length sums, null-pointer foot-guns from `MemoryMarshal.GetReference` on empty spans, drift from `ArgumentNullException.ThrowIfNull` and `checked()` conventions, TFM phrasing errors, and stale PR descriptions.
+license: MIT
 metadata:
-  portability: semi-portable
+    github-path: skills/pre-pr-self-review
+    github-pinned: v0.4.0
+    github-ref: refs/tags/v0.4.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 67efd7e7fdde472bd96326fdf2cb109b1513f759
+    portability: semi-portable
+name: pre-pr-self-review
 ---
-
 # Pre-PR self-review
 
-Run this checklist before invoking the [`create-pr`](../create-pr/SKILL.md)
-skill. Each item is a question your code or PR body must answer. Update
-the skill whenever a reviewer flags something not yet listed.
+Run this checklist before invoking the `create-pr` skill. Each item is a question
+your code or PR body must answer. Update the skill whenever a reviewer flags
+something not yet listed.
 
-**Related skills:**
-
-- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - the
-  source-preference and design rules for adding a new polyfill that
-  this checklist then validates.
-- [`create-pr`](../create-pr/SKILL.md) - the workflow this checklist
-  precedes.
-- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - the
-  follow-up workflow that re-runs this checklist after review comments.
-- [`performance-testing`](../performance-testing/SKILL.md) - benchmark
-  authoring required when a perf claim drives a code change.
-- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md)
-  - net481 RyuJIT tradeoffs cited in the polyfill-correctness items.
-- [`agent-files-review`](../agent-files-review/SKILL.md) - for any
-  changes under `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`.
-- [`security-review`](../security-review/SKILL.md) - the
-  security-specific subset (abusive-input handling, length / integer
-  overflow, allocation and algorithmic DoS, argument validation, and
-  every use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` /
-  `Marshal.*` or any BCL API whose docs say "unsafe" or "caller
-  must"). Invoke alongside this checklist for any change that adds
-  or modifies a member accepting caller-supplied data, or any change
-  that touches one of those caller-validated constructs - the
-  common case, not a niche.
+This skill pairs with several others a consuming repo wires concretely in its
+overlay: a `polyfill-dotnet-api` skill (the source-preference and design rules
+this checklist validates), `create-pr` (the workflow this precedes),
+`address-pr-feedback` (the follow-up that re-runs this checklist),
+`performance-testing` (benchmark authoring required when a perf claim drives a
+change), `framework-jit-optimization` (net481 RyuJIT tradeoffs cited in the
+polyfill-correctness items), `agent-files-review` (for changes under `.agents/`,
+`AGENTS.md`, or `.github/copilot-instructions.md`), and `security-review` (the
+security-specific subset - abusive-input handling, length / integer overflow,
+allocation and algorithmic DoS, argument validation, and every use of `unsafe` /
+`Unsafe.*` / `MemoryMarshal.*` / `Marshal.*` or any BCL API whose docs say
+"unsafe" or "caller must"). Invoke `security-review` alongside this checklist for
+any change that adds or modifies a member accepting caller-supplied data, or that
+touches one of those caller-validated constructs - the common case, not a niche.
 
 ## 1. Tests cover every new branch
 
 For each new `public` (or `InternalsVisibleTo`-internal) member:
 
 - Search the test projects for the symbol; no hits = missing test.
-- Polyfills under `touki/Framework/`: tests run on both TFMs. Wrap
+- Polyfills in the Framework-only tree: tests run on both TFMs. Wrap
   polyfill-only paths (subclass fallbacks, null-receiver guards) in
   `#if NETFRAMEWORK`.
 - Runtime type-check fast paths (`typeof(T) == obj.GetType()`): test
@@ -60,28 +55,24 @@ Test hygiene for the tests themselves - the recurring miss list
 that costs the most review rounds on coverage-only PRs:
 
 - **Test method names start with the method under test.**
-  `MethodName_StateUnderTest_ExpectedBehavior` (see
-  [tests.instructions.md](../../../.github/instructions/tests.instructions.md)).
-  `ReadOnlySpan_Empty_ReturnsEmpty` is *wrong*;
+  `MethodName_StateUnderTest_ExpectedBehavior` per the repo's test
+  conventions. `ReadOnlySpan_Empty_ReturnsEmpty` is *wrong*;
   `SliceAtNull_ReadOnlySpan_Empty_ReturnsEmpty` is right.
 - **Every `IDisposable` test local uses `using` or `try`/`finally`.**
-  `TempFolder`, `IEnumerationMatcher`, anything returned by
-  `MSBuildMatchBuilder.FromSpecification`, `ArrayPoolList<T>` -
-  a bare local leaks the resource when an assertion fails. See
-  the "Disposables in test bodies" section in `tests.instructions.md`
-  for the pattern when the test itself exercises explicit `Dispose()`.
+  A temp-folder helper, a matcher handle, a pooled-list rental - a bare
+  local leaks the resource when an assertion fails. Use the
+  `try`/`finally` pattern when the test itself exercises explicit
+  `Dispose()`.
 - **Don't hard-code `InvariantCulture` for APIs that use
-  `CurrentCulture`.** Touki's provider-less formatting helpers
-  (`string.FormatValue`, `ValueStringBuilder.AppendFormat` without a
-  provider, etc.) format with `CurrentCulture`. Asserting against
-  `InvariantCulture`-formatted strings makes the test locale-dependent.
-  See the "Culture-sensitive assertions" section in
-  `tests.instructions.md`.
+  `CurrentCulture`.** Provider-less formatting helpers generally format
+  with `CurrentCulture`. Asserting against `InvariantCulture`-formatted
+  strings makes the test locale-dependent.
 
 ## 2. Polyfill / framework correctness
 
-For any change under `touki/Framework/`, walk the
-[polyfill-correctness.md](polyfill-correctness.md) items:
+For any change in the Framework-only tree (a polyfill or a framework-only fast
+path), walk these items (a consuming repo may keep the per-item detail and code
+patterns in a `polyfill-correctness` overlay companion):
 
 - Empty / null spans handled before `unsafe` interop (empty source,
   empty destination, both empty; exception type cross-checked).
@@ -94,22 +85,22 @@ For any change under `touki/Framework/`, walk the
 - Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT)
   and are measured or explicitly marked unmeasured.
 
-If the change is not under `touki/Framework/`, skip to &sect;3.
+If the change is not in the Framework-only tree, skip to &sect;3.
 
 ## 3. PR description matches reality
 
-- TFM phrasing: the polyfill TFM is `$(DotNetFrameworkVersion)` =
-  `net472`. The test project's `net481` TFM is just where it runs. Do
-  not call the polyfill "net481-only".
+- TFM phrasing: name the polyfill's *target* TFM (the framework target,
+  e.g. `net472`) distinctly from the TFM the tests merely *run* on (e.g.
+  `net481`). Do not call a `net472`-targeted polyfill "net481-only".
 - File list, test counts, and perf numbers all reflect the *current*
   diff. Re-run after every commit; do not paste numbers from an earlier
   iteration.
 - **Walk each bullet of the description against the diff before
   pushing.** If the body says "covers `Foo` with cases A/B/C", search
   the diff for tests named `Foo_…` and confirm A, B, and C are all
-  there. PR #141 lost a round to a description that claimed a
-  `Span<char>` "null at end" case and a `MatchAnyDirectory` double-
-  dispose test, neither of which was actually in the diff.
+  there. Review rounds have been lost to descriptions claiming a case
+  (a `Span<char>` "null at end", a double-dispose test) that was not
+  actually in the diff.
 - "Deliberately deferred" entries match what's actually absent from
   the working tree.
 
@@ -123,23 +114,22 @@ If the change is not under `touki/Framework/`, skip to &sect;3.
   `upstream`), `origin/main` when cloning the canonical repo directly.
   Recently-merged sister PRs may have introduced files this PR
   cross-references; running off a stale base point makes those links look
-  broken to the offline lychee check that gates `.agents/**`, `AGENTS.md`,
-  and `*.instructions.md` changes. PR #110 lost a review round to exactly
-  this.
-- For changes that touch `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`,
-  also run `pwsh tools/Test-AgentFileLinks.ps1` (see
-  [`agent-files-review`](../agent-files-review/SKILL.md) &sect;7 for
-  options including `-ChangedOnly` and `-Base`).
+  broken to an offline link check that gates `.agents/**`, `AGENTS.md`,
+  and `*.instructions.md` changes. A PR once lost a review round to
+  exactly this.
+- For changes that touch `.agents/`, `AGENTS.md`, or
+  `.github/copilot-instructions.md`, also run the repo's agent-file link
+  checker (see the `agent-files-review` skill for options, including
+  changed-only and base-ref modes).
 - Build both TFMs.
-- Run `dotnet test` in **both Debug and Release**. Release-mode RyuJIT
+- Run the test suite in **both Debug and Release**. Release-mode RyuJIT
   inlining surfaces bugs Debug doesn't - e.g.
   `[AggressiveInlining]` + `Unsafe.As<T, byte>(ref param)` propagates
   the caller's int-promoted argument into the comparison immediate
   (`cmp ecx, 0xFFFFFFFF` instead of `cmp ecx, 0xFF`) for negative
   signed-primitive inputs on net481, but only in Release. Mask
-  explicitly with `& 0xFF` / `& 0xFFFF`. See
-  [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) and
-  [`polyfill-correctness.md`](polyfill-correctness.md).
+  explicitly with `& 0xFF` / `& 0xFFFF`. See the `polyfill-dotnet-api`
+  and `framework-jit-optimization` skills.
 - Stage **by path**, never `git add -A` / `git add .` when the working
   tree spans more than one logical change. If topics are intermingled,
   ask before staging.
@@ -159,13 +149,5 @@ sweep-ups get into history.
 ## 6. Update this skill
 
 If a reviewer flags something not in this checklist, add it. If the
-review touched `.agents/` files, also update via the
-[`agent-files-review`](../agent-files-review/SKILL.md) workflow so the
-validator and CI mirror stay in sync.
-
-## Sub-pages
-
-- [polyfill-correctness.md](polyfill-correctness.md) - the deep
-  per-item detail for &sect;2 (empty-span pinning, `checked()` sums,
-  throw helpers, allocation-free strategies, BCL parity, JIT-naming),
-  with the code patterns and reference files.
+review touched `.agents/` files, also update via the `agent-files-review`
+workflow so the validator and any CI mirror stay in sync.

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,0 +1,62 @@
+# Touki overlay - pre-pr-self-review
+
+Repo-specific companion to the vendored [pre-pr-self-review](SKILL.md) skill. The
+`SKILL.md` is a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in its frontmatter). Do not hand-edit the core -
+`gh skill update` would flag the drift. Everything touki-specific lives here (and
+in `polyfill-correctness.md`, which is a touki overlay sibling, not part of the
+vendored payload).
+
+## Cross-references (the core names these skills generically)
+
+- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - the source-preference
+  and design rules for adding a new polyfill that this checklist validates.
+- [`create-pr`](../create-pr/SKILL.md) - the workflow this checklist precedes.
+- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - the follow-up workflow
+  that re-runs this checklist after review comments.
+- [`performance-testing`](../performance-testing/SKILL.md) - benchmark authoring
+  required when a perf claim drives a code change.
+- [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) - net481
+  RyuJIT tradeoffs cited in the polyfill-correctness items.
+- [`agent-files-review`](../agent-files-review/SKILL.md) - for any changes under
+  `.agents/`, `AGENTS.md`, or `.github/copilot-instructions.md`.
+- [`security-review`](../security-review/SKILL.md) - the security-specific subset;
+  invoke alongside this checklist for any change accepting caller-supplied data or
+  touching `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`.
+
+## Touki specifics the core refers to generically
+
+- The Framework-only tree the core names generically is `touki/Framework/`; the
+  polyfill's target TFM is `$(DotNetFrameworkVersion)` = `net472` (the test
+  project's `net481` is just where it runs - do not call a polyfill "net481-only").
+- Test conventions (the `MethodName_StateUnderTest_ExpectedBehavior` naming, the
+  disposables-in-test-bodies pattern, the culture-sensitive-assertions rule) are in
+  [tests.instructions.md](../../../.github/instructions/tests.instructions.md).
+- The agent-file link checker the core's &sect;4 names generically is
+  [tools/Test-AgentFileLinks.ps1](../../../tools/Test-AgentFileLinks.ps1) (see
+  [`agent-files-review`](../agent-files-review/SKILL.md) &sect;7 for `-ChangedOnly`
+  and `-Base`).
+- Touki utility types referenced in the checklist's test-hygiene items:
+  `Touki.Text.ValueStringBuilder`, `Touki.Io.TempFolder`,
+  `Touki.Collections.ArrayPoolList<T>`, and the MSBuild matcher handles returned by
+  `MSBuildMatchBuilder.FromSpecification`.
+- The war-stories the core anonymized were touki review rounds: PR #141 (a PR body
+  claiming a `Span<char>` "null at end" case and a `MatchAnyDirectory` double-dispose
+  test, neither in the diff) and PR #110 (links broken by a stale base point).
+
+## Polyfill correctness detail (touki overlay sibling)
+
+The deep per-item detail for the core's &sect;2 - empty-span pinning, `checked()`
+sums, throw helpers, the allocation-free strategy catalog, BCL parity, JIT-naming -
+lives in [polyfill-correctness.md](polyfill-correctness.md). It is **not** part of
+the vendored core (it links touki source files under `touki/Framework/`,
+`touki/Touki/`, and `touki.tests/`), so it stays a touki overlay sibling that
+`gh skill update` leaves untouched. A repo adopting this skill writes its own
+equivalent rather than inheriting touki's source links.
+
+## Updating
+
+Pull upstream changes to the core with `gh skill update pre-pr-self-review`
+(review the diff, re-pin). Keep touki-specific additions in this file and in
+`polyfill-correctness.md`, not in the core.

--- a/docs/skills-improvement-plan.md
+++ b/docs/skills-improvement-plan.md
@@ -5,12 +5,17 @@ Status: roadmap. **Phase 0 (the in-repo refactor) is complete** - merged in
 `manage-skills` meta-skill) is implemented** in
 [PR #175](https://github.com/JeremyKuhne/touki/pull/175). **Phase 2 (the commons
 skeleton)** and **Phase 3 (the `security-review` vendoring pilot)** are done - the
-commons is [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills)
-and the pilot vendor-back is in this branch's PR. Phases 4-8 are not started.
+commons is [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills).
+**Phase 4 is in progress**: `scratch-buffer-strategy` (commons `v0.2.1`,
+[PR #177](https://github.com/JeremyKuhne/touki/pull/177)) and
+`framework-jit-optimization` (commons `v0.3.0`,
+[PR #178](https://github.com/JeremyKuhne/touki/pull/178)) are extracted and
+vendored; the four `traceq`-independent cores are next, then the plan **pauses at
+the `traceq` seam** (see Phase 4) before `performance-testing` and Phase 5.
 Section 7 vets the whole sharing design end to end against the two real
 consumers, [`JeremyKuhne/madowaku`](https://github.com/JeremyKuhne/madowaku)
 (a merge) and [`JeremyKuhne/thirtytwo`](https://github.com/JeremyKuhne/thirtytwo)
-(greenfield). Authored 2026-06-04; last updated 2026-06-05.
+(greenfield). Authored 2026-06-04; last updated 2026-06-06.
 
 This plan answers three questions about the agent skills under
 [.agents/skills/](../.agents/skills/):
@@ -775,8 +780,8 @@ heavy content work lives.
 
 **Progress.** `scratch-buffer-strategy` is the first completed Phase 4 increment
 (commons `v0.2.1`, merged in PR #177): its core + bundled
-`references/arraypool-performance.md` are vendored into touki with an overlay. PR
-#177 deferred deleting the touki `docs/arraypool-performance.md` copy; this PR
+`references/arraypool-performance.md` are vendored into touki with an overlay.
+PR #177 deferred deleting the touki `docs/arraypool-performance.md` copy; this PR
 collapses it - the `docs/` original is removed and README, AGENTS.md, and the
 sibling perf docs now point at the single vendored reference.
 `framework-jit-optimization` is the second (commons `v0.3.0`): its core + four
@@ -787,10 +792,39 @@ example plus a pointer up to the vendored field manual, and the live-guidance
 links (README, AGENTS.md, coding_guidelines) are repointed. The remaining
 universal cores are still to do.
 
-- [ ] Extract the remaining universal cores (`pre-pr-self-review`, `create-pr`,
-      `address-pr-feedback`, `agent-files-review`, `performance-testing`,
-      `scratch-buffer-strategy`, `framework-jit-optimization`) into the commons,
-      each host-neutral.
+**Remaining sequence and the `traceq` pause (revised 2026-06-06).** A separate
+effort will productize the EventPipe trace tooling that currently lives in
+`touki.mcp` as a standalone, installable analyzer (`traceq`; see its
+implementation plan). That changes the order of the rest of Phase 4, because
+exactly one remaining skill - `performance-testing` - is entangled with that
+tooling, while the others are not. The revised order:
+
+1. **`pre-pr-self-review`** - next, and a prerequisite for everything downstream.
+   It clears the known YAML blocker (its `description` has a bare colon-space that
+   breaks `gh skill`'s parser - see Phase 3 finding 2) and codifies the
+   "every perf claim carries a benchmark or an explicit 'not measured'" convention
+   that the `traceq` effort builds on. Split `polyfill-correctness.md` out as an
+   **overlay** sibling (it drags ~10 touki source links; it must not ship in the
+   shared payload).
+2. **`create-pr`, `address-pr-feedback`, `agent-files-review`** - the workflow
+   trio. All `traceq`-independent, all small (core + overlay, no large backing-doc
+   splits). `agent-files-review` and the PR skills harden the exact files and flow
+   the `traceq` effort's agent-built milestones run on.
+3. **PAUSE the skills plan here** (see "The `traceq` seam" below) and stand up the
+   `traceq` repository.
+4. **Resume after `traceq`:** extract `performance-testing` **whole, in final
+   form**, then proceed to Phase 5.
+
+- [ ] Extract the `traceq`-independent universal cores in order:
+      `pre-pr-self-review` (+ the `polyfill-correctness.md` overlay split and the
+      `description` YAML fix), then `create-pr`, `address-pr-feedback`,
+      `agent-files-review` - each host-neutral.
+- [ ] **Defer `performance-testing`** until after `traceq` lands (see "The
+      `traceq` seam"). Its BenchmarkDotNet core is portable, but its `profiling.md`
+      sibling and its backing `docs/performance-investigation.md` are written
+      around the `touki.mcp` analyzer that `traceq` replaces. Extracting it now
+      means handling the skill twice (BDN core now, profiling rewrite at `traceq`
+      M6); deferring means one clean extraction in final form.
 - [ ] Move each shared core's generic backing doc into `<skill>/references/`:
       `arraypool-performance.md` -> `scratch-buffer-strategy/references/` (whole,
       class A) **[vendored in PR #177; touki `docs/` copy collapsed and references
@@ -799,6 +833,13 @@ universal cores are still to do.
       (split out of the class-C `framework-span-performance.md`) **[done, commons
       v0.3.0 - touki `docs/` copy thinned to the worked-example appendix]**. Leave
       touki-specific docs behind for the overlay.
+- [ ] **Do not split `docs/performance-investigation.md`** (the old plan said to).
+      It is ~40 KB and ~22 `touki.mcp` references - the `traceq` effort rewrites
+      and single-sources it at M4/M6, so a split now is thrown-away work, and its
+      genuinely-portable part (BDN run commands, result columns, regression
+      thresholds) already duplicates the `performance-testing` siblings. It stays a
+      touki doc, linked from the `performance-testing` overlay, until the `traceq`
+      rewrite.
 - [ ] Tag each sibling **portable** or **overlay**; move overlay siblings (most
       importantly `pre-pr-self-review/polyfill-correctness.md` and the
       example-heavy parts of `polyfill-dotnet-api`) out of the shared payload, and
@@ -813,6 +854,49 @@ universal cores are still to do.
       spot-check that each vendored core plus its overlay reads as one coherent
       skill.
 
+### The `traceq` seam - pause the skills plan, stand up `traceq`
+
+After the four `traceq`-independent cores above (`pre-pr-self-review`, `create-pr`,
+`address-pr-feedback`, `agent-files-review`) are extracted and vendored, **pause
+the skills rollout and begin the `traceq` effort.** This is the cleanest seam in
+the roadmap:
+
+- It leaves **every `traceq`-independent universal core extracted** - Phase 4 is
+  complete except the one skill that is deliberately parked.
+- `performance-testing` is **deferred intact, not left half-finished.** Its final
+  shape depends on `traceq` (the profiling sibling and `performance-investigation.md`
+  are `traceq`'s M6 rewrite targets). Touching it before then means handling the
+  skill twice; deferring means one clean extraction in final form - stable BDN
+  mechanics and `traceq`-based profiling together.
+- It sits just before Phase 5 (the first *external* consumer), which is already the
+  roadmap's biggest commitment boundary.
+
+Why begin `traceq` *at* this seam and not earlier:
+
+- `traceq`'s M0 scaffold seeds its `AGENTS.md` / `copilot-instructions` **from
+  touki's**; the better-factored that surface is, the lighter the seed. The four
+  workflow cores harden exactly that surface, and `agent-files-review` is the skill
+  that governs it.
+- `traceq`'s pre-PR convention ("every surface-text change carries an eval delta or
+  an explicit 'not measured'") is the `pre-pr-self-review` convention; have it solid
+  first.
+- The `traceq` plan flags **solo-maintainer stall mid-extraction** as a top risk.
+  Two large tracks competing for focus is the real cost - reach this documented
+  clean seam, then commit to `traceq` rather than interleaving.
+
+What resumes **after** `traceq` reaches parity (its M6):
+
+- Extract `performance-testing` whole: the portable BDN core
+  (`authoring` / `running` / `interpreting-results`) plus a profiling page now
+  written against `traceq` (`dnx TraceQ.Mcp` / the `traceq` CLI) instead of
+  `touki.mcp`, promoted into the commons core. `docs/performance-investigation.md`
+  is rewritten through `traceq`'s single-source knowledge pipeline at the same time.
+- Hand-off note for `traceq` M4: the commons `performance-testing` core and
+  `traceq`'s own knowledge layer (its SKILL / AGENTS snippet) must single-source
+  against each other, or the profiling prose becomes a third copy that drifts.
+- Then Phase 5 (madowaku), which now *also* validates `traceq` consumption from a
+  second repo - folding two acid tests into one.
+
 ### Phase 5 - first external consumer: madowaku (the full vet)
 
 `madowaku` is the designated first consumer and the end-to-end vet; section 7
@@ -821,8 +905,9 @@ walks it in detail. Crucially, the `performance-testing` reconciliation here
 extracted cleanly, madowaku's fork drops onto it with only an overlay.
 
 - [ ] Reconcile the two `performance-testing` skills: confirm touki's extracted
-      core also subsumes madowaku's hand-forked copy; if not, the core still
-      carried touki specifics - fix the core, not the consumer.
+      core (extracted **after** `traceq`, per the `traceq` seam) also subsumes
+      madowaku's hand-forked copy; if not, the core still carried touki specifics -
+      fix the core, not the consumer.
 - [ ] Contribute madowaku's `cswin32-interop` / `cswin32-com` portable cores into
       the commons (skills flow both ways).
 - [ ] Vendor the applicable shared cores into madowaku (section 6 table), each


### PR DESCRIPTION
Two related Phase 4 items. See `docs/skills-improvement-plan.md`.

## 1. Resequence Phase 4 around the `traceq` effort (commit `c06aa8a`)

A separate effort will productize the `touki.mcp` EventPipe tooling as a standalone `traceq` analyzer. Exactly one remaining Phase 4 skill - `performance-testing` - is entangled with that tooling (its `profiling.md` sibling and `docs/performance-investigation.md` are `traceq`'s M4/M6 rewrite targets); the rest are not. The plan now:

- Extracts the four `traceq`-independent cores first: `pre-pr-self-review` (this PR), then `create-pr`, `address-pr-feedback`, `agent-files-review`.
- **Pauses at a documented "`traceq` seam"** before `performance-testing` and Phase 5, then stands up `traceq`.
- **Defers `performance-testing` intact** (one clean extraction in final form, post-`traceq`, rather than handling it twice).
- **Stops splitting `docs/performance-investigation.md`** - `traceq` rewrites and single-sources it; a split now is thrown-away work that also duplicates the BDN siblings.
- Refreshes the stale status header.

## 2. Vendor `pre-pr-self-review` from the commons at `v0.4.0` (commit `95eae02`)

Replaces the touki-local `SKILL.md` with the pinned portable core from [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) `v0.4.0`:

- Host-neutral checklist; genericized paths (Framework-only tree, test project, the agent-file link checker); `license: MIT`.
- **Clears the Phase 3 YAML blocker** - the bare colon-space in the `description` that broke `gh skill`'s parser is fixed, so the skill now vendors cleanly.
- The eight cross-skill links and touki specifics move to a new `overlay.md`.
- `polyfill-correctness.md` stays a **touki overlay sibling** (it links touki source files); `gh skill install --force` preserved it untouched, so it is not in this diff.

The vendored core is byte-identical to the commons except injected provenance frontmatter; do not hand-edit it (`gh skill update` tracks drift) - touki-specific content lives in `overlay.md` and `polyfill-correctness.md`.

## Validation

- `tools/Validate-AgentFiles.ps1` passes.
- `tools/Test-AgentFileLinks.ps1` passes (53 files, no dangling links).
- markdownlint clean on all gated agent files.
- All changes are markdown/docs; no code touched.