### PR TITLE
Make Codecov upload non-blocking (codecov-action#1940)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -127,7 +127,12 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         files: artifacts/coverage/Cobertura.xml
-        fail_ci_if_error: true
+        # Coverage upload is informational and must not gate the build. The
+        # Codecov uploader has an intermittent sha256/GPG signature race on the
+        # CDN that hard-fails otherwise unrelated PRs (Codecov-side bug, "no
+        # security issue" per the maintainers):
+        # https://github.com/codecov/codecov-action/issues/1940
+        fail_ci_if_error: false
         disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload raw logs


### PR DESCRIPTION
## Problem

The `Upload coverage to Codecov` step in `dotnet.yml` runs with `fail_ci_if_error: true`. The Codecov uploader currently has an intermittent **sha256/GPG signature race** on its CDN - it resolves the CLI version after downloading, so the `SHA256SUM.sig` it verifies can belong to a different binary build:

```
gpg: Signature made Tue Apr 21 19:28:13 2026
gpg:                using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Can't check signature: No public key
```

This is a **Codecov-side bug**, tracked upstream at [codecov/codecov-action#1940](https://github.com/codecov/codecov-action/issues/1940) (open, labeled bug). The Codecov maintainers confirm on that thread that *"the releases are in a valid state and there is no security issue"* - it is a CDN/version-bump misconfiguration, recurring in waves across Windows and Linux runners ecosystem-wide.

With `fail_ci_if_error: true`, every such Codecov hiccup hard-fails our Release build. It has already failed **PR #179** (a markdown-only change with no code or coverage relevance) **twice**.

## Change

Flip the one flag to `false` so coverage upload is informational and a third-party outage no longer gates merges, with an inline comment pointing at the tracking issue:

```yaml
        # https://github.com/codecov/codecov-action/issues/1940
        fail_ci_if_error: false
```

Coverage is still uploaded and reported when Codecov is healthy; it just stops being a merge gate. This is the configuration multiple projects in the upstream thread adopted, and it is the right setting independent of this incident - a third-party coverage service should not be able to block CI.

The coverage report artifact (`actions/upload-artifact`) is unaffected; only the external Codecov push is made non-blocking.