### PR TITLE
Vendor the create-pr / address-pr-feedback / agent-files-review trio (Phase 4)

### DIFF
--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -3,10 +3,10 @@ description: Address feedback on an existing pull request - review comments, req
 license: MIT
 metadata:
     github-path: skills/address-pr-feedback
-    github-pinned: v0.5.0
-    github-ref: refs/tags/v0.5.0
+    github-pinned: v0.5.1
+    github-ref: refs/tags/v0.5.1
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: ca7e22e8fbf08581099ae31c44e14421adbf1ef2
+    github-tree-sha: bdbdca48b1ebc651d9b4b1c63d2684383f2a7c83
     portability: semi-portable
 name: address-pr-feedback
 ---
@@ -86,7 +86,7 @@ force-push, or leave the commit in place.
 ## Related
 
 - Your repo's agent guidance (`AGENTS.md`) - the rule itself.
-- The `create-pr` skill - opening the initial PR (different approval
-  semantics).
+- The `create-pr` skill - opening the initial PR (same publish gate,
+  different edit scope).
 - The `pre-pr-self-review` skill - the validation checklist that applies
   to both initial and follow-up rounds.

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -1,16 +1,21 @@
 ---
-name: address-pr-feedback
 description: Address feedback on an existing pull request - review comments, requested changes, CI failures, or any post-PR follow-up work. Use when the user says "address the review", "fix the comments", "address Copilot's feedback", "fix the CI failure", or any similar phrasing. Distinct from `create-pr`, which covers opening the *initial* PR.
+license: MIT
 metadata:
-  portability: repo-specific
+    github-path: skills/address-pr-feedback
+    github-pinned: v0.5.0
+    github-ref: refs/tags/v0.5.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: ca7e22e8fbf08581099ae31c44e14421adbf1ef2
+    portability: semi-portable
+name: address-pr-feedback
 ---
-
 # Address PR feedback
 
-This skill is the post-PR counterpart to [`create-pr`](../create-pr/SKILL.md).
-Both skills share the **same** publish gate: neither `git commit` nor
-`git push` runs without an explicit publishing verb from the user. The
-difference is what each skill authorizes you to *edit*:
+This skill is the post-PR counterpart to the `create-pr` skill. Both share the
+**same** publish gate: neither `git commit` nor `git push` runs without an
+explicit publishing verb from the user. The difference is what each skill
+authorizes you to *edit*:
 
 - `create-pr` authorizes preparing a new PR from in-progress work -
   branching, staging, proposing a commit message. The commit and push
@@ -18,11 +23,10 @@ difference is what each skill authorizes you to *edit*:
 - This skill authorizes editing files in response to review feedback or
   CI failures on an existing PR. Same approval gate before commit/push.
 
-The
-["Working with the user on changes"](../../../AGENTS.md#working-with-the-user-on-changes)
-section of AGENTS.md is the source of truth for the commit/push approval
-rule. Re-read it at the start of every invocation; this skill is the
-decision-point reminder, not a replacement.
+Your repo's agent guidance (the "Working with the user on changes" rules in
+`AGENTS.md`) is the source of truth for the commit/push approval rule. Re-read it
+at the start of every invocation; this skill is the decision-point reminder, not
+a replacement.
 
 ## Recognizing approval
 
@@ -35,7 +39,7 @@ Pattern-match the words, do not infer intent.
 direct synonyms when paired with a publishing intent.
 
 **Not approval** - everything else, including these phrasings that
-have caused violations on this repo:
+have repeatedly caused violations:
 
 - "Address the review comments." / "Reply to the comments on the PR." /
   "Fix the comments / fix the CI failure."
@@ -60,9 +64,8 @@ Stop and ask one short yes/no question.
    which are out of scope, and which you disagree with. For comments you
    disagree with, plan a written response rather than silently overriding.
 3. **Edit files.** Make the code changes. Run the build and any relevant
-   tests. The applicable validation rules are still
-   [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - a follow-up
-   round needs the same checks as the initial PR.
+   tests. The applicable validation rules are still the `pre-pr-self-review`
+   checklist - a follow-up round needs the same checks as the initial PR.
 4. **Stop. Describe.** Summarize what you changed, why, and what (if
    anything) you chose not to act on. Do **not** run `git add`, `git
    commit`, or `git push`.
@@ -70,7 +73,8 @@ Stop and ask one short yes/no question.
    above).
 6. **Only then** stage by path, commit with a message that summarizes the
    round of changes, and push. The staging/commit/push mechanics are the
-   same as in [`create-pr`](../create-pr/SKILL.md) §3-§4.
+   same as in the `create-pr` skill (its "Commit changes" and "Push the
+   branch" steps).
 
 ## When you've already violated the rule
 
@@ -81,8 +85,8 @@ force-push, or leave the commit in place.
 
 ## Related
 
-- [AGENTS.md](../../../AGENTS.md) - the rule itself.
-- [`create-pr`](../create-pr/SKILL.md) - opening the initial PR
-  (different approval semantics).
-- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - validation
-  checklist that applies to both initial and follow-up rounds.
+- Your repo's agent guidance (`AGENTS.md`) - the rule itself.
+- The `create-pr` skill - opening the initial PR (different approval
+  semantics).
+- The `pre-pr-self-review` skill - the validation checklist that applies
+  to both initial and follow-up rounds.

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,0 +1,28 @@
+# Touki overlay - address-pr-feedback
+
+Repo-specific companion to the vendored [address-pr-feedback](SKILL.md) skill. The
+`SKILL.md` is a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in its frontmatter). Do not hand-edit the core -
+`gh skill update` would flag the drift. Everything touki-specific lives here.
+
+## Cross-references (the core names these skills generically)
+
+- [`create-pr`](../create-pr/SKILL.md) - opening the initial PR (the same publish
+  gate, different edit scope).
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - the validation checklist
+  that applies to both initial and follow-up rounds.
+
+## Touki specifics
+
+- The "Working with the user on changes" approval rule the core points at is in
+  [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes) - the source of
+  truth for the commit/push publish boundary and the not-approval phrasings, which
+  has been violated on this repo specifically during PR-feedback rounds. Re-read it
+  at the start of every invocation.
+
+## Updating
+
+Pull upstream changes to the core with `gh skill update address-pr-feedback`
+(review the diff, re-pin). Keep touki-specific additions in this file, not in the
+core.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -1,28 +1,40 @@
 ---
-name: agent-files-review
-description: Review changes to AI-agent customization files in this repo (AGENTS.md, .github/copilot-instructions.md, *.instructions.md, *.prompt.md, *.agent.md, SKILL.md, validator, CI workflow). Use when asked to review or validate agent-file changes, fix CI failures from agent-files.yml, or audit a draft of any of these files.
+description: Review changes to AI-agent customization files (AGENTS.md, .github/copilot-instructions.md, *.instructions.md, *.prompt.md, *.agent.md, SKILL.md, the validator, the CI workflow). Use when asked to review or validate agent-file changes, fix CI failures from the agent-files workflow, or audit a draft of any of these files.
+license: MIT
 metadata:
-  portability: semi-portable
+    github-path: skills/agent-files-review
+    github-pinned: v0.5.0
+    github-ref: refs/tags/v0.5.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 24e6905b671e90dad22592371365a1f8f4475496
+    portability: semi-portable
+name: agent-files-review
 ---
-
 # Agent customization files - review checklist
 
 Run through every applicable item below before approving a change to an agent
-customization file. The PR review history showed each of these caught a real bug.
+customization file. Each item below caught a real bug in PR review history.
+
+This skill assumes the repository has adopted the agent-file scaffold: an
+`AGENTS.md` single-source with a generated `.github/copilot-instructions.md`
+mirror, a validator script (conventionally `tools/Validate-AgentFiles.ps1`), a
+relative-link checker (conventionally `tools/Test-AgentFileLinks.ps1`), and a CI
+workflow (conventionally `.github/workflows/agent-files.yml`) running markdownlint
+plus an offline lychee link check. A consuming repo wires the exact paths in its
+overlay.
 
 ## 1. AGENTS.md / `.github/copilot-instructions.md`
 
 - The mirror is generated. **Never edit `.github/copilot-instructions.md` by hand.**
-  Edits go in [AGENTS.md](../../../AGENTS.md), then run
-  `pwsh tools/Validate-AgentFiles.ps1 -Fix` to regenerate.
-- Run `pwsh tools/Validate-AgentFiles.ps1` after any AGENTS.md edit. The
-  workflow at [.github/workflows/agent-files.yml](../../../.github/workflows/agent-files.yml)
+  Edits go in `AGENTS.md`, then regenerate the mirror with the validator's
+  fix mode (`Validate-AgentFiles.ps1 -Fix`).
+- Run the validator after any `AGENTS.md` edit. The agent-files CI workflow
   enforces this; out-of-sync mirrors fail CI.
-- **Relative Markdown links must work in both AGENTS.md and the mirror.** The
+- **Relative Markdown links must work in both `AGENTS.md` and the mirror.** The
   generator rewrites them automatically (`.github/x` → `x`, other paths get
   `../` prepended). Don't pre-rewrite links by hand. Don't add absolute
   filesystem paths or `./` prefixes that would defeat the regex.
-- Don't use end-of-line comments in AGENTS.md examples or anywhere else; the
+- Don't use end-of-line comments in `AGENTS.md` examples or anywhere else; the
   file itself bans the pattern. Same applies to YAML examples in the README
   files for `.github/agents/`, `.github/prompts/`, etc. - put `# comment`
   lines above the field, not after it.
@@ -75,21 +87,20 @@ customization file. The PR review history showed each of these caught a real bug
 
 ## 6. Validator and workflow
 
-- The frontmatter parser in [tools/Validate-AgentFiles.ps1](../../../tools/Validate-AgentFiles.ps1)
-  is hand-rolled. It supports flat scalars, inline lists, and block lists.
-  It does **not** handle nested mappings, multi-line strings, anchors, or
-  flow mappings. If a contributor needs those, switch to the
-  `powershell-yaml` module rather than extending the regex.
-- The mirror generator preserves AGENTS.md's on-disk line endings (LF or
+- The frontmatter parser in the validator script is typically hand-rolled. A
+  hand-rolled parser supports flat scalars, inline lists, and block lists, but
+  **not** nested mappings, multi-line strings, anchors, or flow mappings. If a
+  contributor needs those, switch to a real YAML module (e.g.
+  `powershell-yaml`) rather than extending the regex.
+- The mirror generator preserves `AGENTS.md`'s on-disk line endings (LF or
   CRLF) so `core.autocrlf=true` doesn't cause spurious diffs on Windows
   checkouts.
-- [.markdownlint.jsonc](../../../.markdownlint.jsonc) intentionally disables
-  MD013 (line-length), MD022/MD032 (blanks-around), MD033 (inline HTML),
-  MD041 (first-line heading). It keeps MD040 (fenced-code-language),
-  no-trailing-spaces, no-hard-tabs. Don't disable MD040 - adding a `text`
-  language tag is trivial and prevents drift.
-- The CI job runs on `ubuntu-latest`. PowerShell is preinstalled; no `pip`
-  step is needed.
+- The markdownlint config typically disables MD013 (line-length), MD022/MD032
+  (blanks-around), MD033 (inline HTML), MD041 (first-line heading), and keeps
+  MD040 (fenced-code-language), no-trailing-spaces, no-hard-tabs. Don't disable
+  MD040 - adding a `text` language tag is trivial and prevents drift.
+- The CI job typically runs on `ubuntu-latest`. PowerShell is preinstalled
+  there; no `pip` step is needed.
 
 ## 7. Relative Markdown links must resolve in this branch
 
@@ -97,39 +108,21 @@ The CI link check is **offline lychee** - it only follows links that
 resolve to files in the current working tree. A link to a file that exists
 on the canonical repo's `main` but not in your branch will fail.
 
-- **Before opening a PR with agent-file changes, run
-  [`tools/Test-AgentFileLinks.ps1`](../../../tools/Test-AgentFileLinks.ps1).**
+- **Before opening a PR with agent-file changes, run the link checker.**
   Without arguments, it scans every Markdown file in CI's lychee scope and
-  reports any relative link whose target doesn't exist on disk:
-
-  ```pwsh
-  pwsh tools/Test-AgentFileLinks.ps1
-  ```
-
-  The script auto-detects the PR base ref when used with `-ChangedOnly`:
-  it picks `upstream/main` if a remote literally named `upstream` exists
-  (the fork-PR workflow, where `origin` is your fork and `upstream` is the
-  canonical repo) and `origin/main` otherwise (working directly on a clone
-  of the canonical repo). Override with `-Base <ref>` if needed:
-
-  ```pwsh
-  # Audit only files changed on this branch vs the auto-detected base.
-  pwsh tools/Test-AgentFileLinks.ps1 -ChangedOnly
-
-  # Override the base explicitly.
-  pwsh tools/Test-AgentFileLinks.ps1 -Base origin/feature
-  ```
-
+  reports any relative link whose target doesn't exist on disk. It typically
+  auto-detects the PR base ref: `upstream/main` if a remote literally named
+  `upstream` exists (the fork-PR workflow, where `origin` is your fork and
+  `upstream` is the canonical repo), `origin/main` otherwise (working directly
+  on a clone of the canonical repo). A changed-only mode and an explicit
+  base-ref override are the usual options.
 - **If you cite files added by a different in-flight or just-merged PR,
   rebase your branch on the canonical `main`** (`upstream/main` from a
   fork, or `origin/main` from a direct clone) so those files exist
-  locally. PR #110's review feedback was triggered by exactly this
-  scenario: the branch predated PR #109 (which added the polyfill files),
-  so every cross-reference to `ConvertExtensions.cs`, `RandomExtensions.cs`,
-  `StringExtensions.cs`, `EncodingExtensions.cs`, `HashCodeExtensions.cs`,
-  `CryptographicOperations.cs`, `SpanExtensions.StartsEndsWith.cs`,
-  `StartsWithPerf.cs`, and `StringExtensionsConcatTests.cs` failed lychee
-  even though those files existed on the canonical `main`.
+  locally. A recurring review-round loss comes from exactly this scenario:
+  the branch predated a sister PR that added the referenced source files,
+  so every cross-reference to them failed lychee even though those files
+  existed on the canonical `main`.
 - The lychee check runs against the merged tree on `main` only after a
   push, so a stale branch can still ship broken links into your PR. Treat
   rebase-then-link-audit as a single step before pushing any agent-file
@@ -144,7 +137,7 @@ on the canonical repo's `main` but not in your branch will fail.
 - No whitespace-only lines (a "blank" line must be truly empty).
 - Tabs are forbidden in Markdown bodies.
 - **Files must end with a single newline character** (markdownlint MD047).
-  The validator now flags this; markdownlint enforces it in CI. New files
+  The validator flags this; markdownlint enforces it in CI. New files
   created via the standard editor tooling get this for free, but
   hand-edited or copy-pasted content sometimes loses the final `\n`.
 - These rules are enforced both by the validator and by markdownlint.
@@ -153,17 +146,9 @@ on the canonical repo's `main` but not in your branch will fail.
 
 **Always run the validator before declaring a review complete or pushing
 agent-file changes.** It catches mirror drift, missing/invalid frontmatter,
-SKILL.md naming mistakes, missing trailing newlines, and trailing/empty-line
-whitespace - the same rules CI enforces.
-
-```pwsh
-# Validate everything (frontmatter, mirror sync, dir-name match, whitespace,
-# trailing newline).
-pwsh tools/Validate-AgentFiles.ps1
-
-# Regenerate the mirror after editing AGENTS.md.
-pwsh tools/Validate-AgentFiles.ps1 -Fix
-```
+`SKILL.md` naming mistakes, missing trailing newlines, and trailing/empty-line
+whitespace - the same rules CI enforces. Run it in plain mode to validate, and
+in fix mode (`-Fix`) to regenerate the mirror after editing `AGENTS.md`.
 
 The validator does **not** reproduce markdownlint's full rule set. After it
 passes, sanity-check that your Markdown:
@@ -176,4 +161,4 @@ passes, sanity-check that your Markdown:
 If CI fails after a local validator pass, the failure is almost always
 markdownlint (open the failing job's annotations) or the lychee link check
 (broken relative link - remember the mirror rewrites links, so test
-the form in AGENTS.md, not the rewritten copy).
+the form in `AGENTS.md`, not the rewritten copy).

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -3,10 +3,10 @@ description: Review changes to AI-agent customization files (AGENTS.md, .github/
 license: MIT
 metadata:
     github-path: skills/agent-files-review
-    github-pinned: v0.5.0
-    github-ref: refs/tags/v0.5.0
+    github-pinned: v0.5.1
+    github-ref: refs/tags/v0.5.1
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 24e6905b671e90dad22592371365a1f8f4475496
+    github-tree-sha: 06f4a82d587ae2ab8bbf055339473728d081f9fd
     portability: semi-portable
 name: agent-files-review
 ---
@@ -137,7 +137,9 @@ on the canonical repo's `main` but not in your branch will fail.
 - No whitespace-only lines (a "blank" line must be truly empty).
 - Tabs are forbidden in Markdown bodies.
 - **Files must end with a single newline character** (markdownlint MD047).
-  The validator flags this; markdownlint enforces it in CI. New files
+  The validator flags a *missing* trailing newline (it checks the file ends
+  with `\n`, not that there is exactly one); markdownlint enforces the full
+  single-newline rule in CI. New files
   created via the standard editor tooling get this for free, but
   hand-edited or copy-pasted content sometimes loses the final `\n`.
 - These rules are enforced both by the validator and by markdownlint.

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,0 +1,48 @@
+# Touki overlay - agent-files-review
+
+Repo-specific companion to the vendored [agent-files-review](SKILL.md) skill. The
+`SKILL.md` is a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in its frontmatter). Do not hand-edit the core -
+`gh skill update` would flag the drift. Everything touki-specific lives here.
+
+## Touki scaffold paths (the core names these by convention)
+
+- The validator is
+  [tools/Validate-AgentFiles.ps1](../../../tools/Validate-AgentFiles.ps1); run it
+  plain to validate and with `-Fix` to regenerate the
+  [.github/copilot-instructions.md](../../../.github/copilot-instructions.md)
+  mirror from [AGENTS.md](../../../AGENTS.md).
+- The relative-link checker is
+  [tools/Test-AgentFileLinks.ps1](../../../tools/Test-AgentFileLinks.ps1)
+  (`-ChangedOnly` and `-Base <ref>` options).
+- The CI workflow is
+  [.github/workflows/agent-files.yml](../../../.github/workflows/agent-files.yml)
+  (markdownlint + offline lychee, `ubuntu-latest`).
+- The markdownlint config is
+  [.markdownlint.jsonc](../../../.markdownlint.jsonc) - it disables MD013,
+  MD022/MD032, MD033, MD041, MD060 and keeps MD040, no-trailing-spaces,
+  no-hard-tabs, MD047.
+
+## Cross-references
+
+- [`manage-skills`](../manage-skills/SKILL.md) - the lifecycle skill for adding /
+  updating / vendoring skills (distinct from this file-syntax review).
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - its &sect;4 final-audit
+  step calls the link checker for changes under `.agents/`, `AGENTS.md`, or the
+  mirror.
+
+## Touki war-story (the core anonymized this)
+
+The "stale branch predating a sister PR" link-failure the core describes generically
+was PR #110: the branch predated PR #109 (which added the polyfill files), so every
+cross-reference to `ConvertExtensions.cs`, `RandomExtensions.cs`,
+`StringExtensions.cs`, `EncodingExtensions.cs`, `HashCodeExtensions.cs`,
+`CryptographicOperations.cs`, `SpanExtensions.StartsEndsWith.cs`, `StartsWithPerf.cs`,
+and `StringExtensionsConcatTests.cs` failed lychee even though those files existed on
+the canonical `main`. The fix was rebase-then-link-audit before pushing.
+
+## Updating
+
+Pull upstream changes to the core with `gh skill update agent-files-review` (review
+the diff, re-pin). Keep touki-specific additions in this file, not in the core.

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -3,10 +3,10 @@ description: Create a pull request for the current changes. Use when asked to "m
 license: MIT
 metadata:
     github-path: skills/create-pr
-    github-pinned: v0.5.0
-    github-ref: refs/tags/v0.5.0
+    github-pinned: v0.5.1
+    github-ref: refs/tags/v0.5.1
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 7a3628b69012f16c717b27ae9610b3213c30637d
+    github-tree-sha: be419cb9de66ddb7ba97afcf761d7d41c83639a5
     portability: semi-portable
 name: create-pr
 ---
@@ -175,8 +175,8 @@ Tell the user:
 
 Once the PR exists, this skill is done. Subsequent rounds of edits in
 response to review comments, requested changes, or CI failures go through
-the `address-pr-feedback` skill, which has different commit/push approval
-semantics.
+the `address-pr-feedback` skill, which covers a different edit scope under
+the same commit/push publish gate.
 
 ## Guardrails
 

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -1,10 +1,15 @@
 ---
-name: create-pr
 description: Create a pull request for the current changes. Use when asked to "make a PR", "open a pull request", "push and PR", or otherwise publish in-progress work for review. Ensures changes are on a non-`main` branch, commits are made and pushed, and the PR targets `upstream/main` when an `upstream` remote exists, otherwise `origin/main`.
+license: MIT
 metadata:
-  portability: semi-portable
+    github-path: skills/create-pr
+    github-pinned: v0.5.0
+    github-ref: refs/tags/v0.5.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 7a3628b69012f16c717b27ae9610b3213c30637d
+    portability: semi-portable
+name: create-pr
 ---
-
 # Create a pull request
 
 Follow these steps in order. Stop and ask the user if any check is ambiguous;
@@ -16,16 +21,15 @@ confirmation.
 The **Approval checkpoint** inside step 3 (Commit changes) is the gate:
 staging happens before it, `git commit` and everything after happen only
 once the user supplies an explicit publishing verb - `commit`, `push`,
-`ship it`, or equivalent. See AGENTS.md § "Working with the user on
-changes" for the canonical rule and the recurring not-approval phrasings.
+`ship it`, or equivalent. See your repo's agent guidance (the "Working with
+the user on changes" rules in `AGENTS.md`) for the canonical rule and the
+recurring not-approval phrasings.
 
-Before running this workflow, walk through the
-[`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) checklist - it
-catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
-that have repeatedly cost a review round-trip on this repo. If the change
-polyfills a .NET API for .NET Framework, the
-[`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) skill defines the
-design rules the self-review then validates against.
+Before running this workflow, walk through the `pre-pr-self-review` checklist -
+it catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
+that repeatedly cost a review round-trip. If the change polyfills a .NET API for
+.NET Framework, a `polyfill-dotnet-api` skill (where the repo provides one)
+defines the design rules the self-review then validates against.
 
 ## 1. Inspect repository state
 
@@ -73,11 +77,11 @@ Decide the PR base:
 
 **Stop here.** Show the user the staged diff (or summarize it) and the
 proposed commit message. Wait for the user to explicitly say `commit`,
-`push`, or `ship it` (or one of the other verbs listed in AGENTS.md
-§ "Working with the user on changes") before running `git commit`. If
-the user already used one of those verbs in the message that triggered
-this skill, proceed without asking again. Do not infer approval from the
-original "open a PR" request.
+`push`, or `ship it` (or one of the other verbs listed in your repo's
+agent guidance "Working with the user on changes" rules) before running
+`git commit`. If the user already used one of those verbs in the message
+that triggered this skill, proceed without asking again. Do not infer
+approval from the original "open a PR" request.
 
 ## 4. Push the branch
 
@@ -97,8 +101,8 @@ so conflicts surface locally instead of on the PR:
 
 - **Clean:** prefer rebasing onto `<base>` so the PR diff is current.
 - **Conflicts:** rebase (`git rebase <base>`, `$env:GIT_EDITOR='true'`), resolve,
-  `git add` by path, `git rebase --continue`, then re-run `dotnet build` and
-  `dotnet test -c Release` (base may have moved/renamed code you depend on).
+  `git add` by path, `git rebase --continue`, then re-run the build and the
+  test suite in Release (base may have moved/renamed code you depend on).
 - A rebase rewrites commits, so the next push needs `--force-with-lease` - a
   force-push that **requires explicit user approval** per the publish-boundary rule.
 
@@ -149,7 +153,7 @@ Call `github-pull-request_create_pull_request` with:
 
 - Title: same style as the commit subject; reference the area touched.
 - Body: brief summary of what changed and why, bullet list of notable
-  changes, and any test/validation notes (e.g. "ran `dotnet test`"). Link
+  changes, and any test/validation notes (e.g. "ran the test suite"). Link
   related issues with `Fixes #N` when appropriate.
 - If the user has not supplied a title/body, propose one and confirm before
   creating.
@@ -171,8 +175,8 @@ Tell the user:
 
 Once the PR exists, this skill is done. Subsequent rounds of edits in
 response to review comments, requested changes, or CI failures go through
-the [`address-pr-feedback`](../address-pr-feedback/SKILL.md) skill, which
-has different commit/push approval semantics.
+the `address-pr-feedback` skill, which has different commit/push approval
+semantics.
 
 ## Guardrails
 

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,0 +1,29 @@
+# Touki overlay - create-pr
+
+Repo-specific companion to the vendored [create-pr](SKILL.md) skill. The
+`SKILL.md` is a **pinned copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in its frontmatter). Do not hand-edit the core -
+`gh skill update` would flag the drift. Everything touki-specific lives here.
+
+## Cross-references (the core names these skills generically)
+
+- [`pre-pr-self-review`](../pre-pr-self-review/SKILL.md) - the checklist to walk
+  before running this workflow.
+- [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - the design rules the
+  self-review validates against for a .NET Framework polyfill.
+- [`address-pr-feedback`](../address-pr-feedback/SKILL.md) - the post-PR workflow
+  for subsequent edit rounds.
+
+## Touki specifics
+
+- The "Working with the user on changes" approval rule the core points at is in
+  [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes) (the canonical
+  source of the commit/push publish-boundary rule and the not-approval phrasings).
+- touki is the canonical repo (no `upstream` remote in the usual clone), so PRs
+  target `origin/main`.
+
+## Updating
+
+Pull upstream changes to the core with `gh skill update create-pr` (review the
+diff, re-pin). Keep touki-specific additions in this file, not in the core.

--- a/docs/skills-improvement-plan.md
+++ b/docs/skills-improvement-plan.md
@@ -173,7 +173,7 @@ boundary, so the refactor and the extraction are one piece of work.
 | `create-pr` | core extractable | git/PR open workflow + approval gate | branch naming, `dotnet test -c Release`, fork/upstream |
 | `agent-files-review` | core extractable | reviewing agent-customization files generally | `Validate-AgentFiles.ps1`, the mirror generator, `agent-files.yml` |
 | `polyfill-dotnet-api` | repo-specific (small core) | the "MS package -> PolySharp -> hand-roll" decision tree | `touki/Framework/` layout, namespace rules, extension-block coexistence |
-| `address-pr-feedback` | repo-specific | thin approval-gate restatement | touki approval phrasing bank |
+| `address-pr-feedback` | core extractable | the post-PR approval-gate + feedback workflow (shared with `create-pr`) | touki approval phrasing bank, `AGENTS.md` anchor |
 | `publish-release` | repo-specific | none meaningful | MinVer dual tag streams, package names |
 | `run-tests-on-wsl` | repo-specific | the WSL DrvFs / NuGet trap workaround | oracle suite names, `touki.tests` paths |
 


### PR DESCRIPTION
Vendors the three remaining `traceq`-independent universal cores from the [agent-skills commons](https://github.com/JeremyKuhne/agent-skills) `v0.5.0`, completing the pre-`traceq` portion of Phase 4. See `docs/skills-improvement-plan.md`.

## The three skills (all single-file workflow/checklist cores)

- **`create-pr`** - the PR-creation workflow with its approval checkpoint.
- **`address-pr-feedback`** - the post-PR counterpart sharing the same publish gate.
- **`agent-files-review`** - the agent-customization-file review checklist.

Each is replaced by its pinned portable core (byte-identical to the commons except injected provenance frontmatter; do not hand-edit - `gh skill update` tracks drift), plus a touki `overlay.md` carrying:

- the cross-skill links the core names generically,
- the `AGENTS.md` "Working with the user on changes" approval anchor,
- and, for `agent-files-review`, the touki scaffold tool paths (`Validate-AgentFiles.ps1`, `Test-AgentFileLinks.ps1`, `agent-files.yml`, `.markdownlint.jsonc`) plus the anonymized PR #110 link-failure war-story.

## Reclassification

`address-pr-feedback` moves from **repo-specific** to **core-extractable** in the §6 matrix (`docs/skills-improvement-plan.md`): its approval-gate discipline is universal and shared with its `create-pr` sibling, not touki-specific.

## What's next (not in this PR)

These were the last three `traceq`-independent cores. Per the resequencing in PR #179, Phase 4 now **pauses at the `traceq` seam** - `performance-testing` is deferred (it depends on the `traceq` analyzer) until `traceq` reaches parity, then it and Phase 5 follow.

## Validation

- `tools/Validate-AgentFiles.ps1` passes.
- `tools/Test-AgentFileLinks.ps1` passes (56 files, no dangling links).
- markdownlint clean on all gated agent files (45 files).
- All changes are markdown/docs; no code touched.