### PR TITLE
Relocate the analysis core into TraceQ.Core (M1)

### DIFF
--- a/traceq/src/TraceQ.Core/Server/TraceStore.cs
+++ b/traceq/src/TraceQ.Core/Server/TraceStore.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Concurrent;
+using TraceQ.Tracing;
+
+namespace TraceQ.Server;
+
+/// <summary>
+///  Loads traces on demand and caches the parsed model per absolute path, so
+///  repeated queries against the same trace avoid re-parsing.
+/// </summary>
+public sealed class TraceStore
+{
+    private readonly TraceLoader _loader = new();
+
+    // Match the cache's path comparison to the host file system: Windows and macOS
+    // are case-insensitive, Linux is case-sensitive, so distinct-by-case paths must
+    // not be conflated there.
+    private readonly ConcurrentDictionary<string, LoadedTrace> _cache = new(
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    ///  Returns the loaded trace for <paramref name="path"/>, loading and caching
+    ///  it on first use.
+    /// </summary>
+    /// <param name="path">The trace file path.</param>
+    /// <param name="symbolsDirectory">
+    ///  Optional build-output directory whose assemblies' embedded portable PDBs are
+    ///  extracted to resolve managed frames to <c>file:line</c>. The cache keys on it,
+    ///  so the same trace loaded with and without symbols is cached separately.
+    /// </param>
+    /// <returns>The cached loaded trace.</returns>
+    internal LoadedTrace Get(string path, string? symbolsDirectory = null)
+    {
+        string fullPath = Path.GetFullPath(path);
+        string symbolsKey = string.IsNullOrEmpty(symbolsDirectory)
+            ? ""
+            : Path.GetFullPath(symbolsDirectory);
+        string key = $"{fullPath}|{symbolsKey}";
+        return _cache.GetOrAdd(key, _ => _loader.Load(fullPath, symbolsDirectory));
+    }
+}

--- a/traceq/src/TraceQ.Core/Server/TraceStore.cs
+++ b/traceq/src/TraceQ.Core/Server/TraceStore.cs
@@ -35,10 +35,16 @@ public sealed class TraceStore
     internal LoadedTrace Get(string path, string? symbolsDirectory = null)
     {
         string fullPath = Path.GetFullPath(path);
-        string symbolsKey = string.IsNullOrEmpty(symbolsDirectory)
-            ? ""
+        string? fullSymbols = string.IsNullOrEmpty(symbolsDirectory)
+            ? null
             : Path.GetFullPath(symbolsDirectory);
-        string key = $"{fullPath}|{symbolsKey}";
-        return _cache.GetOrAdd(key, _ => _loader.Load(fullPath, symbolsDirectory));
+
+        // Length-prefix the first path so the two components cannot be confused for a
+        // different pair: '|' - like every other ASCII separator - is a legal POSIX
+        // file-name character, so a plain "a|b" delimiter could collide ("a|b" + "c"
+        // versus "a" + "b|c"). Loading uses the normalized symbols path so a relative
+        // symbolsDirectory resolves exactly the way it was keyed.
+        string key = $"{fullPath.Length}|{fullPath}{fullSymbols}";
+        return _cache.GetOrAdd(key, _ => _loader.Load(fullPath, fullSymbols));
     }
 }

--- a/traceq/src/TraceQ.Core/TraceQ.Core.csproj
+++ b/traceq/src/TraceQ.Core/TraceQ.Core.csproj
@@ -11,4 +11,16 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
   </ItemGroup>
 
+  <!--
+    The core analysis types are internal; the CLI head, the MCP facade, and the
+    test projects consume them directly. traceq assemblies are not strong-named,
+    so no PublicKey is required.
+  -->
+  <ItemGroup>
+    <InternalsVisibleTo Include="TraceQ" />
+    <InternalsVisibleTo Include="TraceQ.Mcp" />
+    <InternalsVisibleTo Include="TraceQ.Core.Tests" />
+    <InternalsVisibleTo Include="TraceQ.Parity.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/traceq/src/TraceQ.Core/TraceQCore.cs
+++ b/traceq/src/TraceQ.Core/TraceQCore.cs
@@ -21,5 +21,5 @@ public static class TraceQCore
     /// <summary>
     ///  The implementation-plan milestone this assembly currently corresponds to.
     /// </summary>
-    public static string Milestone => "M0";
+    public static string Milestone => "M1";
 }

--- a/traceq/src/TraceQ.Core/Tracing/FoldingAggregator.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FoldingAggregator.cs
@@ -1,0 +1,468 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Aggregates weighted CPU samples into self-time, inclusive-time and
+///  caller rankings, folding JIT-helper sampling artifacts and the synthetic
+///  BenchmarkDotNet markers back into the real methods that incurred them.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is a direct port of the aggregation in
+///   <c>tools/Get-TraceHotspots.ps1</c>. Two facts make a naive "top self-time"
+///   reading wrong, and this type corrects both:
+///  </para>
+///  <para>
+///   The leaf self-time of every sample collapses into a synthetic
+///   <c>CPU_TIME</c> / <c>UNMANAGED_CODE_TIME</c> marker, so an unfolded
+///   self-time aggregation reports almost all time against that marker. And
+///   when a sample's instruction pointer lands inside a JIT helper (a write
+///   barrier, a memmove, the GC-poll thunk at a loop back-edge), the
+///   managed-only walker resolves the leaf to the helper thunk instead of the
+///   method whose hot loop is actually running.
+///  </para>
+///  <para>
+///   Self-time walks up past folded frames to credit the nearest real leaf;
+///   inclusive-time simply skips folded frames. The result matches what PerfView
+///   produces with <c>/FoldPats</c>.
+///  </para>
+/// </remarks>
+internal sealed class FoldingAggregator
+{
+    private readonly IReadOnlyList<SampleStack> _samples;
+
+    // A single FoldingAggregator is cached on LoadedTrace and can be queried
+    // concurrently through the singleton TraceStore, so the short-name cache must
+    // be safe for parallel readers and writers.
+    private readonly ConcurrentDictionary<string, string> _shortCache = new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///  Initializes a new <see cref="FoldingAggregator"/> over the given samples.
+    /// </summary>
+    /// <param name="samples">The normalized weighted samples.</param>
+    public FoldingAggregator(IReadOnlyList<SampleStack> samples)
+    {
+        _samples = samples;
+    }
+
+    private string ShortOf(string name) => _shortCache.GetOrAdd(name, static n => FrameNames.Short(n));
+
+    /// <summary>
+    ///  Finds the index of the first frame (outermost-first) containing
+    ///  <paramref name="rootFrame"/>, or <c>0</c> when no root scoping is
+    ///  requested. Returns <see langword="false"/> in <paramref name="include"/>
+    ///  when a root frame was requested but not present on the stack.
+    /// </summary>
+    private static int ResolveStart(IReadOnlyList<string> frames, string rootFrame, out bool include)
+    {
+        if (string.IsNullOrEmpty(rootFrame))
+        {
+            include = true;
+            return 0;
+        }
+
+        for (int i = 0; i < frames.Count; i++)
+        {
+            if (frames[i].Contains(rootFrame, StringComparison.Ordinal))
+            {
+                include = true;
+                return i;
+            }
+        }
+
+        include = false;
+        return 0;
+    }
+
+    /// <summary>
+    ///  Computes the folded self-time ranking.
+    /// </summary>
+    /// <param name="rootFrame">Substring scoping the ranking to a subtree, or empty for the whole trace.</param>
+    /// <param name="foldPatterns">Leaf-frame fold patterns.</param>
+    /// <param name="top">Maximum number of rows to return.</param>
+    /// <returns>The self-time ranking.</returns>
+    public RankingResult SelfTime(string rootFrame, IReadOnlyList<string> foldPatterns, int top)
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(foldPatterns);
+        Dictionary<string, double> selfTime = new(StringComparer.Ordinal);
+        double total = 0.0;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string> frames = sample.Frames;
+            int startIdx = ResolveStart(frames, rootFrame, out bool include);
+            if (!include || frames.Count == 0)
+            {
+                continue;
+            }
+
+            total += sample.WeightMs;
+
+            int leafIdx = frames.Count - 1;
+            while (leafIdx > startIdx && FrameNames.IsFolded(ShortOf(frames[leafIdx]), fold))
+            {
+                leafIdx--;
+            }
+
+            string leaf = ShortOf(frames[leafIdx]);
+            selfTime.TryGetValue(leaf, out double current);
+            selfTime[leaf] = current + sample.WeightMs;
+        }
+
+        return new RankingResult(total, rootFrame, RankRows(selfTime, total, top));
+    }
+
+    /// <summary>
+    ///  Computes the inclusive-time ranking, crediting each distinct non-folded
+    ///  frame on a stack once per sample.
+    /// </summary>
+    /// <param name="rootFrame">Substring scoping the ranking to a subtree, or empty for the whole trace.</param>
+    /// <param name="foldPatterns">Frame fold patterns.</param>
+    /// <param name="top">Maximum number of rows to return.</param>
+    /// <returns>The inclusive-time ranking.</returns>
+    public RankingResult InclusiveTime(string rootFrame, IReadOnlyList<string> foldPatterns, int top)
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(foldPatterns);
+        Dictionary<string, double> inclTime = new(StringComparer.Ordinal);
+        HashSet<string> seen = new(StringComparer.Ordinal);
+        double total = 0.0;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string> frames = sample.Frames;
+            int startIdx = ResolveStart(frames, rootFrame, out bool include);
+            if (!include || frames.Count == 0)
+            {
+                continue;
+            }
+
+            total += sample.WeightMs;
+            seen.Clear();
+
+            for (int fi = startIdx; fi < frames.Count; fi++)
+            {
+                string name = ShortOf(frames[fi]);
+                if (FrameNames.IsFolded(name, fold))
+                {
+                    continue;
+                }
+
+                if (seen.Add(name))
+                {
+                    inclTime.TryGetValue(name, out double current);
+                    inclTime[name] = current + sample.WeightMs;
+                }
+            }
+        }
+
+        return new RankingResult(total, rootFrame, RankRows(inclTime, total, top));
+    }
+
+    /// <summary>
+    ///  Reports the immediate callers of the topmost frame matching
+    ///  <paramref name="focus"/>, with the time each caller contributes.
+    /// </summary>
+    /// <param name="focus">Substring identifying the focus frame.</param>
+    /// <param name="rootFrame">Substring scoping the analysis to a subtree, or empty for the whole trace.</param>
+    /// <param name="top">Maximum number of caller rows to return.</param>
+    /// <returns>The caller breakdown.</returns>
+    public CallersResult CallersOf(string focus, string rootFrame, int top)
+    {
+        Dictionary<string, double> callerTime = new(StringComparer.Ordinal);
+        double targetTotal = 0.0;
+        double total = 0.0;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string> frames = sample.Frames;
+            int startIdx = ResolveStart(frames, rootFrame, out bool include);
+            if (!include || frames.Count == 0)
+            {
+                continue;
+            }
+
+            total += sample.WeightMs;
+
+            for (int si = frames.Count - 1; si >= startIdx; si--)
+            {
+                string name = ShortOf(frames[si]);
+                if (!name.Contains(focus, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                targetTotal += sample.WeightMs;
+                string caller = si > startIdx ? ShortOf(frames[si - 1]) : "<root>";
+                callerTime.TryGetValue(caller, out double current);
+                callerTime[caller] = current + sample.WeightMs;
+                break;
+            }
+        }
+
+        List<CallerRow> rows = [];
+        foreach (KeyValuePair<string, double> pair in callerTime)
+        {
+            double pct = targetTotal > 0 ? 100.0 * pair.Value / targetTotal : 0.0;
+            rows.Add(new CallerRow(pair.Key, pair.Value, pct));
+        }
+
+        rows.Sort(static (a, b) => b.Milliseconds.CompareTo(a.Milliseconds));
+        if (rows.Count > top)
+        {
+            rows.RemoveRange(top, rows.Count - top);
+        }
+
+        double pctOfScope = total > 0 ? 100.0 * targetTotal / total : 0.0;
+        return new CallersResult(focus, targetTotal, pctOfScope, total, rows);
+    }
+
+    /// <summary>
+    ///  Computes the line-level self-time ranking: each leaf sample (after
+    ///  folding JIT-helper leaves into their caller) is attributed to the source
+    ///  line that was executing, scoped to the methods whose shortened name
+    ///  contains <paramref name="methodFilter"/>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Only samples carrying per-frame source locations contribute; speedscope
+    ///   inputs have none, so this ranking is meaningful only for
+    ///   <c>.nettrace</c> and <c>.etl</c> traces read with local PDBs present.
+    ///  </para>
+    /// </remarks>
+    /// <param name="methodFilter">Substring scoping to matching methods, or empty for every method.</param>
+    /// <param name="foldPatterns">Leaf-frame fold patterns.</param>
+    /// <param name="top">Maximum number of rows to return.</param>
+    /// <returns>The line-level self-time ranking.</returns>
+    public LineRankingResult HotLines(string methodFilter, IReadOnlyList<string> foldPatterns, int top)
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(foldPatterns);
+        Dictionary<string, (double Ms, string Method, string Location)> lineTime = new(StringComparer.Ordinal);
+        double total = 0.0;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string>? locations = sample.FrameLocations;
+            IReadOnlyList<string> frames = sample.Frames;
+            if (locations is null || frames.Count == 0)
+            {
+                continue;
+            }
+
+            int leafIdx = frames.Count - 1;
+            while (leafIdx > 0 && FrameNames.IsFolded(ShortOf(frames[leafIdx]), fold))
+            {
+                leafIdx--;
+            }
+
+            string method = ShortOf(frames[leafIdx]);
+            if (methodFilter.Length > 0 && !method.Contains(methodFilter, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            total += sample.WeightMs;
+
+            string location = leafIdx < locations.Count && locations[leafIdx].Length > 0
+                ? locations[leafIdx]
+                : "<no source>";
+
+            string key = $"{method}\u0000{location}";
+            lineTime.TryGetValue(key, out (double Ms, string Method, string Location) current);
+            lineTime[key] = (current.Ms + sample.WeightMs, method, location);
+        }
+
+        List<LineRow> rows = [];
+        foreach (KeyValuePair<string, (double Ms, string Method, string Location)> pair in lineTime)
+        {
+            double pct = total > 0 ? 100.0 * pair.Value.Ms / total : 0.0;
+            rows.Add(new LineRow(pair.Value.Method, pair.Value.Location, pair.Value.Ms, pct));
+        }
+
+        rows.Sort(static (a, b) => b.Milliseconds.CompareTo(a.Milliseconds));
+        if (rows.Count > top)
+        {
+            rows.RemoveRange(top, rows.Count - top);
+        }
+
+        return new LineRankingResult(total, methodFilter, rows);
+    }
+
+    /// <summary>
+    ///  Computes a per-line self-time heat map for a single source file: each leaf
+    ///  sample (after folding JIT-helper leaves into their caller) whose executing
+    ///  source line belongs to <paramref name="fileName"/> is bucketed by line
+    ///  number, ordered by line for overlaying onto the source.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Matching is by file name only (the trace records the build-time file name,
+    ///   not its full path), so two source files that share a name are merged. The
+    ///   percent on each line is the share of whole-trace time, making absolute
+    ///   hotness comparable across files.
+    ///  </para>
+    /// </remarks>
+    /// <param name="fileName">The source file name to build the heat map for (no directory).</param>
+    /// <param name="foldPatterns">Leaf-frame fold patterns.</param>
+    /// <returns>The per-line heat map, ordered by line number.</returns>
+    public SourceHeatmapResult SourceHeatmap(string fileName, IReadOnlyList<string> foldPatterns)
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(foldPatterns);
+        Dictionary<int, LineAccumulator> lines = new();
+        double traceTotal = 0.0;
+        double fileTotal = 0.0;
+        string matchedFile = fileName;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string> frames = sample.Frames;
+            if (frames.Count == 0)
+            {
+                continue;
+            }
+
+            traceTotal += sample.WeightMs;
+
+            IReadOnlyList<string>? locations = sample.FrameLocations;
+            if (locations is null)
+            {
+                continue;
+            }
+
+            int leafIdx = frames.Count - 1;
+            while (leafIdx > 0 && FrameNames.IsFolded(ShortOf(frames[leafIdx]), fold))
+            {
+                leafIdx--;
+            }
+
+            if (leafIdx >= locations.Count
+                || !TrySplitLocation(locations[leafIdx], out string leafFile, out int line)
+                || !string.Equals(leafFile, fileName, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            // Preserve the file name's casing as recorded in the trace.
+            matchedFile = leafFile;
+            fileTotal += sample.WeightMs;
+
+            if (!lines.TryGetValue(line, out LineAccumulator? accumulator))
+            {
+                accumulator = new LineAccumulator();
+                lines[line] = accumulator;
+            }
+
+            accumulator.Add(sample.WeightMs, ShortOf(frames[leafIdx]));
+        }
+
+        List<HeatLine> rows = new(lines.Count);
+        foreach (KeyValuePair<int, LineAccumulator> pair in lines)
+        {
+            LineAccumulator accumulator = pair.Value;
+            double pct = traceTotal > 0 ? 100.0 * accumulator.Milliseconds / traceTotal : 0.0;
+            rows.Add(new HeatLine(pair.Key, accumulator.Milliseconds, pct, accumulator.SampleCount, accumulator.DominantMethod));
+        }
+
+        rows.Sort(static (a, b) => a.Line.CompareTo(b.Line));
+        return new SourceHeatmapResult(traceTotal, matchedFile, fileTotal, rows);
+    }
+
+    /// <summary>
+    ///  Splits a <c>file:line</c> location into its file name and line number.
+    ///  Returns <see langword="false"/> for empty, unresolved (<c>&lt;no source&gt;</c>)
+    ///  or otherwise malformed locations.
+    /// </summary>
+    private static bool TrySplitLocation(string location, out string file, out int line)
+    {
+        file = "";
+        line = 0;
+        if (location.Length == 0)
+        {
+            return false;
+        }
+
+        int colon = location.LastIndexOf(':');
+        if (colon <= 0 || colon == location.Length - 1)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(location.AsSpan(colon + 1), out line))
+        {
+            return false;
+        }
+
+        // Line numbers are 1-based; reject zero and negative values that cannot map onto source.
+        if (line < 1)
+        {
+            line = 0;
+            return false;
+        }
+
+        file = location[..colon];
+        return true;
+    }
+
+    private static List<RankRow> RankRows(Dictionary<string, double> times, double total, int top)
+    {
+        List<RankRow> rows = [];
+        foreach (KeyValuePair<string, double> pair in times)
+        {
+            double pct = total > 0 ? 100.0 * pair.Value / total : 0.0;
+            rows.Add(new RankRow(pair.Key, pair.Value, pct));
+        }
+
+        rows.Sort(static (a, b) => b.Milliseconds.CompareTo(a.Milliseconds));
+        if (rows.Count > top)
+        {
+            rows.RemoveRange(top, rows.Count - top);
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    ///  Accumulates the self-time and sample count attributed to one source line,
+    ///  tracking which method dominates the line's time.
+    /// </summary>
+    private sealed class LineAccumulator
+    {
+        private readonly Dictionary<string, double> _methods = new(StringComparer.Ordinal);
+
+        public double Milliseconds { get; private set; }
+
+        public int SampleCount { get; private set; }
+
+        public void Add(double milliseconds, string method)
+        {
+            Milliseconds += milliseconds;
+            SampleCount++;
+            _methods.TryGetValue(method, out double current);
+            _methods[method] = current + milliseconds;
+        }
+
+        public string DominantMethod
+        {
+            get
+            {
+                string dominant = "";
+                double dominantMs = -1.0;
+                foreach (KeyValuePair<string, double> pair in _methods)
+                {
+                    if (pair.Value > dominantMs)
+                    {
+                        dominantMs = pair.Value;
+                        dominant = pair.Key;
+                    }
+                }
+
+                return dominant;
+            }
+        }
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/FrameNames.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FrameNames.cs
@@ -58,14 +58,28 @@ internal static partial class FrameNames
     /// </summary>
     /// <param name="patterns">The fold patterns.</param>
     /// <returns>The compiled matchers.</returns>
+    /// <exception cref="ArgumentException">A pattern is not a valid regular expression.</exception>
     public static Regex[] CompileFoldPatterns(IReadOnlyList<string> patterns)
     {
         Regex[] compiled = new Regex[patterns.Count];
         for (int i = 0; i < patterns.Count; i++)
         {
-            // The fold patterns are user-influenced (the MCP `fold` parameter), so a
-            // match timeout guards against a pathological pattern hanging the server.
-            compiled[i] = new Regex(patterns[i], RegexOptions.CultureInvariant, s_foldPatternTimeout);
+            try
+            {
+                // The fold patterns are user-influenced (the MCP `fold` parameter), so a
+                // match timeout guards against a pathological pattern hanging the server.
+                compiled[i] = new Regex(patterns[i], RegexOptions.CultureInvariant, s_foldPatternTimeout);
+            }
+            catch (ArgumentException ex)
+            {
+                // A malformed pattern surfaces here as a RegexParseException (itself an
+                // ArgumentException); rethrow with the offending entry so the caller can
+                // report which fold pattern is bad instead of a context-free message.
+                throw new ArgumentException(
+                    $"Invalid fold pattern '{patterns[i]}' at index {i}: {ex.Message}",
+                    nameof(patterns),
+                    ex);
+            }
         }
 
         return compiled;
@@ -81,9 +95,18 @@ internal static partial class FrameNames
     {
         foreach (Regex pattern in foldPatterns)
         {
-            if (pattern.IsMatch(shortName))
+            try
             {
-                return true;
+                if (pattern.IsMatch(shortName))
+                {
+                    return true;
+                }
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // A pathological pattern/input pair that hits the match timeout is
+                // treated as a non-match: folding is a display nicety and must never
+                // fail a ranking query.
             }
         }
 

--- a/traceq/src/TraceQ.Core/Tracing/FrameNames.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FrameNames.cs
@@ -1,0 +1,92 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text.RegularExpressions;
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Frame-name shortening and fold matching shared by every reader and the
+///  aggregator. Ports the <c>Short</c> and <c>IsFolded</c> helpers from
+///  <c>tools/Get-TraceHotspots.ps1</c> so the folding semantics stay identical
+///  across input formats.
+/// </summary>
+internal static partial class FrameNames
+{
+    // Cap any single fold-pattern match so a pathological user pattern cannot hang the server.
+    private static readonly TimeSpan s_foldPatternTimeout = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    ///  The default set of leaf-frame fold patterns. A leaf frame whose shortened
+    ///  name matches any of these is folded into its caller. Covers the synthetic
+    ///  BenchmarkDotNet sample markers and the common JIT-helper thunks the
+    ///  managed-only stack walker mis-attributes time to.
+    /// </summary>
+    public static IReadOnlyList<string> DefaultFoldPatterns { get; } =
+    [
+        "CPU_TIME",
+        "UNMANAGED_CODE_TIME",
+        "BulkMoveWithWriteBarrier",
+        "PollGC",
+        "Memmove",
+        "WriteBarrier",
+        "JIT_"
+    ];
+
+    [GeneratedRegex(@"!([^(]+)")]
+    private static partial Regex AfterModuleRegex();
+
+    /// <summary>
+    ///  Trims a verbose CLR frame signature to a method identifier for ranking
+    ///  and display: keeps the text after the <c>module!</c> prefix and before
+    ///  the argument list, and strips <c>value class</c> / <c>class</c> noise.
+    /// </summary>
+    /// <param name="name">The full frame name.</param>
+    /// <returns>The shortened identifier.</returns>
+    public static string Short(string name)
+    {
+        Match match = AfterModuleRegex().Match(name);
+        string result = match.Success ? match.Groups[1].Value : name;
+        result = result.Replace("value class ", "").Replace("class ", "");
+        return result;
+    }
+
+    /// <summary>
+    ///  Compiles a list of fold patterns into regular expressions once so the
+    ///  per-sample hot loop avoids repeated pattern parsing.
+    /// </summary>
+    /// <param name="patterns">The fold patterns.</param>
+    /// <returns>The compiled matchers.</returns>
+    public static Regex[] CompileFoldPatterns(IReadOnlyList<string> patterns)
+    {
+        Regex[] compiled = new Regex[patterns.Count];
+        for (int i = 0; i < patterns.Count; i++)
+        {
+            // The fold patterns are user-influenced (the MCP `fold` parameter), so a
+            // match timeout guards against a pathological pattern hanging the server.
+            compiled[i] = new Regex(patterns[i], RegexOptions.CultureInvariant, s_foldPatternTimeout);
+        }
+
+        return compiled;
+    }
+
+    /// <summary>
+    ///  Determines whether a shortened frame name matches any compiled fold pattern.
+    /// </summary>
+    /// <param name="shortName">The shortened frame name.</param>
+    /// <param name="foldPatterns">The compiled fold patterns.</param>
+    /// <returns><see langword="true"/> if the frame should be folded into its caller.</returns>
+    public static bool IsFolded(string shortName, Regex[] foldPatterns)
+    {
+        foreach (Regex pattern in foldPatterns)
+        {
+            if (pattern.IsMatch(shortName))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/LoadedTrace.cs
+++ b/traceq/src/TraceQ.Core/Tracing/LoadedTrace.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  A fully loaded trace: its metadata, the normalized samples, and the
+///  aggregator that ranks them.
+/// </summary>
+internal sealed class LoadedTrace
+{
+    /// <summary>
+    ///  Initializes a new <see cref="LoadedTrace"/>.
+    /// </summary>
+    public LoadedTrace(TraceInfo info, IReadOnlyList<SampleStack> samples)
+    {
+        Info = info;
+        Samples = samples;
+        Aggregator = new FoldingAggregator(samples);
+    }
+
+    /// <summary>
+    ///  Metadata and quality signals describing the trace.
+    /// </summary>
+    public TraceInfo Info { get; }
+
+    /// <summary>
+    ///  The normalized weighted samples.
+    /// </summary>
+    public IReadOnlyList<SampleStack> Samples { get; }
+
+    /// <summary>
+    ///  The folding aggregator over <see cref="Samples"/>.
+    /// </summary>
+    public FoldingAggregator Aggregator { get; }
+}

--- a/traceq/src/TraceQ.Core/Tracing/RankingResult.cs
+++ b/traceq/src/TraceQ.Core/Tracing/RankingResult.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  A single ranked frame in a self-time or inclusive-time report.
+/// </summary>
+/// <param name="Frame">The shortened frame name.</param>
+/// <param name="Milliseconds">Time attributed to the frame, in milliseconds.</param>
+/// <param name="PercentOfScope">Share of the scoped total, in percent.</param>
+internal sealed record RankRow(string Frame, double Milliseconds, double PercentOfScope);
+
+/// <summary>
+///  A self-time or inclusive-time ranking over a scoped trace.
+/// </summary>
+/// <param name="ScopeMilliseconds">Total scoped wall-clock time, in milliseconds.</param>
+/// <param name="RootFrame">The root frame the ranking was scoped to, or empty for the whole trace.</param>
+/// <param name="Rows">The ranked frames, highest first.</param>
+internal sealed record RankingResult(double ScopeMilliseconds, string RootFrame, IReadOnlyList<RankRow> Rows);
+
+/// <summary>
+///  A single immediate caller of a focus frame.
+/// </summary>
+/// <param name="Caller">The shortened caller frame name, or <c>&lt;root&gt;</c>.</param>
+/// <param name="Milliseconds">Time this caller contributes to the focus frame, in milliseconds.</param>
+/// <param name="PercentOfTarget">Share of the focus frame's total, in percent.</param>
+internal sealed record CallerRow(string Caller, double Milliseconds, double PercentOfTarget);
+
+/// <summary>
+///  The immediate callers of a focus frame, with the time each contributes.
+/// </summary>
+/// <param name="Focus">The substring the focus frame was matched on.</param>
+/// <param name="TargetMilliseconds">Total inclusive time spent in the focus frame, in milliseconds.</param>
+/// <param name="PercentOfScope">The focus frame's share of the scoped total, in percent.</param>
+/// <param name="ScopeMilliseconds">Total scoped wall-clock time, in milliseconds.</param>
+/// <param name="Callers">The immediate callers, highest first.</param>
+internal sealed record CallersResult(
+    string Focus,
+    double TargetMilliseconds,
+    double PercentOfScope,
+    double ScopeMilliseconds,
+    IReadOnlyList<CallerRow> Callers);
+
+/// <summary>
+///  A single source line in a line-level self-time report.
+/// </summary>
+/// <param name="Method">The shortened method the line belongs to.</param>
+/// <param name="Location">The source location (<c>file:line</c>), or <c>&lt;no source&gt;</c> when unresolved.</param>
+/// <param name="Milliseconds">Time attributed to the line, in milliseconds.</param>
+/// <param name="PercentOfScope">Share of the scoped total, in percent.</param>
+internal sealed record LineRow(string Method, string Location, double Milliseconds, double PercentOfScope);
+
+/// <summary>
+///  A line-level self-time ranking: leaf samples attributed to the source line
+///  executing when each was taken, scoped to the methods matching a filter.
+/// </summary>
+/// <param name="ScopeMilliseconds">Total scoped wall-clock time, in milliseconds.</param>
+/// <param name="MethodFilter">The substring the methods were matched on, or empty for every method.</param>
+/// <param name="Rows">The ranked source lines, highest first.</param>
+internal sealed record LineRankingResult(double ScopeMilliseconds, string MethodFilter, IReadOnlyList<LineRow> Rows);
+
+/// <summary>
+///  Self-time attributed to a single source line of a file in a heat map.
+/// </summary>
+/// <param name="Line">The 1-based source line number.</param>
+/// <param name="Milliseconds">Self-time attributed to the line, in milliseconds.</param>
+/// <param name="PercentOfScope">Share of the whole-trace self-time, in percent.</param>
+/// <param name="SampleCount">Number of leaf samples attributed to the line.</param>
+/// <param name="Method">The shortened method that dominates the line's self-time.</param>
+internal sealed record HeatLine(int Line, double Milliseconds, double PercentOfScope, int SampleCount, string Method);
+
+/// <summary>
+///  A per-line self-time heat map for a single source file: each leaf sample
+///  (after folding JIT-helper leaves into their caller) is bucketed by the source
+///  line that was executing, ordered by line number for overlaying onto the source.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Only samples carrying per-frame source locations contribute; speedscope
+///   inputs have none, so a heat map is meaningful only for <c>.nettrace</c> and
+///   <c>.etl</c> traces read with local PDBs present.
+///  </para>
+/// </remarks>
+/// <param name="ScopeMilliseconds">Total whole-trace time, in milliseconds (the percent denominator).</param>
+/// <param name="File">The source file name the lines belong to (no directory).</param>
+/// <param name="FileMilliseconds">Self-time attributed to the file across all its lines, in milliseconds.</param>
+/// <param name="Lines">The hot lines of the file, ordered by line number.</param>
+internal sealed record SourceHeatmapResult(
+    double ScopeMilliseconds,
+    string File,
+    double FileMilliseconds,
+    IReadOnlyList<HeatLine> Lines);

--- a/traceq/src/TraceQ.Core/Tracing/Readers/EmbeddedPdbExtractor.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/EmbeddedPdbExtractor.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Buffers.Binary;
+using System.IO.Compression;
+using System.Reflection.PortableExecutable;
+
+namespace TraceQ.Tracing.Readers;
+
+/// <summary>
+///  Extracts embedded portable PDBs (the <c>&lt;DebugType&gt;embedded&lt;/DebugType&gt;</c>
+///  stream baked into a managed assembly for SourceLink) out of the DLLs in a
+///  build-output directory and writes them as standalone <c>.pdb</c> files into a
+///  temporary directory.
+/// </summary>
+/// <remarks>
+///  <para>
+///   TraceEvent's <c>SymbolReader</c> resolves source lines only from standalone
+///   <c>.pdb</c> files - it never reads a PDB embedded in the PE image. Libraries
+///   such as touki ship <c>embedded</c> PDBs, and BenchmarkDotNet runs each
+///   benchmark from an ephemeral build directory that is deleted before the trace
+///   is analyzed, so no standalone PDB is ever locatable by the recorded module
+///   path. Re-materializing the embedded PDB next to a copy on disk and pointing
+///   the symbol reader at it lets TraceEvent match the module by its PDB GUID and
+///   resolve <c>file:line</c> for the managed frames.
+///  </para>
+///  <para>
+///   See <c>docs/traceevent-embedded-pdb.md</c> for the upstream follow-up to make
+///   TraceEvent read embedded PDBs directly so this workaround can be retired.
+///  </para>
+/// </remarks>
+internal static class EmbeddedPdbExtractor
+{
+    // 'M' 'P' 'D' 'B' little-endian: the signature of an embedded portable PDB blob.
+    private const uint EmbeddedPdbMagic = 0x4244504D;
+
+    /// <summary>
+    ///  Extracts every embedded portable PDB found in the DLLs of
+    ///  <paramref name="buildOutputDirectory"/> into a fresh temporary directory.
+    /// </summary>
+    /// <param name="buildOutputDirectory">A directory containing built managed assemblies.</param>
+    /// <returns>
+    ///  The temporary directory holding the extracted standalone PDBs, or
+    ///  <see langword="null"/> when the directory does not exist or contains no
+    ///  embedded PDBs. The caller owns the returned directory and should delete it
+    ///  when finished.
+    /// </returns>
+    public static string? Extract(string buildOutputDirectory)
+    {
+        if (string.IsNullOrEmpty(buildOutputDirectory) || !Directory.Exists(buildOutputDirectory))
+        {
+            return null;
+        }
+
+        string? tempDirectory = null;
+
+        foreach (string dll in Directory.EnumerateFiles(buildOutputDirectory, "*.dll"))
+        {
+            try
+            {
+                byte[] image = File.ReadAllBytes(dll);
+                using MemoryStream peStream = new(image, writable: false);
+                using PEReader peReader = new(peStream);
+
+                foreach (DebugDirectoryEntry entry in peReader.ReadDebugDirectory())
+                {
+                    if (entry.Type != DebugDirectoryEntryType.EmbeddedPortablePdb)
+                    {
+                        continue;
+                    }
+
+                    int dataOffset = entry.DataPointer;
+                    if (dataOffset < 0 || dataOffset + 8 > image.Length || entry.DataSize <= 8)
+                    {
+                        continue;
+                    }
+
+                    if (BinaryPrimitives.ReadUInt32LittleEndian(image.AsSpan(dataOffset, 4)) != EmbeddedPdbMagic)
+                    {
+                        continue;
+                    }
+
+                    tempDirectory ??= CreateTempDirectory();
+                    string pdbPath = Path.Combine(
+                        tempDirectory,
+                        Path.GetFileNameWithoutExtension(dll) + ".pdb");
+
+                    // Layout of the embedded blob: 4-byte 'MPDB' magic, 4-byte
+                    // uncompressed size, then the portable PDB as a raw deflate stream.
+                    using MemoryStream compressed = new(image, dataOffset + 8, entry.DataSize - 8, writable: false);
+                    using DeflateStream deflate = new(compressed, CompressionMode.Decompress);
+                    using FileStream outPdb = File.Create(pdbPath);
+                    deflate.CopyTo(outPdb);
+                }
+            }
+            catch (Exception)
+            {
+                // Extraction is best-effort: a DLL that cannot be read or whose
+                // embedded PDB cannot be decompressed simply contributes no symbols.
+            }
+        }
+
+        return tempDirectory;
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "touki-mcp-pdb-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/Readers/EmbeddedPdbExtractor.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/EmbeddedPdbExtractor.cs
@@ -106,7 +106,7 @@ internal static class EmbeddedPdbExtractor
 
     private static string CreateTempDirectory()
     {
-        string path = Path.Combine(Path.GetTempPath(), "touki-mcp-pdb-" + Guid.NewGuid().ToString("N"));
+        string path = Path.Combine(Path.GetTempPath(), "traceq-pdb-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(path);
         return path;
     }

--- a/traceq/src/TraceQ.Core/Tracing/Readers/EtlReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/EtlReader.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.Diagnostics.Tracing.Etlx;
+
+namespace TraceQ.Tracing.Readers;
+
+/// <summary>
+///  Reads a Windows ETW trace (<c>.etl</c>) - the net481 <c>[EtwProfiler]</c>
+///  output - into weighted samples. This closes the net481 gap: the same
+///  rankings an agent can self-serve from a net10 EventPipe trace become
+///  available for Framework profiling.
+/// </summary>
+internal sealed class EtlReader : TraceLogReader
+{
+    /// <inheritdoc/>
+    public override TraceFormat Format => TraceFormat.Etl;
+
+    /// <inheritdoc/>
+    public override bool CanRead(string path) =>
+        path.EndsWith(".etl", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    protected override TraceLog OpenTraceLog(string path) =>
+        TraceLog.OpenOrConvert(path, new TraceLogOptions { ContinueOnError = true });
+}

--- a/traceq/src/TraceQ.Core/Tracing/Readers/ITraceReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/ITraceReader.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing.Readers;
+
+/// <summary>
+///  The normalized output of a trace reader: weighted samples plus the
+///  format-specific quality signals the loader folds into a <see cref="TraceInfo"/>.
+/// </summary>
+/// <param name="Samples">The weighted samples, each ordered outermost-first.</param>
+/// <param name="SymbolResolutionRate">Fraction in <c>[0, 1]</c> of frames that resolved to a method name.</param>
+/// <param name="Warnings">Format-specific quality warnings.</param>
+internal sealed record TraceReadResult(
+    IReadOnlyList<SampleStack> Samples,
+    double SymbolResolutionRate,
+    IReadOnlyList<string> Warnings);
+
+/// <summary>
+///  Reads a trace file of a specific on-disk format into the normalized
+///  weighted-sample model.
+/// </summary>
+internal interface ITraceReader
+{
+    /// <summary>
+    ///  The format this reader handles.
+    /// </summary>
+    TraceFormat Format { get; }
+
+    /// <summary>
+    ///  Determines whether this reader can read the file at <paramref name="path"/>,
+    ///  by file extension.
+    /// </summary>
+    /// <param name="path">The trace file path.</param>
+    /// <returns><see langword="true"/> if the extension is recognized.</returns>
+    bool CanRead(string path);
+
+    /// <summary>
+    ///  Reads the trace into the normalized weighted-sample model.
+    /// </summary>
+    /// <param name="path">The trace file path.</param>
+    /// <param name="symbolsDirectory">
+    ///  Optional build-output directory whose assemblies' embedded portable PDBs are
+    ///  extracted to resolve managed frames to <c>file:line</c>. Ignored by formats
+    ///  that carry no native frames (speedscope).
+    /// </param>
+    /// <returns>The normalized samples and quality signals.</returns>
+    TraceReadResult Read(string path, string? symbolsDirectory = null);
+}

--- a/traceq/src/TraceQ.Core/Tracing/Readers/NetTraceReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/NetTraceReader.cs
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.Diagnostics.Tracing.Etlx;
+
+namespace TraceQ.Tracing.Readers;
+
+/// <summary>
+///  Reads a .NET EventPipe trace (<c>.nettrace</c>) - the net10
+///  <c>[EventPipeProfiler]</c> output - into weighted samples.
+/// </summary>
+internal sealed class NetTraceReader : TraceLogReader
+{
+    /// <inheritdoc/>
+    public override TraceFormat Format => TraceFormat.NetTrace;
+
+    /// <inheritdoc/>
+    public override bool CanRead(string path) =>
+        path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    protected override TraceLog OpenTraceLog(string path)
+    {
+        string etlxPath = TraceLog.CreateFromEventPipeDataFile(
+            path,
+            null,
+            new TraceLogOptions { ContinueOnError = true });
+
+        return new TraceLog(etlxPath);
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/Readers/SpeedscopeReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/SpeedscopeReader.cs
@@ -1,0 +1,137 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text.Json;
+
+namespace TraceQ.Tracing.Readers;
+
+/// <summary>
+///  Reads a BenchmarkDotNet EventPipe speedscope export
+///  (<c>.speedscope.json</c>) into weighted samples.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The evented speedscope format records frame open (<c>O</c>) and close
+///   (<c>C</c>) events with timestamps. The wall-clock delta between consecutive
+///   events is attributed to whatever frames are open at that moment - exactly
+///   the model the aggregator consumes. Each profile maps to one thread, and
+///   frame names are already symbol-resolved.
+///  </para>
+/// </remarks>
+internal sealed class SpeedscopeReader : ITraceReader
+{
+    /// <inheritdoc/>
+    public TraceFormat Format => TraceFormat.Speedscope;
+
+    /// <inheritdoc/>
+    public bool CanRead(string path) =>
+        path.EndsWith(".speedscope.json", StringComparison.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public TraceReadResult Read(string path, string? symbolsDirectory = null)
+    {
+        using FileStream stream = File.OpenRead(path);
+        using JsonDocument document = JsonDocument.Parse(stream);
+        JsonElement root = document.RootElement;
+
+        string[] frameNames = ReadFrameNames(root);
+        List<SampleStack> samples = [];
+
+        if (root.TryGetProperty("profiles", out JsonElement profiles)
+            && profiles.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement profile in profiles.EnumerateArray())
+            {
+                ReadProfile(profile, frameNames, samples);
+            }
+        }
+
+        List<string> warnings = [];
+        if (samples.Count == 0)
+        {
+            warnings.Add("No timed samples were found in the speedscope file.");
+        }
+
+        return new TraceReadResult(samples, 1.0, warnings);
+    }
+
+    private static string[] ReadFrameNames(JsonElement root)
+    {
+        if (!root.TryGetProperty("shared", out JsonElement shared)
+            || !shared.TryGetProperty("frames", out JsonElement frames)
+            || frames.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        string[] names = new string[frames.GetArrayLength()];
+        int i = 0;
+        foreach (JsonElement frame in frames.EnumerateArray())
+        {
+            names[i++] = frame.TryGetProperty("name", out JsonElement name)
+                ? name.GetString() ?? ""
+                : "";
+        }
+
+        return names;
+    }
+
+    private static void ReadProfile(JsonElement profile, string[] frameNames, List<SampleStack> samples)
+    {
+        if (!profile.TryGetProperty("events", out JsonElement events)
+            || events.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        string thread = profile.TryGetProperty("name", out JsonElement profileName)
+            ? profileName.GetString() ?? ""
+            : "";
+
+        List<int> stack = [];
+        double? lastAt = null;
+
+        foreach (JsonElement e in events.EnumerateArray())
+        {
+            double at = e.GetProperty("at").GetDouble();
+
+            if (lastAt is double previous && stack.Count > 0)
+            {
+                double delta = at - previous;
+                if (delta > 0)
+                {
+                    string[] frames = new string[stack.Count];
+                    for (int i = 0; i < stack.Count; i++)
+                    {
+                        int index = stack[i];
+                        frames[i] = (uint)index < (uint)frameNames.Length ? frameNames[index] : "?";
+                    }
+
+                    samples.Add(new SampleStack(frames, delta, thread));
+                }
+            }
+
+            string type = e.GetProperty("type").GetString() ?? "";
+            int frameIndex = e.GetProperty("frame").GetInt32();
+
+            if (type == "O")
+            {
+                stack.Add(frameIndex);
+            }
+            else if (type == "C")
+            {
+                for (int k = stack.Count - 1; k >= 0; k--)
+                {
+                    if (stack[k] == frameIndex)
+                    {
+                        stack.RemoveAt(k);
+                        break;
+                    }
+                }
+            }
+
+            lastAt = at;
+        }
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/Readers/TraceLogReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/TraceLogReader.cs
@@ -1,0 +1,224 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.Diagnostics.Symbols;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.EventPipe;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+
+namespace TraceQ.Tracing.Readers;
+
+/// <summary>
+///  Shared core for the TraceEvent-backed readers. Converts an ETW (<c>.etl</c>)
+///  or EventPipe (<c>.nettrace</c>) trace into the normalized weighted-sample
+///  model by walking the call stack of every sampled-profile event.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Both formats normalize, through <see cref="TraceLog"/>, onto the same
+///   <see cref="SampledProfileTraceData"/> CPU-sample event with a resolvable
+///   <see cref="TraceCallStack"/>. Managed method names resolve from the CLR
+///   rundown embedded in the trace, so no external symbol server is needed for
+///   managed frames; native frames may remain unresolved.
+///  </para>
+///  <para>
+///   Each sample is weighted as one millisecond. Sampled-profile CPU profiling
+///   runs at roughly a 1 kHz cadence on both runtimes, so scoped durations are
+///   accurate to within the sampling interval and the relative percentages -
+///   what the rankings actually report - are unaffected.
+///  </para>
+/// </remarks>
+internal abstract class TraceLogReader : ITraceReader
+{
+    /// <inheritdoc/>
+    public abstract TraceFormat Format { get; }
+
+    /// <inheritdoc/>
+    public abstract bool CanRead(string path);
+
+    /// <summary>
+    ///  Converts the trace at <paramref name="path"/> to an ETLX
+    ///  <see cref="TraceLog"/> the caller then reads.
+    /// </summary>
+    /// <param name="path">The trace file path.</param>
+    /// <returns>The opened trace log.</returns>
+    protected abstract TraceLog OpenTraceLog(string path);
+
+    /// <inheritdoc/>
+    public TraceReadResult Read(string path, string? symbolsDirectory = null)
+    {
+        using TraceLog traceLog = OpenTraceLog(path);
+
+        // Local-only symbol reader: an empty symbol path never reaches a symbol
+        // server, but portable PDBs sitting next to a traced module still
+        // resolve, which is all the managed touki frames need for line-level
+        // attribution. Frames without a local PDB (BCL, OS) simply carry no line.
+        using SymbolReader symbolReader = new(TextWriter.Null, "", null);
+
+        // touki and its sibling assemblies ship embedded portable PDBs, which
+        // TraceEvent's SymbolReader cannot read, and BenchmarkDotNet's ephemeral
+        // run directory is gone by analysis time. When the caller points us at a
+        // build-output directory we re-materialize those embedded PDBs as
+        // standalone files in a temp directory and add it to the symbol path so
+        // TraceEvent can match a module by its PDB GUID and resolve source lines.
+        string? extractedPdbDirectory = symbolsDirectory is null
+            ? null
+            : EmbeddedPdbExtractor.Extract(symbolsDirectory);
+
+        try
+        {
+            if (extractedPdbDirectory is not null)
+            {
+                symbolReader.SymbolPath = $"{symbolsDirectory}{Path.PathSeparator}{extractedPdbDirectory}";
+            }
+            else if (!string.IsNullOrEmpty(symbolsDirectory))
+            {
+                symbolReader.SymbolPath = symbolsDirectory;
+            }
+
+            return ReadCore(traceLog, symbolReader);
+        }
+        finally
+        {
+            if (extractedPdbDirectory is not null)
+            {
+                try
+                {
+                    Directory.Delete(extractedPdbDirectory, recursive: true);
+                }
+                catch (Exception)
+                {
+                    // Best-effort cleanup of a temp directory; a leftover under
+                    // %TEMP% is harmless if the delete races a still-open handle.
+                }
+            }
+        }
+    }
+
+    private static TraceReadResult ReadCore(TraceLog traceLog, SymbolReader symbolReader)
+    {
+        Dictionary<int, string> locationCache = [];
+
+        List<SampleStack> samples = [];
+        long totalFrames = 0;
+        long resolvedFrames = 0;
+        List<string> leafToRoot = [];
+        List<string> leafToRootLocations = [];
+
+        foreach (TraceEvent data in traceLog.Events)
+        {
+            // ETW (.etl) surfaces CPU samples as SampledProfileTraceData; EventPipe
+            // (.nettrace) surfaces them as the SampleProfiler's ClrThreadSampleTraceData.
+            if (data is ClrThreadSampleTraceData clrSample)
+            {
+                if (clrSample.Type == ClrThreadSampleType.Error)
+                {
+                    continue;
+                }
+            }
+            else if (data is not SampledProfileTraceData)
+            {
+                continue;
+            }
+
+            TraceCallStack? callStack = data.CallStack();
+            if (callStack is null)
+            {
+                continue;
+            }
+
+            leafToRoot.Clear();
+            leafToRootLocations.Clear();
+            for (TraceCallStack? frame = callStack; frame is not null; frame = frame.Caller)
+            {
+                TraceCodeAddress address = frame.CodeAddress;
+                string method = address.FullMethodName;
+                string module = address.ModuleName;
+
+                totalFrames++;
+                string name;
+                if (string.IsNullOrEmpty(method))
+                {
+                    name = $"{(string.IsNullOrEmpty(module) ? "?" : module)}!?";
+                }
+                else
+                {
+                    resolvedFrames++;
+                    name = string.IsNullOrEmpty(module) ? method : $"{module}!{method}";
+                }
+
+                leafToRoot.Add(name);
+                leafToRootLocations.Add(ResolveLocation(symbolReader, address, locationCache));
+            }
+
+            if (leafToRoot.Count == 0)
+            {
+                continue;
+            }
+
+            int count = leafToRoot.Count;
+            string[] frames = new string[count];
+            string[] locations = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                frames[i] = leafToRoot[count - 1 - i];
+                locations[i] = leafToRootLocations[count - 1 - i];
+            }
+
+            samples.Add(new SampleStack(frames, 1.0, data.ThreadID.ToString(), locations));
+        }
+
+        double resolutionRate = totalFrames > 0 ? (double)resolvedFrames / totalFrames : 0.0;
+
+        List<string> warnings = [];
+        if (samples.Count == 0)
+        {
+            warnings.Add("No sampled-profile (CPU) events were found. Was the trace captured with a CPU sampler?");
+        }
+
+        if (totalFrames > 0 && resolutionRate < 0.8)
+        {
+            warnings.Add(
+                $"Only {resolutionRate:P0} of frames resolved to a method name; native frames may be unresolved. "
+                + "Managed touki frames resolve from CLR rundown, so self/inclusive rankings of managed methods are still usable.");
+        }
+
+        warnings.Add("Sample weight is approximate (1 ms per sample); relative percentages are exact.");
+
+        return new TraceReadResult(samples, resolutionRate, warnings);
+    }
+
+    /// <summary>
+    ///  Resolves the source location (<c>file:line</c>) for a code address,
+    ///  caching the result by code-address index so repeated frames cost one
+    ///  symbol lookup. Returns an empty string when no local PDB maps the
+    ///  address to a source line.
+    /// </summary>
+    private static string ResolveLocation(SymbolReader reader, TraceCodeAddress address, Dictionary<int, string> cache)
+    {
+        int key = (int)address.CodeAddressIndex;
+        if (cache.TryGetValue(key, out string? cached))
+        {
+            return cached;
+        }
+
+        string location = "";
+        try
+        {
+            SourceLocation? source = address.GetSourceLine(reader);
+            if (source?.SourceFile is { } file)
+            {
+                location = $"{Path.GetFileName(file.BuildTimeFilePath)}:{source.LineNumber}";
+            }
+        }
+        catch (Exception)
+        {
+            // Symbol resolution is best-effort; an unresolved frame carries no line.
+        }
+
+        cache[key] = location;
+        return location;
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/SampleStack.cs
+++ b/traceq/src/TraceQ.Core/Tracing/SampleStack.cs
@@ -1,0 +1,68 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  A single weighted CPU sample: the full call stack captured at a point in
+///  time, ordered outermost-first (<c>Frames[0]</c> is the process/thread root,
+///  <c>Frames[^1]</c> is the leaf), together with the wall-clock weight in
+///  milliseconds attributed to it.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Frame strings are stored in their full, unshortened form (typically
+///   <c>module!Namespace.Type.Method(args)</c>). The aggregator shortens them
+///   on demand so root-frame scoping can still match against the full text.
+///  </para>
+/// </remarks>
+internal sealed class SampleStack
+{
+    /// <summary>
+    ///  Initializes a new <see cref="SampleStack"/>.
+    /// </summary>
+    /// <param name="frames">Frames ordered outermost-first.</param>
+    /// <param name="weightMs">Wall-clock weight attributed to the sample, in milliseconds.</param>
+    /// <param name="thread">A label identifying the thread the sample came from.</param>
+    /// <param name="frameLocations">
+    ///  Optional per-frame source locations (<c>file:line</c>), parallel to
+    ///  <paramref name="frames"/> and ordered the same way. An entry is empty
+    ///  when the frame did not resolve to a source line. Pass
+    ///  <see langword="null"/> when the source format carries no line data.
+    /// </param>
+    public SampleStack(
+        IReadOnlyList<string> frames,
+        double weightMs,
+        string thread = "",
+        IReadOnlyList<string>? frameLocations = null)
+    {
+        Frames = frames;
+        WeightMs = weightMs;
+        Thread = thread;
+        FrameLocations = frameLocations;
+    }
+
+    /// <summary>
+    ///  The call stack, ordered outermost-first.
+    /// </summary>
+    public IReadOnlyList<string> Frames { get; }
+
+    /// <summary>
+    ///  Per-frame source locations (<c>file:line</c>), parallel to <see cref="Frames"/>
+    ///  and ordered the same way, or <see langword="null"/> when the source format
+    ///  carries no line data. An individual entry is empty when that frame did not
+    ///  resolve to a source line.
+    /// </summary>
+    public IReadOnlyList<string>? FrameLocations { get; }
+
+    /// <summary>
+    ///  Wall-clock weight attributed to this sample, in milliseconds.
+    /// </summary>
+    public double WeightMs { get; }
+
+    /// <summary>
+    ///  A label identifying the thread the sample came from.
+    /// </summary>
+    public string Thread { get; }
+}

--- a/traceq/src/TraceQ.Core/Tracing/SourceAnnotator.cs
+++ b/traceq/src/TraceQ.Core/Tracing/SourceAnnotator.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text;
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Renders a <see cref="SourceHeatmapResult"/> over a source file's text as a
+///  ready-to-read annotated listing with a per-line <c>ms / %file / heat</c>
+///  gutter. Shared by the <c>source_heatmap</c> MCP tool and the console
+///  analyzer's <c>--heatmap</c> command.
+/// </summary>
+internal static class SourceAnnotator
+{
+    // Files larger than this render only windows around hot lines; smaller files
+    // render in full so the heat map reads top to bottom.
+    private const int FullRenderLineCap = 600;
+
+    // Lines of unchanged context shown around each hot line in windowed mode.
+    private const int HeatContextLines = 4;
+
+    /// <summary>
+    ///  Reads the source file at <paramref name="file"/> if it exists on disk.
+    /// </summary>
+    /// <param name="file">The on-disk path to read.</param>
+    /// <param name="lines">The file's lines on success, otherwise empty.</param>
+    /// <returns><see langword="true"/> when the file was read.</returns>
+    public static bool TryReadSourceLines(string file, out string[] lines)
+    {
+        lines = [];
+        try
+        {
+            if (!File.Exists(file))
+            {
+                return false;
+            }
+
+            lines = File.ReadAllLines(file);
+            return true;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///  Renders source with a per-line ms/percent/heat gutter, in full for small
+    ///  files or as windows around hot lines for large ones.
+    /// </summary>
+    /// <param name="sourceLines">The source file's lines.</param>
+    /// <param name="heat">The per-line heat, in any order.</param>
+    /// <param name="fileMilliseconds">Total self-time attributed to the file.</param>
+    /// <returns>The annotated source listing.</returns>
+    public static string Render(string[] sourceLines, IReadOnlyList<HeatLine> heat, double fileMilliseconds)
+    {
+        Dictionary<int, HeatLine> byLine = new(heat.Count);
+        double maxMs = 0.0;
+        foreach (HeatLine line in heat)
+        {
+            byLine[line.Line] = line;
+            if (line.Milliseconds > maxMs)
+            {
+                maxMs = line.Milliseconds;
+            }
+        }
+
+        StringBuilder builder = new();
+        builder.AppendLine("       ms   %file  heat      | line  source");
+        builder.AppendLine("  -------  ------  --------  | ----  ------");
+
+        if (sourceLines.Length <= FullRenderLineCap)
+        {
+            for (int i = 0; i < sourceLines.Length; i++)
+            {
+                AppendSourceLine(builder, i + 1, sourceLines[i], byLine, maxMs, fileMilliseconds);
+            }
+
+            return builder.ToString();
+        }
+
+        SortedSet<int> show = [];
+        foreach (HeatLine line in heat)
+        {
+            for (int l = line.Line - HeatContextLines; l <= line.Line + HeatContextLines; l++)
+            {
+                if (l >= 1 && l <= sourceLines.Length)
+                {
+                    show.Add(l);
+                }
+            }
+        }
+
+        int previous = 0;
+        foreach (int l in show)
+        {
+            if (previous != 0 && l > previous + 1)
+            {
+                builder.AppendLine("     ...");
+            }
+
+            AppendSourceLine(builder, l, sourceLines[l - 1], byLine, maxMs, fileMilliseconds);
+            previous = l;
+        }
+
+        return builder.ToString();
+    }
+
+    /// <summary>
+    ///  Appends one annotated source line: a populated gutter for hot lines, a
+    ///  blank gutter for cold ones.
+    /// </summary>
+    private static void AppendSourceLine(
+        StringBuilder builder,
+        int lineNumber,
+        string text,
+        Dictionary<int, HeatLine> byLine,
+        double maxMilliseconds,
+        double fileMilliseconds)
+    {
+        if (byLine.TryGetValue(lineNumber, out HeatLine? line))
+        {
+            double percentOfFile = fileMilliseconds > 0 ? 100.0 * line.Milliseconds / fileMilliseconds : 0.0;
+            int bars = maxMilliseconds > 0 ? (int)Math.Round(8.0 * line.Milliseconds / maxMilliseconds) : 0;
+            string heat = new string('#', bars);
+            builder.AppendLine($"  {line.Milliseconds,7:F1}  {percentOfFile,5:F1}  {heat,-8}  | {lineNumber,4}  {text}");
+        }
+        else
+        {
+            builder.AppendLine($"  {"",7}  {"",5}  {"",8}  | {lineNumber,4}  {text}");
+        }
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/SourceAnnotator.cs
+++ b/traceq/src/TraceQ.Core/Tracing/SourceAnnotator.cs
@@ -40,12 +40,16 @@ internal static class SourceAnnotator
             lines = File.ReadAllLines(file);
             return true;
         }
-        catch (IOException)
+        catch (Exception ex) when (
+            ex is IOException
+                or UnauthorizedAccessException
+                or ArgumentException
+                or NotSupportedException
+                or System.Security.SecurityException)
         {
-            return false;
-        }
-        catch (UnauthorizedAccessException)
-        {
+            // Honor the Try* contract for user-supplied paths: a malformed, too-long,
+            // unsupported, or access-denied path yields "not read" rather than throwing.
+            // PathTooLongException and FileNotFoundException derive from IOException.
             return false;
         }
     }

--- a/traceq/src/TraceQ.Core/Tracing/TraceFormat.cs
+++ b/traceq/src/TraceQ.Core/Tracing/TraceFormat.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  The on-disk format a trace was loaded from.
+/// </summary>
+internal enum TraceFormat
+{
+    /// <summary>
+    ///  BenchmarkDotNet EventPipe speedscope export (<c>.speedscope.json</c>).
+    /// </summary>
+    Speedscope,
+
+    /// <summary>
+    ///  .NET EventPipe trace (<c>.nettrace</c>).
+    /// </summary>
+    NetTrace,
+
+    /// <summary>
+    ///  Windows ETW trace (<c>.etl</c>), the net481 <c>[EtwProfiler]</c> output.
+    /// </summary>
+    Etl
+}

--- a/traceq/src/TraceQ.Core/Tracing/TraceInfo.cs
+++ b/traceq/src/TraceQ.Core/Tracing/TraceInfo.cs
@@ -1,0 +1,100 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Metadata and quality signals describing a loaded trace, returned up front so
+///  a caller can pick its next query from real signals rather than empty results.
+/// </summary>
+internal sealed class TraceInfo
+{
+    /// <summary>
+    ///  Initializes a new <see cref="TraceInfo"/>.
+    /// </summary>
+    public TraceInfo(
+        string path,
+        TraceFormat format,
+        double durationMs,
+        int sampleCount,
+        double symbolResolutionRate,
+        IReadOnlyList<ThreadSampleInfo> threads,
+        IReadOnlyList<string> warnings)
+    {
+        Path = path;
+        Format = format;
+        DurationMs = durationMs;
+        SampleCount = sampleCount;
+        SymbolResolutionRate = symbolResolutionRate;
+        Threads = threads;
+        Warnings = warnings;
+    }
+
+    /// <summary>
+    ///  The absolute path the trace was loaded from.
+    /// </summary>
+    public string Path { get; }
+
+    /// <summary>
+    ///  The on-disk format the trace was read from.
+    /// </summary>
+    public TraceFormat Format { get; }
+
+    /// <summary>
+    ///  Sum of the per-sample weights across all samples, in milliseconds. This is
+    ///  CPU time, not wall-clock: because every thread's samples are included, the
+    ///  value can exceed the trace's wall-clock span when multiple threads ran
+    ///  concurrently.
+    /// </summary>
+    public double DurationMs { get; }
+
+    /// <summary>
+    ///  Number of weighted samples in the normalized model.
+    /// </summary>
+    public int SampleCount { get; }
+
+    /// <summary>
+    ///  Fraction in <c>[0, 1]</c> of stack frames whose symbol resolved to a
+    ///  managed method name. A value below <c>0.8</c> usually means symbols are
+    ///  missing and the rankings should not be trusted.
+    /// </summary>
+    public double SymbolResolutionRate { get; }
+
+    /// <summary>
+    ///  Per-thread sample counts, useful for picking a root frame or spotting
+    ///  idle thread-pool noise.
+    /// </summary>
+    public IReadOnlyList<ThreadSampleInfo> Threads { get; }
+
+    /// <summary>
+    ///  Human-readable quality warnings (low symbol resolution, no samples, etc.).
+    /// </summary>
+    public IReadOnlyList<string> Warnings { get; }
+}
+
+/// <summary>
+///  Per-thread sample count within a loaded trace.
+/// </summary>
+internal sealed class ThreadSampleInfo
+{
+    /// <summary>
+    ///  Initializes a new <see cref="ThreadSampleInfo"/>.
+    /// </summary>
+    public ThreadSampleInfo(string thread, int sampleCount)
+    {
+        Thread = thread;
+        SampleCount = sampleCount;
+    }
+
+    /// <summary>
+    ///  A label identifying the thread (OS thread id, or a synthetic id for
+    ///  speedscope profiles).
+    /// </summary>
+    public string Thread { get; }
+
+    /// <summary>
+    ///  Number of samples attributed to the thread.
+    /// </summary>
+    public int SampleCount { get; }
+}

--- a/traceq/src/TraceQ.Core/Tracing/TraceLoader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/TraceLoader.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Tracing.Readers;
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Dispatches a trace file to the reader for its format and assembles the
+///  <see cref="LoadedTrace"/>, computing the format-agnostic metadata (duration,
+///  sample count, per-thread breakdown) from the normalized samples.
+/// </summary>
+internal sealed class TraceLoader
+{
+    private readonly IReadOnlyList<ITraceReader> _readers =
+    [
+        new SpeedscopeReader(),
+        new NetTraceReader(),
+        new EtlReader()
+    ];
+
+    /// <summary>
+    ///  Loads the trace at <paramref name="path"/>.
+    /// </summary>
+    /// <param name="path">The trace file path.</param>
+    /// <param name="symbolsDirectory">
+    ///  Optional build-output directory whose assemblies' embedded portable PDBs are
+    ///  extracted to resolve managed frames to <c>file:line</c> for line-level
+    ///  rankings. Ignored for speedscope inputs.
+    /// </param>
+    /// <returns>The loaded trace.</returns>
+    /// <exception cref="FileNotFoundException">The file does not exist.</exception>
+    /// <exception cref="NotSupportedException">No reader recognizes the file extension.</exception>
+    public LoadedTrace Load(string path, string? symbolsDirectory = null)
+    {
+        string fullPath = Path.GetFullPath(path);
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"Trace file not found: {fullPath}", fullPath);
+        }
+
+        ITraceReader reader = ResolveReader(fullPath)
+            ?? throw new NotSupportedException(
+                $"Unrecognized trace format for '{fullPath}'. Supported: .speedscope.json, .nettrace, .etl");
+
+        TraceReadResult result = reader.Read(fullPath, symbolsDirectory);
+
+        double durationMs = 0.0;
+        Dictionary<string, int> threadCounts = new(StringComparer.Ordinal);
+        foreach (SampleStack sample in result.Samples)
+        {
+            durationMs += sample.WeightMs;
+            threadCounts.TryGetValue(sample.Thread, out int count);
+            threadCounts[sample.Thread] = count + 1;
+        }
+
+        List<ThreadSampleInfo> threads = [];
+        foreach (KeyValuePair<string, int> pair in threadCounts)
+        {
+            threads.Add(new ThreadSampleInfo(pair.Key, pair.Value));
+        }
+
+        threads.Sort(static (a, b) => b.SampleCount.CompareTo(a.SampleCount));
+
+        TraceInfo info = new(
+            fullPath,
+            reader.Format,
+            durationMs,
+            result.Samples.Count,
+            result.SymbolResolutionRate,
+            threads,
+            result.Warnings);
+
+        return new LoadedTrace(info, result.Samples);
+    }
+
+    private ITraceReader? ResolveReader(string path)
+    {
+        foreach (ITraceReader reader in _readers)
+        {
+            if (reader.CanRead(path))
+            {
+                return reader;
+            }
+        }
+
+        return null;
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/TraceLoader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/TraceLoader.cs
@@ -30,10 +30,15 @@ internal sealed class TraceLoader
     ///  rankings. Ignored for speedscope inputs.
     /// </param>
     /// <returns>The loaded trace.</returns>
+    /// <exception cref="ArgumentException">
+    ///  <paramref name="path"/> is <see langword="null"/>, empty, or not a valid file path.
+    /// </exception>
     /// <exception cref="FileNotFoundException">The file does not exist.</exception>
     /// <exception cref="NotSupportedException">No reader recognizes the file extension.</exception>
     public LoadedTrace Load(string path, string? symbolsDirectory = null)
     {
+        ArgumentException.ThrowIfNullOrEmpty(path);
+
         string fullPath = Path.GetFullPath(path);
         if (!File.Exists(fullPath))
         {

--- a/traceq/tests/TraceQ.Core.Tests/Fixtures/folding.speedscope.json
+++ b/traceq/tests/TraceQ.Core.Tests/Fixtures/folding.speedscope.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://www.speedscope.app/file-format-schema.json",
+  "shared": {
+    "frames": [
+      { "name": "Program.Main" },
+      { "name": "MyApp.Work" },
+      { "name": "MyApp.Inner" },
+      { "name": "CPU_TIME" },
+      { "name": "WriteBarrier" },
+      { "name": "MyApp.Other" }
+    ]
+  },
+  "profiles": [
+    {
+      "type": "evented",
+      "name": "Worker",
+      "unit": "milliseconds",
+      "startValue": 0,
+      "endValue": 25,
+      "events": [
+        { "type": "O", "frame": 0, "at": 0 },
+        { "type": "O", "frame": 1, "at": 0 },
+        { "type": "O", "frame": 2, "at": 0 },
+        { "type": "O", "frame": 3, "at": 0 },
+        { "type": "C", "frame": 3, "at": 10 },
+        { "type": "C", "frame": 2, "at": 10 },
+        { "type": "O", "frame": 4, "at": 10 },
+        { "type": "C", "frame": 4, "at": 14 },
+        { "type": "O", "frame": 2, "at": 14 },
+        { "type": "C", "frame": 2, "at": 20 },
+        { "type": "C", "frame": 1, "at": 20 },
+        { "type": "O", "frame": 5, "at": 20 },
+        { "type": "C", "frame": 5, "at": 25 },
+        { "type": "C", "frame": 0, "at": 25 }
+      ]
+    }
+  ]
+}

--- a/traceq/tests/TraceQ.Core.Tests/FoldingAggregatorTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/FoldingAggregatorTests.cs
@@ -1,0 +1,371 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class FoldingAggregatorTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+
+    private static LoadedTrace LoadFolding() =>
+        new TraceLoader().Load(FixturePath("folding.speedscope.json"));
+
+    private static Dictionary<string, double> ByFrame(RankingResult result)
+    {
+        Dictionary<string, double> map = new(StringComparer.Ordinal);
+        foreach (RankRow row in result.Rows)
+        {
+            map[row.Frame] = row.Milliseconds;
+        }
+
+        return map;
+    }
+
+    [TestMethod]
+    public void Load_SpeedscopeFixture_ReportsFormatDurationAndSamples()
+    {
+        LoadedTrace trace = LoadFolding();
+        trace.Info.Format.Should().Be(TraceFormat.Speedscope);
+        trace.Info.SampleCount.Should().Be(4);
+        trace.Info.DurationMs.Should().Be(25.0);
+        trace.Info.SymbolResolutionRate.Should().Be(1.0);
+    }
+
+    [TestMethod]
+    public void SelfTime_FoldsHelperLeavesIntoNearestRealLeaf()
+    {
+        RankingResult result = LoadFolding().Aggregator.SelfTime("", FrameNames.DefaultFoldPatterns, 25);
+        result.ScopeMilliseconds.Should().Be(25.0);
+
+        Dictionary<string, double> self = ByFrame(result);
+        // CPU_TIME folds into MyApp.Inner (10) plus the direct Inner sample (6) = 16.
+        self["MyApp.Inner"].Should().Be(16.0);
+        // WriteBarrier folds into MyApp.Work (4).
+        self["MyApp.Work"].Should().Be(4.0);
+        self["MyApp.Other"].Should().Be(5.0);
+        self.Should().NotContainKey("CPU_TIME");
+        self.Should().NotContainKey("WriteBarrier");
+    }
+
+    [TestMethod]
+    public void SelfTime_TopFrameByMilliseconds_IsRankedFirst()
+    {
+        RankingResult result = LoadFolding().Aggregator.SelfTime("", FrameNames.DefaultFoldPatterns, 25);
+        result.Rows[0].Frame.Should().Be("MyApp.Inner");
+        result.Rows[0].PercentOfScope.Should().Be(64.0);
+    }
+
+    [TestMethod]
+    public void InclusiveTime_CreditsEachDistinctFrameOncePerSample()
+    {
+        RankingResult result = LoadFolding().Aggregator.InclusiveTime("", FrameNames.DefaultFoldPatterns, 25);
+        result.ScopeMilliseconds.Should().Be(25.0);
+
+        Dictionary<string, double> incl = ByFrame(result);
+        incl["Program.Main"].Should().Be(25.0);
+        incl["MyApp.Work"].Should().Be(20.0);
+        incl["MyApp.Inner"].Should().Be(16.0);
+        incl["MyApp.Other"].Should().Be(5.0);
+        incl.Should().NotContainKey("CPU_TIME");
+        incl.Should().NotContainKey("WriteBarrier");
+    }
+
+    [TestMethod]
+    public void CallersOf_ReportsImmediateCallerAndScopePercent()
+    {
+        CallersResult result = LoadFolding().Aggregator.CallersOf("MyApp.Inner", "", 25);
+        result.TargetMilliseconds.Should().Be(16.0);
+        result.ScopeMilliseconds.Should().Be(25.0);
+        result.PercentOfScope.Should().Be(64.0);
+
+        result.Callers.Should().ContainSingle();
+        result.Callers[0].Caller.Should().Be("MyApp.Work");
+        result.Callers[0].Milliseconds.Should().Be(16.0);
+        result.Callers[0].PercentOfTarget.Should().Be(100.0);
+    }
+
+    [TestMethod]
+    public void CallersOf_MoreCallersThanTop_TruncatesToHeaviest()
+    {
+        // Three distinct callers of Target; top of 2 keeps only the two heaviest.
+        List<SampleStack> samples =
+        [
+            new(["Ccc", "Target"], 1.0, "1"),
+            new(["Bbb", "Target"], 2.0, "1"),
+            new(["Aaa", "Target"], 3.0, "1")
+        ];
+
+        CallersResult result = new FoldingAggregator(samples).CallersOf("Target", "", top: 2);
+
+        result.Callers.Should().HaveCount(2);
+        result.Callers[0].Milliseconds.Should().Be(3.0);
+        result.Callers[1].Milliseconds.Should().Be(2.0);
+        // The 1 ms caller is dropped by the truncation.
+        result.Callers.Should().NotContain(static c => c.Milliseconds == 1.0);
+    }
+
+    [TestMethod]
+    public void SelfTime_RootScoping_ExcludesSamplesWithoutRootFrame()
+    {
+        RankingResult result = LoadFolding().Aggregator.SelfTime("MyApp.Work", FrameNames.DefaultFoldPatterns, 25);
+        // The MyApp.Other sample (5 ms) has no MyApp.Work frame and is excluded.
+        result.ScopeMilliseconds.Should().Be(20.0);
+
+        Dictionary<string, double> self = ByFrame(result);
+        self["MyApp.Inner"].Should().Be(16.0);
+        self["MyApp.Work"].Should().Be(4.0);
+        self.Should().NotContainKey("MyApp.Other");
+    }
+
+    [TestMethod]
+    public void InclusiveTime_RootScoping_StartsFromRootFrame()
+    {
+        RankingResult result = LoadFolding().Aggregator.InclusiveTime("MyApp.Work", FrameNames.DefaultFoldPatterns, 25);
+        result.ScopeMilliseconds.Should().Be(20.0);
+
+        Dictionary<string, double> incl = ByFrame(result);
+        incl["MyApp.Work"].Should().Be(20.0);
+        incl["MyApp.Inner"].Should().Be(16.0);
+        // Program.Main is outside the root scope and must not be credited.
+        incl.Should().NotContainKey("Program.Main");
+    }
+
+    private static Dictionary<string, double> ByLocation(LineRankingResult result)
+    {
+        Dictionary<string, double> map = new(StringComparer.Ordinal);
+        foreach (LineRow row in result.Rows)
+        {
+            map[row.Location] = row.Milliseconds;
+        }
+
+        return map;
+    }
+
+    [TestMethod]
+    public void HotLines_AttributesLeafSamplesToSourceLineFoldingHelperLeaves()
+    {
+        // Two samples land directly on Run at two different lines; a third lands
+        // on a folded WriteBarrier leaf whose real caller is Run at the first line.
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 3.0, "1", ["Engine.cs:20"]),
+            new(["app!Run", "app!WriteBarrier"], 4.0, "1", ["Engine.cs:10", "Helpers.cs:99"])
+        ];
+
+        LineRankingResult result = new FoldingAggregator(samples).HotLines("Run", FrameNames.DefaultFoldPatterns, 25);
+
+        result.ScopeMilliseconds.Should().Be(12.0);
+        result.MethodFilter.Should().Be("Run");
+
+        Dictionary<string, double> byLine = ByLocation(result);
+        // Line 10 collects the direct 5 ms plus the 4 ms folded back from WriteBarrier.
+        byLine["Engine.cs:10"].Should().Be(9.0);
+        byLine["Engine.cs:20"].Should().Be(3.0);
+        byLine.Should().NotContainKey("Helpers.cs:99");
+
+        result.Rows[0].Location.Should().Be("Engine.cs:10");
+        result.Rows[0].Method.Should().Be("Run");
+        result.Rows[0].PercentOfScope.Should().Be(75.0);
+    }
+
+    [TestMethod]
+    public void HotLines_MethodFilter_ExcludesNonMatchingLeafMethods()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Other"], 7.0, "1", ["Other.cs:42"])
+        ];
+
+        LineRankingResult result = new FoldingAggregator(samples).HotLines("Run", FrameNames.DefaultFoldPatterns, 25);
+
+        result.ScopeMilliseconds.Should().Be(5.0);
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].Location.Should().Be("Engine.cs:10");
+    }
+
+    [TestMethod]
+    public void HotLines_SamplesWithoutLocations_AreIgnored()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 9.0, "1")
+        ];
+
+        LineRankingResult result = new FoldingAggregator(samples).HotLines("", FrameNames.DefaultFoldPatterns, 25);
+
+        result.ScopeMilliseconds.Should().Be(5.0);
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].Location.Should().Be("Engine.cs:10");
+    }
+
+    [TestMethod]
+    public void HotLines_UnresolvedLeafLocation_BucketsAsNoSource()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", [""])
+        ];
+
+        LineRankingResult result = new FoldingAggregator(samples).HotLines("Run", FrameNames.DefaultFoldPatterns, 25);
+
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].Location.Should().Be("<no source>");
+        result.Rows[0].Milliseconds.Should().Be(5.0);
+    }
+
+    [TestMethod]
+    public void HotLines_TopLimit_TruncatesToHottestRows()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 3.0, "1", ["Engine.cs:20"])
+        ];
+
+        LineRankingResult result = new FoldingAggregator(samples).HotLines("Run", FrameNames.DefaultFoldPatterns, 1);
+
+        result.Rows.Should().ContainSingle();
+        result.Rows[0].Location.Should().Be("Engine.cs:10");
+    }
+
+    [TestMethod]
+    public void CallersOf_FocusAtStackRoot_CreditsRootCaller()
+    {
+        // Program.Main is the outermost frame, so its only caller is the synthetic <root>.
+        CallersResult result = LoadFolding().Aggregator.CallersOf("Program.Main", "", 25);
+
+        result.Callers.Should().ContainSingle();
+        result.Callers[0].Caller.Should().Be("<root>");
+        result.Callers[0].Milliseconds.Should().Be(25.0);
+    }
+
+    [TestMethod]
+    public void SourceHeatmap_BucketsLeafSamplesByLineFoldingHelperLeaves()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 3.0, "1", ["Engine.cs:20"]),
+            new(["app!Run", "app!WriteBarrier"], 4.0, "1", ["Engine.cs:10", "Helpers.cs:99"]),
+            new(["app!Other"], 8.0, "1", ["Other.cs:1"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        // Percent is over the whole trace (20 ms), file total is the 12 ms in Engine.cs.
+        result.ScopeMilliseconds.Should().Be(20.0);
+        result.File.Should().Be("Engine.cs");
+        result.FileMilliseconds.Should().Be(12.0);
+
+        result.Lines.Should().HaveCount(2);
+        // Ordered by line number, not by time.
+        result.Lines[0].Line.Should().Be(10);
+        result.Lines[0].Milliseconds.Should().Be(9.0);
+        result.Lines[0].SampleCount.Should().Be(2);
+        result.Lines[0].Method.Should().Be("Run");
+        result.Lines[0].PercentOfScope.Should().Be(45.0);
+        result.Lines[1].Line.Should().Be(20);
+        result.Lines[1].Milliseconds.Should().Be(3.0);
+    }
+
+    [TestMethod]
+    public void SourceHeatmap_MatchesFileNameCaseInsensitively()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("ENGINE.CS", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().ContainSingle();
+        // The file name keeps the casing recorded in the trace.
+        result.File.Should().Be("Engine.cs");
+    }
+
+    [TestMethod]
+    public void SourceHeatmap_SamplesWithoutLocationsOrOtherFiles_AreExcluded()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"]),
+            new(["app!Run"], 9.0, "1"),
+            new(["app!Run"], 4.0, "1", [""]),
+            new(["app!Run"], 2.0, "1", ["Other.cs:3"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        // Whole-trace total still counts every sample; only Engine.cs contributes lines.
+        result.ScopeMilliseconds.Should().Be(20.0);
+        result.FileMilliseconds.Should().Be(5.0);
+        result.Lines.Should().ContainSingle();
+        result.Lines[0].Line.Should().Be(10);
+    }
+
+    [TestMethod]
+    public void SourceHeatmap_NoMatchingFile_ReturnsEmptyLines()
+    {
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", ["Engine.cs:10"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Missing.cs", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().BeEmpty();
+        result.FileMilliseconds.Should().Be(0.0);
+        result.ScopeMilliseconds.Should().Be(5.0);
+    }
+
+    [TestMethod]
+    public void SourceHeatmap_CompetingMethodsOnOneLine_ReportsDominantByTime()
+    {
+        // Two methods resolve to the same Engine.cs:10; the heaviest one dominates.
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 3.0, "1", ["Engine.cs:10"]),
+            new(["app!Helper"], 7.0, "1", ["Engine.cs:10"])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().ContainSingle();
+        result.Lines[0].Line.Should().Be(10);
+        result.Lines[0].Milliseconds.Should().Be(10.0);
+        result.Lines[0].SampleCount.Should().Be(2);
+        // Helper (7 ms) outweighs Run (3 ms) for the line.
+        result.Lines[0].Method.Should().Be("Helper");
+    }
+
+    [TestMethod]
+    [DataRow("Engine.cs")]
+    [DataRow("Engine.cs:")]
+    [DataRow("Engine.cs:abc")]
+    [DataRow(":10")]
+    [DataRow("Engine.cs:0")]
+    [DataRow("Engine.cs:-1")]
+    public void SourceHeatmap_MalformedLeafLocation_IsExcluded(string location)
+    {
+        // A location with no colon, a trailing colon, a non-numeric line, no file
+        // name, or a non-positive (non 1-based) line cannot be split into file:line
+        // and must not contribute to any file.
+        List<SampleStack> samples =
+        [
+            new(["app!Run"], 5.0, "1", [location])
+        ];
+
+        SourceHeatmapResult result = new FoldingAggregator(samples).SourceHeatmap("Engine.cs", FrameNames.DefaultFoldPatterns);
+
+        result.Lines.Should().BeEmpty();
+        result.FileMilliseconds.Should().Be(0.0);
+        // The sample still counts toward the whole-trace total.
+        result.ScopeMilliseconds.Should().Be(5.0);
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/FrameNamesTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/FrameNamesTests.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class FrameNamesTests
+{
+    [TestMethod]
+    public void Short_ModuleAndSignature_KeepsMethodIdentifier()
+    {
+        string result = FrameNames.Short("touki!Touki.Io.Globbing.CompiledGlobStrategy.RunEngine(int32, bool)");
+        result.Should().Be("Touki.Io.Globbing.CompiledGlobStrategy.RunEngine");
+    }
+
+    [TestMethod]
+    public void Short_ValueClassNoise_IsStripped()
+    {
+        string result = FrameNames.Short("mod!value class Some.Type.Method(int32)");
+        result.Should().Be("Some.Type.Method");
+    }
+
+    [TestMethod]
+    public void Short_NoModulePrefix_ReturnsNameUnchanged()
+    {
+        FrameNames.Short("CPU_TIME").Should().Be("CPU_TIME");
+    }
+
+    [TestMethod]
+    public void IsFolded_DefaultPatterns_FoldSyntheticAndHelperLeaves()
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(FrameNames.DefaultFoldPatterns);
+        FrameNames.IsFolded("CPU_TIME", fold).Should().BeTrue();
+        FrameNames.IsFolded("UNMANAGED_CODE_TIME", fold).Should().BeTrue();
+        FrameNames.IsFolded("JIT_WriteBarrier", fold).Should().BeTrue();
+        FrameNames.IsFolded("System.Buffer.Memmove", fold).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void IsFolded_RealMethod_IsNotFolded()
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(FrameNames.DefaultFoldPatterns);
+        FrameNames.IsFolded("Touki.Io.Globbing.CompiledGlobStrategy.RunEngine", fold).Should().BeFalse();
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/FrameNamesTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/FrameNamesTests.cs
@@ -43,4 +43,13 @@ public sealed class FrameNamesTests
         Regex[] fold = FrameNames.CompileFoldPatterns(FrameNames.DefaultFoldPatterns);
         FrameNames.IsFolded("Touki.Io.Globbing.CompiledGlobStrategy.RunEngine", fold).Should().BeFalse();
     }
+
+    [TestMethod]
+    public void CompileFoldPatterns_InvalidPattern_ThrowsArgumentNamingTheEntry()
+    {
+        // An unclosed group is not a valid regular expression.
+        Action act = () => FrameNames.CompileFoldPatterns(["valid", "(unclosed"]);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*(unclosed*");
+    }
 }

--- a/traceq/tests/TraceQ.Core.Tests/GlobalUsings.cs
+++ b/traceq/tests/TraceQ.Core.Tests/GlobalUsings.cs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+global using System.Text.RegularExpressions;
 global using AwesomeAssertions;
 global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/traceq/tests/TraceQ.Core.Tests/ScaffoldTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/ScaffoldTests.cs
@@ -17,6 +17,6 @@ public sealed class ScaffoldTests
     [TestMethod]
     public void TraceQCore_Milestone_IsReferenceable()
     {
-        TraceQCore.Milestone.Should().Be("M0");
+        TraceQCore.Milestone.Should().Be("M1");
     }
 }

--- a/traceq/tests/TraceQ.Core.Tests/SourceAnnotatorTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/SourceAnnotatorTests.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class SourceAnnotatorTests
+{
+    [TestMethod]
+    public void TryReadSourceLines_ExistingFile_ReturnsLines()
+    {
+        string temp = Path.GetTempFileName();
+        try
+        {
+            File.WriteAllLines(temp, ["first", "second", "third"]);
+
+            SourceAnnotator.TryReadSourceLines(temp, out string[] lines).Should().BeTrue();
+            lines.Should().Equal("first", "second", "third");
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+
+    [TestMethod]
+    public void TryReadSourceLines_MissingFile_ReturnsFalseAndEmpty()
+    {
+        string missing = Path.Combine(Path.GetTempPath(), $"does-not-exist-{Guid.NewGuid():N}.cs");
+
+        SourceAnnotator.TryReadSourceLines(missing, out string[] lines).Should().BeFalse();
+        lines.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public void Render_SmallFile_RendersEveryLineWithHeaderAndGutter()
+    {
+        string[] source = ["alpha", "beta", "gamma"];
+        List<HeatLine> heat = [new HeatLine(2, 6.0, 50.0, 3, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 12.0);
+
+        // Header is always present.
+        output.Should().Contain("ms");
+        output.Should().Contain("%file");
+        output.Should().Contain("heat");
+
+        // Every source line is rendered, hot or cold.
+        output.Should().Contain("alpha");
+        output.Should().Contain("beta");
+        output.Should().Contain("gamma");
+    }
+
+    [TestMethod]
+    public void Render_HotLine_ShowsMillisecondsPercentOfFileAndHeatBars()
+    {
+        string[] source = ["cold", "hot"];
+        List<HeatLine> heat = [new HeatLine(2, 6.0, 30.0, 3, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 12.0);
+
+        string[] lines = output.Split('\n');
+        string hotRow = lines.Single(static l => l.Contains("hot"));
+
+        // 6 of 12 file ms = 50.0% of file, and a full 8-bar heat (it is the max line).
+        hotRow.Should().Contain("6.0");
+        hotRow.Should().Contain("50.0");
+        hotRow.Should().Contain("########");
+    }
+
+    [TestMethod]
+    public void Render_ColdLine_HasBlankGutter()
+    {
+        string[] source = ["cold", "hot"];
+        List<HeatLine> heat = [new HeatLine(2, 6.0, 30.0, 3, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 12.0);
+
+        string[] lines = output.Split('\n');
+        string coldRow = lines.Single(static l => l.Contains("cold"));
+
+        // The cold line carries no ms/percent/heat - only the line number and text.
+        coldRow.Should().NotContain("#");
+        coldRow.Should().Contain("cold");
+    }
+
+    [TestMethod]
+    public void Render_ZeroFileMilliseconds_DoesNotDivideByZero()
+    {
+        string[] source = ["only"];
+        List<HeatLine> heat = [new HeatLine(1, 5.0, 0.0, 1, "Foo")];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 0.0);
+
+        string[] lines = output.Split('\n');
+        string row = lines.Single(static l => l.Contains("only"));
+        // Percent-of-file collapses to 0.0 rather than NaN/Infinity.
+        row.Should().Contain("0.0");
+        row.Should().Contain("5.0");
+    }
+
+    [TestMethod]
+    public void Render_LargeFile_WindowsAroundHotLinesWithGapMarkers()
+    {
+        string[] source = new string[700];
+        for (int i = 0; i < source.Length; i++)
+        {
+            source[i] = $"line{i + 1}";
+        }
+
+        // Two hot lines far apart force two separate windows with a gap between them.
+        List<HeatLine> heat =
+        [
+            new HeatLine(100, 4.0, 40.0, 1, "Foo"),
+            new HeatLine(400, 6.0, 60.0, 1, "Bar")
+        ];
+
+        string output = SourceAnnotator.Render(source, heat, fileMilliseconds: 10.0);
+
+        // Hot lines and their context are shown.
+        output.Should().Contain("line100");
+        output.Should().Contain("line400");
+
+        // A line in neither window is omitted. Match the rendered gutter so the
+        // check is newline-agnostic (AppendLine emits \r\n on Windows).
+        output.Should().NotContain("|  250  line250");
+
+        // A gap marker separates the two windows.
+        output.Should().Contain("...");
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/TraceLoaderTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/TraceLoaderTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class TraceLoaderTests
+{
+    [TestMethod]
+    public void Load_MissingFile_ThrowsFileNotFound()
+    {
+        TraceLoader loader = new();
+        string missing = Path.Combine(AppContext.BaseDirectory, "Fixtures", "missing.speedscope.json");
+
+        Action act = () => loader.Load(missing);
+
+        act.Should().Throw<FileNotFoundException>();
+    }
+
+    [TestMethod]
+    public void Load_UnsupportedExtension_ThrowsNotSupported()
+    {
+        TraceLoader loader = new();
+        string temp = Path.GetTempFileName();
+        try
+        {
+            Action act = () => loader.Load(temp);
+
+            act.Should().Throw<NotSupportedException>();
+        }
+        finally
+        {
+            File.Delete(temp);
+        }
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/TraceLoaderTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/TraceLoaderTests.cs
@@ -34,4 +34,16 @@ public sealed class TraceLoaderTests
             File.Delete(temp);
         }
     }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
+    public void Load_NullOrEmptyPath_ThrowsArgument(string? path)
+    {
+        TraceLoader loader = new();
+
+        Action act = () => loader.Load(path!);
+
+        act.Should().Throw<ArgumentException>();
+    }
 }

--- a/traceq/tests/TraceQ.Core.Tests/TraceQ.Core.Tests.csproj
+++ b/traceq/tests/TraceQ.Core.Tests/TraceQ.Core.Tests.csproj
@@ -23,4 +23,10 @@
     <ProjectReference Include="..\..\src\TraceQ.Core\TraceQ.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="Fixtures\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/traceq/tests/TraceQ.Core.Tests/TraceStoreTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/TraceStoreTests.cs
@@ -29,11 +29,17 @@ public sealed class TraceStoreTests
     {
         TraceStore store = new();
         string absolute = FixturePath("folding.speedscope.json");
+        string relative = Path.GetRelativePath(Directory.GetCurrentDirectory(), absolute);
+
+        // Guard against a degenerate run where the two spellings come out identical:
+        // the point is that a genuinely relative path and its absolute form collapse
+        // onto a single cache entry.
+        relative.Should().NotBe(absolute);
 
         LoadedTrace viaAbsolute = store.Get(absolute);
-        LoadedTrace viaFullPath = store.Get(Path.GetFullPath(absolute));
+        LoadedTrace viaRelative = store.Get(relative);
 
-        viaFullPath.Should().BeSameAs(viaAbsolute);
+        viaRelative.Should().BeSameAs(viaAbsolute);
     }
 
     [TestMethod]

--- a/traceq/tests/TraceQ.Core.Tests/TraceStoreTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/TraceStoreTests.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Tracing;
+
+namespace TraceQ.Server;
+
+[TestClass]
+public sealed class TraceStoreTests
+{
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+
+    [TestMethod]
+    public void Get_SamePath_ReturnsCachedInstance()
+    {
+        TraceStore store = new();
+        string path = FixturePath("folding.speedscope.json");
+
+        LoadedTrace first = store.Get(path);
+        LoadedTrace second = store.Get(path);
+
+        second.Should().BeSameAs(first);
+    }
+
+    [TestMethod]
+    public void Get_RelativeAndAbsolutePath_ShareCacheEntry()
+    {
+        TraceStore store = new();
+        string absolute = FixturePath("folding.speedscope.json");
+
+        LoadedTrace viaAbsolute = store.Get(absolute);
+        LoadedTrace viaFullPath = store.Get(Path.GetFullPath(absolute));
+
+        viaFullPath.Should().BeSameAs(viaAbsolute);
+    }
+
+    [TestMethod]
+    public void Get_DifferentSymbolsKey_CachesSeparately()
+    {
+        TraceStore store = new();
+        string path = FixturePath("folding.speedscope.json");
+
+        LoadedTrace withoutSymbols = store.Get(path);
+        LoadedTrace withSymbols = store.Get(path, AppContext.BaseDirectory);
+
+        withSymbols.Should().NotBeSameAs(withoutSymbols);
+    }
+
+    [TestMethod]
+    public void Get_LoadsTraceWithExpectedInfo()
+    {
+        TraceStore store = new();
+
+        LoadedTrace trace = store.Get(FixturePath("folding.speedscope.json"));
+
+        trace.Info.Format.Should().Be(TraceFormat.Speedscope);
+        trace.Info.SampleCount.Should().Be(4);
+    }
+}

--- a/traceq/tests/TraceQ.Parity.Tests/ParityTests.cs
+++ b/traceq/tests/TraceQ.Parity.Tests/ParityTests.cs
@@ -21,10 +21,10 @@ public sealed class ParityTests
     [TestMethod]
     public void Harness_IsWired_AgainstCore()
     {
-        // M0 smoke: the parity project compiles and references the core. Replaced
-        // by the real corpus comparison in M1 (this keeps the project running at
-        // least one test so the runner does not report "zero tests ran").
-        TraceQCore.Milestone.Should().Be("M0");
+        // Smoke: the parity project compiles and references the core. Replaced
+        // by the real corpus comparison later in M1 (this keeps the project running
+        // at least one test so the runner does not report "zero tests ran").
+        TraceQCore.Milestone.Should().Be("M1");
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary

First step of milestone **M1 (core extraction)** for the `traceq` incubation subtree: relocate the `touki.mcp` trace-analysis core into `TraceQ.Core` and re-namespace `Touki.Mcp` -> `TraceQ`. A plain copy with no git history, per [docs/traceq-implementation-plan.md](docs/traceq-implementation-plan.md).

## What changed

All changes are under `traceq/`; no `touki` production files are touched.

- **`TraceQ.Core/Tracing`** - FoldingAggregator, FrameNames, LoadedTrace, RankingResult, SampleStack, SourceAnnotator, TraceFormat, TraceInfo, TraceLoader, plus the readers (EmbeddedPdbExtractor, EtlReader, ITraceReader, NetTraceReader, SpeedscopeReader, TraceLogReader).
- **`TraceQ.Core/Server`** - TraceStore.
- **`InternalsVisibleTo`** - the core types are `internal`. `touki.mcp` shared them within a single assembly; `traceq` splits into Core/CLI/Mcp, so the CLI, MCP, and test projects need IVT (traceq is not strong-named, so no PublicKey).
- **Tests** - ported the five core suites (TUnit -> MSTest) and the `folding.speedscope.json` fixture into `TraceQ.Core.Tests`.
- **Milestone marker** - bumped `TraceQCore.Milestone` M0 -> M1.

## Deferred to follow-on M1 increments

The provider/engine two-layer split, the output contract, the ETLX cache, the new stack-source providers, and the trim verb. The CLI `analyze` verb (M2) and the MCP facade (M3) stay stubbed.

## Verification

- `dotnet build traceq.slnx` - 0 warnings / 0 errors.
- `dotnet test traceq.slnx` - 46 total, 45 passed, 1 skipped (the `[Ignore]`'d parity oracle).
- **Extraction rehearsal** - copied the subtree outside the repo and built + tested it standalone; still proves zero coupling to `touki`.