### PR TITLE
Add ValueStringBuilder interpolation APIs and wire Touki into traceq

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "dotnet",
+			"task": "build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"label": "dotnet: build"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,15 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "dotnet",
-			"task": "build",
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"problemMatcher": [],
-			"label": "dotnet: build"
-		}
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "dotnet",
+      "task": "build",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": [],
+      "label": "dotnet: build"
+    }
+  ]
 }

--- a/touki.tests/Touki/Text/DefaultInterpolatedStringHandlerTests.cs
+++ b/touki.tests/Touki/Text/DefaultInterpolatedStringHandlerTests.cs
@@ -389,6 +389,31 @@ public unsafe class DefaultInterpolatedStringHandlerTests
         interpolatedResult.Should().Be(formatResult);
     }
 
+    [TestMethod]
+    public void Text_ReturnsAppendedCharacters()
+    {
+        DefaultInterpolatedStringHandler handler = new(literalLength: 0, formattedCount: 0);
+        handler.AppendLiteral("Hello");
+        handler.AppendFormatted(42);
+
+        handler.Text.ToString().Should().Be("Hello42");
+
+        handler.Clear();
+    }
+
+    [TestMethod]
+    public void Clear_ReleasesGrownBuffer()
+    {
+        DefaultInterpolatedStringHandler handler = new(literalLength: 0, formattedCount: 0);
+
+        // Append enough to force the handler past its initial buffer and rent from the pool.
+        handler.AppendFormatted(new string('x', 1000));
+        handler.Text.Length.Should().Be(1000);
+
+        // Clear releases the rented buffer; it must be the last operation on the handler.
+        handler.Clear();
+    }
+
     public static IEnumerable<object[]> IntegerData() =>
     [
         [42],

--- a/touki.tests/Touki/Text/DefaultInterpolatedStringHandlerTests.cs
+++ b/touki.tests/Touki/Text/DefaultInterpolatedStringHandlerTests.cs
@@ -393,25 +393,34 @@ public unsafe class DefaultInterpolatedStringHandlerTests
     public void Text_ReturnsAppendedCharacters()
     {
         DefaultInterpolatedStringHandler handler = new(literalLength: 0, formattedCount: 0);
-        handler.AppendLiteral("Hello");
-        handler.AppendFormatted(42);
+        try
+        {
+            handler.AppendLiteral("Hello");
+            handler.AppendFormatted(42);
 
-        handler.Text.ToString().Should().Be("Hello42");
-
-        handler.Clear();
+            handler.Text.ToString().Should().Be("Hello42");
+        }
+        finally
+        {
+            handler.Clear();
+        }
     }
 
     [TestMethod]
     public void Clear_ReleasesGrownBuffer()
     {
         DefaultInterpolatedStringHandler handler = new(literalLength: 0, formattedCount: 0);
-
-        // Append enough to force the handler past its initial buffer and rent from the pool.
-        handler.AppendFormatted(new string('x', 1000));
-        handler.Text.Length.Should().Be(1000);
-
-        // Clear releases the rented buffer; it must be the last operation on the handler.
-        handler.Clear();
+        try
+        {
+            // Append enough to force the handler past its initial buffer and rent from the pool.
+            handler.AppendFormatted(new string('x', 1000));
+            handler.Text.Length.Should().Be(1000);
+        }
+        finally
+        {
+            // Clear releases the rented buffer; it must be the last operation on the handler.
+            handler.Clear();
+        }
     }
 
     public static IEnumerable<object[]> IntegerData() =>

--- a/touki.tests/Touki/Text/ValueStringBuilderTests.cs
+++ b/touki.tests/Touki/Text/ValueStringBuilderTests.cs
@@ -3067,7 +3067,7 @@ public unsafe class ValueStringBuilderTests
     }
 
     [TestMethod]
-    public void Append_And_AppendLine_Interpolated_Chained()
+    public void Append_ChainedWithInterpolatedAppendLine_AccumulatesWithNewLine()
     {
         using ValueStringBuilder builder = new(stackalloc char[128]);
         int count = 3;

--- a/touki.tests/Touki/Text/ValueStringBuilderTests.cs
+++ b/touki.tests/Touki/Text/ValueStringBuilderTests.cs
@@ -78,6 +78,96 @@ public unsafe class ValueStringBuilderTests
     }
 
     [TestMethod]
+    public void Append_InterpolatedString_AppendsFormattedValue()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[20]);
+        builder.Append("Before ");
+
+        builder.Append($"Value {42:X2}");
+
+        builder.ToString().Should().Be("Before Value 2A");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedStringLongerThanInitialCapacity_GrowsSafely()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[4]);
+        builder.Append("A");
+
+        builder.Append($"{1234567890}-{1234567890}-{1234567890}");
+
+        builder.ToString().Should().Be("A1234567890-1234567890-1234567890");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedStringWithProvider_UsesProvider()
+    {
+        CultureInfo originalCulture = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo culture = CultureInfo.GetCultureInfo("fr-FR");
+            using ValueStringBuilder builder = new(stackalloc char[32], culture);
+
+            builder.Append($"{1234.5:N1}");
+
+            builder.ToString().Should().Be(1234.5.ToString("N1", culture));
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = originalCulture;
+        }
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedString_AppendsFormattedValueAndNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+
+        builder.AppendLine($"Value {42:X2}");
+
+        builder.ToString().Should().Be($"Value 2A{Environment.NewLine}");
+    }
+
+#if !DEBUG
+    [TestMethod]
+    public void Append_InterpolatedStringWithLargeContent_DoesNotAllocateIntermediateString()
+    {
+        string large = new('x', 8192);
+        {
+            using ValueStringBuilder warmup = new(stackalloc char[32]);
+            warmup.Append($"<{large}>");
+        }
+
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+        using (MemoryWatch.Create)
+        {
+            builder.Append($"<{large}>");
+        }
+
+        builder.ToString().Should().Be("<" + large + ">");
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedStringWithLargeContent_DoesNotAllocateIntermediateString()
+    {
+        string large = new('x', 8192);
+        {
+            using ValueStringBuilder warmup = new(stackalloc char[32]);
+            warmup.AppendLine($"<{large}>");
+        }
+
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+        using (MemoryWatch.Create)
+        {
+            builder.AppendLine($"<{large}>");
+        }
+
+        builder.ToString().Should().Be("<" + large + ">" + Environment.NewLine);
+    }
+#endif
+
+    [TestMethod]
     public void Append_CharPointer()
     {
         using ValueStringBuilder builder = new(stackalloc char[10]);
@@ -2769,6 +2859,285 @@ public unsafe class ValueStringBuilderTests
         {
             builder.Dispose();
         }
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_AppendsToExistingContent()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        builder.Append("Start: ");
+
+        int value = 42;
+        builder.Append($"value={value}");
+
+        builder.ToString().Should().Be("Start: value=42");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_OnlyLiteral_AppendsLiteral()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+
+        builder.Append($"just literal text");
+
+        builder.ToString().Should().Be("just literal text");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_MultipleHoles_FormatsEach()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        int a = 1;
+        string b = "two";
+        int c = 3;
+
+        builder.Append($"{a}-{b}-{c}");
+
+        builder.ToString().Should().Be("1-two-3");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_WithFormatSpecifier_AppliesFormat()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+        int value = 255;
+
+        builder.Append($"hex={value:X4}");
+
+        builder.ToString().Should().Be("hex=00FF");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_GrowsBeyondInitialBuffer()
+    {
+        // Start with a tiny stack buffer so the interpolated content forces a pool rental.
+        using ValueStringBuilder builder = new(stackalloc char[4]);
+        builder.Append("AB");
+
+        string large = new('x', 500);
+        builder.Append($"{large}");
+
+        builder.Length.Should().Be(502);
+        builder.ToString().Should().Be("AB" + large);
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_MultipleCalls_Accumulate()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        int x = 1;
+        int y = 2;
+
+        builder.Append($"a={x}");
+        builder.Append($";b={y}");
+
+        builder.ToString().Should().Be("a=1;b=2");
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_MatchesStringBuilder()
+    {
+        int id = 7;
+        string name = "widget";
+
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        builder.Append($"id={id}, name={name}");
+
+        StringBuilder expected = new();
+        expected.Append($"id={id}, name={name}");
+
+        builder.ToString().Should().Be(expected.ToString());
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedString_EmptyContent_AppendsNothing()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+        builder.Append("kept");
+
+        builder.Append($"");
+
+        builder.ToString().Should().Be("kept");
+        builder.Length.Should().Be(4);
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedStringWithCustomProvider_UsesProvider()
+    {
+        UpperCaseFormatProvider provider = new();
+        ValueStringBuilder builder = new(literalLength: 0, formattedCount: 0, provider: provider, initialBuffer: stackalloc char[64]);
+        try
+        {
+            string text = "hi";
+            builder.Append($"x{text}");
+
+            builder.ToString().Should().Be("x[HI]");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedStringHoleMutatesBuilder_AppendsAfterMutation()
+    {
+        ValueStringBuilder builder = new(stackalloc char[64]);
+        try
+        {
+            builder.Append("a");
+
+            builder.Append($"b{AppendAndReturn(ref builder, "c", "d")}");
+
+            builder.ToString().Should().Be("acbd");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void Append_InterpolatedStringReferencingSelf_AppendsSnapshotOfReceiver()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        builder.Append("A");
+
+        // The hole reads the receiver through its implicit ReadOnlySpan<char> conversion. The
+        // interpolation is built in an independent buffer, so the hole sees a snapshot of the
+        // receiver ("A") taken when the hole is evaluated, not the in-progress interpolation.
+        builder.Append($"pre{builder}post");
+
+        builder.ToString().Should().Be("ApreApost");
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedString_AppendsContentAndNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        int value = 42;
+
+        builder.AppendLine($"value={value}");
+
+        builder.ToString().Should().Be("value=42" + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedString_AppendsToExistingContent()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+        builder.Append("header");
+
+        builder.AppendLine($" {1}");
+
+        builder.ToString().Should().Be("header 1" + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedString_MultipleLines_ProduceMultipleNewLines()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[64]);
+
+        builder.AppendLine($"line {1}");
+        builder.AppendLine($"line {2}");
+
+        builder.ToString().Should().Be(
+            "line 1" + Environment.NewLine + "line 2" + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedString_EmptyContent_AppendsOnlyNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+
+        builder.AppendLine($"");
+
+        builder.ToString().Should().Be(Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_InterpolatedString_GrowsBeyondInitialBuffer()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[4]);
+
+        string large = new('y', 300);
+        builder.AppendLine($"{large}");
+
+        builder.ToString().Should().Be(large + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void Append_And_AppendLine_Interpolated_Chained()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[128]);
+        int count = 3;
+
+        builder.Append($"count={count}");
+        builder.AppendLine($" done");
+        builder.Append($"next");
+
+        builder.ToString().Should().Be("count=3 done" + Environment.NewLine + "next");
+    }
+
+    [TestMethod]
+    public void AppendLine_NoArgs_AppendsNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+        builder.Append("text");
+
+        builder.AppendLine();
+
+        builder.ToString().Should().Be("text" + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_NoArgs_OnEmpty_AppendsOnlyNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+
+        builder.AppendLine();
+
+        builder.ToString().Should().Be(Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_NoArgs_MultipleCalls_AppendMultipleNewLines()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[16]);
+
+        builder.AppendLine();
+        builder.AppendLine();
+
+        builder.ToString().Should().Be(Environment.NewLine + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_String_AppendsValueAndNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+        builder.Append("start ");
+        string value = "hello";
+
+        builder.AppendLine(value);
+
+        builder.ToString().Should().Be("start hello" + Environment.NewLine);
+    }
+
+    [TestMethod]
+    public void AppendLine_StringSegment_AppendsSegmentAndNewLine()
+    {
+        using ValueStringBuilder builder = new(stackalloc char[32]);
+        StringSegment segment = new("Hello World", 0, 5);
+
+        builder.AppendLine(segment);
+
+        builder.ToString().Should().Be("Hello" + Environment.NewLine);
+    }
+
+    private static string AppendAndReturn(ref ValueStringBuilder builder, string text, string result)
+    {
+        builder.Append(text);
+        return result;
     }
 
     private sealed class UpperCaseFormatProvider : IFormatProvider, ICustomFormatter

--- a/touki/Framework/Polyfills/System.Runtime.CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/touki/Framework/Polyfills/System.Runtime.CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -81,4 +81,17 @@ public ref struct DefaultInterpolatedStringHandler
 
     /// <inheritdoc cref="ValueStringBuilder.ToStringAndDispose()"/>
     public string ToStringAndClear() => _builder.ToStringAndDispose();
+
+    /// <summary>Clears the handler.</summary>
+    /// <remarks>
+    /// This releases any resources used by the handler. The method should be invoked only
+    /// once and as the last thing performed on the handler. Subsequent use is erroneous, ill-defined,
+    /// and may destabilize the process, as may using any other copies of the handler after <see cref="Clear"/>
+    /// is called on any one of them.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Clear() => _builder.Dispose();
+
+    /// <summary>Gets a span of the characters appended to the handler.</summary>
+    public readonly ReadOnlySpan<char> Text => _builder.AsSpan();
 }

--- a/touki/Touki/Text/ValueStringBuilder.AppendInterpolatedStringHandler.cs
+++ b/touki/Touki/Text/ValueStringBuilder.AppendInterpolatedStringHandler.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Text;
+
+public ref partial struct ValueStringBuilder
+{
+    /// <summary>
+    ///  Provides an interpolated string handler for appending formatted text to a
+    ///  <see cref="ValueStringBuilder"/>.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [InterpolatedStringHandler]
+    public ref struct InterpolatedStringHandler
+    {
+        private ValueStringBuilder _builder;
+
+        /// <summary>
+        ///  Initializes a new instance of the <see cref="InterpolatedStringHandler"/> struct.
+        /// </summary>
+        /// <param name="literalLength">The length of literal content in the interpolated string.</param>
+        /// <param name="formattedCount">The number of formatted holes in the interpolated string.</param>
+        /// <param name="builder">The builder receiving the interpolated string.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public InterpolatedStringHandler(int literalLength, int formattedCount, ValueStringBuilder builder)
+            => _builder = new(literalLength, formattedCount, builder._formatProvider);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendLiteral(string?)"/>
+        public void AppendLiteral(string value) => _builder.AppendLiteral(value);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, StringSpan)"/>
+        public void AppendFormatted<T>(T value) => _builder.AppendFormatted(value);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted(Value, StringSpan)"/>
+        public void AppendFormatted(Value value) => _builder.AppendFormatted(value);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, string?)"/>
+        public void AppendFormatted<T>(T value, string? format) => _builder.AppendFormatted(value, format);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted(Value, string?)"/>
+        public void AppendFormatted(Value value, string? format) => _builder.AppendFormatted(value, format);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, int)"/>
+        public void AppendFormatted<T>(T value, int alignment) => _builder.AppendFormatted(value, alignment);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted{T}(T, int, StringSpan)"/>
+        public void AppendFormatted<T>(T value, int alignment, string? format) =>
+            _builder.AppendFormatted<T>(value, alignment, (StringSpan)format);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted(ReadOnlySpan{char})"/>
+        public void AppendFormatted(scoped ReadOnlySpan<char> value) => _builder.AppendFormatted(value);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted(ReadOnlySpan{char}, int, string?)"/>
+        public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null) =>
+            _builder.AppendFormatted(value, alignment, format);
+
+        /// <inheritdoc cref="ValueStringBuilder.AppendFormatted(string?)"/>
+        public void AppendFormatted(string? value) => _builder.AppendFormatted(value);
+
+        /// <inheritdoc cref="ValueStringBuilder.AsSpan()"/>
+        public readonly ReadOnlySpan<char> AsSpan() => _builder.AsSpan();
+
+        /// <inheritdoc cref="ValueStringBuilder.Dispose()"/>
+        public void Dispose() => _builder.Dispose();
+    }
+}

--- a/touki/Touki/Text/ValueStringBuilder.cs
+++ b/touki/Touki/Text/ValueStringBuilder.cs
@@ -496,6 +496,57 @@ public ref partial struct ValueStringBuilder
     public void Append(StringSegment value) => Append(value.AsSpan());
 
     /// <summary>
+    ///  Appends the interpolated string represented by <paramref name="handler"/> to this builder.
+    /// </summary>
+    /// <param name="handler">The handler that contains the interpolated string to append.</param>
+    public void Append([InterpolatedStringHandlerArgument("")] ref InterpolatedStringHandler handler)
+    {
+        try
+        {
+            Append(handler.AsSpan());
+        }
+        finally
+        {
+            handler.Dispose();
+        }
+    }
+
+    /// <summary>
+    ///  Appends the <paramref name="value"/> followed by <see cref="Environment.NewLine"/> to this builder.
+    /// </summary>
+    public void AppendLine(string value)
+    {
+        AppendLiteral(value);
+        Append(Environment.NewLine);
+    }
+
+    /// <inheritdoc cref="AppendLine(string)"/>
+    public void AppendLine([InterpolatedStringHandlerArgument("")] ref InterpolatedStringHandler handler)
+    {
+        try
+        {
+            Append(handler.AsSpan());
+            AppendLine();
+        }
+        finally
+        {
+            handler.Dispose();
+        }
+    }
+
+    /// <inheritdoc cref="AppendLine(string)"/>
+    public void AppendLine(StringSegment value)
+    {
+        Append(value.AsSpan());
+        AppendLine();
+    }
+
+    /// <summary>
+    ///  Appends <see cref="Environment.NewLine"/> to this builder.
+    /// </summary>
+    public void AppendLine() => Append(Environment.NewLine);
+
+    /// <summary>
     ///  Replace all occurrences of a character in the segment with another character.
     /// </summary>
     /// <returns>
@@ -593,12 +644,14 @@ public ref partial struct ValueStringBuilder
     /// </summary>
     public static implicit operator ReadOnlySpan<char>(ValueStringBuilder builder) => builder._chars[..builder._length];
 
-#pragma warning disable IDE0251 // Member can be made readonly
-
     /// <summary>
     ///  Writes the string to the specified stream.
     /// </summary>
-    public void CopyTo(Stream stream)
+    public
+#if NET
+    readonly
+#endif
+    void CopyTo(Stream stream)
     {
         if (_chars[.._length].IsEmpty)
         {
@@ -628,7 +681,11 @@ public ref partial struct ValueStringBuilder
     ///   This attempts to make use of optimized paths for known <see cref="TextWriter"/> types.
     ///  </para>
     /// </remarks>
-    public void CopyTo(TextWriter writer)
+    public
+#if NET
+    readonly
+#endif
+    void CopyTo(TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(writer);
 
@@ -679,6 +736,4 @@ public ref partial struct ValueStringBuilder
         writer.Write(chars, 0, _length);
 #endif
     }
-
-#pragma warning restore IDE0251
 }

--- a/traceq/Directory.Packages.props
+++ b/traceq/Directory.Packages.props
@@ -14,6 +14,14 @@
     <!-- Trace parsing and analysis core. -->
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.3" />
 
+    <!--
+      Touki's shared utilities (ValueStringBuilder, StringSegment, the allocation-
+      aware collections, ...). Consumed as the published NuGet package, not a project
+      reference, so the subtree stays self-contained and promotion remains a plain
+      file copy: a standalone traceq repo references the same package unchanged.
+    -->
+    <PackageVersion Include="KlutzyNinja.Touki" Version="0.3.0-alpha.1" />
+
     <!-- Fixture generation: captures the EventPipe corpus (traceq/fixtures). -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <!-- The ETW (.etl) profiler for the net481 fixture half; Windows-only, capture needs elevation. -->

--- a/traceq/src/TraceQ.Core/TraceQ.Core.csproj
+++ b/traceq/src/TraceQ.Core/TraceQ.Core.csproj
@@ -9,6 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
+    <!--
+      Touki's shared utilities. Referenced from the core so they flow transitively
+      to the CLI head, the MCP facade, and the tests, which lets every TraceQ
+      project consume Touki without each declaring the dependency.
+    -->
+    <PackageReference Include="KlutzyNinja.Touki" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## Summary

Adds interpolated-string append support to `ValueStringBuilder`, brings the net481 `DefaultInterpolatedStringHandler` polyfill to BCL parity, and wires the published `KlutzyNinja.Touki` package into the traceq subtree.

## Changes

**`ValueStringBuilder`**
- New interpolated `Append($"...")` and `AppendLine($"...")` overloads via a nested `InterpolatedStringHandler` that builds into an independent buffer and copies the resulting span in. The hole sees a snapshot of the receiver, avoiding ref-struct aliasing.
- New `AppendLine(string)`, `AppendLine(StringSegment)`, and `AppendLine()`.
- `CopyTo(Stream)` and `CopyTo(TextWriter)` are now `readonly` on .NET, replacing the `IDE0251` suppression.

**`DefaultInterpolatedStringHandler` (net481 polyfill)**
- Added `Clear()` and `Text` for parity with the BCL type.

**traceq**
- `TraceQ.Core` references the published `KlutzyNinja.Touki` package (central version `0.3.0-alpha.1`), flowing transitively to the CLI head, the MCP facade, and the tests. Consumed as a NuGet package (not a project reference) so the subtree stays self-contained.

**Tooling**
- Added `.vscode/tasks.json` with the default `dotnet: build` task.

## Validation

- `dotnet build -c Release` clean on net10.0 and net481.
- `dotnet test -c Release` for the `ValueStringBuilder` and handler suites: 864 passed, 2 skipped (manual allocation test) on both TFMs.
- `TraceQ.Core` builds clean against the package reference.