### PR TITLE
Add the MCP facade server and read-only query tools (M3)

### DIFF
--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -179,6 +179,27 @@ Help is treated as a build artifact (**landed**): the README carries an examples
 
 ### M3 — MCP facade
 
+> **Progress:** the facade has begun. The first slice stands up the **standalone
+> `TraceQ.Mcp` stdio server** (stderr-only logging, a singleton `TraceStore`, the
+> server `instructions` field carrying the workflow summary, `readOnlyHint` /
+> `openWorldHint` / `idempotentHint` annotations) plus the **read-only query
+> tools**: `trace_info` (folding the old `load_trace` and `list_threads` into one
+> metadata call), `trace_rank` (the D5 consolidation - one tool with a
+> `metric: cpu|threadtime|alloc|exceptions` selector and a `measure: self|inclusive`
+> switch), `trace_callers`, `trace_lines`, and `trace_heatmap`. Each returns the
+> same `AnalysisResult` envelope through `OutputJson`, byte-identical to the CLI's
+> `--format json`, with the warnings forwarded whole and the ranking/callers steering
+> hints reused. The selector vocabulary moved to a canonical
+> `TraceMetricSelector` in the core so the CLI's `RankRequestFactory` and the tool
+> share one mapping. `TraceQ.Mcp.Tests` exercises every tool, the metric and measure
+> guards, the `top >= 1` boundary, and the load-failure path; a manual stdio
+> handshake confirmed `tools/list` registration, the instructions field, and stdout
+> purity. **Deferred to the next slice:** `trace_diff`, `trace_export`, and a
+> `trace_gc` / `trace_query_events` report tool; the **stdout-purity** and
+> **schema-budget** CI checks; the MCP Inspector smoke and scripted client
+> round-trip; and `outputSchema` / `structuredContent`. `trace_trim` stays parked
+> with the `trim` verb.
+
 The eight tools (§5.2) re-cut over the same services: port touki.mcp's description text, apply the D5 consolidation (`trace_rank` with `metric`), fold `list_threads` into `trace_info`, add `trace_gc`/`trace_diff`/`trace_query_events`. The broadened surface (section 1A) raises the consolidation stakes, not the tool count: the **engine** tools take a `metric`/provider parameter, so `trace_rank(metric: cpu|threadtime|alloc|…)` is *one* tool spanning every family rather than one tool per family - the token budget below is what forces this. `trace_export` and `trace_trim` join the curated set (they are how an agent hands a human a flame graph or shrinks a trace); the rich family reports (`alloc`/`jit`/`exceptions`/`heap`) stay CLI-first and are promoted to MCP only when an eval task demands it (backlog O4). Annotations (`readOnlyHint` et al.), `outputSchema` + `structuredContent` where the C# SDK supports them, the server `instructions` field carrying the workflow summary, and `traceq mcp` hosting with stderr-only logging.
 
 Two CI checks born here and kept forever: the **stdout-purity test** (run the server under load, including a deliberately chatty logging provider, and assert nothing but JSON-RPC reaches stdout) and the **schema budget check** (serialize the tool list, fail above ~1.5k tokens). MCP Inspector smoke plus one scripted client round-trip test.
@@ -198,7 +219,7 @@ With the facade demonstrably standing alone, execute the rehearsed extraction:
 
 ### M4 — Knowledge layer and distribution
 
-Write the SKILL.md, trap catalog, and AGENTS.md snippet from `docs/` single-sourcing with the drift check (§6 of the design); generate `server.json`; self-contained non-AOT publish profiles (D13); **first packages (Core, tool, Mcp shim) land on the promoted repo's GitHub Packages feed — private until v1.0.** Feed-auth realities are an M4 deliverable because they bite every consumer: CI uses `GITHUB_TOKEN`; local installs need a PAT-backed `nuget.config` source; the Copilot cloud agent needs the credential supplied through `copilot-setup-steps.yml` env/secrets — ship that snippet alongside the §8.2 one. The NuGet MCP package-type metadata rides along now so nothing changes shape at 1.0; install badges and the MCP registry entry wait for the public publish (M6).
+Write the SKILL.md, trap catalog, and AGENTS.md snippet from `docs/` single-sourcing with the drift check (§6 of the design); generate `server.json`; self-contained publish profiles (interim non-AOT - full Native AOT is the goal, but TraceEvent blocks it today; this reverses D13, see the AOT-goal note in section 6); **first packages (Core, tool, Mcp shim) land on the promoted repo's GitHub Packages feed — private until v1.0.** Feed-auth realities are an M4 deliverable because they bite every consumer: CI uses `GITHUB_TOKEN`; local installs need a PAT-backed `nuget.config` source; the Copilot cloud agent needs the credential supplied through `copilot-setup-steps.yml` env/secrets — ship that snippet alongside the §8.2 one. The NuGet MCP package-type metadata rides along now so nothing changes shape at 1.0; install badges and the MCP registry entry wait for the public publish (M6).
 
 **Exit:** cold-discovery (eval task 8) passes from a fresh clone carrying only the AGENTS.md pointer; `dotnet tool install --add-source <feed>` and `dnx <Pkg>@<ver>` against the feed both work on clean, feed-authenticated Windows and Linux machines.
 
@@ -271,6 +292,29 @@ The extraction's safety net is a fixed corpus of traces with known-good answers:
 For the record, the road not taken on Q1: extract-now was recommended on identity grounds (a product accrues stars/issues/registry presence from day one). Incubation trades that for the tightest dogfood loop and a deferred commitment — a trade the rehearsal check and the M3½ gate are designed to keep cheap. If incubation drags past M3 with the facade green, that's the signal the deferral has stopped paying.
 
 Recorded in the design document's decision log as **D15–D17**.
+
+### AOT - full Native AOT is a goal (reverses D13; 2026-06-09)
+
+The published heads (the `TraceQ` CLI and the `TraceQ.Mcp` server) target full
+Native AOT. This reverses D13's "non-AOT" framing: non-AOT is now the *interim*
+state, not the end state. Blockers, in dependency order:
+
+1. **TraceEvent** (`Microsoft.Diagnostics.Tracing.TraceEvent`) - the long pole.
+   Reflection, dynamically built event parsers, and ETW native interop; no AOT
+   annotations, so neither AOT- nor trim-safe. It is mandatory (every analysis
+   path reads a trace through it) and flows transitively to both heads, so the
+   whole graph stays non-AOT until it is made AOT-safe or replaced. No
+   `IsAotCompatible` / `PublishAot` flag goes on any traceq project until this
+   clears - the per-assembly analyzer would pass while a real publish still
+   fails.
+2. **Reflection-based `System.Text.Json`** in `OutputJson` - swap the reflection
+   serializer for a `JsonSerializerContext` source-gen resolver.
+3. **Reflection-based MCP tool discovery** - `WithToolsFromAssembly()` (warns
+   IL2026) becomes the generic `WithTools<T>()`, which requires `TraceTools` to
+   stop being a static class.
+
+Items 2 and 3 are inside our control and can land incrementally; item 1 gates
+the actual AOT publish.
 
 ### D-N — Naming (gate: M3½ promotion; availability pass: M0)
 

--- a/traceq/src/TraceQ.Core/TraceQ.Core.csproj
+++ b/traceq/src/TraceQ.Core/TraceQ.Core.csproj
@@ -8,6 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!--
+      TraceEvent is the trace-reading engine (.nettrace / .etl / .etlx) and is
+      mandatory: every analysis path goes through it. Full Native AOT is a goal
+      for the published heads (the TraceQ CLI and the TraceQ.Mcp server), and
+      TraceEvent is the current hard blocker: it relies on reflection,
+      dynamically built event parsers, and ETW native interop, and ships no AOT
+      annotations, so it is neither AOT- nor trim-safe. It flows transitively to
+      both heads, so the whole graph stays non-AOT until TraceEvent is made
+      AOT-safe or replaced. Do not set IsAotCompatible or PublishAot here or on a
+      referencing project yet - that would green-light the per-assembly analyzer
+      while a real publish still fails. See the AOT-goal note in
+      docs/traceq-implementation-plan.md (it reverses the earlier D13 framing).
+    -->
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" />
     <!--
       Touki's shared utilities. Referenced from the core so they flow transitively

--- a/traceq/src/TraceQ.Core/Tracing/TraceMetricSelector.cs
+++ b/traceq/src/TraceQ.Core/Tracing/TraceMetricSelector.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Resolves the user-facing <c>metric</c> selector string - the same one the
+///  <c>rank</c> verb and the <c>trace_rank</c> MCP tool accept - to the
+///  <see cref="TraceMetric"/> the loader builds.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is the single source of truth for the selector vocabulary so the CLI and
+///   MCP heads cannot drift: both resolve <c>cpu</c>, <c>threadtime</c>,
+///   <c>alloc</c> (or its <c>allocations</c> alias), and <c>exceptions</c> through
+///   here, and both report an unknown selector against the one
+///   <see cref="Selectors"/> list.
+///  </para>
+/// </remarks>
+public static class TraceMetricSelector
+{
+    /// <summary>
+    ///  The canonical selector names, lowest-level first, for help and error text.
+    ///  The <c>alloc</c> selector also accepts the <c>allocations</c> alias.
+    /// </summary>
+    public static IReadOnlyList<string> Selectors { get; } = ["cpu", "threadtime", "alloc", "exceptions"];
+
+    /// <summary>
+    ///  Resolves a <c>metric</c> selector string to the provider view it names.
+    /// </summary>
+    /// <param name="selector">The requested provider metric (case-insensitive).</param>
+    /// <param name="metric">The resolved provider view when recognized; otherwise <see cref="TraceMetric.Cpu"/>.</param>
+    /// <returns>
+    ///  <see langword="true"/> when <paramref name="selector"/> names a wired provider;
+    ///  otherwise <see langword="false"/>, and the caller should report a usage error.
+    /// </returns>
+    public static bool TryResolve(string selector, out TraceMetric metric)
+    {
+        switch (selector.ToLowerInvariant())
+        {
+            case "cpu":
+                metric = TraceMetric.Cpu;
+                return true;
+            case "threadtime":
+                metric = TraceMetric.ThreadTime;
+                return true;
+            case "alloc":
+            case "allocations":
+                metric = TraceMetric.Allocations;
+                return true;
+            case "exceptions":
+                metric = TraceMetric.Exceptions;
+                return true;
+            default:
+                metric = TraceMetric.Cpu;
+                return false;
+        }
+    }
+}

--- a/traceq/src/TraceQ.Mcp/Program.cs
+++ b/traceq/src/TraceQ.Mcp/Program.cs
@@ -12,7 +12,10 @@ using TraceQ.Server;
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
 // stdout carries the MCP JSON-RPC stream; every diagnostic must go to stderr or it
-// corrupts the protocol. Route all logging - down to the most verbose level - to stderr.
+// corrupts the protocol. Drop the host's default providers first so nothing the host
+// pre-registered can reach stdout, then add a single console provider pinned to stderr
+// for every level.
+builder.Logging.ClearProviders();
 builder.Logging.AddConsole(static options => options.LogToStandardErrorThreshold = LogLevel.Trace);
 
 // One cache of parsed traces is shared across every tool call for the server's lifetime.

--- a/traceq/src/TraceQ.Mcp/Program.cs
+++ b/traceq/src/TraceQ.Mcp/Program.cs
@@ -2,15 +2,36 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using TraceQ;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using TraceQ.Mcp;
+using TraceQ.Server;
 
-// M0 scaffold for the MCP shim. The curated tool surface (trace_info,
-// trace_rank with a metric selector, trace_callers, trace_diff, trace_export,
-// trace_trim, ...) is built in M3 over the shared TraceQ.Core service layer,
-// with stderr-only logging and the stdout-purity guarantee. This stub exists so
-// the ModelContextProtocol + Hosting dependencies resolve and the shim is wired
-// to the same core assembly the CLI uses.
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
-Console.Error.WriteLine(
-    $"traceq MCP facade ({TraceQCore.Milestone} scaffold): not implemented until milestone M3.");
+// stdout carries the MCP JSON-RPC stream; every diagnostic must go to stderr or it
+// corrupts the protocol. Route all logging - down to the most verbose level - to stderr.
+builder.Logging.AddConsole(static options => options.LogToStandardErrorThreshold = LogLevel.Trace);
+
+// One cache of parsed traces is shared across every tool call for the server's lifetime.
+builder.Services.AddSingleton<TraceStore>();
+
+builder.Services
+    .AddMcpServer(static options =>
+    {
+        options.ServerInfo = new Implementation
+        {
+            Name = "traceq",
+            Version = typeof(TraceTools).Assembly.GetName().Version?.ToString() ?? "0.0.0"
+        };
+
+        // The workflow summary the client surfaces to the model at initialize time.
+        options.ServerInstructions = TraceServerInstructions.Text;
+    })
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+
+await builder.Build().RunAsync().ConfigureAwait(false);
 return 0;

--- a/traceq/src/TraceQ.Mcp/TraceInfoView.cs
+++ b/traceq/src/TraceQ.Mcp/TraceInfoView.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Tracing;
+
+namespace TraceQ.Mcp;
+
+/// <summary>
+///  The <c>trace_info</c> payload: a loaded trace's identity and quality signals.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The trace's quality warnings are not repeated here; they travel in the
+///   <see cref="TraceQ.Output.AnalysisResult{T}.Warnings"/> channel of the
+///   envelope this view is wrapped in, the same uniform channel every other tool
+///   reports them through.
+///  </para>
+/// </remarks>
+/// <param name="Path">The absolute path the trace was loaded from.</param>
+/// <param name="Format">The on-disk format the trace was read from.</param>
+/// <param name="TotalWeight">
+///  Sum of the per-sample weights, in the metric's unit (CPU milliseconds, bytes
+///  allocated, or one count per event).
+/// </param>
+/// <param name="SampleCount">Number of weighted samples in the normalized model.</param>
+/// <param name="SymbolResolutionRate">
+///  Fraction in <c>[0, 1]</c> of frames that resolved to a managed method name; below
+///  <c>0.8</c> usually means symbols are missing and the rankings are unreliable.
+/// </param>
+/// <param name="Threads">Per-thread sample counts, highest first.</param>
+public sealed record TraceInfoView(
+    string Path,
+    string Format,
+    double TotalWeight,
+    int SampleCount,
+    double SymbolResolutionRate,
+    IReadOnlyList<ThreadSampleInfo> Threads);

--- a/traceq/src/TraceQ.Mcp/TraceServerInstructions.cs
+++ b/traceq/src/TraceQ.Mcp/TraceServerInstructions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Mcp;
+
+/// <summary>
+///  The MCP server's <c>instructions</c> text: the workflow summary a client shows
+///  the model so it picks the right tool order without trial and error.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The text is carried on the server's <c>instructions</c> field at initialize
+///   time. It is kept short on purpose - it shares the model's context budget with
+///   the per-tool descriptions - and names the tools in the order an investigation
+///   naturally runs them.
+///  </para>
+/// </remarks>
+public static class TraceServerInstructions
+{
+    /// <summary>
+    ///  The server instructions text.
+    /// </summary>
+    public const string Text =
+        "traceq analyzes .NET CPU, allocation, exception, and thread-time traces (.nettrace, .etl, and "
+        + "speedscope) from the command line - no GUI. Workflow: call trace_info first to see the format, "
+        + "sample count, and symbol-resolution rate; a rate below 0.8 means symbols are missing and the "
+        + "rankings should not be trusted. Use trace_rank (metric: cpu, threadtime, alloc, or exceptions) "
+        + "to find the hottest frames by self or inclusive time, then trace_callers to see what drives a "
+        + "frame. trace_lines and trace_heatmap attribute time to a source file:line and need a .nettrace "
+        + "or .etl trace read with portable PDBs - pass the build-output directory as 'symbols'. Every "
+        + "result shares one envelope: a schemaVersion, a warnings list, next-step hints, and the typed result.";
+}

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -1,0 +1,288 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol;
+using ModelContextProtocol.Server;
+using TraceQ.Output;
+using TraceQ.Server;
+using TraceQ.Tracing;
+
+namespace TraceQ.Mcp;
+
+/// <summary>
+///  The curated read-only MCP tool surface over the TraceQ analysis core: load a
+///  trace and query its quality signals, folded self/inclusive rankings, immediate
+///  callers, and line-level attribution across speedscope, EventPipe
+///  (<c>.nettrace</c>), and ETW (<c>.etl</c>) inputs.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Each tool returns the same JSON the CLI's <c>--format json</c> emits: an
+///   <see cref="AnalysisResult{T}"/> envelope serialized by <see cref="OutputJson"/>,
+///   so a client gets one shape - schema version, warnings, hints, typed result -
+///   across every tool. The single injected <see cref="TraceStore"/> caches parsed
+///   traces, so repeated queries against the same path reuse one parse.
+///  </para>
+/// </remarks>
+[McpServerToolType]
+public static class TraceTools
+{
+    /// <summary>
+    ///  Loads a trace and returns its format, total weight, sample count, symbol
+    ///  resolution rate, per-thread sample counts, and quality warnings.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The trace summary envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_info", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Load a trace (.speedscope.json, .nettrace, or .etl) and return its format, total weight (CPU "
+        + "milliseconds, bytes allocated, or event counts depending on the trace), sample count, "
+        + "symbol-resolution rate, per-thread sample counts, and quality warnings. Call this first: a "
+        + "resolution rate below 0.8 means symbols are missing and the rankings should not be trusted.")]
+    public static string Info(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
+        [Description(
+            "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' "
+            + "embedded portable PDBs are extracted so managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        TraceInfo info = Load(store, path, NullIfEmpty(symbols)).Info;
+        TraceInfoView view = new(
+            info.Path,
+            info.Format.ToString(),
+            info.TotalWeight,
+            info.SampleCount,
+            info.SymbolResolutionRate,
+            info.Threads);
+        return OutputJson.Serialize(new AnalysisResult<TraceInfoView>(view, info.Warnings));
+    }
+
+    /// <summary>
+    ///  Ranks the hottest frames over a chosen provider metric by self or inclusive
+    ///  time, folding JIT-helper sampling artifacts back into the real methods.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="metric">The provider view to rank.</param>
+    /// <param name="measure">Whether to report self time or inclusive time.</param>
+    /// <param name="root">Optional substring scoping the ranking to a subtree.</param>
+    /// <param name="top">Maximum rows to return.</param>
+    /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The ranking envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Rank the hottest frames over a chosen provider metric. measure=self credits the executing leaf "
+        + "(JIT-helper leaves folded into the real method that incurred them); measure=inclusive credits a "
+        + "frame and everything it calls. One tool spans every family - metric=cpu (sampled milliseconds, any "
+        + "format), threadtime (wall-clock per thread, .etl only), alloc (bytes allocated, .nettrace only), or "
+        + "exceptions (throw count, .nettrace only). Scope to a subtree with root; for a BenchmarkDotNet "
+        + "capture set root to the measured workload to exclude harness warmup.")]
+    public static string Rank(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
+        [Description("Provider view to rank: cpu, threadtime, alloc, or exceptions.")] string metric = "cpu",
+        [Description("Which measure to report: self or inclusive.")] string measure = "self",
+        [Description("Optional substring of a frame name to scope the ranking to its subtree.")] string root = "",
+        [Description("Maximum number of ranked rows to return.")] int top = 25,
+        [Description("Optional regex fold patterns; omit to use the built-in JIT-helper defaults.")] string[]? fold = null,
+        [Description(
+            "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
+            + "managed frames resolve to source lines (cpu metric only).")]
+        string symbols = "")
+    {
+        TraceMetric resolved = ResolveMetric(metric);
+        bool inclusive = ResolveMeasure(measure);
+        RequirePositiveTop(top);
+        IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), resolved);
+        TraceInfo info = trace.Info;
+        RankingResult ranking = inclusive
+            ? trace.Aggregator.InclusiveTime(root, foldPatterns, top)
+            : trace.Aggregator.SelfTime(root, foldPatterns, top);
+
+        return OutputJson.Serialize(
+            new AnalysisResult<RankingResult>(ranking, info.Warnings, SteeringHints.ForRanking(ranking)));
+    }
+
+    /// <summary>
+    ///  Reports the immediate callers of the frame matching <paramref name="frame"/>,
+    ///  with the CPU time each contributes.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="frame">Substring identifying the focus frame whose callers to report.</param>
+    /// <param name="root">Optional substring scoping the analysis to a subtree.</param>
+    /// <param name="top">Maximum caller rows to return.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The caller-breakdown envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_callers", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Immediate callers of the frame matching 'frame', with the CPU time each contributes. Use it to learn "
+        + "what a JIT-helper or shared-utility frame (e.g. BulkMoveWithWriteBarrier) is really attributable to, "
+        + "or to walk up a hot stack one level at a time. Scope to a subtree with root.")]
+    public static string Callers(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
+        [Description("Substring identifying the focus frame whose callers to report.")] string frame,
+        [Description("Optional substring of a frame name to scope the analysis to its subtree.")] string root = "",
+        [Description("Maximum number of caller rows to return.")] int top = 25,
+        [Description(
+            "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
+            + "managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        RequirePositiveTop(top);
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        TraceInfo info = trace.Info;
+        CallersResult callers = trace.Aggregator.CallersOf(frame, root, top);
+
+        return OutputJson.Serialize(
+            new AnalysisResult<CallersResult>(callers, info.Warnings, SteeringHints.ForCallers(callers)));
+    }
+
+    /// <summary>
+    ///  Returns the line-level self-time ranking, attributing leaf samples to the
+    ///  source line that was executing, scoped to the matching methods.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="method">Optional substring scoping to matching methods.</param>
+    /// <param name="top">Maximum rows to return.</param>
+    /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The line-level self-time envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_lines", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Line-level self time: each leaf sample (JIT-helper leaves folded into their caller) attributed to the "
+        + "source file:line that was executing, scoped to methods whose name contains 'method'. Requires a "
+        + ".nettrace or .etl trace whose modules have portable PDBs; pass 'symbols' pointing at the build-output "
+        + "directory. Speedscope inputs carry no line data and return an empty ranking. A '<no source>' row is "
+        + "time in matching methods whose PDB was not found.")]
+    public static string Lines(
+        TraceStore store,
+        [Description("Path to a .nettrace or .etl trace file (speedscope carries no line data).")] string path,
+        [Description("Optional substring of a method name to scope the ranking; omit for every method.")] string method = "",
+        [Description("Maximum number of rows to return.")] int top = 25,
+        [Description("Optional regex fold patterns; omit to use the built-in JIT-helper defaults.")] string[]? fold = null,
+        [Description(
+            "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' embedded "
+            + "portable PDBs are extracted so managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        RequirePositiveTop(top);
+        IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        TraceInfo info = trace.Info;
+        LineRankingResult lines = trace.Aggregator.HotLines(method, foldPatterns, top);
+
+        return OutputJson.Serialize(new AnalysisResult<LineRankingResult>(lines, info.Warnings));
+    }
+
+    /// <summary>
+    ///  Builds a per-line self-time heat map for one source file, ordered by line
+    ///  number for overlaying onto the source.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="file">Path or file name of the source file to map.</param>
+    /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The heat-map envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_heatmap", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Per-line self-time heat map for one source file: each leaf sample (JIT-helper leaves folded into their "
+        + "caller) attributed to the line that was executing, ordered by line number to overlay onto the source. "
+        + "Matching is by file name only. Requires a .nettrace or .etl trace whose modules have portable PDBs; "
+        + "pass 'symbols' pointing at the build-output directory. Speedscope inputs return an empty map.")]
+    public static string Heatmap(
+        TraceStore store,
+        [Description("Path to a .nettrace or .etl trace file (speedscope carries no line data).")] string path,
+        [Description("Path or bare name of the source file to map, e.g. ExtGlob.cs.")] string file,
+        [Description("Optional regex fold patterns; omit to use the built-in JIT-helper defaults.")] string[]? fold = null,
+        [Description(
+            "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' embedded "
+            + "portable PDBs are extracted so managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        TraceInfo info = trace.Info;
+
+        // The trace records the build-time file name, not its full path, so match on the file name.
+        string fileName = Path.GetFileName(file);
+        SourceHeatmapResult heatmap = trace.Aggregator.SourceHeatmap(fileName, foldPatterns);
+
+        return OutputJson.Serialize(new AnalysisResult<SourceHeatmapResult>(heatmap, info.Warnings));
+    }
+
+    /// <summary>
+    ///  Loads the <paramref name="metric"/> view of the trace, mapping the loader's
+    ///  failure modes to a clean <see cref="McpException"/> rather than letting an
+    ///  opaque exception propagate to the client.
+    /// </summary>
+    private static LoadedTrace Load(
+        TraceStore store,
+        string path,
+        string? symbols,
+        TraceMetric metric = TraceMetric.Cpu)
+    {
+        try
+        {
+            return store.Get(path, symbols, metric);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or JsonException
+            or KeyNotFoundException
+            or InvalidOperationException
+            or FormatException
+            or ArgumentException)
+        {
+            // Missing, unreadable, or malformed trace input - including a format that
+            // does not carry the selected metric's data (NotSupportedException) -
+            // surfaces as a clean tool error rather than an unhandled exception.
+            throw new McpException(ex.Message);
+        }
+    }
+
+    private static TraceMetric ResolveMetric(string metric) =>
+        TraceMetricSelector.TryResolve(metric, out TraceMetric resolved)
+            ? resolved
+            : throw new McpException(
+                $"Unknown metric '{metric}'. Valid metrics: {string.Join(", ", TraceMetricSelector.Selectors)}.");
+
+    private static bool ResolveMeasure(string measure)
+    {
+        if (string.Equals(measure, "self", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.Equals(measure, "inclusive", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        throw new McpException($"Unknown measure '{measure}'. Valid measures: self, inclusive.");
+    }
+
+    private static void RequirePositiveTop(int top)
+    {
+        if (top < 1)
+        {
+            throw new McpException("top must be 1 or greater.");
+        }
+    }
+
+    private static string? NullIfEmpty(string value) => string.IsNullOrEmpty(value) ? null : value;
+}

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -100,7 +100,7 @@ public static class TraceTools
         TraceMetric resolved = ResolveMetric(metric);
         bool inclusive = ResolveMeasure(measure);
         RequirePositiveTop(top);
-        IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+        IReadOnlyList<string> foldPatterns = ResolveFold(fold);
 
         LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), resolved);
         TraceInfo info = trace.Info;
@@ -178,7 +178,7 @@ public static class TraceTools
         string symbols = "")
     {
         RequirePositiveTop(top);
-        IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+        IReadOnlyList<string> foldPatterns = ResolveFold(fold);
         LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
         TraceInfo info = trace.Info;
         LineRankingResult lines = trace.Aggregator.HotLines(method, foldPatterns, top);
@@ -212,7 +212,7 @@ public static class TraceTools
             + "portable PDBs are extracted so managed frames resolve to source lines.")]
         string symbols = "")
     {
-        IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+        IReadOnlyList<string> foldPatterns = ResolveFold(fold);
         LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
         TraceInfo info = trace.Info;
 
@@ -282,6 +282,33 @@ public static class TraceTools
         {
             throw new McpException("top must be 1 or greater.");
         }
+    }
+
+    /// <summary>
+    ///  Resolves the fold patterns to use - the caller's patterns or the built-in
+    ///  JIT-helper defaults - and validates them up front so a malformed user-supplied
+    ///  regex surfaces as a clean, actionable tool error rather than escaping the
+    ///  aggregator as a framework-level exception.
+    /// </summary>
+    private static IReadOnlyList<string> ResolveFold(string[]? fold)
+    {
+        IReadOnlyList<string> patterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
+
+        try
+        {
+            // Compile only to validate; the aggregator compiles its own copy when it runs.
+            // CompileFoldPatterns also caps each match with a timeout, so a pathological
+            // user pattern cannot hang the server.
+            _ = FrameNames.CompileFoldPatterns(patterns);
+        }
+        catch (ArgumentException ex)
+        {
+            // A malformed fold regex is a usage error; surface the message (which names the
+            // offending pattern) as a clean tool error instead of an internal failure.
+            throw new McpException(ex.Message);
+        }
+
+        return patterns;
     }
 
     private static string? NullIfEmpty(string value) => string.IsNullOrEmpty(value) ? null : value;

--- a/traceq/src/TraceQ/Cli/RankRequestFactory.cs
+++ b/traceq/src/TraceQ/Cli/RankRequestFactory.cs
@@ -40,28 +40,14 @@ internal static class RankRequestFactory
     ///  <see langword="true"/> when <paramref name="metric"/> names a wired provider;
     ///  otherwise <see langword="false"/>, and the caller should report a usage error.
     /// </returns>
-    public static bool TryResolveMetric(string metric, out TraceMetric resolved)
-    {
-        switch (metric.ToLowerInvariant())
-        {
-            case CpuMetric:
-                resolved = TraceMetric.Cpu;
-                return true;
-            case "alloc":
-            case "allocations":
-                resolved = TraceMetric.Allocations;
-                return true;
-            case "exceptions":
-                resolved = TraceMetric.Exceptions;
-                return true;
-            case "threadtime":
-                resolved = TraceMetric.ThreadTime;
-                return true;
-            default:
-                resolved = TraceMetric.Cpu;
-                return false;
-        }
-    }
+    /// <remarks>
+    ///  <para>
+    ///   Delegates to <see cref="TraceMetricSelector.TryResolve"/> so the CLI and the
+    ///   MCP <c>trace_rank</c> tool share one selector vocabulary.
+    ///  </para>
+    /// </remarks>
+    public static bool TryResolveMetric(string metric, out TraceMetric resolved) =>
+        TraceMetricSelector.TryResolve(metric, out resolved);
 
     /// <summary>
     ///  Builds a ranking request from the verb parameters, applying the built-in fold

--- a/traceq/tests/TraceQ.Core.Tests/TraceMetricSelectorTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/TraceMetricSelectorTests.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class TraceMetricSelectorTests
+{
+    [TestMethod]
+    [DataRow("cpu", TraceMetric.Cpu)]
+    [DataRow("threadtime", TraceMetric.ThreadTime)]
+    [DataRow("alloc", TraceMetric.Allocations)]
+    [DataRow("allocations", TraceMetric.Allocations)]
+    [DataRow("exceptions", TraceMetric.Exceptions)]
+    public void TryResolve_KnownSelector_ResolvesToProviderView(string selector, TraceMetric expected)
+    {
+        TraceMetricSelector.TryResolve(selector, out TraceMetric metric).Should().BeTrue();
+        metric.Should().Be(expected);
+    }
+
+    [TestMethod]
+    [DataRow("CPU")]
+    [DataRow("Alloc")]
+    [DataRow("ThreadTime")]
+    public void TryResolve_IsCaseInsensitive(string selector)
+    {
+        TraceMetricSelector.TryResolve(selector, out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TryResolve_UnknownSelector_ReturnsFalseAndDefaultsToCpu()
+    {
+        TraceMetricSelector.TryResolve("ipc", out TraceMetric metric).Should().BeFalse();
+        metric.Should().Be(TraceMetric.Cpu);
+    }
+
+    [TestMethod]
+    public void Selectors_ListsTheCanonicalNames()
+    {
+        TraceMetricSelector.Selectors.Should().Equal("cpu", "threadtime", "alloc", "exceptions");
+    }
+}

--- a/traceq/tests/TraceQ.Mcp.Tests/GlobalUsings.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/GlobalUsings.cs
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+global using AwesomeAssertions;
+global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceQ.Mcp.Tests.csproj
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceQ.Mcp.Tests.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TraceQ.Mcp.Tests</RootNamespace>
+
+    <!-- Microsoft.Testing.Platform + MSTest, matching the other traceq test projects. -->
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="MSTest.TestFramework" PrivateAssets="all" />
+    <PackageReference Include="MSTest.TestAdapter" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\TraceQ.Mcp\TraceQ.Mcp.csproj" />
+  </ItemGroup>
+
+  <!-- Reuse the fixtures committed under TraceQ.Core.Tests rather than duplicate them. -->
+  <ItemGroup>
+    <None Include="..\TraceQ.Core.Tests\Fixtures\folding.speedscope.json" Link="Fixtures\folding.speedscope.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\TraceQ.Core.Tests\Fixtures\alloc.nettrace" Link="Fixtures\alloc.nettrace">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\TraceQ.Core.Tests\Fixtures\exceptions.nettrace" Link="Fixtures\exceptions.nettrace">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\TraceQ.Core.Tests\Fixtures\etw.etl" Link="Fixtures\etw.etl">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceServerInstructionsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceServerInstructionsTests.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Mcp;
+
+[TestClass]
+public sealed class TraceServerInstructionsTests
+{
+    [TestMethod]
+    public void Text_NamesTheToolsInWorkflowOrder()
+    {
+        string text = TraceServerInstructions.Text;
+
+        text.Should().NotBeNullOrWhiteSpace();
+        text.IndexOf("trace_info", StringComparison.Ordinal).Should().BeGreaterThanOrEqualTo(0);
+
+        // The workflow nudges the model to load before ranking, so trace_info is named
+        // before trace_rank.
+        text.IndexOf("trace_info", StringComparison.Ordinal)
+            .Should().BeLessThan(text.IndexOf("trace_rank", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void Text_CallsOutTheSymbolResolutionThreshold()
+    {
+        TraceServerInstructions.Text.Should().Contain("0.8");
+    }
+}

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -157,6 +157,18 @@ public sealed class TraceToolsTests
     }
 
     [TestMethod]
+    public void Rank_InvalidFoldPattern_ThrowsMcpExceptionNamingThePattern()
+    {
+        TraceStore store = new();
+
+        // A malformed user-supplied fold regex is a usage error, not an internal failure:
+        // it must surface as a clean tool error that names the offending pattern.
+        Action act = () => TraceTools.Rank(store, FixturePath(Speedscope), fold: ["("]);
+
+        act.Should().Throw<McpException>().WithMessage("*Invalid fold pattern*");
+    }
+
+    [TestMethod]
     public void Callers_Speedscope_ReturnsCallerBreakdown()
     {
         TraceStore store = new();
@@ -185,6 +197,16 @@ public sealed class TraceToolsTests
     }
 
     [TestMethod]
+    public void Lines_InvalidFoldPattern_ThrowsMcpException()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Lines(store, FixturePath(Speedscope), fold: ["("]);
+
+        act.Should().Throw<McpException>().WithMessage("*Invalid fold pattern*");
+    }
+
+    [TestMethod]
     public void Heatmap_SpeedscopeWithoutLineData_ReturnsEmptyMap()
     {
         TraceStore store = new();
@@ -195,6 +217,16 @@ public sealed class TraceToolsTests
         JsonElement root = doc.RootElement;
         AssertEnvelopeShape(root);
         root.GetProperty("result").GetProperty("lines").GetArrayLength().Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Heatmap_InvalidFoldPattern_ThrowsMcpException()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Heatmap(store, FixturePath(Speedscope), file: "ExtGlob.cs", fold: ["("]);
+
+        act.Should().Throw<McpException>().WithMessage("*Invalid fold pattern*");
     }
 
     [TestMethod]

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text.Json;
+using ModelContextProtocol;
+using TraceQ.Server;
+
+namespace TraceQ.Mcp;
+
+[TestClass]
+public sealed class TraceToolsTests
+{
+    private const string Speedscope = "folding.speedscope.json";
+    private const string Alloc = "alloc.nettrace";
+    private const string Exceptions = "exceptions.nettrace";
+    private const string Etw = "etw.etl";
+
+    private static string FixturePath(string name) =>
+        Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
+
+    private static void AssertEnvelopeShape(JsonElement root)
+    {
+        root.GetProperty("schemaVersion").GetInt32().Should().Be(2);
+        root.TryGetProperty("warnings", out JsonElement warnings).Should().BeTrue();
+        warnings.ValueKind.Should().Be(JsonValueKind.Array);
+        root.TryGetProperty("hints", out JsonElement hints).Should().BeTrue();
+        hints.ValueKind.Should().Be(JsonValueKind.Array);
+        root.TryGetProperty("result", out _).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Info_Speedscope_ReturnsFormatSampleCountAndThreads()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Info(store, FixturePath(Speedscope));
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+
+        JsonElement result = root.GetProperty("result");
+        result.GetProperty("path").GetString().Should().EndWith(Speedscope);
+        result.GetProperty("format").GetString().Should().Be("Speedscope");
+        result.GetProperty("sampleCount").GetInt32().Should().Be(4);
+        result.GetProperty("symbolResolutionRate").GetDouble().Should().BeInRange(0.0, 1.0);
+        result.GetProperty("threads").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void Info_DoesNotRepeatWarningsInsideResult()
+    {
+        TraceStore store = new();
+
+        // The quality warnings travel only in the envelope's warnings channel; the
+        // trace_info payload itself must not carry a second copy of them.
+        string json = TraceTools.Info(store, FixturePath(Speedscope));
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("result").TryGetProperty("warnings", out _).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Rank_SpeedscopeSelf_RanksFramesAndEmitsHint()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Rank(store, FixturePath(Speedscope));
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("hints").GetArrayLength().Should().BeGreaterThan(0);
+        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void Rank_SpeedscopeInclusive_RanksFrames()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Rank(store, FixturePath(Speedscope), measure: "inclusive");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void Rank_AllocMetric_ReadsTheAllocationView()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Rank(store, FixturePath(Alloc), metric: "alloc");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void Rank_ExceptionsMetric_ReadsTheExceptionView()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Rank(store, FixturePath(Exceptions), metric: "exceptions");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Rank_ThreadTimeMetric_ReadsTheEtlView()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Rank(store, FixturePath(Etw), metric: "threadtime");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void Rank_UnknownMetric_ThrowsWithSelectorList()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Rank(store, FixturePath(Speedscope), metric: "ipc");
+
+        act.Should().Throw<McpException>().WithMessage("*Unknown metric 'ipc'*cpu*");
+    }
+
+    [TestMethod]
+    public void Rank_UnknownMeasure_Throws()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Rank(store, FixturePath(Speedscope), measure: "average");
+
+        act.Should().Throw<McpException>().WithMessage("*Unknown measure 'average'*");
+    }
+
+    [TestMethod]
+    public void Rank_NonPositiveTop_Throws()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Rank(store, FixturePath(Speedscope), top: 0);
+
+        act.Should().Throw<McpException>().WithMessage("*top must be 1 or greater*");
+    }
+
+    [TestMethod]
+    public void Callers_Speedscope_ReturnsCallerBreakdown()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Callers(store, FixturePath(Speedscope), frame: "");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").TryGetProperty("callers", out JsonElement callers).Should().BeTrue();
+        callers.ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [TestMethod]
+    public void Lines_SpeedscopeWithoutLineData_ReturnsEmptyRanking()
+    {
+        TraceStore store = new();
+
+        // Speedscope carries no per-frame source locations, so the line ranking is empty.
+        string json = TraceTools.Lines(store, FixturePath(Speedscope));
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Heatmap_SpeedscopeWithoutLineData_ReturnsEmptyMap()
+    {
+        TraceStore store = new();
+
+        string json = TraceTools.Heatmap(store, FixturePath(Speedscope), file: "ExtGlob.cs");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").GetProperty("lines").GetArrayLength().Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Info_MissingFile_ThrowsMcpException()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Info(store, FixturePath("does-not-exist.nettrace"));
+
+        act.Should().Throw<McpException>();
+    }
+}

--- a/traceq/traceq.slnx
+++ b/traceq/traceq.slnx
@@ -15,6 +15,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/TraceQ.Core.Tests/TraceQ.Core.Tests.csproj" />
     <Project Path="tests/TraceQ.Cli.Tests/TraceQ.Cli.Tests.csproj" />
+    <Project Path="tests/TraceQ.Mcp.Tests/TraceQ.Mcp.Tests.csproj" />
     <Project Path="tests/TraceQ.Parity.Tests/TraceQ.Parity.Tests.csproj" />
   </Folder>
 </Solution>


### PR DESCRIPTION
## M3 — MCP facade, slice 1: server + read-only query tools

Stands up the standalone `TraceQ.Mcp` stdio server over the existing `TraceQ.Core` services, replacing the M0 stub.

### Server host
- stderr-only logging (stdout reserved for the JSON-RPC stream)
- singleton `TraceStore` shared across every tool call
- server `instructions` field carrying the workflow summary
- `readOnlyHint` / `openWorldHint=false` / `idempotentHint` tool annotations

### Five read-only tools
All return the same `AnalysisResult` envelope through `OutputJson` — byte-identical to the CLI's `--format json` — forwarding `info.Warnings` whole and reusing the ranking/callers steering hints.

- `trace_info` — folds the old `load_trace` + `list_threads` into one metadata call (uses a small `TraceInfoView` so warnings live only in the envelope channel)
- `trace_rank` — the D5 consolidation: one tool with `metric: cpu|threadtime|alloc|exceptions` and `measure: self|inclusive`
- `trace_callers`, `trace_lines`, `trace_heatmap`

Bad `metric`/`measure` selectors and `top < 1` raise `McpException` with actionable messages; load failures map to clean tool errors.

### Shared metric vocabulary
Extracted `TraceMetricSelector` into the core; the CLI's `RankRequestFactory.TryResolveMetric` now delegates to it so the CLI and MCP can't drift.

### AOT goal recorded
Captured that **full Native AOT is a goal** for the published heads (reversing the earlier D13 non-AOT framing): a new note in the plan and a comment in the core csproj record TraceEvent as the current hard blocker. No `IsAotCompatible`/`PublishAot` flag is set yet (the per-assembly analyzer would pass while a real publish still fails).

### Tests / validation
- New `TraceQ.Mcp.Tests` (16 tests): every tool, the metric/measure guards, the `top >= 1` boundary, the load-failure path, the instructions text, and the no-duplicate-warnings invariant. `.etl` thread-time test is `[OSCondition(OperatingSystems.Windows)]`.
- New `TraceMetricSelectorTests` in the core.
- Full `traceq.slnx` builds with **0 warnings** (`TreatWarningsAsErrors` on); **413 tests pass** (Core 250, CLI 145, MCP 16, Parity 2); help lint green.
- Manual stdio handshake confirmed `tools/list` registration of all 5 tools, the instructions field, and stdout purity (every emitted line is valid JSON-RPC).

### Deferred to the next slice
`trace_diff`, `trace_export`, a `trace_gc`/`trace_query_events` report tool, the **stdout-purity** and **schema-budget** CI checks, the MCP Inspector smoke + scripted client round-trip, and `outputSchema`/`structuredContent`. `trace_trim` stays parked with the `trim` verb.