### PR TITLE
Make OutputJson AOT-safe via System.Text.Json source generation

### DIFF
--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -307,14 +307,22 @@ state, not the end state. Blockers, in dependency order:
    `IsAotCompatible` / `PublishAot` flag goes on any traceq project until this
    clears - the per-assembly analyzer would pass while a real publish still
    fails.
-2. **Reflection-based `System.Text.Json`** in `OutputJson` - swap the reflection
-   serializer for a `JsonSerializerContext` source-gen resolver.
+2. **Reflection-based `System.Text.Json`** in `OutputJson` - **done.** A
+   `TraceQJsonContext` source-generation context declares every closed
+   `AnalysisResult<T>` the CLI and MCP heads serialize; `OutputJson` seeds its
+   options from that context and serializes through the resolved `JsonTypeInfo`,
+   so the reflection IL2026/IL3050 are gone (verified by the per-assembly AOT
+   analyzer). The custom double-rounding converter and relaxed encoder are layered
+   on the runtime options under metadata-mode generation, keeping the golden output
+   byte-identical. `TraceInfoView` moved from the MCP head into `TraceQ.Core/Output`
+   so one context covers all payloads. A new payload type must be registered in the
+   context or `Serialize` throws `NotSupportedException` (pinned by a test).
 3. **Reflection-based MCP tool discovery** - `WithToolsFromAssembly()` (warns
    IL2026) becomes the generic `WithTools<T>()`, which requires `TraceTools` to
    stop being a static class.
 
-Items 2 and 3 are inside our control and can land incrementally; item 1 gates
-the actual AOT publish.
+Item 3 is inside our control and can land incrementally; item 1 gates the actual
+AOT publish.
 
 ### D-N — Naming (gate: M3½ promotion; availability pass: M0)
 

--- a/traceq/src/TraceQ.Core/Output/OutputJson.cs
+++ b/traceq/src/TraceQ.Core/Output/OutputJson.cs
@@ -5,6 +5,7 @@
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 
 namespace TraceQ.Output;
 
@@ -20,6 +21,13 @@ namespace TraceQ.Output;
 ///   tokens on whitespace and, having no line breaks, compares cleanly in
 ///   cross-platform golden-file tests. Rounding the doubles keeps the output
 ///   stable and free of floating-point noise.
+///  </para>
+///  <para>
+///   Serialization goes through the <see cref="TraceQJsonContext"/> source-generated
+///   metadata rather than reflection, so the published heads stay Native-AOT- and
+///   trim-safe. The shared options seed from that context (inheriting the camel-case
+///   naming and the type-info resolver) and layer on the relaxed encoder and the
+///   double-rounding converter that the wire format requires.
 ///  </para>
 /// </remarks>
 public static class OutputJson
@@ -38,19 +46,30 @@ public static class OutputJson
     /// <param name="result">The envelope to serialize.</param>
     /// <returns>The compact JSON representation.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="result"/> is <see langword="null"/>.</exception>
+    /// <exception cref="NotSupportedException">
+    ///  <typeparamref name="T"/> has no entry in <see cref="TraceQJsonContext"/>; add a
+    ///  <c>[JsonSerializable(typeof(AnalysisResult&lt;T&gt;))]</c> declaration there.
+    /// </exception>
     public static string Serialize<T>(AnalysisResult<T> result)
     {
         ArgumentNullException.ThrowIfNull(result);
-        return JsonSerializer.Serialize(result, s_options);
+
+        // Resolve the source-generated metadata for this closed generic and serialize
+        // through the JsonTypeInfo overload - the reflection-based Serialize overload is
+        // neither AOT- nor trim-safe.
+        JsonTypeInfo<AnalysisResult<T>> typeInfo =
+            (JsonTypeInfo<AnalysisResult<T>>)s_options.GetTypeInfo(typeof(AnalysisResult<T>));
+        return JsonSerializer.Serialize(result, typeInfo);
     }
 
     private static JsonSerializerOptions CreateOptions()
     {
-        JsonSerializerOptions options = new()
+        // Seed from the source-gen context so the camel-case naming policy and the
+        // type-info resolver carry over, then layer on the write-time concerns the
+        // context attribute cannot express: the relaxed encoder and the rounding
+        // converter.
+        JsonSerializerOptions options = new(TraceQJsonContext.Default.Options)
         {
-            WriteIndented = false,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-
             // Frame names carry '<', '>', '&' (for example "<root>" and generic
             // arguments). This output is an agent / CLI wire format, never embedded
             // in HTML, so the relaxed encoder leaves those characters literal rather

--- a/traceq/src/TraceQ.Core/Output/TraceInfoView.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceInfoView.cs
@@ -4,7 +4,7 @@
 
 using TraceQ.Tracing;
 
-namespace TraceQ.Mcp;
+namespace TraceQ.Output;
 
 /// <summary>
 ///  The <c>trace_info</c> payload: a loaded trace's identity and quality signals.
@@ -12,9 +12,8 @@ namespace TraceQ.Mcp;
 /// <remarks>
 ///  <para>
 ///   The trace's quality warnings are not repeated here; they travel in the
-///   <see cref="TraceQ.Output.AnalysisResult{T}.Warnings"/> channel of the
-///   envelope this view is wrapped in, the same uniform channel every other tool
-///   reports them through.
+///   <see cref="AnalysisResult{T}.Warnings"/> channel of the envelope this view is
+///   wrapped in, the same uniform channel every other tool reports them through.
 ///  </para>
 /// </remarks>
 /// <param name="Path">The absolute path the trace was loaded from.</param>

--- a/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text.Json.Serialization;
+using TraceQ.Tracing;
+using TraceQ.Tracing.Providers;
+
+namespace TraceQ.Output;
+
+/// <summary>
+///  The System.Text.Json source-generation context for every analysis payload the
+///  CLI and MCP heads serialize through <see cref="OutputJson"/>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Native AOT is a goal for the published heads, and the reflection-based
+///   <c>JsonSerializer.Serialize</c> overload is not AOT- or trim-safe. Declaring
+///   each closed <see cref="AnalysisResult{T}"/> here makes the metadata available
+///   ahead of time so <see cref="OutputJson"/> can serialize through a
+///   <c>JsonTypeInfo</c> rather than reflecting at run time. The generator walks
+///   each declared type transitively, so the nested payload records (ranking rows,
+///   call-tree nodes, and so on) do not need their own entries.
+///  </para>
+///  <para>
+///   <see cref="JsonSourceGenerationMode.Metadata"/> is used rather than the
+///   serialization fast path because the output contract relies on a custom
+///   double-rounding converter and a relaxed encoder configured on the runtime
+///   options (see <see cref="OutputJson"/>); metadata mode resolves writing through
+///   that converter chain, while the fast path would bypass it.
+///  </para>
+/// </remarks>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    GenerationMode = JsonSourceGenerationMode.Metadata,
+    WriteIndented = false)]
+[JsonSerializable(typeof(AnalysisResult<TraceInfoView>))]
+[JsonSerializable(typeof(AnalysisResult<RankingResult>))]
+[JsonSerializable(typeof(AnalysisResult<CallersResult>))]
+[JsonSerializable(typeof(AnalysisResult<LineRankingResult>))]
+[JsonSerializable(typeof(AnalysisResult<SourceHeatmapResult>))]
+[JsonSerializable(typeof(AnalysisResult<CallTreeResult>))]
+[JsonSerializable(typeof(AnalysisResult<RankingDiffResult>))]
+[JsonSerializable(typeof(AnalysisResult<JitStatsResult>))]
+[JsonSerializable(typeof(AnalysisResult<GcStatsResult>))]
+[JsonSerializable(typeof(AnalysisResult<EventQueryResult>))]
+internal sealed partial class TraceQJsonContext : JsonSerializerContext
+{
+}

--- a/traceq/tests/TraceQ.Core.Tests/OutputContractTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/OutputContractTests.cs
@@ -107,4 +107,42 @@ public sealed class OutputContractTests
 
         json.Should().Be(expected);
     }
+
+    [TestMethod]
+    public void Serialize_TraceInfoViewPayload_ResolvesThroughSourceGenContext()
+    {
+        // trace_info's payload is a second closed generic over AnalysisResult; serializing
+        // it confirms the source-gen context covers more than the ranking envelope and
+        // that the camel-case naming and double rounding apply uniformly.
+        TraceInfoView view = new(
+            "/traces/sample.nettrace",
+            "EventPipe",
+            1234.567,
+            42,
+            0.91234,
+            [new ThreadSampleInfo("tid-1", 30)]);
+        AnalysisResult<TraceInfoView> envelope = new(view);
+
+        string json = OutputJson.Serialize(envelope);
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement result = doc.RootElement.GetProperty("result");
+        result.GetProperty("format").GetString().Should().Be("EventPipe");
+        result.GetProperty("totalWeight").GetDouble().Should().Be(1234.57);
+        result.GetProperty("symbolResolutionRate").GetDouble().Should().Be(0.91);
+        result.GetProperty("threads")[0].GetProperty("thread").GetString().Should().Be("tid-1");
+    }
+
+    [TestMethod]
+    public void Serialize_UnregisteredPayloadType_Throws()
+    {
+        // The source-gen context is the only type-info resolver, so a payload type that
+        // is not declared in TraceQJsonContext has no metadata and cannot be serialized.
+        // This pins the maintenance invariant: every new payload type must be registered.
+        AnalysisResult<int> envelope = new(42);
+
+        Action act = () => OutputJson.Serialize(envelope);
+
+        act.Should().Throw<NotSupportedException>();
+    }
 }


### PR DESCRIPTION
## Make `OutputJson` AOT-safe via System.Text.Json source generation

Native AOT is a goal for the published heads (the `TraceQ` CLI and the `TraceQ.Mcp` server). An audit of every JSON touchpoint found a single AOT/trim blocker in the JSON code: `OutputJson`'s reflection-based `JsonSerializer.Serialize` overload (IL2026 + IL3050). Everything else - the `JsonDocument`/`JsonElement` readers, the `Utf8JsonWriter` exporters, and the custom rounding converter - was already AOT-clean.

### Changes
- **New `TraceQJsonContext`** - a `JsonSerializerContext` declaring every closed `AnalysisResult<T>` the CLI and MCP heads serialize (the generator reaches the nested payload records transitively). Metadata-generation mode so the custom converter and encoder are honored.
- **`OutputJson` rewired** - seeds its options from the context (inheriting the camel-case naming and the type-info resolver), layers on the relaxed encoder and the double-rounding converter, and serializes through the resolved `JsonTypeInfo<AnalysisResult<T>>` (the AOT-safe overload) instead of reflecting at run time.
- **`TraceInfoView` moved** from `TraceQ.Mcp` into `TraceQ.Core/Output` so one context covers every payload (Core cannot reference the MCP head). It is a pure output-contract DTO; `TraceTools` already imported `TraceQ.Output`, so no call-site change.

### Behavior
- **Byte-identical output** - the golden test, the rounding test, the relaxed-encoder test, and the compact-output test all pass unchanged.
- A payload type with no entry in the context now throws `NotSupportedException` from `Serialize`, pinning the maintenance invariant that every payload must be registered (covered by a new test).

### Validation
- The per-assembly AOT analyzer (`-p:IsAotCompatible=true`) reports **no IL warnings** for `TraceQ.Core` (the `OutputJson` IL2026/IL3050 are gone).
- Full `traceq.slnx` builds 0 warnings (`TreatWarningsAsErrors` on); **418 tests pass** (+2 new `OutputContract` tests); help lint green.

### Remaining AOT blockers (tracked, not in scope here)
TraceEvent (the long pole - reflection + ETW interop, blocks the actual publish) and the MCP `WithToolsFromAssembly()` -> generic `WithTools<T>()` switch. See the AOT note in [docs/traceq-implementation-plan.md](docs/traceq-implementation-plan.md).