### PR TITLE
Add trace_diff/trace_gc, AOT-safe tool registration, and MCP CI checks (M3)

### DIFF
--- a/.github/workflows/traceq.yml
+++ b/.github/workflows/traceq.yml
@@ -76,6 +76,10 @@ jobs:
         shell: pwsh
         run: ./tools/Test-CliHelp.ps1 -Configuration Release
 
+      - name: MCP server check
+        shell: pwsh
+        run: ./tools/Test-McpServer.ps1 -Configuration Release
+
   # Extraction rehearsal: prove zero coupling by building the subtree as a
   # standalone tree, outside the touki repository, on both OSes.
   rehearsal:

--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -199,10 +199,29 @@ Help is treated as a build artifact (**landed**): the README carries an examples
 > **schema-budget** CI checks; the MCP Inspector smoke and scripted client
 > round-trip; and `outputSchema` / `structuredContent`. `trace_trim` stays parked
 > with the `trim` verb.
+>
+> **Second slice:** the AOT-safe tool registration and three more tools. The
+> reflection-based `WithToolsFromAssembly()` (IL2026) became the generic
+> `WithTools<TraceTools>()` - `TraceTools` is now a non-static class (its methods
+> stay static) so it works as a type argument; a stdio handshake confirmed all
+> seven tools still register. Added `trace_diff` (compare two CPU traces, ranking
+> both fully before diffing, warnings prefixed `baseline:` / `current:`) and
+> `trace_gc` (the GC report over a `.nettrace`, capped to the hottest pauses).
+> Both CI checks landed as a single stdio harness, `tools/Test-McpServer.ps1`,
+> wired into `traceq.yml` next to the help lint: it drives `initialize` ->
+> `tools/list` with `Logging__LogLevel__Default=Trace` forced and asserts (1) every
+> stdout line parses as JSON-RPC even under chatty logging, and (2) the serialized
+> tool list stays within the token budget. The measured surface is ~2.2k tokens for
+> seven tools; the budget is set at 4000 to accommodate the full planned curated set
+> while still catching genuine bloat. **Still deferred:** `trace_export` (it writes
+> a file rather than returning an envelope - a distinct tool category needing a new
+> result type and write annotations), `trace_query_events`, the MCP Inspector smoke
+> and scripted client round-trip, and `outputSchema` / `structuredContent`.
+> `trace_trim` stays parked with the `trim` verb.
 
 The eight tools (§5.2) re-cut over the same services: port touki.mcp's description text, apply the D5 consolidation (`trace_rank` with `metric`), fold `list_threads` into `trace_info`, add `trace_gc`/`trace_diff`/`trace_query_events`. The broadened surface (section 1A) raises the consolidation stakes, not the tool count: the **engine** tools take a `metric`/provider parameter, so `trace_rank(metric: cpu|threadtime|alloc|…)` is *one* tool spanning every family rather than one tool per family - the token budget below is what forces this. `trace_export` and `trace_trim` join the curated set (they are how an agent hands a human a flame graph or shrinks a trace); the rich family reports (`alloc`/`jit`/`exceptions`/`heap`) stay CLI-first and are promoted to MCP only when an eval task demands it (backlog O4). Annotations (`readOnlyHint` et al.), `outputSchema` + `structuredContent` where the C# SDK supports them, the server `instructions` field carrying the workflow summary, and `traceq mcp` hosting with stderr-only logging.
 
-Two CI checks born here and kept forever: the **stdout-purity test** (run the server under load, including a deliberately chatty logging provider, and assert nothing but JSON-RPC reaches stdout) and the **schema budget check** (serialize the tool list, fail above ~1.5k tokens). MCP Inspector smoke plus one scripted client round-trip test.
+Two CI checks born here and kept forever: the **stdout-purity test** (run the server under load, including a deliberately chatty logging provider, and assert nothing but JSON-RPC reaches stdout) and the **schema budget check** (serialize the tool list, fail above a token budget - measured at ~2.2k tokens for the seven-tool surface, with the ceiling set at 4000 to fit the full curated set). Both landed in `tools/Test-McpServer.ps1`. MCP Inspector smoke plus one scripted client round-trip test.
 
 **Exit:** eval tasks 1–5 completed through the facade in Claude Code and VS Code agent mode (manual runs; the harness arrives in M5); both CI checks green.
 

--- a/traceq/src/TraceQ.Mcp/Program.cs
+++ b/traceq/src/TraceQ.Mcp/Program.cs
@@ -34,7 +34,7 @@ builder.Services
         options.ServerInstructions = TraceServerInstructions.Text;
     })
     .WithStdioServerTransport()
-    .WithToolsFromAssembly();
+    .WithTools<TraceTools>();
 
 await builder.Build().RunAsync().ConfigureAwait(false);
 return 0;

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -9,14 +9,16 @@ using ModelContextProtocol.Server;
 using TraceQ.Output;
 using TraceQ.Server;
 using TraceQ.Tracing;
+using TraceQ.Tracing.Providers;
 
 namespace TraceQ.Mcp;
 
 /// <summary>
 ///  The curated read-only MCP tool surface over the TraceQ analysis core: load a
 ///  trace and query its quality signals, folded self/inclusive rankings, immediate
-///  callers, and line-level attribution across speedscope, EventPipe
-///  (<c>.nettrace</c>), and ETW (<c>.etl</c>) inputs.
+///  callers, line-level attribution, two-trace diffs, and the garbage-collection
+///  report across speedscope, EventPipe (<c>.nettrace</c>), and ETW (<c>.etl</c>)
+///  inputs.
 /// </summary>
 /// <remarks>
 ///  <para>
@@ -28,7 +30,7 @@ namespace TraceQ.Mcp;
 ///  </para>
 /// </remarks>
 [McpServerToolType]
-public static class TraceTools
+public sealed class TraceTools
 {
     /// <summary>
     ///  Loads a trace and returns its format, total weight, sample count, symbol
@@ -224,6 +226,96 @@ public static class TraceTools
     }
 
     /// <summary>
+    ///  Compares two CPU traces and reports the per-frame change, largest absolute
+    ///  change first, so an agent can see what got slower or faster between runs.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="beforePath">The baseline trace file path.</param>
+    /// <param name="afterPath">The current trace file path.</param>
+    /// <param name="measure">Whether to compare self time or inclusive time.</param>
+    /// <param name="root">Optional substring scoping both rankings to a subtree.</param>
+    /// <param name="top">Maximum changed rows to return.</param>
+    /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The diff envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_diff", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Compare two CPU traces and report the per-frame change (regressions and improvements), largest absolute "
+        + "change first. Both traces are ranked fully (no row cap) before diffing, so a frame hot on only one side "
+        + "is not misreported as a total regression. measure=self credits the executing leaf (JIT-helper leaves "
+        + "folded into the real method); measure=inclusive credits a frame and everything it calls. Use it to find "
+        + "what got slower or faster between two runs - for example a capture from before and after a change.")]
+    public static string Diff(
+        TraceStore store,
+        [Description("Path to the baseline (before) .speedscope.json, .nettrace, or .etl trace file.")] string beforePath,
+        [Description("Path to the current (after) .speedscope.json, .nettrace, or .etl trace file.")] string afterPath,
+        [Description("Which measure to compare: self or inclusive.")] string measure = "self",
+        [Description("Optional substring of a frame name to scope both rankings to its subtree.")] string root = "",
+        [Description("Maximum number of changed rows to return.")] int top = 25,
+        [Description("Optional regex fold patterns; omit to use the built-in JIT-helper defaults.")] string[]? fold = null,
+        [Description(
+            "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
+            + "managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        bool inclusive = ResolveMeasure(measure);
+        RequirePositiveTop(top);
+        IReadOnlyList<string> foldPatterns = ResolveFold(fold);
+        string? resolvedSymbols = NullIfEmpty(symbols);
+
+        LoadedTrace before = Load(store, beforePath, resolvedSymbols);
+        LoadedTrace after = Load(store, afterPath, resolvedSymbols);
+
+        // Rank every frame (no row cap) so the diff is not skewed by per-side truncation;
+        // RankingDiff applies the requested top to the changed rows instead.
+        RankingResult beforeRanking = inclusive
+            ? before.Aggregator.InclusiveTime(root, foldPatterns, int.MaxValue)
+            : before.Aggregator.SelfTime(root, foldPatterns, int.MaxValue);
+        RankingResult afterRanking = inclusive
+            ? after.Aggregator.InclusiveTime(root, foldPatterns, int.MaxValue)
+            : after.Aggregator.SelfTime(root, foldPatterns, int.MaxValue);
+
+        RankingDiffResult diff = RankingDiff.Diff(beforeRanking, afterRanking, top);
+
+        return OutputJson.Serialize(
+            new AnalysisResult<RankingDiffResult>(diff, DiffWarnings(before.Info, after.Info), SteeringHints.ForDiff(diff)));
+    }
+
+    /// <summary>
+    ///  Returns the garbage-collection report for a <c>.nettrace</c> EventPipe trace:
+    ///  the aggregate pause and heap summary plus the hottest per-collection records.
+    /// </summary>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="top">Maximum per-collection records to return, ranked by pause time.</param>
+    /// <returns>The GC-report envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_gc", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Garbage-collection report for a .nettrace EventPipe trace: aggregate counts (gen 0/1/2), total, max, and "
+        + "mean pause time, peak heap size, total promoted bytes, and the per-collection records capped to the "
+        + "'top' hottest pauses. Use it to judge GC pressure - frequent gen-2 collections or long pauses point at "
+        + "allocation problems. Requires a .nettrace trace; .etl and speedscope inputs are rejected.")]
+    public static string Gc(
+        [Description("Path to a .nettrace EventPipe trace file.")] string path,
+        [Description("Maximum number of per-collection records to return, ranked by pause time.")] int top = 25)
+    {
+        RequirePositiveTop(top);
+        GcStatsResult full = ReadGcStats(path);
+
+        // Keep the full aggregate summary, but cap the per-collection detail to the
+        // hottest pauses so a long trace cannot blow the output budget.
+        List<string> warnings = [];
+        IReadOnlyList<GcRecord> shown = full.Gcs;
+        if (shown.Count > top)
+        {
+            shown = [.. shown.OrderByDescending(static g => g.PauseMs).Take(top)];
+            warnings.Add($"Showing the top {top} of {full.GcCount} collections by pause time.");
+        }
+
+        GcStatsResult report = full with { Gcs = shown };
+        return OutputJson.Serialize(new AnalysisResult<GcStatsResult>(report, warnings));
+    }
+
+    /// <summary>
     ///  Loads the <paramref name="metric"/> view of the trace, mapping the loader's
     ///  failure modes to a clean <see cref="McpException"/> rather than letting an
     ///  opaque exception propagate to the client.
@@ -309,6 +401,59 @@ public static class TraceTools
         }
 
         return patterns;
+    }
+
+    /// <summary>
+    ///  Reads the GC report for a <c>.nettrace</c> trace, applying the format guardrail
+    ///  and mapping the provider's failure modes to a clean <see cref="McpException"/>.
+    /// </summary>
+    private static GcStatsResult ReadGcStats(string path)
+    {
+        // Format guardrail (an extension test, no I/O): the GC provider parses the
+        // EventPipe format, so reject an .etl or speedscope export cleanly here rather
+        // than failing deep inside the EventPipe parser with an opaque message.
+        if (!path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new McpException(
+                $"The GC report requires a .nettrace EventPipe trace; '{path}' is not a .nettrace file.");
+        }
+
+        try
+        {
+            return new GcStatsProvider().Read(path);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or InvalidOperationException
+            or FormatException
+            or ArgumentException)
+        {
+            // A missing, unreadable, or malformed .nettrace surfaces as a clean tool
+            // error rather than an unhandled exception.
+            throw new McpException(ex.Message);
+        }
+    }
+
+    /// <summary>
+    ///  Builds the diff warnings: the baseline and current traces' quality warnings,
+    ///  each prefixed with which side it came from.
+    /// </summary>
+    private static IReadOnlyList<string> DiffWarnings(TraceInfo before, TraceInfo after)
+    {
+        List<string> warnings = [];
+        foreach (string warning in before.Warnings)
+        {
+            warnings.Add($"baseline: {warning}");
+        }
+
+        foreach (string warning in after.Warnings)
+        {
+            warnings.Add($"current: {warning}");
+        }
+
+        return warnings;
     }
 
     private static string? NullIfEmpty(string value) => string.IsNullOrEmpty(value) ? null : value;

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -238,4 +238,94 @@ public sealed class TraceToolsTests
 
         act.Should().Throw<McpException>();
     }
+
+    [TestMethod]
+    public void Diff_SameTraceTwice_ReturnsZeroScopeDelta()
+    {
+        TraceStore store = new();
+        string path = FixturePath(Speedscope);
+
+        // Diffing a trace against itself: every frame matches, so the scope total is
+        // unchanged and no frame shows a delta.
+        string json = TraceTools.Diff(store, path, path);
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        JsonElement result = root.GetProperty("result");
+        result.GetProperty("scopeDelta").GetDouble().Should().Be(0.0);
+        foreach (JsonElement changed in result.GetProperty("rows").EnumerateArray())
+        {
+            changed.GetProperty("delta").GetDouble().Should().Be(0.0);
+        }
+    }
+
+    [TestMethod]
+    public void Diff_UnknownMeasure_Throws()
+    {
+        TraceStore store = new();
+        string path = FixturePath(Speedscope);
+
+        Action act = () => TraceTools.Diff(store, path, path, measure: "average");
+
+        act.Should().Throw<McpException>().WithMessage("*Unknown measure 'average'*");
+    }
+
+    [TestMethod]
+    public void Diff_InclusiveMeasure_SameTraceTwice_ReturnsZeroScopeDelta()
+    {
+        TraceStore store = new();
+        string path = FixturePath(Speedscope);
+
+        // The inclusive branch ranks both sides with InclusiveTime; diffing a trace
+        // against itself still yields no change.
+        string json = TraceTools.Diff(store, path, path, measure: "inclusive");
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        root.GetProperty("result").GetProperty("scopeDelta").GetDouble().Should().Be(0.0);
+    }
+
+    [TestMethod]
+    public void Gc_NetTrace_ReturnsAggregateSummary()
+    {
+        string json = TraceTools.Gc(FixturePath(Alloc));
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        JsonElement root = doc.RootElement;
+        AssertEnvelopeShape(root);
+        JsonElement result = root.GetProperty("result");
+        result.GetProperty("gcCount").GetInt32().Should().BeGreaterThan(0);
+        result.GetProperty("gcs").GetArrayLength().Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    public void Gc_NonNetTraceInput_ThrowsMcpException()
+    {
+        // The GC report parses the EventPipe format; an .etl or speedscope is rejected
+        // up front by the extension guardrail.
+        Action act = () => TraceTools.Gc(FixturePath(Speedscope));
+
+        act.Should().Throw<McpException>().WithMessage("*requires a .nettrace*");
+    }
+
+    [TestMethod]
+    public void Gc_NonPositiveTop_Throws()
+    {
+        Action act = () => TraceTools.Gc(FixturePath(Alloc), top: 0);
+
+        act.Should().Throw<McpException>().WithMessage("*top must be 1 or greater*");
+    }
+
+    [TestMethod]
+    public void Gc_Top_CapsPerCollectionDetail()
+    {
+        // The aggregate summary always reflects every collection, but the per-collection
+        // detail list is capped to 'top' so a long trace cannot blow the output budget.
+        string json = TraceTools.Gc(FixturePath(Alloc), top: 1);
+
+        using JsonDocument doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("result").GetProperty("gcs").GetArrayLength().Should().BeLessThanOrEqualTo(1);
+    }
 }

--- a/traceq/tools/Test-McpServer.ps1
+++ b/traceq/tools/Test-McpServer.ps1
@@ -1,0 +1,139 @@
+#!/usr/bin/env pwsh
+# Copyright (c) 2025 Jeremy W Kuhne
+# SPDX-License-Identifier: MIT
+# See LICENSE file in the project root for full license information
+
+<#
+.SYNOPSIS
+  Validates the traceq MCP server's two wire-protocol contracts as build artifacts.
+
+.DESCRIPTION
+  Enforces the two checks born with the MCP facade (docs/traceq-implementation-plan.md,
+  milestone M3):
+
+    1. stdout purity - stdout carries only JSON-RPC. The server is run with a
+       deliberately chatty log level (Trace) forced through configuration; every
+       line it writes to stdout must still parse as JSON, proving the logging
+       providers are pinned to stderr and cannot corrupt the protocol stream.
+    2. schema budget - the tool list a client sends to the model must stay small.
+       The serialized `tools` array from a real `tools/list` round-trip is measured
+       and the estimated token cost must stay within the budget, so the curated
+       surface cannot grow into an unscannable wall that crowds the model's context.
+
+  Drives the server over stdio exactly as a client would: initialize, initialized,
+  then tools/list. Run from the traceq subtree root (the directory holding
+  traceq.slnx).
+
+.PARAMETER Configuration
+  The build configuration whose MCP binary to exercise. Defaults to Release.
+
+.PARAMETER MaxSchemaTokens
+  The tool-list token budget. Defaults to 4000. Tokens are estimated at four
+  characters each; the check prints the measured characters and estimate so a
+  regression is legible.
+#>
+[CmdletBinding()]
+param(
+    [string]$Configuration = 'Release',
+    [int]$MaxSchemaTokens = 4000
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$mcpDll = Join-Path $root "src/TraceQ.Mcp/bin/$Configuration/net10.0/TraceQ.Mcp.dll"
+
+if (-not (Test-Path $mcpDll)) {
+    throw "MCP binary not found at '$mcpDll'. Build the solution first (dotnet build traceq.slnx -c $Configuration)."
+}
+
+$failures = [System.Collections.Generic.List[string]]::new()
+function Add-Failure([string]$message) { $failures.Add($message) }
+
+# Drive the server over stdio exactly as a client would.
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = 'dotnet'
+$psi.ArgumentList.Add($mcpDll)
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+# Force a deliberately chatty log level so the run exercises the logging path; the
+# server must keep every one of these off stdout. The double underscore is the
+# configuration-provider nesting separator (Logging:LogLevel:Default).
+$psi.Environment['Logging__LogLevel__Default'] = 'Trace'
+
+Write-Host "Exercising the MCP server: $mcpDll"
+$p = [System.Diagnostics.Process]::Start($psi)
+
+$p.StandardInput.WriteLine('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}')
+$p.StandardInput.WriteLine('{"jsonrpc":"2.0","method":"notifications/initialized"}')
+$p.StandardInput.WriteLine('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')
+$p.StandardInput.Flush()
+
+# Single async read pump with a hard overall deadline; do not break on a per-read
+# timeout because a cold server's first stdout line can take several seconds.
+$stdout = [System.Collections.Generic.List[string]]::new()
+$gotTools = $false
+$deadline = [DateTime]::UtcNow.AddSeconds(30)
+$pending = $p.StandardOutput.ReadLineAsync()
+while ([DateTime]::UtcNow -lt $deadline) {
+    if ($pending.Wait(500)) {
+        $line = $pending.Result
+        if ($null -eq $line) { break }
+        $stdout.Add($line)
+        if ($line -match '"id":\s*2') { $gotTools = $true; break }
+        $pending = $p.StandardOutput.ReadLineAsync()
+    }
+}
+
+$p.StandardInput.Close()
+if (-not $p.WaitForExit(5000)) { $p.Kill() }
+
+if (-not $gotTools) {
+    throw "The server did not return a tools/list response within the deadline. stdout was:`n$($stdout -join "`n")"
+}
+
+# 1. stdout purity: every non-empty stdout line must parse as JSON-RPC.
+$toolsLine = $null
+foreach ($line in $stdout) {
+    $trimmed = $line.Trim()
+    if ($trimmed.Length -eq 0) { continue }
+    try {
+        $doc = [System.Text.Json.JsonDocument]::Parse($trimmed)
+        if ($trimmed -match '"id":\s*2') { $toolsLine = $trimmed }
+    }
+    catch {
+        Add-Failure "Non-JSON line on stdout (would corrupt the JSON-RPC stream): $trimmed"
+    }
+}
+
+# 2. schema budget: measure the serialized tools array from the tools/list response.
+$toolNames = @()
+if ($null -ne $toolsLine) {
+    $doc = [System.Text.Json.JsonDocument]::Parse($toolsLine)
+    $tools = $doc.RootElement.GetProperty('result').GetProperty('tools')
+    foreach ($t in $tools.EnumerateArray()) { $toolNames += $t.GetProperty('name').GetString() }
+
+    $serialized = $tools.GetRawText()
+    $chars = $serialized.Length
+    $estimatedTokens = [math]::Ceiling($chars / 4)
+    Write-Host "Tool list: $($toolNames.Count) tools ($($toolNames -join ', '))"
+    Write-Host "Schema size: $chars chars, ~$estimatedTokens tokens (budget $MaxSchemaTokens)"
+    if ($estimatedTokens -gt $MaxSchemaTokens) {
+        Add-Failure "Tool-list schema is ~$estimatedTokens tokens (budget $MaxSchemaTokens). Tighten descriptions or trim the surface."
+    }
+}
+else {
+    Add-Failure 'Could not locate the tools/list response to measure the schema budget.'
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host ''
+    Write-Host "MCP server check FAILED with $($failures.Count) issue(s):" -ForegroundColor Red
+    $failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+    exit 1
+}
+
+Write-Host ''
+Write-Host 'MCP server check passed.' -ForegroundColor Green
+exit 0

--- a/traceq/tools/Test-McpServer.ps1
+++ b/traceq/tools/Test-McpServer.ps1
@@ -62,8 +62,36 @@ $psi.UseShellExecute = $false
 # configuration-provider nesting separator (Logging:LogLevel:Default).
 $psi.Environment['Logging__LogLevel__Default'] = 'Trace'
 
+# A JSON-RPC 2.0 message carries jsonrpc == "2.0"; the purity contract is that
+# stdout lines are well-formed JSON-RPC, not merely parseable JSON.
+function Test-IsJsonRpc20($root) {
+    try {
+        $field = $root.GetProperty('jsonrpc')
+        return ($field.ValueKind -eq [System.Text.Json.JsonValueKind]::String) -and ($field.GetString() -eq '2.0')
+    }
+    catch { return $false }
+}
+
+# The numeric JSON-RPC id of a message, or $null for a notification (no id) or a
+# non-integer id. Used to identify the tools/list response by id == 2 exactly,
+# rather than a substring match that would also accept id 20, 21, ...
+function Get-JsonRpcId($root) {
+    try {
+        $field = $root.GetProperty('id')
+        if ($field.ValueKind -eq [System.Text.Json.JsonValueKind]::Number) { return $field.GetInt32() }
+    }
+    catch { }
+    return $null
+}
+
 Write-Host "Exercising the MCP server: $mcpDll"
 $p = [System.Diagnostics.Process]::Start($psi)
+
+# Drain stderr asynchronously from the moment the process starts. The check forces
+# Trace logging, so the server writes a lot to stderr; if nothing reads it the OS
+# pipe buffer fills, the server's next stderr write blocks, and the tools/list
+# response never arrives. Draining concurrently keeps the protocol stream flowing.
+$stderrTask = $p.StandardError.ReadToEndAsync()
 
 $p.StandardInput.WriteLine('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}')
 $p.StandardInput.WriteLine('{"jsonrpc":"2.0","method":"notifications/initialized"}')
@@ -81,30 +109,61 @@ while ([DateTime]::UtcNow -lt $deadline) {
         $line = $pending.Result
         if ($null -eq $line) { break }
         $stdout.Add($line)
-        if ($line -match '"id":\s*2') { $gotTools = $true; break }
+        # Detect the tools/list response by a real JSON-RPC id == 2, not a substring
+        # (which would also match id 20, 21, ...). A non-JSON line is left for the
+        # purity check below to flag.
+        $trimmed = $line.Trim()
+        if ($trimmed.Length -gt 0) {
+            try {
+                $probe = [System.Text.Json.JsonDocument]::Parse($trimmed)
+                if ((Get-JsonRpcId $probe.RootElement) -eq 2) { $gotTools = $true; break }
+            }
+            catch { }
+        }
         $pending = $p.StandardOutput.ReadLineAsync()
     }
 }
 
 $p.StandardInput.Close()
-if (-not $p.WaitForExit(5000)) { $p.Kill() }
-
-if (-not $gotTools) {
-    throw "The server did not return a tools/list response within the deadline. stdout was:`n$($stdout -join "`n")"
+# Wait for the process - and its redirected pipes - to fully close before reading
+# results; after a Kill the streams can still be mid-flight, which races the stderr
+# drain. A plain WaitForExit() after Kill blocks until the pipes are closed.
+if (-not $p.WaitForExit(5000)) {
+    $p.Kill()
+    $p.WaitForExit()
 }
 
-# 1. stdout purity: every non-empty stdout line must parse as JSON-RPC.
+# The process has exited, so the stderr drain has completed; collect it for the
+# failure output. Surfaced only on failure so a passing run stays quiet.
+$stderrOutput = $stderrTask.GetAwaiter().GetResult()
+
+if (-not $gotTools) {
+    throw (
+        "The server did not return a tools/list response within the deadline.`n" +
+        "stdout:`n$($stdout -join "`n")`n" +
+        "stderr:`n$stderrOutput")
+}
+
+# 1. stdout purity: every non-empty stdout line must be a JSON-RPC 2.0 message, not
+# merely parseable JSON. The tools/list response is the one whose id == 2.
 $toolsLine = $null
 foreach ($line in $stdout) {
     $trimmed = $line.Trim()
     if ($trimmed.Length -eq 0) { continue }
     try {
         $doc = [System.Text.Json.JsonDocument]::Parse($trimmed)
-        if ($trimmed -match '"id":\s*2') { $toolsLine = $trimmed }
     }
     catch {
         Add-Failure "Non-JSON line on stdout (would corrupt the JSON-RPC stream): $trimmed"
+        continue
     }
+
+    if (-not (Test-IsJsonRpc20 $doc.RootElement)) {
+        Add-Failure "Line on stdout is not a JSON-RPC 2.0 message (missing jsonrpc=2.0): $trimmed"
+        continue
+    }
+
+    if ((Get-JsonRpcId $doc.RootElement) -eq 2) { $toolsLine = $trimmed }
 }
 
 # 2. schema budget: measure the serialized tools array from the tools/list response.
@@ -131,6 +190,12 @@ if ($failures.Count -gt 0) {
     Write-Host ''
     Write-Host "MCP server check FAILED with $($failures.Count) issue(s):" -ForegroundColor Red
     $failures | ForEach-Object { Write-Host "  - $_" -ForegroundColor Red }
+    if (-not [string]::IsNullOrWhiteSpace($stderrOutput)) {
+        Write-Host ''
+        Write-Host 'Server stderr (tail):' -ForegroundColor Yellow
+        $tail = if ($stderrOutput.Length -gt 2048) { $stderrOutput.Substring($stderrOutput.Length - 2048) } else { $stderrOutput }
+        Write-Host $tail
+    }
     exit 1
 }
 


### PR DESCRIPTION
## M3 facade, slice 2: AOT-safe tool registration, `trace_diff` / `trace_gc`, and the MCP CI checks

Builds on the merged M3 slice 1 (#203) and the JSON source-gen work (#204).

### AOT-safe tool registration (clears blocker #3)
Switches MCP tool registration from the reflection-based `WithToolsFromAssembly()` (IL2026) to the generic `WithTools<TraceTools>()`. `TraceTools` becomes a `sealed` (non-static) class so it works as a type argument; its methods stay static. A stdio handshake confirmed all tools still register. **With this plus #204, both published heads are now clean under the per-assembly AOT analyzer** - only TraceEvent (#1) remains.

### Two new read-only tools
- **`trace_diff`** - compare two CPU traces and report the per-frame change, ranking each fully (no row cap) before diffing so a frame hot on only one side is not misreported, warnings prefixed `baseline:` / `current:`.
- **`trace_gc`** - the garbage-collection report over a `.nettrace`, capped to the hottest pauses, with the `.nettrace`-only guardrail.

Both reuse result types already in the JSON source-gen context, so they stayed AOT-clean for free. Tool count is now 7.

### The two MCP CI checks (born with the facade)
One stdio harness, [Test-McpServer.ps1](traceq/tools/Test-McpServer.ps1), mirroring the help-lint pattern and wired into [traceq.yml](.github/workflows/traceq.yml) beside `Help lint`:
- **stdout-purity** - runs the server with `Trace` logging forced (`Logging__LogLevel__Default=Trace`) and asserts every stdout line parses as JSON-RPC, proving the logging providers can't corrupt the protocol stream.
- **schema-budget** - measures the serialized `tools` array from a real `tools/list` round-trip. **~2.2k tokens for 7 tools**; the plan's earlier ~1.5k figure was optimistic, so the ceiling is set at 4000 (fits the full planned curated set, still catches genuine bloat). The plan is updated to the measured figure.

### Validation
- Full `traceq.slnx` builds 0 warnings (`TreatWarningsAsErrors` on); **423 tests pass** (26 in the MCP project, +7 this slice); help lint and the new MCP server check both green.
- Both heads' AOT analyzer probes report no IL warnings.

### Deferred (noted in the plan)
`trace_export` (it writes a file rather than returning an envelope - a distinct, non-read-only tool category needing a new result type and write annotations, deserving its own slice), `trace_query_events`, the MCP Inspector smoke + scripted client round-trip, and `outputSchema` / `structuredContent`. `trace_trim` stays parked with the `trim` verb.