### PR TITLE
Add the trace_export MCP tool (M3)

### DIFF
--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -218,6 +218,19 @@ Help is treated as a build artifact (**landed**): the README carries an examples
 > result type and write annotations), `trace_query_events`, the MCP Inspector smoke
 > and scripted client round-trip, and `outputSchema` / `structuredContent`.
 > `trace_trim` stays parked with the `trim` verb.
+>
+> **Third slice:** `trace_export`, the first write tool. It exports a trace's CPU
+> sample source to a speedscope or Chrome-trace flame-graph file, taking a required
+> `output` path (there is no stdout to write to under the protocol) and a `format`
+> selector, and is annotated `readOnlyHint=false` (the others are read-only). Its
+> product is a file, so it returns an `ExportResult` receipt (format, absolute path,
+> byte count, profile name) through the same envelope, with a viewer hint
+> (speedscope.app or the Perfetto UI) in the hints channel; `ExportResult` joins the
+> source-gen JSON context so the head stays AOT-clean. Write failures map to a clean
+> `McpException`. The surface is now eight tools at ~2.6k tokens, still under budget.
+> **Still deferred:** `trace_query_events`, the MCP Inspector smoke and scripted
+> client round-trip, and `outputSchema` / `structuredContent`. `trace_trim` stays
+> parked with the `trim` verb.
 
 The eight tools (§5.2) re-cut over the same services: port touki.mcp's description text, apply the D5 consolidation (`trace_rank` with `metric`), fold `list_threads` into `trace_info`, add `trace_gc`/`trace_diff`/`trace_query_events`. The broadened surface (section 1A) raises the consolidation stakes, not the tool count: the **engine** tools take a `metric`/provider parameter, so `trace_rank(metric: cpu|threadtime|alloc|…)` is *one* tool spanning every family rather than one tool per family - the token budget below is what forces this. `trace_export` and `trace_trim` join the curated set (they are how an agent hands a human a flame graph or shrinks a trace); the rich family reports (`alloc`/`jit`/`exceptions`/`heap`) stay CLI-first and are promoted to MCP only when an eval task demands it (backlog O4). Annotations (`readOnlyHint` et al.), `outputSchema` + `structuredContent` where the C# SDK supports them, the server `instructions` field carrying the workflow summary, and `traceq mcp` hosting with stderr-only logging.
 

--- a/traceq/src/TraceQ.Core/Output/ExportResult.cs
+++ b/traceq/src/TraceQ.Core/Output/ExportResult.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Output;
+
+/// <summary>
+///  The <c>trace_export</c> confirmation payload: what flame-graph file was written,
+///  where, and how large it is.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Unlike the query tools, export's product is a file on disk, not trace data in
+///   the response. This payload is the receipt an agent reads back to confirm the
+///   write succeeded and to tell a human where the flame graph is and how to open it
+///   (the viewer hint travels in the envelope's hints channel).
+///  </para>
+/// </remarks>
+/// <param name="Format">The flame-graph format written (<c>speedscope</c> or <c>chromium</c>).</param>
+/// <param name="OutputPath">The absolute path the flame graph was written to.</param>
+/// <param name="ByteCount">The size of the written file, in bytes.</param>
+/// <param name="Name">The profile name embedded in the flame graph, shown in the viewer.</param>
+public sealed record ExportResult(
+    string Format,
+    string OutputPath,
+    long ByteCount,
+    string Name);

--- a/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
@@ -44,6 +44,7 @@ namespace TraceQ.Output;
 [JsonSerializable(typeof(AnalysisResult<JitStatsResult>))]
 [JsonSerializable(typeof(AnalysisResult<GcStatsResult>))]
 [JsonSerializable(typeof(AnalysisResult<EventQueryResult>))]
+[JsonSerializable(typeof(AnalysisResult<ExportResult>))]
 internal sealed partial class TraceQJsonContext : JsonSerializerContext
 {
 }

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -14,11 +14,12 @@ using TraceQ.Tracing.Providers;
 namespace TraceQ.Mcp;
 
 /// <summary>
-///  The curated read-only MCP tool surface over the TraceQ analysis core: load a
-///  trace and query its quality signals, folded self/inclusive rankings, immediate
-///  callers, line-level attribution, two-trace diffs, and the garbage-collection
-///  report across speedscope, EventPipe (<c>.nettrace</c>), and ETW (<c>.etl</c>)
-///  inputs.
+///  The curated MCP tool surface over the TraceQ analysis core: load a trace and
+///  query its quality signals, folded self/inclusive rankings, immediate callers,
+///  line-level attribution, two-trace diffs, and the garbage-collection report
+///  across speedscope, EventPipe (<c>.nettrace</c>), and ETW (<c>.etl</c>) inputs,
+///  plus export a flame graph to a file. Every tool but <c>trace_export</c> is
+///  read-only; <c>trace_export</c> writes a file.
 /// </summary>
 /// <remarks>
 ///  <para>
@@ -316,6 +317,61 @@ public sealed class TraceTools
     }
 
     /// <summary>
+    ///  Exports a trace's CPU sample source to a speedscope or Chrome-trace flame-graph
+    ///  file an agent can hand a human to open in a viewer.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="output">The file path to write the flame graph to.</param>
+    /// <param name="format">The flame-graph format: <c>speedscope</c> or <c>chromium</c>.</param>
+    /// <param name="name">The profile name embedded in the flame graph, shown in the viewer.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <returns>The export-confirmation envelope, as compact JSON.</returns>
+    [McpServerTool(Name = "trace_export", ReadOnly = false, Idempotent = true, OpenWorld = false)]
+    [Description(
+        "Export a trace's CPU samples to a flame-graph file for a human to open in a viewer - this is how you hand "
+        + "off a visual. format=speedscope (the default) opens at speedscope.app; format=chromium writes the Chrome "
+        + "Trace Event Format for chrome://tracing or the Perfetto UI. 'output' is the file path to write (required; "
+        + "unlike the query tools this writes a file rather than returning the data, and overwrites an existing file "
+        + "at that path). The whole sample source is exported - no folding, scoping, or ranking. The response "
+        + "confirms the path, format, and byte count.")]
+    public static string Export(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
+        [Description("The file path to write the flame graph to (it is overwritten if it exists).")] string output,
+        [Description("The flame-graph format: speedscope or chromium.")] string format = "speedscope",
+        [Description("The profile name embedded in the flame graph, shown in the viewer.")] string name = "traceq",
+        [Description(
+            "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
+            + "managed frames resolve to source lines.")]
+        string symbols = "")
+    {
+        bool chromium = ResolveExportFormat(format);
+
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            throw new McpException("output is required: the file path to write the flame graph to.");
+        }
+
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        TraceInfo info = trace.Info;
+
+        string exported = chromium
+            ? ChromiumExporter.Export(trace.Source, name)
+            : SpeedscopeExporter.Export(trace.Source, name);
+
+        string outputPath = WriteExport(output, exported);
+        long byteCount = new FileInfo(outputPath).Length;
+
+        ExportResult result = new(chromium ? "chromium" : "speedscope", outputPath, byteCount, name);
+        string hint = chromium
+            ? $"open {outputPath} in chrome://tracing or the Perfetto UI (https://ui.perfetto.dev)"
+            : $"open {outputPath} at https://speedscope.app";
+
+        return OutputJson.Serialize(new AnalysisResult<ExportResult>(result, info.Warnings, [hint]));
+    }
+
+    /// <summary>
     ///  Loads the <paramref name="metric"/> view of the trace, mapping the loader's
     ///  failure modes to a clean <see cref="McpException"/> rather than letting an
     ///  opaque exception propagate to the client.
@@ -366,6 +422,52 @@ public sealed class TraceTools
         }
 
         throw new McpException($"Unknown measure '{measure}'. Valid measures: self, inclusive.");
+    }
+
+    /// <summary>
+    ///  Resolves the export <c>format</c> selector to whether the Chrome-trace exporter
+    ///  is used (otherwise speedscope).
+    /// </summary>
+    private static bool ResolveExportFormat(string format)
+    {
+        if (string.Equals(format, "speedscope", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.Equals(format, "chromium", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        throw new McpException($"Unknown format '{format}'. Valid formats: speedscope, chromium.");
+    }
+
+    /// <summary>
+    ///  Writes the exported flame graph to <paramref name="output"/>, mapping a bad or
+    ///  unwritable path to a clean <see cref="McpException"/>, and returns the absolute
+    ///  path written.
+    /// </summary>
+    private static string WriteExport(string output, string content)
+    {
+        try
+        {
+            string fullPath = Path.GetFullPath(output);
+            File.WriteAllText(fullPath, content);
+            return fullPath;
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or System.Security.SecurityException
+            or ArgumentException)
+        {
+            // A bad or unwritable output path (missing directory, permission denied,
+            // invalid characters) surfaces as a clean tool error rather than an
+            // unhandled exception.
+            throw new McpException($"Could not write '{output}': {ex.Message}");
+        }
     }
 
     private static void RequirePositiveTop(int top)

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -383,6 +383,13 @@ public sealed class TraceToolsTests
             root.GetProperty("result").GetProperty("format").GetString().Should().Be("chromium");
             root.GetProperty("hints").EnumerateArray().Should().Contain(h =>
                 h.GetString()!.Contains("perfetto", StringComparison.OrdinalIgnoreCase));
+
+            // The written file is the Chrome Trace Event Format the exporter produced; its
+            // distinctive marker is the traceEvents array. Asserting on the file content -
+            // not just the envelope - catches a regression that writes the wrong or empty
+            // content to disk.
+            string written = File.ReadAllText(outputPath);
+            written.Should().Contain("\"traceEvents\"");
         }
         finally
         {

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -328,4 +328,104 @@ public sealed class TraceToolsTests
         using JsonDocument doc = JsonDocument.Parse(json);
         doc.RootElement.GetProperty("result").GetProperty("gcs").GetArrayLength().Should().BeLessThanOrEqualTo(1);
     }
+
+    [TestMethod]
+    public void Export_Speedscope_WritesFileAndConfirms()
+    {
+        TraceStore store = new();
+        string outputPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.speedscope.json");
+
+        try
+        {
+            string json = TraceTools.Export(store, FixturePath(Speedscope), outputPath);
+
+            File.Exists(outputPath).Should().BeTrue();
+            using JsonDocument doc = JsonDocument.Parse(json);
+            JsonElement root = doc.RootElement;
+            AssertEnvelopeShape(root);
+
+            JsonElement result = root.GetProperty("result");
+            result.GetProperty("format").GetString().Should().Be("speedscope");
+            result.GetProperty("outputPath").GetString().Should().Be(Path.GetFullPath(outputPath));
+            result.GetProperty("byteCount").GetInt64().Should().BeGreaterThan(0);
+
+            // The hint steers a human to the viewer for the chosen format.
+            root.GetProperty("hints").EnumerateArray().Should().Contain(h =>
+                h.GetString()!.Contains("speedscope.app", StringComparison.Ordinal));
+
+            // The written file is the same speedscope JSON the exporter produced.
+            string written = File.ReadAllText(outputPath);
+            written.Should().Contain("\"$schema\"");
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Export_Chromium_WritesChromeTraceFormat()
+    {
+        TraceStore store = new();
+        string outputPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.chrome.json");
+
+        try
+        {
+            string json = TraceTools.Export(store, FixturePath(Speedscope), outputPath, format: "chromium");
+
+            File.Exists(outputPath).Should().BeTrue();
+            using JsonDocument doc = JsonDocument.Parse(json);
+            JsonElement root = doc.RootElement;
+            AssertEnvelopeShape(root);
+            root.GetProperty("result").GetProperty("format").GetString().Should().Be("chromium");
+            root.GetProperty("hints").EnumerateArray().Should().Contain(h =>
+                h.GetString()!.Contains("perfetto", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Export_UnknownFormat_Throws()
+    {
+        TraceStore store = new();
+        string outputPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.json");
+
+        Action act = () => TraceTools.Export(store, FixturePath(Speedscope), outputPath, format: "perfetto");
+
+        act.Should().Throw<McpException>().WithMessage("*Unknown format 'perfetto'*");
+        File.Exists(outputPath).Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void Export_EmptyOutput_Throws()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Export(store, FixturePath(Speedscope), output: "  ");
+
+        act.Should().Throw<McpException>().WithMessage("*output is required*");
+    }
+
+    [TestMethod]
+    public void Export_UnwritablePath_ThrowsMcpException()
+    {
+        TraceStore store = new();
+
+        // A path into a directory that does not exist is not writable; the failure
+        // surfaces as a clean tool error rather than an unhandled exception.
+        string badPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "nested", "out.json");
+
+        Action act = () => TraceTools.Export(store, FixturePath(Speedscope), badPath);
+
+        act.Should().Throw<McpException>().WithMessage("*Could not write*");
+    }
 }


### PR DESCRIPTION
## Add `trace_export` - the MCP facade's first write tool

Builds on the merged M3 work (#203, #204, #205). Exports a trace's CPU sample source to a speedscope or Chrome-trace flame-graph file an agent can hand a human to open in a viewer.

### A different tool category
Unlike the read-only query tools, `trace_export` writes a file, and the design reflects that:
- annotated `readOnlyHint = false` (the other seven tools are read-only)
- `output` is a **required** path - there is no "write to stdout" under the MCP protocol (stdout is the JSON-RPC stream), unlike the CLI's optional `--output`
- `format` selects `speedscope` (default, opens at speedscope.app) or `chromium` (Chrome Trace Event Format for chrome://tracing or the Perfetto UI); an unknown format is a clean `McpException`
- exports the whole sample source (no folding/scoping/ranking), matching the CLI `export` verb

### The receipt
Its product is a file, not trace data, so it returns a new `ExportResult` (format, absolute path, byte count, profile name) through the **same `AnalysisResult` envelope**, with a **viewer hint** (speedscope.app or the Perfetto UI) in the hints channel. Write failures (missing directory, permission denied, invalid path) map to a clean `McpException`.

`ExportResult` lives in `TraceQ.Core/Output` and joins the source-gen JSON context, so the head stays AOT-clean.

### Tests
Five tool tests (temp files cleaned up via `try`/`finally`): both formats write and confirm, the unknown-format guard (and writes nothing), the empty-output guard, and the unwritable-path failure.

### Validation
- Full `traceq.slnx` builds 0 warnings (`TreatWarningsAsErrors` on); **430 tests pass** (31 in the MCP project, +7 this change).
- The MCP server check sees **8 tools at ~2.6k tokens** (budget 4000) and stdout stays pure; the MCP head reports no IL warnings under the AOT analyzer.

### Deferred (noted in the plan)
`trace_query_events`, the MCP Inspector smoke + scripted client round-trip, and `outputSchema` / `structuredContent`. `trace_trim` stays parked with the `trim` verb.