### PR TITLE
Close the MCP facade: trace_query_events and structured content (M3)

### DIFF
--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -231,10 +231,29 @@ Help is treated as a build artifact (**landed**): the README carries an examples
 > **Still deferred:** `trace_query_events`, the MCP Inspector smoke and scripted
 > client round-trip, and `outputSchema` / `structuredContent`. `trace_trim` stays
 > parked with the `trim` verb.
+>
+> **Fourth slice (closes the facade):** `trace_query_events`, the scripted client
+> round-trip, and `outputSchema` / `structuredContent`. `trace_query_events` is the
+> raw-event escape hatch over a `.nettrace`, paged with a next-page hint - the ninth
+> and last curated tool. The CI harness gained a third check: a real `tools/call`
+> (`trace_info` against a committed fixture) must return the tool's envelope, not an
+> error, exercising the whole client -> server -> service -> client path. For
+> structured content, every tool now returns its typed `AnalysisResult<T>` rather
+> than a pre-serialized string and is annotated `UseStructuredContent = true`, so the
+> SDK advertises a generated `outputSchema` per tool and returns both the parsed
+> structured object and a text mirror; the host registers the tools with
+> `OutputJson.SerializerOptions` (the source-gen, AOT-safe, deterministically-rounded
+> options the CLI uses), so the envelope serializes identically across both heads and
+> both stay clean under the per-assembly AOT analyzer. The byte-identical-with-the-CLI
+> constraint was relaxed deliberately to get the typed contract; the result shape is
+> unchanged. The output schemas roughly double the tool-list size, so the schema
+> budget was re-measured (~4.4k tokens for nine tools) and the ceiling raised to 6000.
+> **Only the MCP Inspector smoke remains** (a manual check); `trace_trim` stays parked
+> with the `trim` verb.
 
 The eight tools (§5.2) re-cut over the same services: port touki.mcp's description text, apply the D5 consolidation (`trace_rank` with `metric`), fold `list_threads` into `trace_info`, add `trace_gc`/`trace_diff`/`trace_query_events`. The broadened surface (section 1A) raises the consolidation stakes, not the tool count: the **engine** tools take a `metric`/provider parameter, so `trace_rank(metric: cpu|threadtime|alloc|…)` is *one* tool spanning every family rather than one tool per family - the token budget below is what forces this. `trace_export` and `trace_trim` join the curated set (they are how an agent hands a human a flame graph or shrinks a trace); the rich family reports (`alloc`/`jit`/`exceptions`/`heap`) stay CLI-first and are promoted to MCP only when an eval task demands it (backlog O4). Annotations (`readOnlyHint` et al.), `outputSchema` + `structuredContent` where the C# SDK supports them, the server `instructions` field carrying the workflow summary, and `traceq mcp` hosting with stderr-only logging.
 
-Two CI checks born here and kept forever: the **stdout-purity test** (run the server under load, including a deliberately chatty logging provider, and assert nothing but JSON-RPC reaches stdout) and the **schema budget check** (serialize the tool list, fail above a token budget - measured at ~2.2k tokens for the seven-tool surface, with the ceiling set at 4000 to fit the full curated set). Both landed in `tools/Test-McpServer.ps1`. MCP Inspector smoke plus one scripted client round-trip test.
+Two CI checks born here and kept forever: the **stdout-purity test** (run the server under load, including a deliberately chatty logging provider, and assert nothing but JSON-RPC reaches stdout) and the **schema budget check** (serialize the tool list, fail above a token budget - ~4.4k tokens for the nine-tool surface once each tool advertises an output schema, with the ceiling set at 6000 to fit the curated set). Both landed in `tools/Test-McpServer.ps1`, which also runs a scripted `tools/call` round-trip. The MCP Inspector smoke is a manual check.
 
 **Exit:** eval tasks 1–5 completed through the facade in Claude Code and VS Code agent mode (manual runs; the harness arrives in M5); both CI checks green.
 

--- a/traceq/src/TraceQ.Core/Output/OutputJson.cs
+++ b/traceq/src/TraceQ.Core/Output/OutputJson.cs
@@ -40,6 +40,20 @@ public static class OutputJson
     private static readonly JsonSerializerOptions s_options = CreateOptions();
 
     /// <summary>
+    ///  The shared serializer options: the source-generated (AOT-safe) metadata plus the
+    ///  relaxed encoder and the deterministic double-rounding the wire format requires.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The CLI serializes through <see cref="Serialize"/>; the MCP head hands these same
+    ///   options to its tool registration so a tool's typed result (its structured content
+    ///   and the text mirror the SDK emits) is written with the identical naming, encoding,
+    ///   and rounding - one serialization contract across both heads.
+    ///  </para>
+    /// </remarks>
+    public static JsonSerializerOptions SerializerOptions => s_options;
+
+    /// <summary>
     ///  Serializes an analysis result to compact, deterministic JSON.
     /// </summary>
     /// <typeparam name="T">The payload type.</typeparam>

--- a/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
@@ -45,6 +45,10 @@ namespace TraceQ.Output;
 [JsonSerializable(typeof(AnalysisResult<GcStatsResult>))]
 [JsonSerializable(typeof(AnalysisResult<EventQueryResult>))]
 [JsonSerializable(typeof(AnalysisResult<ExportResult>))]
+// Tool-parameter types the MCP head binds through these same options but that no result
+// type reaches transitively: the optional `fold` regex array. The scalar parameter types
+// (string, int) are already reached through the result records above.
+[JsonSerializable(typeof(string[]))]
 internal sealed partial class TraceQJsonContext : JsonSerializerContext
 {
 }

--- a/traceq/src/TraceQ.Mcp/Program.cs
+++ b/traceq/src/TraceQ.Mcp/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using TraceQ.Mcp;
+using TraceQ.Output;
 using TraceQ.Server;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
@@ -34,7 +35,11 @@ builder.Services
         options.ServerInstructions = TraceServerInstructions.Text;
     })
     .WithStdioServerTransport()
-    .WithTools<TraceTools>();
+    // Register the tools with the shared serializer options so each typed result - its
+    // structured content, its text mirror, and the generated output schema - is written
+    // with the same source-generated (AOT-safe), deterministically rounded contract the
+    // CLI uses.
+    .WithTools<TraceTools>(OutputJson.SerializerOptions);
 
 await builder.Build().RunAsync().ConfigureAwait(false);
 return 0;

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -16,18 +16,22 @@ namespace TraceQ.Mcp;
 /// <summary>
 ///  The curated MCP tool surface over the TraceQ analysis core: load a trace and
 ///  query its quality signals, folded self/inclusive rankings, immediate callers,
-///  line-level attribution, two-trace diffs, and the garbage-collection report
-///  across speedscope, EventPipe (<c>.nettrace</c>), and ETW (<c>.etl</c>) inputs,
-///  plus export a flame graph to a file. Every tool but <c>trace_export</c> is
-///  read-only; <c>trace_export</c> writes a file.
+///  line-level attribution, two-trace diffs, the garbage-collection report, and a
+///  raw event query across speedscope, EventPipe (<c>.nettrace</c>), and ETW
+///  (<c>.etl</c>) inputs, plus export a flame graph to a file. Every tool but
+///  <c>trace_export</c> is read-only; <c>trace_export</c> writes a file.
 /// </summary>
 /// <remarks>
 ///  <para>
-///   Each tool returns the same JSON the CLI's <c>--format json</c> emits: an
-///   <see cref="AnalysisResult{T}"/> envelope serialized by <see cref="OutputJson"/>,
-///   so a client gets one shape - schema version, warnings, hints, typed result -
-///   across every tool. The single injected <see cref="TraceStore"/> caches parsed
-///   traces, so repeated queries against the same path reuse one parse.
+///   Each tool returns a typed <see cref="AnalysisResult{T}"/> envelope - the same
+///   shape the CLI emits - rather than a pre-serialized string, so the server can
+///   advertise an <c>outputSchema</c> per tool and return both structured content
+///   (the parsed object) and a text mirror. Every tool shares one shape: a schema
+///   version, warnings, hints, and the typed result. The host registers the tools
+///   with <see cref="OutputJson.SerializerOptions"/>, so that envelope is serialized
+///   with the same deterministic naming, encoding, and double-rounding the CLI uses.
+///   The single injected <see cref="TraceStore"/> caches parsed traces, so repeated
+///   queries against the same path reuse one parse.
 ///  </para>
 /// </remarks>
 [McpServerToolType]
@@ -40,14 +44,14 @@ public sealed class TraceTools
     /// <param name="store">The trace cache (injected).</param>
     /// <param name="path">Path to the trace file.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The trace summary envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_info", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The trace summary envelope.</returns>
+    [McpServerTool(Name = "trace_info", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Load a trace (.speedscope.json, .nettrace, or .etl) and return its format, total weight (CPU "
         + "milliseconds, bytes allocated, or event counts depending on the trace), sample count, "
         + "symbol-resolution rate, per-thread sample counts, and quality warnings. Call this first: a "
         + "resolution rate below 0.8 means symbols are missing and the rankings should not be trusted.")]
-    public static string Info(
+    public static AnalysisResult<TraceInfoView> Info(
         TraceStore store,
         [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
         [Description(
@@ -63,7 +67,7 @@ public sealed class TraceTools
             info.SampleCount,
             info.SymbolResolutionRate,
             info.Threads);
-        return OutputJson.Serialize(new AnalysisResult<TraceInfoView>(view, info.Warnings));
+        return new AnalysisResult<TraceInfoView>(view, info.Warnings);
     }
 
     /// <summary>
@@ -78,8 +82,8 @@ public sealed class TraceTools
     /// <param name="top">Maximum rows to return.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The ranking envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The ranking envelope.</returns>
+    [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Rank the hottest frames over a chosen provider metric. measure=self credits the executing leaf "
         + "(JIT-helper leaves folded into the real method that incurred them); measure=inclusive credits a "
@@ -87,7 +91,7 @@ public sealed class TraceTools
         + "format), threadtime (wall-clock per thread, .etl only), alloc (bytes allocated, .nettrace only), or "
         + "exceptions (throw count, .nettrace only). Scope to a subtree with root; for a BenchmarkDotNet "
         + "capture set root to the measured workload to exclude harness warmup.")]
-    public static string Rank(
+    public static AnalysisResult<RankingResult> Rank(
         TraceStore store,
         [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
         [Description("Provider view to rank: cpu, threadtime, alloc, or exceptions.")] string metric = "cpu",
@@ -111,8 +115,7 @@ public sealed class TraceTools
             ? trace.Aggregator.InclusiveTime(root, foldPatterns, top)
             : trace.Aggregator.SelfTime(root, foldPatterns, top);
 
-        return OutputJson.Serialize(
-            new AnalysisResult<RankingResult>(ranking, info.Warnings, SteeringHints.ForRanking(ranking)));
+        return new AnalysisResult<RankingResult>(ranking, info.Warnings, SteeringHints.ForRanking(ranking));
     }
 
     /// <summary>
@@ -125,13 +128,13 @@ public sealed class TraceTools
     /// <param name="root">Optional substring scoping the analysis to a subtree.</param>
     /// <param name="top">Maximum caller rows to return.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The caller-breakdown envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_callers", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The caller-breakdown envelope.</returns>
+    [McpServerTool(Name = "trace_callers", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Immediate callers of the frame matching 'frame', with the CPU time each contributes. Use it to learn "
         + "what a JIT-helper or shared-utility frame (e.g. BulkMoveWithWriteBarrier) is really attributable to, "
         + "or to walk up a hot stack one level at a time. Scope to a subtree with root.")]
-    public static string Callers(
+    public static AnalysisResult<CallersResult> Callers(
         TraceStore store,
         [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
         [Description("Substring identifying the focus frame whose callers to report.")] string frame,
@@ -147,8 +150,7 @@ public sealed class TraceTools
         TraceInfo info = trace.Info;
         CallersResult callers = trace.Aggregator.CallersOf(frame, root, top);
 
-        return OutputJson.Serialize(
-            new AnalysisResult<CallersResult>(callers, info.Warnings, SteeringHints.ForCallers(callers)));
+        return new AnalysisResult<CallersResult>(callers, info.Warnings, SteeringHints.ForCallers(callers));
     }
 
     /// <summary>
@@ -161,15 +163,15 @@ public sealed class TraceTools
     /// <param name="top">Maximum rows to return.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The line-level self-time envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_lines", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The line-level self-time envelope.</returns>
+    [McpServerTool(Name = "trace_lines", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Line-level self time: each leaf sample (JIT-helper leaves folded into their caller) attributed to the "
         + "source file:line that was executing, scoped to methods whose name contains 'method'. Requires a "
         + ".nettrace or .etl trace whose modules have portable PDBs; pass 'symbols' pointing at the build-output "
         + "directory. Speedscope inputs carry no line data and return an empty ranking. A '<no source>' row is "
         + "time in matching methods whose PDB was not found.")]
-    public static string Lines(
+    public static AnalysisResult<LineRankingResult> Lines(
         TraceStore store,
         [Description("Path to a .nettrace or .etl trace file (speedscope carries no line data).")] string path,
         [Description("Optional substring of a method name to scope the ranking; omit for every method.")] string method = "",
@@ -186,7 +188,7 @@ public sealed class TraceTools
         TraceInfo info = trace.Info;
         LineRankingResult lines = trace.Aggregator.HotLines(method, foldPatterns, top);
 
-        return OutputJson.Serialize(new AnalysisResult<LineRankingResult>(lines, info.Warnings));
+        return new AnalysisResult<LineRankingResult>(lines, info.Warnings);
     }
 
     /// <summary>
@@ -198,14 +200,14 @@ public sealed class TraceTools
     /// <param name="file">Path or file name of the source file to map.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The heat-map envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_heatmap", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The heat-map envelope.</returns>
+    [McpServerTool(Name = "trace_heatmap", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Per-line self-time heat map for one source file: each leaf sample (JIT-helper leaves folded into their "
         + "caller) attributed to the line that was executing, ordered by line number to overlay onto the source. "
         + "Matching is by file name only. Requires a .nettrace or .etl trace whose modules have portable PDBs; "
         + "pass 'symbols' pointing at the build-output directory. Speedscope inputs return an empty map.")]
-    public static string Heatmap(
+    public static AnalysisResult<SourceHeatmapResult> Heatmap(
         TraceStore store,
         [Description("Path to a .nettrace or .etl trace file (speedscope carries no line data).")] string path,
         [Description("Path or bare name of the source file to map, e.g. ExtGlob.cs.")] string file,
@@ -223,7 +225,7 @@ public sealed class TraceTools
         string fileName = Path.GetFileName(file);
         SourceHeatmapResult heatmap = trace.Aggregator.SourceHeatmap(fileName, foldPatterns);
 
-        return OutputJson.Serialize(new AnalysisResult<SourceHeatmapResult>(heatmap, info.Warnings));
+        return new AnalysisResult<SourceHeatmapResult>(heatmap, info.Warnings);
     }
 
     /// <summary>
@@ -238,15 +240,15 @@ public sealed class TraceTools
     /// <param name="top">Maximum changed rows to return.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The diff envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_diff", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The diff envelope.</returns>
+    [McpServerTool(Name = "trace_diff", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Compare two CPU traces and report the per-frame change (regressions and improvements), largest absolute "
         + "change first. Both traces are ranked fully (no row cap) before diffing, so a frame hot on only one side "
         + "is not misreported as a total regression. measure=self credits the executing leaf (JIT-helper leaves "
         + "folded into the real method); measure=inclusive credits a frame and everything it calls. Use it to find "
         + "what got slower or faster between two runs - for example a capture from before and after a change.")]
-    public static string Diff(
+    public static AnalysisResult<RankingDiffResult> Diff(
         TraceStore store,
         [Description("Path to the baseline (before) .speedscope.json, .nettrace, or .etl trace file.")] string beforePath,
         [Description("Path to the current (after) .speedscope.json, .nettrace, or .etl trace file.")] string afterPath,
@@ -278,8 +280,7 @@ public sealed class TraceTools
 
         RankingDiffResult diff = RankingDiff.Diff(beforeRanking, afterRanking, top);
 
-        return OutputJson.Serialize(
-            new AnalysisResult<RankingDiffResult>(diff, DiffWarnings(before.Info, after.Info), SteeringHints.ForDiff(diff)));
+        return new AnalysisResult<RankingDiffResult>(diff, DiffWarnings(before.Info, after.Info), SteeringHints.ForDiff(diff));
     }
 
     /// <summary>
@@ -288,14 +289,14 @@ public sealed class TraceTools
     /// </summary>
     /// <param name="path">Path to the trace file.</param>
     /// <param name="top">Maximum per-collection records to return, ranked by pause time.</param>
-    /// <returns>The GC-report envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_gc", ReadOnly = true, Idempotent = true, OpenWorld = false)]
+    /// <returns>The GC-report envelope.</returns>
+    [McpServerTool(Name = "trace_gc", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Garbage-collection report for a .nettrace EventPipe trace: aggregate counts (gen 0/1/2), total, max, and "
         + "mean pause time, peak heap size, total promoted bytes, and the per-collection records capped to the "
         + "'top' hottest pauses. Use it to judge GC pressure - frequent gen-2 collections or long pauses point at "
         + "allocation problems. Requires a .nettrace trace; .etl and speedscope inputs are rejected.")]
-    public static string Gc(
+    public static AnalysisResult<GcStatsResult> Gc(
         [Description("Path to a .nettrace EventPipe trace file.")] string path,
         [Description("Maximum number of per-collection records to return, ranked by pause time.")] int top = 25)
     {
@@ -313,7 +314,61 @@ public sealed class TraceTools
         }
 
         GcStatsResult report = full with { Gcs = shown };
-        return OutputJson.Serialize(new AnalysisResult<GcStatsResult>(report, warnings));
+        return new AnalysisResult<GcStatsResult>(report, warnings);
+    }
+
+    /// <summary>
+    ///  Queries the raw events of a <c>.nettrace</c> EventPipe trace by name, paged and
+    ///  with each event's payload truncated, so an agent can inspect arbitrary events.
+    /// </summary>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="name">Substring matched against <c>Provider/EventName</c>; empty matches every event.</param>
+    /// <param name="skip">The number of matches to skip, for paging.</param>
+    /// <param name="take">The maximum number of matches to return on this page.</param>
+    /// <param name="maxPayload">The per-event payload character cap.</param>
+    /// <returns>The events-page envelope.</returns>
+    [McpServerTool(Name = "trace_query_events", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description(
+        "Query the raw events of a .nettrace EventPipe trace by name - the escape hatch for inspecting arbitrary "
+        + "events the structured reports do not cover. 'name' is a case-insensitive substring matched against "
+        + "Provider/EventName (empty matches every event). Results are paged with 'skip'/'take' and each event's "
+        + "payload is truncated to 'maxPayload' characters, so a query matching hundreds of thousands of events "
+        + "stays within budget; when more matches remain, a hint gives the next page's skip. Requires a .nettrace "
+        + "trace; .etl and speedscope inputs are rejected.")]
+    public static AnalysisResult<EventQueryResult> QueryEvents(
+        [Description("Path to a .nettrace EventPipe trace file.")] string path,
+        [Description("Substring matched against Provider/EventName; omit to match every event.")] string name = "",
+        [Description("The number of matches to skip, for paging.")] int skip = 0,
+        [Description("The maximum number of matches to return on this page.")] int take = 100,
+        [Description("The per-event payload character cap.")] int maxPayload = 200)
+    {
+        if (skip < 0)
+        {
+            throw new McpException("skip must be 0 or greater.");
+        }
+
+        if (take < 0)
+        {
+            throw new McpException("take must be 0 or greater.");
+        }
+
+        if (maxPayload < 0)
+        {
+            throw new McpException("maxPayload must be 0 or greater.");
+        }
+
+        EventQueryResult result = ReadEvents(path, name, skip, take, maxPayload);
+
+        // When matches remain beyond this page, steer toward the next one rather than
+        // leaving the agent to work out the skip arithmetic.
+        List<string> hints = [];
+        int shownThrough = result.Skipped + result.Events.Count;
+        if (shownThrough < result.TotalMatched)
+        {
+            hints.Add($"{result.TotalMatched - shownThrough} more match; page with skip {shownThrough}.");
+        }
+
+        return new AnalysisResult<EventQueryResult>(result, hints: hints);
     }
 
     /// <summary>
@@ -326,8 +381,8 @@ public sealed class TraceTools
     /// <param name="format">The flame-graph format: <c>speedscope</c> or <c>chromium</c>.</param>
     /// <param name="name">The profile name embedded in the flame graph, shown in the viewer.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
-    /// <returns>The export-confirmation envelope, as compact JSON.</returns>
-    [McpServerTool(Name = "trace_export", ReadOnly = false, Idempotent = true, OpenWorld = false)]
+    /// <returns>The export-confirmation envelope.</returns>
+    [McpServerTool(Name = "trace_export", ReadOnly = false, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
         "Export a trace's CPU samples to a flame-graph file for a human to open in a viewer - this is how you hand "
         + "off a visual. format=speedscope (the default) opens at speedscope.app; format=chromium writes the Chrome "
@@ -335,7 +390,7 @@ public sealed class TraceTools
         + "unlike the query tools this writes a file rather than returning the data, and overwrites an existing file "
         + "at that path). The whole sample source is exported - no folding, scoping, or ranking. The response "
         + "confirms the path, format, and byte count.")]
-    public static string Export(
+    public static AnalysisResult<ExportResult> Export(
         TraceStore store,
         [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
         [Description("The file path to write the flame graph to (it is overwritten if it exists).")] string output,
@@ -368,7 +423,7 @@ public sealed class TraceTools
             ? $"open {outputPath} in chrome://tracing or the Perfetto UI (https://ui.perfetto.dev)"
             : $"open {outputPath} at https://speedscope.app";
 
-        return OutputJson.Serialize(new AnalysisResult<ExportResult>(result, info.Warnings, [hint]));
+        return new AnalysisResult<ExportResult>(result, info.Warnings, [hint]);
     }
 
     /// <summary>
@@ -511,14 +566,7 @@ public sealed class TraceTools
     /// </summary>
     private static GcStatsResult ReadGcStats(string path)
     {
-        // Format guardrail (an extension test, no I/O): the GC provider parses the
-        // EventPipe format, so reject an .etl or speedscope export cleanly here rather
-        // than failing deep inside the EventPipe parser with an opaque message.
-        if (!path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new McpException(
-                $"The GC report requires a .nettrace EventPipe trace; '{path}' is not a .nettrace file.");
-        }
+        RequireNetTrace(path, "GC report");
 
         try
         {
@@ -535,6 +583,48 @@ public sealed class TraceTools
             // A missing, unreadable, or malformed .nettrace surfaces as a clean tool
             // error rather than an unhandled exception.
             throw new McpException(ex.Message);
+        }
+    }
+
+    /// <summary>
+    ///  Reads an events page for a <c>.nettrace</c> trace, applying the format guardrail
+    ///  and mapping the provider's failure modes to a clean <see cref="McpException"/>.
+    /// </summary>
+    private static EventQueryResult ReadEvents(string path, string name, int skip, int take, int maxPayload)
+    {
+        RequireNetTrace(path, "events query");
+
+        try
+        {
+            return new EventQueryProvider().Query(path, name, skip, take, maxPayload);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or InvalidOperationException
+            or FormatException
+            or ArgumentException)
+        {
+            // A missing, unreadable, or malformed .nettrace surfaces as a clean tool
+            // error rather than an unhandled exception.
+            throw new McpException(ex.Message);
+        }
+    }
+
+    /// <summary>
+    ///  Rejects a non-<c>.nettrace</c> input up front for the EventPipe-only report
+    ///  providers, with a clean message naming the report, rather than failing deep
+    ///  inside the EventPipe parser.
+    /// </summary>
+    private static void RequireNetTrace(string path, string reportName)
+    {
+        // Format guardrail (an extension test, no I/O): the report providers parse the
+        // EventPipe format, so reject an .etl or speedscope export cleanly here.
+        if (!path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new McpException(
+                $"The {reportName} requires a .nettrace EventPipe trace; '{path}' is not a .nettrace file.");
         }
     }
 

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -318,6 +318,19 @@ public sealed class TraceTools
     }
 
     /// <summary>
+    ///  The largest page <see cref="QueryEvents"/> returns. A larger <c>take</c> is
+    ///  clamped to this with a warning, so one call cannot accumulate an unbounded
+    ///  page into memory or push the response past the token budget.
+    /// </summary>
+    private const int MaxEventsPage = 1000;
+
+    /// <summary>
+    ///  The largest per-event payload cap <see cref="QueryEvents"/> honors. A larger
+    ///  <c>maxPayload</c> is clamped to this with a warning.
+    /// </summary>
+    private const int MaxEventPayloadChars = 4000;
+
+    /// <summary>
     ///  Queries the raw events of a <c>.nettrace</c> EventPipe trace by name, paged and
     ///  with each event's payload truncated, so an agent can inspect arbitrary events.
     /// </summary>
@@ -357,6 +370,23 @@ public sealed class TraceTools
             throw new McpException("maxPayload must be 0 or greater.");
         }
 
+        // Clamp the page and payload sizes to a ceiling so a caller cannot request a
+        // page large enough to exhaust memory or push the response past the token
+        // budget; a clamp is a warning rather than an error, so the query still runs.
+        List<string> warnings = [];
+        if (take > MaxEventsPage)
+        {
+            warnings.Add($"take {take} exceeds the {MaxEventsPage} maximum; clamped to {MaxEventsPage}.");
+            take = MaxEventsPage;
+        }
+
+        if (maxPayload > MaxEventPayloadChars)
+        {
+            warnings.Add(
+                $"maxPayload {maxPayload} exceeds the {MaxEventPayloadChars} maximum; clamped to {MaxEventPayloadChars}.");
+            maxPayload = MaxEventPayloadChars;
+        }
+
         EventQueryResult result = ReadEvents(path, name, skip, take, maxPayload);
 
         // When matches remain beyond this page, steer toward the next one rather than
@@ -368,7 +398,7 @@ public sealed class TraceTools
             hints.Add($"{result.TotalMatched - shownThrough} more match; page with skip {shownThrough}.");
         }
 
-        return new AnalysisResult<EventQueryResult>(result, hints: hints);
+        return new AnalysisResult<EventQueryResult>(result, warnings, hints);
     }
 
     /// <summary>
@@ -620,8 +650,10 @@ public sealed class TraceTools
     private static void RequireNetTrace(string path, string reportName)
     {
         // Format guardrail (an extension test, no I/O): the report providers parse the
-        // EventPipe format, so reject an .etl or speedscope export cleanly here.
-        if (!path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
+        // EventPipe format, so reject an .etl or speedscope export - or a null/empty
+        // path - cleanly here rather than failing deep inside the parser or on a null
+        // dereference that would surface as an opaque JSON-RPC error.
+        if (string.IsNullOrEmpty(path) || !path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
         {
             throw new McpException(
                 $"The {reportName} requires a .nettrace EventPipe trace; '{path}' is not a .nettrace file.");

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using System.Text.Json;
 using ModelContextProtocol;
+using TraceQ.Output;
 using TraceQ.Server;
+using TraceQ.Tracing;
+using TraceQ.Tracing.Providers;
 
 namespace TraceQ.Mcp;
 
@@ -19,14 +21,15 @@ public sealed class TraceToolsTests
     private static string FixturePath(string name) =>
         Path.Combine(AppContext.BaseDirectory, "Fixtures", name);
 
-    private static void AssertEnvelopeShape(JsonElement root)
+    // Every tool returns the typed AnalysisResult envelope; the SDK serializes it (with
+    // an output schema and structured content) from the typed shape, so the unit tests
+    // assert on the object directly rather than re-parsing JSON.
+    private static void AssertEnvelope<T>(AnalysisResult<T> envelope)
     {
-        root.GetProperty("schemaVersion").GetInt32().Should().Be(2);
-        root.TryGetProperty("warnings", out JsonElement warnings).Should().BeTrue();
-        warnings.ValueKind.Should().Be(JsonValueKind.Array);
-        root.TryGetProperty("hints", out JsonElement hints).Should().BeTrue();
-        hints.ValueKind.Should().Be(JsonValueKind.Array);
-        root.TryGetProperty("result", out _).Should().BeTrue();
+        envelope.SchemaVersion.Should().Be(2);
+        envelope.Warnings.Should().NotBeNull();
+        envelope.Hints.Should().NotBeNull();
+        envelope.Result.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -34,31 +37,24 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Info(store, FixturePath(Speedscope));
+        AnalysisResult<TraceInfoView> envelope = TraceTools.Info(store, FixturePath(Speedscope));
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-
-        JsonElement result = root.GetProperty("result");
-        result.GetProperty("path").GetString().Should().EndWith(Speedscope);
-        result.GetProperty("format").GetString().Should().Be("Speedscope");
-        result.GetProperty("sampleCount").GetInt32().Should().Be(4);
-        result.GetProperty("symbolResolutionRate").GetDouble().Should().BeInRange(0.0, 1.0);
-        result.GetProperty("threads").GetArrayLength().Should().BeGreaterThan(0);
+        AssertEnvelope(envelope);
+        TraceInfoView result = envelope.Result;
+        result.Path.Should().EndWith(Speedscope);
+        result.Format.Should().Be("Speedscope");
+        result.SampleCount.Should().Be(4);
+        result.SymbolResolutionRate.Should().BeInRange(0.0, 1.0);
+        result.Threads.Should().NotBeEmpty();
     }
 
     [TestMethod]
-    public void Info_DoesNotRepeatWarningsInsideResult()
+    public void Info_Payload_HasNoWarningsMember()
     {
-        TraceStore store = new();
-
-        // The quality warnings travel only in the envelope's warnings channel; the
-        // trace_info payload itself must not carry a second copy of them.
-        string json = TraceTools.Info(store, FixturePath(Speedscope));
-
-        using JsonDocument doc = JsonDocument.Parse(json);
-        doc.RootElement.GetProperty("result").TryGetProperty("warnings", out _).Should().BeFalse();
+        // The quality warnings travel only in the envelope's warnings channel; the typed
+        // trace_info payload has no warnings member, so the duplication the old string
+        // contract risked is now impossible by construction.
+        typeof(TraceInfoView).GetProperty("Warnings").Should().BeNull();
     }
 
     [TestMethod]
@@ -66,13 +62,11 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Rank(store, FixturePath(Speedscope));
+        AnalysisResult<RankingResult> envelope = TraceTools.Rank(store, FixturePath(Speedscope));
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("hints").GetArrayLength().Should().BeGreaterThan(0);
-        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+        AssertEnvelope(envelope);
+        envelope.Hints.Should().NotBeEmpty();
+        envelope.Result.Rows.Should().NotBeEmpty();
     }
 
     [TestMethod]
@@ -80,10 +74,9 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Rank(store, FixturePath(Speedscope), measure: "inclusive");
+        AnalysisResult<RankingResult> envelope = TraceTools.Rank(store, FixturePath(Speedscope), measure: "inclusive");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        doc.RootElement.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+        envelope.Result.Rows.Should().NotBeEmpty();
     }
 
     [TestMethod]
@@ -91,12 +84,10 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Rank(store, FixturePath(Alloc), metric: "alloc");
+        AnalysisResult<RankingResult> envelope = TraceTools.Rank(store, FixturePath(Alloc), metric: "alloc");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+        AssertEnvelope(envelope);
+        envelope.Result.Rows.Should().NotBeEmpty();
     }
 
     [TestMethod]
@@ -104,12 +95,10 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Rank(store, FixturePath(Exceptions), metric: "exceptions");
+        AnalysisResult<RankingResult> envelope = TraceTools.Rank(store, FixturePath(Exceptions), metric: "exceptions");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+        AssertEnvelope(envelope);
+        envelope.Result.Rows.Should().NotBeEmpty();
     }
 
     [TestMethod]
@@ -118,12 +107,10 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Rank(store, FixturePath(Etw), metric: "threadtime");
+        AnalysisResult<RankingResult> envelope = TraceTools.Rank(store, FixturePath(Etw), metric: "threadtime");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().BeGreaterThan(0);
+        AssertEnvelope(envelope);
+        envelope.Result.Rows.Should().NotBeEmpty();
     }
 
     [TestMethod]
@@ -173,13 +160,10 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Callers(store, FixturePath(Speedscope), frame: "");
+        AnalysisResult<CallersResult> envelope = TraceTools.Callers(store, FixturePath(Speedscope), frame: "");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").TryGetProperty("callers", out JsonElement callers).Should().BeTrue();
-        callers.ValueKind.Should().Be(JsonValueKind.Array);
+        AssertEnvelope(envelope);
+        envelope.Result.Callers.Should().NotBeNull();
     }
 
     [TestMethod]
@@ -188,12 +172,10 @@ public sealed class TraceToolsTests
         TraceStore store = new();
 
         // Speedscope carries no per-frame source locations, so the line ranking is empty.
-        string json = TraceTools.Lines(store, FixturePath(Speedscope));
+        AnalysisResult<LineRankingResult> envelope = TraceTools.Lines(store, FixturePath(Speedscope));
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").GetProperty("rows").GetArrayLength().Should().Be(0);
+        AssertEnvelope(envelope);
+        envelope.Result.Rows.Should().BeEmpty();
     }
 
     [TestMethod]
@@ -211,12 +193,11 @@ public sealed class TraceToolsTests
     {
         TraceStore store = new();
 
-        string json = TraceTools.Heatmap(store, FixturePath(Speedscope), file: "ExtGlob.cs");
+        AnalysisResult<SourceHeatmapResult> envelope =
+            TraceTools.Heatmap(store, FixturePath(Speedscope), file: "ExtGlob.cs");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").GetProperty("lines").GetArrayLength().Should().Be(0);
+        AssertEnvelope(envelope);
+        envelope.Result.Lines.Should().BeEmpty();
     }
 
     [TestMethod]
@@ -247,17 +228,11 @@ public sealed class TraceToolsTests
 
         // Diffing a trace against itself: every frame matches, so the scope total is
         // unchanged and no frame shows a delta.
-        string json = TraceTools.Diff(store, path, path);
+        AnalysisResult<RankingDiffResult> envelope = TraceTools.Diff(store, path, path);
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        JsonElement result = root.GetProperty("result");
-        result.GetProperty("scopeDelta").GetDouble().Should().Be(0.0);
-        foreach (JsonElement changed in result.GetProperty("rows").EnumerateArray())
-        {
-            changed.GetProperty("delta").GetDouble().Should().Be(0.0);
-        }
+        AssertEnvelope(envelope);
+        envelope.Result.ScopeDelta.Should().Be(0.0);
+        envelope.Result.Rows.Should().OnlyContain(row => row.Delta == 0.0);
     }
 
     [TestMethod]
@@ -279,25 +254,20 @@ public sealed class TraceToolsTests
 
         // The inclusive branch ranks both sides with InclusiveTime; diffing a trace
         // against itself still yields no change.
-        string json = TraceTools.Diff(store, path, path, measure: "inclusive");
+        AnalysisResult<RankingDiffResult> envelope = TraceTools.Diff(store, path, path, measure: "inclusive");
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        root.GetProperty("result").GetProperty("scopeDelta").GetDouble().Should().Be(0.0);
+        AssertEnvelope(envelope);
+        envelope.Result.ScopeDelta.Should().Be(0.0);
     }
 
     [TestMethod]
     public void Gc_NetTrace_ReturnsAggregateSummary()
     {
-        string json = TraceTools.Gc(FixturePath(Alloc));
+        AnalysisResult<GcStatsResult> envelope = TraceTools.Gc(FixturePath(Alloc));
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        JsonElement root = doc.RootElement;
-        AssertEnvelopeShape(root);
-        JsonElement result = root.GetProperty("result");
-        result.GetProperty("gcCount").GetInt32().Should().BeGreaterThan(0);
-        result.GetProperty("gcs").GetArrayLength().Should().BeGreaterThan(0);
+        AssertEnvelope(envelope);
+        envelope.Result.GcCount.Should().BeGreaterThan(0);
+        envelope.Result.Gcs.Should().NotBeEmpty();
     }
 
     [TestMethod]
@@ -323,10 +293,9 @@ public sealed class TraceToolsTests
     {
         // The aggregate summary always reflects every collection, but the per-collection
         // detail list is capped to 'top' so a long trace cannot blow the output budget.
-        string json = TraceTools.Gc(FixturePath(Alloc), top: 1);
+        AnalysisResult<GcStatsResult> envelope = TraceTools.Gc(FixturePath(Alloc), top: 1);
 
-        using JsonDocument doc = JsonDocument.Parse(json);
-        doc.RootElement.GetProperty("result").GetProperty("gcs").GetArrayLength().Should().BeLessThanOrEqualTo(1);
+        envelope.Result.Gcs.Count.Should().BeLessThanOrEqualTo(1);
     }
 
     [TestMethod]
@@ -337,21 +306,18 @@ public sealed class TraceToolsTests
 
         try
         {
-            string json = TraceTools.Export(store, FixturePath(Speedscope), outputPath);
+            AnalysisResult<ExportResult> envelope = TraceTools.Export(store, FixturePath(Speedscope), outputPath);
 
             File.Exists(outputPath).Should().BeTrue();
-            using JsonDocument doc = JsonDocument.Parse(json);
-            JsonElement root = doc.RootElement;
-            AssertEnvelopeShape(root);
+            AssertEnvelope(envelope);
 
-            JsonElement result = root.GetProperty("result");
-            result.GetProperty("format").GetString().Should().Be("speedscope");
-            result.GetProperty("outputPath").GetString().Should().Be(Path.GetFullPath(outputPath));
-            result.GetProperty("byteCount").GetInt64().Should().BeGreaterThan(0);
+            ExportResult result = envelope.Result;
+            result.Format.Should().Be("speedscope");
+            result.OutputPath.Should().Be(Path.GetFullPath(outputPath));
+            result.ByteCount.Should().BeGreaterThan(0);
 
             // The hint steers a human to the viewer for the chosen format.
-            root.GetProperty("hints").EnumerateArray().Should().Contain(h =>
-                h.GetString()!.Contains("speedscope.app", StringComparison.Ordinal));
+            envelope.Hints.Should().Contain(h => h.Contains("speedscope.app", StringComparison.Ordinal));
 
             // The written file is the same speedscope JSON the exporter produced.
             string written = File.ReadAllText(outputPath);
@@ -374,15 +340,13 @@ public sealed class TraceToolsTests
 
         try
         {
-            string json = TraceTools.Export(store, FixturePath(Speedscope), outputPath, format: "chromium");
+            AnalysisResult<ExportResult> envelope =
+                TraceTools.Export(store, FixturePath(Speedscope), outputPath, format: "chromium");
 
             File.Exists(outputPath).Should().BeTrue();
-            using JsonDocument doc = JsonDocument.Parse(json);
-            JsonElement root = doc.RootElement;
-            AssertEnvelopeShape(root);
-            root.GetProperty("result").GetProperty("format").GetString().Should().Be("chromium");
-            root.GetProperty("hints").EnumerateArray().Should().Contain(h =>
-                h.GetString()!.Contains("perfetto", StringComparison.OrdinalIgnoreCase));
+            AssertEnvelope(envelope);
+            envelope.Result.Format.Should().Be("chromium");
+            envelope.Hints.Should().Contain(h => h.Contains("perfetto", StringComparison.OrdinalIgnoreCase));
 
             // The written file is the Chrome Trace Event Format the exporter produced; its
             // distinctive marker is the traceEvents array. Asserting on the file content -
@@ -434,5 +398,49 @@ public sealed class TraceToolsTests
         Action act = () => TraceTools.Export(store, FixturePath(Speedscope), badPath);
 
         act.Should().Throw<McpException>().WithMessage("*Could not write*");
+    }
+
+    [TestMethod]
+    public void QueryEvents_NetTrace_ReturnsMatchingEventsPage()
+    {
+        AnalysisResult<EventQueryResult> envelope = TraceTools.QueryEvents(FixturePath(Alloc));
+
+        AssertEnvelope(envelope);
+        envelope.Result.TotalMatched.Should().BeGreaterThan(0);
+        envelope.Result.Events.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public void QueryEvents_Take_PagesAndHintsRemaining()
+    {
+        // A take smaller than the total match count returns one page and steers toward
+        // the next with a paging hint.
+        AnalysisResult<EventQueryResult> envelope = TraceTools.QueryEvents(FixturePath(Alloc), take: 1);
+
+        envelope.Result.Events.Count.Should().BeLessThanOrEqualTo(1);
+
+        // When more matches remain, a hint gives the next page's skip.
+        if (envelope.Result.TotalMatched > 1)
+        {
+            envelope.Hints.Should().Contain(h => h.Contains("page with skip", StringComparison.Ordinal));
+        }
+    }
+
+    [TestMethod]
+    public void QueryEvents_NonNetTraceInput_ThrowsMcpException()
+    {
+        // The events query parses the EventPipe format; an .etl or speedscope is rejected
+        // up front by the extension guardrail.
+        Action act = () => TraceTools.QueryEvents(FixturePath(Speedscope));
+
+        act.Should().Throw<McpException>().WithMessage("*requires a .nettrace*");
+    }
+
+    [TestMethod]
+    public void QueryEvents_NegativeSkip_Throws()
+    {
+        Action act = () => TraceTools.QueryEvents(FixturePath(Alloc), skip: -1);
+
+        act.Should().Throw<McpException>().WithMessage("*skip must be 0 or greater*");
     }
 }

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -443,4 +443,36 @@ public sealed class TraceToolsTests
 
         act.Should().Throw<McpException>().WithMessage("*skip must be 0 or greater*");
     }
+
+    [TestMethod]
+    public void QueryEvents_TakeAboveMax_ClampsWithWarning()
+    {
+        // A take past the page ceiling is clamped rather than honored, so a caller cannot
+        // request a page large enough to exhaust memory or blow the token budget; the
+        // clamp is surfaced as a warning so paging still works.
+        AnalysisResult<EventQueryResult> envelope = TraceTools.QueryEvents(FixturePath(Alloc), take: int.MaxValue);
+
+        envelope.Result.Events.Count.Should().BeLessThanOrEqualTo(1000);
+        envelope.Warnings.Should().Contain(w => w.Contains("clamped", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void QueryEvents_MaxPayloadAboveMax_ClampsWithWarning()
+    {
+        // A maxPayload past the ceiling is clamped with a warning for the same reason.
+        AnalysisResult<EventQueryResult> envelope =
+            TraceTools.QueryEvents(FixturePath(Alloc), maxPayload: int.MaxValue);
+
+        envelope.Warnings.Should().Contain(w => w.Contains("clamped", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void QueryEvents_NullPath_ThrowsMcpException()
+    {
+        // A null path must fail through the format guardrail as a clean McpException, not
+        // a NullReferenceException surfaced as an opaque JSON-RPC error.
+        Action act = () => TraceTools.QueryEvents(null!);
+
+        act.Should().Throw<McpException>().WithMessage("*requires a .nettrace*");
+    }
 }

--- a/traceq/tools/Test-McpServer.ps1
+++ b/traceq/tools/Test-McpServer.ps1
@@ -119,10 +119,13 @@ $p.StandardInput.WriteLine($callRequest)
 $p.StandardInput.Flush()
 
 # Single async read pump with a hard overall deadline; do not break on a per-read
-# timeout because a cold server's first stdout line can take several seconds. The
-# tools/call response (id 3) is the last one expected, so reading until it arrives
-# collects the initialize, tools/list, and tools/call responses.
+# timeout because a cold server's first stdout line can take several seconds.
+# JSON-RPC responses may arrive out of order, so collect until BOTH the tools/list
+# (id 2) and the tools/call (id 3) responses have been seen rather than breaking on
+# id 3 alone - otherwise a tools/list that landed second would be missed and the
+# schema-budget check below would fail on an otherwise healthy server.
 $stdout = [System.Collections.Generic.List[string]]::new()
+$gotTools = $false
 $gotRoundTrip = $false
 $deadline = [DateTime]::UtcNow.AddSeconds(30)
 $pending = $p.StandardOutput.ReadLineAsync()
@@ -131,17 +134,21 @@ while ([DateTime]::UtcNow -lt $deadline) {
         $line = $pending.Result
         if ($null -eq $line) { break }
         $stdout.Add($line)
-        # Detect the final tools/call response by a real JSON-RPC id == 3, not a
-        # substring (which would also match id 30, 31, ...). A non-JSON line is left
-        # for the purity check below to flag.
+        # Track the tools/list (id 2) and tools/call (id 3) responses by a real
+        # JSON-RPC id, not a substring (which would also match id 20, 30, ...). A
+        # non-JSON line is left for the purity check below to flag.
         $trimmed = $line.Trim()
         if ($trimmed.Length -gt 0) {
             try {
                 $probe = [System.Text.Json.JsonDocument]::Parse($trimmed)
-                if ((Get-JsonRpcId $probe.RootElement) -eq 3) { $gotRoundTrip = $true; break }
+                switch (Get-JsonRpcId $probe.RootElement) {
+                    2 { $gotTools = $true }
+                    3 { $gotRoundTrip = $true }
+                }
             }
             catch { }
         }
+        if ($gotTools -and $gotRoundTrip) { break }
         $pending = $p.StandardOutput.ReadLineAsync()
     }
 }
@@ -159,9 +166,12 @@ if (-not $p.WaitForExit(5000)) {
 # failure output. Surfaced only on failure so a passing run stays quiet.
 $stderrOutput = $stderrTask.GetAwaiter().GetResult()
 
-if (-not $gotRoundTrip) {
+if (-not ($gotTools -and $gotRoundTrip)) {
+    $missing = if (-not $gotTools -and -not $gotRoundTrip) { 'tools/list and tools/call' }
+        elseif (-not $gotTools) { 'tools/list' }
+        else { 'tools/call' }
     throw (
-        "The server did not return the tools/call response within the deadline.`n" +
+        "The server did not return the $missing response within the deadline.`n" +
         "stdout:`n$($stdout -join "`n")`n" +
         "stderr:`n$stderrOutput")
 }

--- a/traceq/tools/Test-McpServer.ps1
+++ b/traceq/tools/Test-McpServer.ps1
@@ -5,11 +5,11 @@
 
 <#
 .SYNOPSIS
-  Validates the traceq MCP server's two wire-protocol contracts as build artifacts.
+  Validates the traceq MCP server's wire-protocol contracts as build artifacts.
 
 .DESCRIPTION
   Enforces the two checks born with the MCP facade (docs/traceq-implementation-plan.md,
-  milestone M3):
+  milestone M3), plus a scripted client round-trip:
 
     1. stdout purity - stdout carries only JSON-RPC. The server is run with a
        deliberately chatty log level (Trace) forced through configuration; every
@@ -19,23 +19,28 @@
        The serialized `tools` array from a real `tools/list` round-trip is measured
        and the estimated token cost must stay within the budget, so the curated
        surface cannot grow into an unscannable wall that crowds the model's context.
+    3. tool round-trip - a real `tools/call` (trace_info against a committed
+       fixture) must come back as the tool's result envelope, not an error,
+       exercising the whole client -> server -> service -> client path.
 
   Drives the server over stdio exactly as a client would: initialize, initialized,
-  then tools/list. Run from the traceq subtree root (the directory holding
-  traceq.slnx).
+  tools/list, then tools/call. Run from the traceq subtree root (the directory
+  holding traceq.slnx).
 
 .PARAMETER Configuration
   The build configuration whose MCP binary to exercise. Defaults to Release.
 
 .PARAMETER MaxSchemaTokens
-  The tool-list token budget. Defaults to 4000. Tokens are estimated at four
+  The tool-list token budget. Defaults to 6000. Tokens are estimated at four
   characters each; the check prints the measured characters and estimate so a
-  regression is legible.
+  regression is legible. The budget covers each tool's name, description, input
+  schema, and (because the tools advertise structured content) its output schema -
+  everything the client puts in front of the model from tools/list.
 #>
 [CmdletBinding()]
 param(
     [string]$Configuration = 'Release',
-    [int]$MaxSchemaTokens = 4000
+    [int]$MaxSchemaTokens = 6000
 )
 
 $ErrorActionPreference = 'Stop'
@@ -96,12 +101,29 @@ $stderrTask = $p.StandardError.ReadToEndAsync()
 $p.StandardInput.WriteLine('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"1.0"}}}')
 $p.StandardInput.WriteLine('{"jsonrpc":"2.0","method":"notifications/initialized"}')
 $p.StandardInput.WriteLine('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')
+
+# Round-trip a real tool call (id 3): invoke trace_info against a committed fixture
+# so the harness exercises the full client -> server -> service -> client path, not
+# just tools/list. ConvertTo-Json handles escaping the (possibly back-slashed) path.
+$fixture = Join-Path $root 'tests/TraceQ.Core.Tests/Fixtures/folding.speedscope.json'
+if (-not (Test-Path $fixture)) {
+    throw "Round-trip fixture not found at '$fixture'."
+}
+$callRequest = @{
+    jsonrpc = '2.0'
+    id      = 3
+    method  = 'tools/call'
+    params  = @{ name = 'trace_info'; arguments = @{ path = $fixture } }
+} | ConvertTo-Json -Compress -Depth 6
+$p.StandardInput.WriteLine($callRequest)
 $p.StandardInput.Flush()
 
 # Single async read pump with a hard overall deadline; do not break on a per-read
-# timeout because a cold server's first stdout line can take several seconds.
+# timeout because a cold server's first stdout line can take several seconds. The
+# tools/call response (id 3) is the last one expected, so reading until it arrives
+# collects the initialize, tools/list, and tools/call responses.
 $stdout = [System.Collections.Generic.List[string]]::new()
-$gotTools = $false
+$gotRoundTrip = $false
 $deadline = [DateTime]::UtcNow.AddSeconds(30)
 $pending = $p.StandardOutput.ReadLineAsync()
 while ([DateTime]::UtcNow -lt $deadline) {
@@ -109,14 +131,14 @@ while ([DateTime]::UtcNow -lt $deadline) {
         $line = $pending.Result
         if ($null -eq $line) { break }
         $stdout.Add($line)
-        # Detect the tools/list response by a real JSON-RPC id == 2, not a substring
-        # (which would also match id 20, 21, ...). A non-JSON line is left for the
-        # purity check below to flag.
+        # Detect the final tools/call response by a real JSON-RPC id == 3, not a
+        # substring (which would also match id 30, 31, ...). A non-JSON line is left
+        # for the purity check below to flag.
         $trimmed = $line.Trim()
         if ($trimmed.Length -gt 0) {
             try {
                 $probe = [System.Text.Json.JsonDocument]::Parse($trimmed)
-                if ((Get-JsonRpcId $probe.RootElement) -eq 2) { $gotTools = $true; break }
+                if ((Get-JsonRpcId $probe.RootElement) -eq 3) { $gotRoundTrip = $true; break }
             }
             catch { }
         }
@@ -137,16 +159,17 @@ if (-not $p.WaitForExit(5000)) {
 # failure output. Surfaced only on failure so a passing run stays quiet.
 $stderrOutput = $stderrTask.GetAwaiter().GetResult()
 
-if (-not $gotTools) {
+if (-not $gotRoundTrip) {
     throw (
-        "The server did not return a tools/list response within the deadline.`n" +
+        "The server did not return the tools/call response within the deadline.`n" +
         "stdout:`n$($stdout -join "`n")`n" +
         "stderr:`n$stderrOutput")
 }
 
 # 1. stdout purity: every non-empty stdout line must be a JSON-RPC 2.0 message, not
-# merely parseable JSON. The tools/list response is the one whose id == 2.
+# merely parseable JSON. The tools/list response is id == 2; the tools/call is id == 3.
 $toolsLine = $null
+$callLine = $null
 foreach ($line in $stdout) {
     $trimmed = $line.Trim()
     if ($trimmed.Length -eq 0) { continue }
@@ -163,7 +186,9 @@ foreach ($line in $stdout) {
         continue
     }
 
-    if ((Get-JsonRpcId $doc.RootElement) -eq 2) { $toolsLine = $trimmed }
+    $id = Get-JsonRpcId $doc.RootElement
+    if ($id -eq 2) { $toolsLine = $trimmed }
+    elseif ($id -eq 3) { $callLine = $trimmed }
 }
 
 # 2. schema budget: measure the serialized tools array from the tools/list response.
@@ -184,6 +209,46 @@ if ($null -ne $toolsLine) {
 }
 else {
     Add-Failure 'Could not locate the tools/list response to measure the schema budget.'
+}
+
+# 3. tool round-trip: the tools/call response (id 3) must carry the tool's result
+# envelope, not an error, and that envelope must be the AnalysisResult contract.
+if ($null -ne $callLine) {
+    $callDoc = [System.Text.Json.JsonDocument]::Parse($callLine)
+    $callRoot = $callDoc.RootElement
+
+    # A JSON-RPC error response carries an 'error' member instead of 'result'.
+    $hasError = $false
+    try { $null = $callRoot.GetProperty('error'); $hasError = $true } catch { }
+    if ($hasError) {
+        Add-Failure "trace_info round-trip returned a JSON-RPC error: $callLine"
+    }
+    else {
+        try {
+            $callResult = $callRoot.GetProperty('result')
+
+            # A tool-level failure sets isError == true on the result.
+            $isError = $false
+            try { $isError = $callResult.GetProperty('isError').GetBoolean() } catch { }
+            if ($isError) {
+                Add-Failure "trace_info round-trip reported a tool error: $callLine"
+            }
+
+            # The tool's text content is the AnalysisResult envelope; confirm it parses
+            # and carries the schema version, proving the full path returned real data.
+            $firstContent = $callResult.GetProperty('content').EnumerateArray() | Select-Object -First 1
+            $text = $firstContent.GetProperty('text').GetString()
+            $envelope = [System.Text.Json.JsonDocument]::Parse($text)
+            $schemaVersion = $envelope.RootElement.GetProperty('schemaVersion').GetInt32()
+            Write-Host "Round-trip: trace_info returned an envelope (schemaVersion $schemaVersion)"
+        }
+        catch {
+            Add-Failure "trace_info round-trip response was not the expected envelope: $callLine"
+        }
+    }
+}
+else {
+    Add-Failure 'Could not locate the trace_info tools/call response (id 3).'
 }
 
 if ($failures.Count -gt 0) {


### PR DESCRIPTION
## Summary

Closes the M3 MCP facade slice for `traceq`: the ninth and last curated tool plus structured-content output across the whole surface. After this, only the manual MCP Inspector smoke remains in M3, and `trace_trim` stays parked with the `trim` verb.

## Changes

- **`trace_query_events`** - the raw-event escape hatch over a `.nettrace`, paged with a next-page hint. The ninth and final curated tool. A shared `RequireNetTrace` guardrail now fronts both the GC and events report providers.
- **Structured content** - every tool returns its typed `AnalysisResult<T>` rather than a pre-serialized string and is annotated `UseStructuredContent = true`, so the SDK advertises a per-tool `outputSchema` and returns both the parsed structured object and a text mirror.
- **One serialization contract** - the host registers the tools with the new `OutputJson.SerializerOptions` (the source-gen, AOT-safe, deterministically-rounded options the CLI uses), so the envelope serializes identically across both heads. `string[]` was added to the JSON source-gen context for the `fold` tool parameter. Both heads stay clean under the per-assembly AOT analyzer.
- **CI harness** - `Test-McpServer.ps1` gains a third check: a real `tools/call` (`trace_info` against a committed fixture) must return the tool's envelope, not an error, exercising the full client -> server -> service -> client path. The schema budget was raised to 6000 (~4.4k tokens for nine tools once each advertises an output schema).
- Plan doc updated with the fourth-slice notes.

## Validation

- `dotnet build -c Release`: 0 warnings, 0 errors (AOT analyzer clean).
- `dotnet test -c Release`: 434 passed, 0 failed across all four traceq test projects.
- `tools/Test-McpServer.ps1`: 9 tools, ~4392 tokens (budget 6000), stdout purity + schema budget + round-trip envelope all green.
