### PR TITLE
Add traceq process scoping, processes verb, and ETW capture workflow

### DIFF
--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-testing
-description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `touki.mcp` trace analyzer), or evaluating allocations / memory usage for code in the `touki` library.
+description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project, and translate a user's outcome-shaped performance question into a measurement. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `traceq` trace analyzer), evaluating allocations / memory usage, or when a user asks how long something takes, how much memory it uses, where time is spent, or to help make a method faster - which this skill turns into a scenario, a benchmark, and a drill-down.
 metadata:
   portability: semi-portable
 ---
@@ -17,6 +17,19 @@ available to perf code).
 
 Note: code under `touki/Framework/` is only compiled for the .NET Framework target.
 References to those types from a benchmark must be guarded with `#if NETFRAMEWORK`.
+
+## Starting from a user's question
+
+Users ask outcome questions - "how long does this take?", "how much memory does
+this use?", "where is the time going?", "help me make this faster?" - not tooling
+commands. They will not pick a scenario, write a benchmark, or capture a trace on
+their own; **translating the question into a measurement and leading them through
+it is the job.** Before reaching for the mechanics below, read
+[interpreting-requests.md](interpreting-requests.md): it maps each kind of
+question to the right workflow, says which clarifications to ask (and which to
+answer yourself from the code), walks the "make X faster" journey end to end, and
+lists the follow-ups to offer once a result is in hand. The rest of this skill is
+the *how*; that page is the *what to measure and why*.
 
 **Related skills:**
 
@@ -89,11 +102,15 @@ benchmarks themselves.
 
 ## Sub-pages
 
+- [interpreting-requests.md](interpreting-requests.md) - turning a user's
+  outcome question ("how long?", "how much memory?", "where's the time?", "make
+  it faster") into a scenario, a measurement, an answer in their words, and the
+  next follow-up to offer. Start here when the request is a question, not a task.
 - [authoring.md](authoring.md) - file/class layout, the imported globals, the
   required and optional attributes, and what a benchmark method must do.
 - [running.md](running.md) - the `-f <tfm>` requirement, filtering to a class or
   method, the interactive picker, and useful switches.
 - [profiling.md](profiling.md) - capturing an EventPipe trace and drilling it
-  with the `touki.mcp` analyzer from operation to method to line.
+  with the `traceq` analyzer from operation to method to line.
 - [interpreting-results.md](interpreting-results.md) - before/after discipline on
   both TFMs, reading the memory columns, and the tuple-swap exception.

--- a/.agents/skills/performance-testing/interpreting-requests.md
+++ b/.agents/skills/performance-testing/interpreting-requests.md
@@ -1,0 +1,135 @@
+# From a user's question to a measurement
+
+Detail for the [performance-testing](SKILL.md) skill. The other sub-pages cover
+the *mechanics* - authoring a benchmark, running it, profiling, reading the
+columns. This page covers the step before all of them: turning a vague,
+outcome-shaped user question into a concrete scenario, the right measurement, and
+a useful answer.
+
+Users almost never ask in tooling terms. They ask "how long does this take?",
+"how much memory does this use?", "where is the time going?", or "help me make
+this faster". They do not know to capture a trace, write a benchmark, pick a
+scenario, or drill from method to line - **that translation is your job.** Lead
+them through it; do not hand back a tool and a shrug.
+
+## Map the question to the workflow
+
+| The user asks | They want | What you do |
+|---|---|---|
+| "How long does X take?" / "Is X fast enough?" | a latency number for a real scenario | benchmark the scenario, report `Mean` + error on both TFMs ([authoring](authoring.md), [running](running.md)) |
+| "How much memory does X use?" / "Does X allocate?" | bytes per operation | `[MemoryDiagnoser]` benchmark, report `Allocated` on both TFMs ([interpreting-results](interpreting-results.md)) |
+| "Where is the time spent?" / "Why is X slow?" | the hot method or line | profile a trace (EventPipe on net10, **ETW on net481**), rank -> callers -> lines ([profiling](profiling.md)) |
+| "What's allocating?" / "What's the GC doing?" | the hot alloc site / GC pressure | the allocation or GC view of a trace ([profiling](profiling.md)) |
+| "Make X faster" / "improve this method" | a *verified* improvement | the full loop below: scenario -> baseline -> profile -> change -> re-measure |
+| "Did my change help / regress anything?" | a before/after delta | baseline before, re-run after, diff both TFMs ([interpreting-results](interpreting-results.md)) |
+
+## First, nail the scenario - a method has no single "speed"
+
+Cost depends on inputs. Before writing any benchmark, decide *what* to measure.
+Read the method and answer as much as you can from the code, then ask the user
+only what the code cannot tell you. Offer a default with every question so they
+can just say "yes".
+
+Things worth pinning down:
+
+- **Inputs and sizes.** Typical case, and the worst case that matters. For a
+  span/string API: empty, small, large, and any pathological shape (all-match,
+  no-match, deep nesting). Propose a representative set.
+- **Target framework(s).** Default to **both** `net10.0` and `net481` when the
+  code compiles for both - results diverge and that divergence is often the
+  point. Only narrow to one if the user says so or the code is `#if NET`-only.
+- **Latency vs throughput.** A per-call latency number and a bulk-throughput
+  number answer different questions; ask which they care about.
+- **A baseline to compare against.** "Fast" is meaningless alone. Compare against
+  the BCL equivalent, the previous implementation, or a stated target.
+
+**Do not stall on questions you can answer yourself.** If the inputs are obvious
+from the signature, state the scenario set you picked ("I'll measure empty, a
+32-char, and a 4 KB input on both TFMs") and proceed. Asking the user to spell
+out what you could have read is its own failure.
+
+## The "make X faster" journey - lead them through it
+
+This is the request that most needs handholding. Walk these steps out loud, one
+at a time, so the user sees the method:
+
+1. **Find the scenario.** Read the method, identify the inputs that drive cost,
+   propose a representative set. Confirm or proceed with stated assumptions.
+2. **Establish the baseline.** Write a benchmark in `touki.perf` ([authoring](authoring.md)),
+   run it on both TFMs, and report the table. This *is* the answer to "how slow
+   is it today", and it is the thing every later change is measured against. The
+   benchmark stays in the repo as the regression guard - do not throw the
+   scenario away.
+3. **Find where the cost is.** Profile the baseline ([profiling](profiling.md)):
+   rank -> callers -> lines for CPU, or the allocation view if `Allocated` is the
+   problem. Tell the user the hot spot in plain language ("62% of the time is in
+   the inner copy loop at `ExtGlob.cs:214`; it re-walks the segment each pass").
+4. **Form a hypothesis tied to the evidence, then change one thing.** Connect the
+   edit to what the profile showed. For *how* to write the hot path, branch to
+   the codegen skills: [framework-jit-optimization](../framework-jit-optimization/SKILL.md)
+   for specialization / unrolling / BCL-delegation, and
+   [scratch-buffer-strategy](../scratch-buffer-strategy/SKILL.md) for
+   stackalloc vs pool vs `BufferScope`.
+5. **Verify on both TFMs.** Re-run the baseline benchmark, diff against the saved
+   numbers, and confirm the *targeted* frame actually moved and nothing regressed
+   - especially `Allocated`, and especially the *other* TFM ([interpreting-results](interpreting-results.md)).
+   A faster wall clock with the targeted frame unchanged is noise or a different
+   win; say so.
+6. **Report and offer the next drill.** Show the before/after for both TFMs and
+   the line-level evidence, then suggest the logical follow-up.
+
+## Translate the numbers back into the user's words
+
+Do not paste a raw table and stop. Answer the question they asked:
+
+- *How long?* -> "About 180 ns per call for a typical 32-char input, rising to
+  ~12 us for a 4 KB input. That's roughly 1.4x the BCL's `string.Format` on
+  net10, and 3x faster on net481 where the BCL path has no vectorization."
+- *How much memory?* -> "It's allocation-free on the span path (0 B). The string
+  overload allocates one result string of N bytes and nothing else." or "It
+  allocates a 1 KB array per call - that's the buffer it never pools."
+- *Where?* -> "Two thirds of the time is in `<method>` at `<file:line>`, doing
+  `<what>`. The rest is the bounds checks the loop repeats."
+
+Always surface a **both-TFM divergence** when there is one - it is frequently the
+most actionable thing you can say.
+
+## Follow up - suggest the next question, don't wait for it
+
+After every result, the user usually has a next question they have not formed
+yet. Offer it:
+
+- After a **latency** number -> "Want the allocation profile too, or a comparison
+  against the BCL / your previous version?"
+- After a **memory** number -> "Want me to find the allocation site, or try a
+  pooled / `stackalloc` version and measure it?"
+- After a **hot spot** -> "Want me to try `<specific change the evidence
+  suggests>` and measure whether it helps?"
+- After a **shallow line/heat map** (too few samples to attribute per line) ->
+  "EventPipe sampled too coarsely to pin the hot lines; want me to re-capture
+  under ETW (~1 kHz) for a deeper heat map?" See
+  [profiling.md](profiling.md) - "When line attribution is too sparse".
+- After an **improvement** -> "Want me to push the scenario harder (larger input,
+  worst case), or check whether the win holds on the other TFM?"
+- After a **surprising divergence** -> "The net481 path is 3x slower here; want me
+  to dig into why (likely the missing vectorized BCL API)?"
+
+## Anti-patterns
+
+- **Handing back tooling instead of an answer.** "You can run a benchmark with
+  `dotnet run ...`" is a failure when the user asked "is this fast?". Run it and
+  tell them.
+- **Measuring without a scenario.** A benchmark over an unrepresentative input
+  answers a question nobody asked. Pin the scenario first.
+- **One TFM when the code targets both.** The divergence is usually the story -
+  and on net481 it is often not just a different number but a different *hotspot*:
+  the Framework JIT inlines far less, so the hot frame can move entirely. Profile
+  net481 directly under ETW rather than reading its hotspot off the net10 EventPipe
+  trace (see [profiling](profiling.md)).
+- **A single Mean with no error bars or allocation column.** Sub-microsecond
+  deltas on this machine are noise; trust `Allocated` and deltas outside
+  `Error`/`StdDev` ([interpreting-results](interpreting-results.md)).
+- **Optimizing before profiling.** "Where is the time" has an evidence-based
+  answer; guessing wastes the change.
+- **Declaring victory from a wall-clock drop alone.** Confirm the targeted cost
+  moved and nothing else regressed.

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -4,9 +4,13 @@ Detail for the [performance-testing](SKILL.md) skill.
 
 To find where a benchmark spends its time - optimizing a hot path or chasing a
 regression - capture an EventPipe CPU trace on `net10.0`, then drill it with the
-in-workspace [touki.mcp](../../../touki.mcp/touki.mcp.csproj) analyzer. It reads
-the trace through TraceEvent, folds the JIT-helper sampling artifacts, and ranks
-by method or by source `file:line`. One capture serves both:
+in-workspace [traceq](../../../traceq/README.md) analyzer. It reads the trace
+through TraceEvent, folds the JIT-helper sampling artifacts, and ranks by method
+or by source `file:line`. traceq is registered as an MCP server in
+[.vscode/mcp.json](../../../.vscode/mcp.json), so **an agent calls its tools
+directly** - `trace_info` first, then `trace_rank` / `trace_callers` /
+`trace_lines` / `trace_heatmap`. The equivalent CLI verbs (below) are the manual
+fallback. One capture serves every drill:
 
 ```powershell
 # Capture once. --keepFiles preserves BDN's build so its PDB GUID survives for
@@ -21,23 +25,32 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
 $sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
 
 # Method ranking, scoped to a workload frame (which method owns the self-time).
-dotnet run --project touki.mcp -c Release -- analyze $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+dotnet run --project traceq/src/TraceQ -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
 
 # Line ranking inside the dominant method (which lines of its hot loop dominate).
-dotnet run --project touki.mcp -c Release -- analyze $trace --lines RunEngine --symbols $sym --top 30
+dotnet run --project traceq/src/TraceQ -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
 
 # Who calls a folded JIT-helper artifact, to confirm what it's attributable to.
-dotnet run --project touki.mcp -c Release -- analyze $trace --callers 'BulkMoveWithWriteBarrier'
+dotnet run --project traceq/src/TraceQ -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
 ```
 
-An agent that speaks MCP calls the equivalent tools directly (`hotspots_self`,
-`hotspots_inclusive`, `hot_lines`, `callers_of`, `load_trace`, `list_threads`).
+The MCP tools map onto those verbs one-to-one: `trace_rank` (with
+`measure: self|inclusive`) for the method ranking, `trace_lines` for the line
+ranking, `trace_callers` for the caller breakdown, and `trace_info` for the
+load-and-summarize the other tools do implicitly.
 
 Things that bite, kept short - full rationale in
 [docs/performance-investigation.md](../../../docs/performance-investigation.md)
 sections 3a (methods) and 3f (lines):
 
-- **EventPipe is net10.0-only** - net481 needs `[EtwProfiler]` + admin.
+- **EventPipe is net10.0-only** - net481 has no EventPipe, so profile it under
+  ETW instead (see [Capturing under ETW](#capturing-under-etw-net481-denser-samples-native-frames)
+  and [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1)); never
+  read a net481 hotspot off a net10 trace. EventPipe's CPU sampler is also fixed
+  at **~100 Hz** and **net10 cannot raise it**
+  (`DOTNET_EventPipeThreadSamplingRate` is .NET 11+, and only makes sampling
+  *coarser*); when that resolution is too sparse for line-level work, escalate to
+  ETW (see below).
 - **Fold the artifacts.** A raw self-time view shows `0 ms` per method (the leaf
   is a synthetic `CPU_TIME` marker), and the managed-only walker mislabels
   JIT-helper thunks (`BulkMoveWithWriteBarrier`, `Thread.PollGCWorker`,
@@ -52,8 +65,77 @@ sections 3a (methods) and 3f (lines):
   `<no source>` or is rejected with a GUID mismatch.
 - **Line attribution stops at inlined boundaries** - a fully-inlined callee
   collapses onto its caller's call-site line. If the ranking piles onto one or
-  two call-site lines, scope `--lines` to the callee (`--lines ExtGlobEngine`)
+  two call-site lines, scope `--method` to the callee (`--method ExtGlobEngine`)
   or add a temporary `[MethodImpl(MethodImplOptions.NoInlining)]`.
+
+## Capturing under ETW (net481, denser samples, native frames)
+
+EventPipe is net10-only and managed-only. Reach for an ETW (`.etl`) capture in
+three situations - the first is the one that bites hardest:
+
+1. **Profiling net481 at all.** The Framework target has no EventPipe, so ETW is
+   the only profiler - and the net481 hotspot can differ *completely* from net10,
+   so never extrapolate a Framework ranking from a net10 EventPipe trace. Worked
+   example (the `!(bin|obj)/**/*.cs` glob enumeration): `ExtGlobEngine.ProduceAlternative`
+   was **~1.5 %** of self-time on the net10 EventPipe trace and **56 %** on the
+   net481 ETW trace, because .NET Framework 4.8.1 RyuJIT inlines far less and
+   leaves that method standing as its own frame. The net10 profile actively
+   misleads about where net481 spends its time.
+2. **Native frames are the suspect** - ETW resolves coreclr / clrjit / ntdll and
+   the GC, which the managed-only EventPipe walker cannot see.
+3. **Line attribution is too sparse** - kernel CPU sampling is ~1 kHz, ~10x
+   EventPipe's fixed ~100 Hz, so a short hot path spreads across more source lines
+   (escalation detail below).
+
+**Capture it with one command.** [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1)
+self-elevates (one UAC prompt), shows the benchmark's **live** progress in the
+elevated window (output is teed, never redirected with `*>`, so it never looks
+hung), checks that the `BenchmarkDotNet.Diagnostics.Windows` package is
+referenced - without it `-p ETW` silently no-ops - and prints the exact,
+process-scoped next-step traceq commands:
+
+```powershell
+./tools/Capture-EtwTrace.ps1 -Filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingle'
+```
+
+**An `.etl` is a machine-wide capture - scope it to your process.** traceq
+auto-scopes to the busiest process *by CPU sample count* (the quantity the
+rankings consume), which is normally the benchmark; but a noisy background app
+(antivirus, a VPN client) can own enough samples to win, so pass `--process <name>`
+to pin it. **Every CPU verb takes it** - `cpu`, `rank`, `threadtime`, `lines`,
+`callers`, `heatmap` (and the matching `trace_*` MCP tools). `traceq processes
+<etl>` lists every process by weight so you can choose the right target. Quiesce
+other CPU consumers before capturing, or scope explicitly.
+
+**`threadtime` vs `cpu`.** `threadtime` (ETL-only) is wall-clock per thread -
+running *and* blocked - while `cpu` is on-CPU time. When they agree closely the
+work is CPU-bound (the glob example: 56.45 % cpu vs 56.46 % threadtime - no
+blocking); when `threadtime` is much larger the frame is waiting on I/O or a lock.
+
+### When line attribution is too sparse
+
+EventPipe's CPU sampler is fixed at **~100 Hz** - one sample per managed thread
+roughly every 10 ms - and on **net10 you cannot raise it**
+(`DOTNET_EventPipeThreadSamplingRate` is .NET 11+, and only makes sampling
+*coarser*, never finer). A `lines` or `heatmap` over a short benchmark therefore
+lands too few samples in the hot code to spread across source lines: you get a
+handful of rows, not a dense per-line picture. **When the resolution is not
+granular enough for the attribution you need, say so and escalate** - cheapest
+first:
+
+1. **Rule out inlining collapse first** (the bullet above). A fully-inlined
+   callee piles its heat onto one call-site line at *any* sample rate, so a finer
+   capture will not help until you split it. Cheap to check, so check it first.
+2. **Lengthen the measured work** so more 10 ms ticks fall inside the hot path -
+   profile a larger input or the long-running scenario rather than a
+   microbenchmark. The fixed rate over a multi-second workload still accumulates
+   thousands of samples and a stable per-line tree.
+3. **Capture under ETW** (the one-command recipe above). Kernel CPU sampling
+   defaults to **~1 ms (~1 kHz)** - roughly 10x denser than EventPipe's fixed
+   ~100 Hz - and is true on-CPU time that also resolves native frames, so a
+   genuinely short hot path spreads across far more source lines. This is the real
+   lever for line-level depth. See [docs/performance-investigation.md](../../../docs/performance-investigation.md)
+   sections 3b (`EtwProfiler`) and 3e (sample density).
 
 The older `Profile-Benchmark.ps1` / `Get-TraceHotspots.ps1` scripts predate the
 analyzer and remain as a no-MCP fallback (plus `speedscope-to-flamegraph.ps1`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <!-- Referencing our own package for the sample project to document consumption. -->
     <PackageVersion Include="KlutzyNinja.Touki" Version="0.2.0-alpha.1" />

--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -1,6 +1,16 @@
 # `traceq` implementation plan
 
 **Status:** Active — Q1–Q3 resolved (§6)
+**Dogfooding hardening (2026-06-10):** A real net481 ETW profiling session folded
+its findings back into the tool - see [§7](#7-dogfooding-hardening-2026-06-10-etw-capture-process-scoping-and-the-runtime-symbol-plan).
+Shipped: process scoping on the line-level verbs and the MCP tools (A1), a
+sample-count busiest-process auto-scope (A2), a `processes` inventory verb (A3),
+the [tools/Capture-EtwTrace.ps1](../tools/Capture-EtwTrace.ps1) capture wrapper
+(C1), and the rewritten ETW skill (D). **What's next: the runtime-symbol plan
+([§7.6](#76-whats-next-the-runtime-symbol-plan-managed--unmanaged))** - resolve
+managed *and* unmanaged runtime symbols so a profile can say where time actually
+goes (zeroing memory? copying strings?), then resume the product milestones at
+M3½ (promotion).
 **Progress (2026-06-09):** M0 complete (PR #182). M1's analysis core is complete and M2 (the CLI head) is the active milestone. M1 landings - core relocation merged (PR #183); provider/engine seam laid (`StackSampleSource` + `MetricInfo`); output-contract envelope landed (`AnalysisResult<T>` + compact, rounded, deterministic JSON with golden tests); symbol gate landed (`SymbolGate`; `--strict`/exit-3 deferred to M2); tier-2 LRU landed (`LruCache`); token budget landed (`OutputBudget`; truncation + text renderer deferred to M2); fixture corpus + parity harness landed for the net10 EventPipe half (PR #186); allocation provider landed (`AllocationProvider` reads `GCAllocationTick` into byte-weighted stacks ranked by the same metric-generic engine - `SampleStack.Weight`); GC-stats provider landed (`GcStatsProvider` reads `TraceGC` structured records, reusing the GC-verbose fixture). **ThreadTime landed (ETW):** the earlier EventPipe spike was a strictly worse CPU view (no `BLOCKED_TIME`, since EventPipe samples only running threads), but the net481 ETW capture carries context switches, so `ThreadTimeProvider` reconstructs each thread's running and blocked intervals into elapsed-millisecond stacks (`MetricInfo.ThreadTime`) the metric-generic engine ranks unchanged. Export engine verb landed (`SpeedscopeExporter` writes any provider's stacks to the speedscope sampled format, metric-aware unit). Filter/scope grammar subset landed (`ScopeFilter` include/exclude on frame names; sample-level time/process scoping deferred for model + fixture reasons). Diff engine verb landed (`RankingDiff` compares two rankings - provider-agnostic regression/improvement deltas). Group transform landed (`GroupTransform` collapses a matched module's frames into a `module!` box). Chromium export landed (`ChromiumExporter` writes any provider's stacks to the Chrome Trace Event Format). EventQuery provider landed (`EventQueryProvider` paginated raw-event query with payload cap). JitStats provider landed (`JitStatsProvider` per-method JIT compile-time / size / tier records, with a tuned `JitLoop` smoke fixture). Steering-hint taxonomy landed (`SteeringHints` turns a ranking, callers, or diff result into the canonical next-step nudge). The net481 ETW (`.etl`) corpus half landed: an `EtwLoop` benchmark captured under the ETW profiler with context-switch keywords, a process-tree relog `trim` (native-only; the managed-JIT limit and the physical-trim follow-up are captured in [traceq-etl-trimming.md](traceq-etl-trimming.md)), and a committed ~1 MB multi-process scenario fixture. Process-tree scoping landed (`ProcessScope` + read-time filtering in the ETL/EventPipe reader): a machine-wide capture is scoped losslessly to the workload process tree and its children at analysis time, resolving the workload's managed frames. The tier-1 ETLX disk cache is deferred with reason (TraceEvent already caches `.nettrace`/`.etl` -> `.etlx` on both paths; a custom cache adds nothing measurable without the elevated `.etl` half). ThreadTime landed over the ETW capture (`ThreadTimeProvider`: running + blocked intervals into elapsed-millisecond stacks). The O1 cross-machine hand-off spike passed: a Windows-converted `.etlx` resolves managed frames byte-identically on Ubuntu 26.04, so the hand-off is advertised (only the `.etl` -> `.etlx` conversion stays Windows-only). Exceptions provider landed (`ExceptionsProvider` reads `Exception/Start` events into count-weighted throw-site stacks). The text renderer (landed in M2) and the grouping altitude (`GroupTransform`, landed in M1) are no longer outstanding, so the only deferred M1 work is the sample-level time- and process-filter altitudes (M1 step 5, parked for want of fixture data - distinct from the read-time `ProcessScope`, which is already built). **M2 (CLI head):** the engine verbs `rank`/`cpu`/`callers`/`lines`/`heatmap`/`diff`/`tree`/`export` have merged (PRs #195-198); the fifth slice has wired the provider-selection seam (a `TraceMetric` selector threaded through `TraceStore` -> `TraceLoader`, which dispatches to each provider and synthesizes the `TraceInfo` for the non-CPU families) and lit up the three stack-source family shortcuts - `alloc`, `exceptions`, and `threadtime` - each selectable as `rank --metric <name>` or its own verb (PR #199), and added the three report verbs `gcstats` / `jitstats` / `events` (structured records rather than rankable stacks, each with its own executor and renderer), and wired the `--process` / `--all-processes` scope options onto the stack-ranking verbs (a `ScopeRequest` intent the loader resolves to a process tree, defaulting to the busiest process automatically). M2's verb surface is complete, and the CLI head is closed out: the `--benchmark` scope option (frame-based, presets the root to the BenchmarkDotNet workload wrapper) and the `convert` / `clean` file-op verbs landed, the CLI packages as a local `dotnet tool` (an exit criterion), and a CI help-lint guards the help/README contract. `heap` stays unbuilt (no provider yet, Addendum A capture work); `trim` stays parked (the relog rewrite resolves native frames only - see traceq-etl-trimming.md); the eval-task exit criterion rides the M5 harness. See the M2 section for detail.
 **Date:** 2026-06-04
 **Basis:** *Agentic access to TraceEvent — design document* (2026-06-04). Section references (§) and decisions (D#) below point at that document.
@@ -380,6 +390,193 @@ AOT publish.
 The promoted repo and the first private packages need the final name, so the *decision* gates promotion — but the availability pass is an M0 task because it's cheap, and a squatted ID discovered mid-promotion would be annoying. Criteria: ≤ 7 chars for the tool command, unsquatted on NuGet (`<Name>`, `<Name>.Core`, `<Name>.Mcp`) and as a GitHub repo, no collision with existing .NET perf tooling (note: "TraceLens" is taken by an existing tracing product), pronounceable in a sentence ("just traceq it"). Current placeholder `traceq` plausibly survives; alternatives worth the pass: `perfq`, `hotpath`, `stackq`. Bikeshedding is not an M0 task.
 
 ---
+
+## 7. Dogfooding hardening (2026-06-10): ETW capture, process scoping, and the runtime-symbol plan
+
+> Folded in from the standalone ETW-improvement plan after a real net481 ETW
+> profiling session (the `!(bin|obj)/**/*.cs` extended-glob enumeration worst
+> case) drove a round of fixes back into the tool. Evidence is recorded in repo
+> memory (`extglob-perf.md`, `mcp-line-level.md`). A1-A3, C1, and D shipped
+> (built + tested green); the runtime-symbol plan (§7.6) is the explicit next
+> step.
+
+### 7.0 Why this section exists
+
+EventPipe (`-p EP`, `.nettrace`) is net10-only and managed-only. The real pain
+in this library is **net481** (.NET Framework 4.8.1 RyuJIT), where the same glob
+workload ran ~11.8x slower than net10 - and where weaker inlining relocates the
+hot frame entirely. Only ETW can profile net481, and the session proved the
+EventPipe ranking actively *misleads* for Framework: `ExtGlobEngine.ProduceAlternative`
+was ~1.5% self-time on the net10 EventPipe trace and **56%** on the net481 ETW
+trace (56.45% cpu vs 56.46% threadtime - so purely CPU-bound, no blocking).
+`CompareOrdinalIgnoreCaseAsciiFold` + `CompareAscii` were ~9% (the IgnoreCase
+ASCII fold net481 cannot vectorize). Capturing and analyzing that ETW trace
+exposed four sharp edges, now fixed, plus one gap that is the next milestone.
+
+### 7.1 The friction the session surfaced
+
+| Friction | Root cause | Fix |
+|---|---|---|
+| `lines` / `callers` / `heatmap` analyzed the wrong process (a background VPN client, not the benchmark) | Those three verbs had no `--process`; auto-scope picked max `CPUMSec` over the whole capture | A1 |
+| The MCP tools could not scope to a process at all | No `process` param on any MCP tool | A1 |
+| The auto-scope itself picked the wrong process | `FindBusiestProcessName` ranked by whole-capture `CPUMSec`, which a long-lived service wins over a short benchmark | A2 |
+| "Who is even in this capture?" had no answer | No process-inventory verb | A3 |
+| `-p ETW` was unavailable; the elevated capture window looked hung | `BenchmarkDotNet.Diagnostics.Windows` not referenced; capture redirected all streams to a log with `*>` | C1 / C2 |
+| Native runtime frames stay unresolved (~10% of the net481 trace was an unresolved `?` leaf - memcpy / GC / zeroing) | `SymbolReader` built with an empty symbol path, never reaches a symbol server | **§7.6 (next)** |
+
+### 7.2 A1 - process scoping on `lines` / `callers` / `heatmap` (shipped)
+
+The machinery already existed (`RankRequestFactory.TryResolveScope`, the
+scope-threaded `TraceExecution.TryLoad(..., ScopeRequest)` overload used by
+`cpu` / `rank` / `threadtime`); the line-level verbs just did not pass it. Now
+all three CLI verbs take `--process` / `--all-processes`, the three request
+records carry a `ScopeRequest`, and the MCP `trace_lines` / `trace_callers` /
+`trace_heatmap` (and `trace_rank` / `trace_info`) tools take a `process`
+parameter. Covered by new CLI and MCP tests (mutual-exclusion on every leg;
+Windows narrowing on the `etw.etl` fixture).
+
+### 7.3 A2 - sample-count busiest-process auto-scope (shipped)
+
+`ProcessTree.FindBusiestProcessName` now ranks by **CPU sample count** - the
+quantity the rankings actually consume - instead of `TraceProcess.CPUMSec`. A
+long-lived background service (antivirus, a VPN client) accumulates more kernel
+CPU across the whole capture window than a short benchmark, yet owns a tiny
+fraction of the profile's samples; counting samples picks the workload (39,003
+samples) over the noise (~600). One extra lightweight event pass (process id
+only, no stack walk), run only for the automatic scope. Pinned by a regression
+test asserting the auto-scope retains the most-sampled process's samples.
+
+### 7.4 A3 - the `processes` inventory verb (shipped)
+
+`traceq processes <trace>` lists every process by sample weight (CLI-only, like
+`tree` / `jitstats`), so the first move on any multi-process `.etl` is "who is
+actually here?" before scoping. Backed by `FoldingAggregator.Processes()` ->
+`ProcessListResult`; the `Capture-EtwTrace.ps1` output points at it first.
+
+### 7.5 C1 / C2 / D - capture script, package, skill (shipped)
+
+- **C1** - [tools/Capture-EtwTrace.ps1](../tools/Capture-EtwTrace.ps1): the net481
+  ETW analog of `tools/Profile-Benchmark.ps1`. Self-elevates (one UAC prompt),
+  shows the benchmark's **live** progress in the elevated window (output is
+  `Tee-Object`'d, never redirected with `*>`, so it never looks hung), checks the
+  `BenchmarkDotNet.Diagnostics.Windows` reference, and prints the exact
+  process-scoped next-step traceq commands.
+- **C2** - `BenchmarkDotNet.Diagnostics.Windows` (0.15.8) added to
+  `Directory.Packages.props` + `touki.perf.csproj`; the prerequisite for `-p ETW`
+  to exist. Kept.
+- **D** - the ETW section of
+  [.agents/skills/performance-testing/profiling.md](../.agents/skills/performance-testing/profiling.md)
+  was rewritten to lead with "always ETW-profile net481 directly; never
+  extrapolate the ranking from a net10 EventPipe trace," plus the multi-process
+  trap, the capture recipe, and threadtime-vs-cpu;
+  [interpreting-requests.md](../.agents/skills/performance-testing/interpreting-requests.md)
+  warns that the net481 hotspot can be a different *frame*, not just a different
+  number.
+
+### 7.6 What's next: the runtime-symbol plan (managed + unmanaged)
+
+**The question this answers.** "Where do we actually spend time - zeroing memory?
+copying strings? in the GC? in the JIT?" Today a profile cannot say: the hot
+*managed* method resolves, but the runtime work it bottoms out in shows as an
+unresolved `?` leaf (~10% of the net481 trace) or is folded away as a JIT-helper
+artifact. The goal is to name that work.
+
+**Two symbol classes, two very different costs:**
+
+1. **Managed frames - already resolved, free.** JITted method names come from the
+   CLR rundown baked into every trace, so `System.*`, `Buffer.Memmove`,
+   `SpanHelpers.*`, and all touki methods already rank correctly on both TFMs with
+   no symbol server. The one gap is **precompiled images**: on net481 the
+   Framework assemblies are NGENed (need NGEN PDBs), and on net10 the runtime
+   ships ReadyToRun (R2R) - TraceEvent usually resolves R2R from the rundown, but
+   this must be verified, not assumed.
+2. **Native runtime frames - the missing 10%, needs a symbol server.** These are
+   the frames that answer the question, and they live in unmanaged modules whose
+   PDBs are on the **Microsoft public symbol server**
+   (`https://msdl.microsoft.com/download/symbols`):
+   - **Zeroing:** `ntdll!RtlZeroMemory`, `ucrtbase!memset`, `coreclr!JIT_MemSet`,
+     the GC's clear-on-allocation, `coreclr!ZeroMemoryInGCHeap`.
+   - **Copying:** `ucrtbase!memcpy` / `memmove`, `coreclr!JIT_MemCpy`,
+     `ntdll!wmemcmp`, and the managed `Buffer.Memmove` they back.
+   - **GC:** `coreclr!WKS::gc_heap::*` / `SVR::gc_heap::*`.
+   - **Write barriers:** `coreclr!JIT_WriteBarrier`, `BulkMoveWithWriteBarrier`.
+   - **JIT:** `clrjit!*`, `coreclr!*::CompileMethod` (startup / first-call cost).
+
+**Phase 1 - reach the symbol server (opt-in).** Replace the empty symbol path in
+`new SymbolReader(TextWriter.Null, "", null)` with a real one *only when opted
+in*: a new `--native-symbols` CLI flag (and `nativeSymbols: true` MCP parameter)
+builds the reader with `srv*<cache>*https://msdl.microsoft.com/download/symbols`,
+backed by a local cache dir (`--symbol-cache <dir>`, default under
+`%TEMP%/traceq-symbols`). Honor an existing `_NT_SYMBOL_PATH` when set and the
+flag is absent. Use `SymbolReader.LookupWarmSymbols` so only modules that carry
+samples are fetched - bounding the download to what the trace actually hit, not
+every loaded DLL. The current offline, deterministic, local-PDB-only mode stays
+the **default**.
+
+**Phase 2 - precompiled-image PDBs.** For NGEN modules (net481), call
+`SymbolReader.GenerateNGenSymbolsForModule` during the read (TraceEvent
+regenerates the NGEN PDB from the native image locally; Windows-only). We
+confirmed BDN's `EtwProfiler` writes **no** `.etl.ngenpdb` folder, so
+analysis-time generation is the only path. For net10, verify R2R frames resolve
+from the rundown; if not, the R2R PDB comes from the same symbol server as the
+native modules.
+
+**Phase 3 - surface the work (the part that actually answers the question).**
+The default fold list *hides* exactly these frames: it folds `memmove`,
+`BulkMoveWithWriteBarrier`, and `PollGC` into their managed caller, which is right
+for "which method is hot" but wrong for "what kind of work dominates." So Phase 3
+adds two things:
+
+- **`--no-fold`** (a.k.a. `--raw`): disable artifact folding so native leaves rank
+  on their own. The fast way to see the leaf distribution once symbols resolve.
+- **A work-classification view** (`traceq classify`, or a grouping preset over
+  resolved leaves): bucket leaves by name pattern into **zeroing**, **copying**,
+  **GC**, **write-barrier**, **JIT**, and **other**, and report each bucket's
+  share of total time. This is the literal answer to "are we zeroing or copying?"
+  and reuses the existing `GroupTransform` machinery - the classification is just
+  a curated set of name->category rules over native frames.
+
+**Plumbing surface.** `ITraceReader.Read` already takes a symbols directory;
+extend symbol setup to a small `SymbolOptions` (native on/off, cache dir). Thread
+it through `TraceLoader`, the `TraceStore` cache key (a trace resolved with native
+symbols is a distinct cache entry), the CPU-reading CLI verbs, and the MCP tools.
+The classification view is a new engine transform plus a `classify` verb /
+`trace_classify` tool.
+
+**Safety, determinism, and why it was deferred.** Never auto-download in CI or by
+default; the local-only path stays the default so the `< 0.8` symbol-resolution
+warning and the test suite stay environment-independent. (The deferral reason was
+exactly this: honoring `_NT_SYMBOL_PATH` ambiently would make a developer with
+symbols configured resolve native frames during tests and flip the `< 0.8`
+assertions such as `Run_Cpu_ForwardsTheLoaderQualityWarnings`.) First run with
+`--native-symbols` is slow (network); later runs hit the cache. Tests that
+exercise native resolution are opt-in / network-gated and excluded from the
+default suite. The `-NativeSymbols` switch returns to `Capture-EtwTrace.ps1` with
+this work.
+
+**Validation target.** Capture the net481 glob enumeration under ETW with
+`--native-symbols`, then `traceq classify` (or `cpu --no-fold --native-symbols`),
+and produce a named split - e.g. "56% in `ProduceAlternative`'s ASCII-fold
+compare, N% in memory zeroing, M% in copying" - turning the unresolved `?` ~10%
+into an actionable answer.
+
+**Exit criteria.** `--native-symbols` resolves `ntdll` / `ucrtbase` / `coreclr`
+leaves on the net481 fixture (Windows, network, opt-in test); `classify` reports
+a zeroing-vs-copying-vs-GC split that sums to ~100% of scope; the default offline
+suite is unchanged and stays green with no network; `Capture-EtwTrace.ps1`
+re-gains `-NativeSymbols`.
+
+### 7.7 Sequencing
+
+1. **The runtime-symbol plan (§7.6)** - Phase 1 (symbol server, opt-in), then
+   Phase 2 (NGEN/R2R), then Phase 3 (`--no-fold` + `classify`). This is the next
+   work and directly answers a recurring need.
+2. Resume the product milestones: **M3½ promotion** (the facade stands alone),
+   then M4 distribution, M5 eval harness, M6 Touki migration + v1.0.
+
+The native-symbol work slots into the M1 symbol pipeline and Addendum A; it does
+not block promotion, but it is the highest-value analysis gap left for the
+day-to-day touki perf loop.
 
 ---
 

--- a/docs/traceq-local-demo.md
+++ b/docs/traceq-local-demo.md
@@ -1,0 +1,140 @@
+# traceq manual demo - user-oriented prompts
+
+A short, manual follow-along for exercising **traceq** from Copilot Chat the way
+a real touki developer actually talks to it: outcome questions - "how long does
+this take?", "how much does it allocate?", "where's the time going?", "make this
+faster?" - not tool-by-tool instructions.
+
+> Drive this from **Copilot Chat in Agent mode**. Paste each prompt as-is and
+> watch the agent *lead*: translate the question into a measurement, write or run
+> a benchmark, capture a trace when it needs one, drill in, and answer **in your
+> words**. If it hands you a command to run, or makes you pick a tool, that is a
+> skill gap worth noting - leading is the whole point. The behavior is shaped by
+> the [performance-testing skill](../.agents/skills/performance-testing/SKILL.md)
+> and its [interpreting-requests](../.agents/skills/performance-testing/interpreting-requests.md)
+> page.
+
+## Setup (one time)
+
+Build the MCP server and register it, then start it from the Command Palette
+(*MCP: List Servers* -> `traceq` -> *Start Server*):
+
+```pwsh
+dotnet build traceq/src/TraceQ.Mcp/TraceQ.Mcp.csproj -c Release
+```
+
+The server entry lives in [.vscode/mcp.json](../.vscode/mcp.json) (rebuild the
+DLL and restart the server after changing traceq). Confirm nine `trace_*` tools
+register in the chat tool picker.
+
+---
+
+## The prompts
+
+Each step is the prompt to paste plus what a good answer looks like. They build
+on each other - later steps reuse the scenario and trace the earlier ones set up.
+
+### 1. "How long does this take?"
+
+> **Prompt:** How long does it take Touki to format a string with `ValueStringBuilder` compared to a plain `StringBuilder`?
+
+**Good:** the agent pins a scenario (what's formatted, how big - by asking or by
+stating a representative one), finds or adds a `touki.perf` benchmark, runs it on
+**both** net10 and net481, and answers in nanoseconds with the comparison and any
+TFM divergence. Not a "here's a command to run."
+
+### 2. "How much memory does it use?"
+
+> **Prompt:** Does Touki's glob matching allocate when it checks a path against a pattern? How much?
+
+**Good:** a `[MemoryDiagnoser]` benchmark over a representative pattern/path,
+reported as **bytes per operation** on both TFMs ("allocation-free (0 B)" or
+"N bytes - one array of ..."), with an offer to find the allocation site if there
+is one.
+
+### 3. "Where's the time going?" (net10)
+
+> **Prompt:** Enumerating files with Touki's extended-glob matcher feels slow. Where's the time actually going?
+
+**Good:** the agent recognizes this needs a *profile*, not just a benchmark. It
+captures an EventPipe trace of the relevant `touki.perf` benchmark (`-p EP`),
+then drives **rank -> callers -> lines** scoped past the BenchmarkDotNet harness
+to the real work, and reports the hot method/line in plain language. Follow up:
+
+> **Prompt:** Show me that hot source file with the time marked on each line.
+
+(should produce a per-line heat map ordered to overlay on the source.)
+
+### 4. "...and on .NET Framework?" (the net481 / ETW lesson)
+
+> **Prompt:** Is the hot spot the same on .NET Framework 4.8.1, or different?
+
+**Good:** the agent does **not** reuse the net10 ranking - it knows EventPipe is
+net10-only and that net481's weaker inlining can move the hot frame *entirely*.
+It captures an **ETW** trace (via [tools/Capture-EtwTrace.ps1](../tools/Capture-EtwTrace.ps1),
+which self-elevates with visible progress), scopes it with `--process`, and
+reports the net481 hotspot - which may be a different method than net10. In the
+glob case it was: a method that was ~1.5% on net10 was ~56% on net481. A bare
+"same as net10" without an ETW capture is the failure to watch for.
+
+### 5. "Which process is this even measuring?" (multi-process scope)
+
+> **Prompt:** That ETW capture is machine-wide. How do I make sure we're looking at the benchmark and not something else running on my box?
+
+**Good:** the agent runs `traceq processes <etl>` to list the processes by weight,
+then scopes every later query with `--process touki.perf` (or the right name).
+It should explain that an `.etl` is machine-wide, that the auto-scope picks the
+most-sampled process, and that a noisy background app can otherwise steal the
+ranking.
+
+### 6. "Where does the runtime spend the time - zeroing or copying?"
+
+> **Prompt:** Of that net481 time, how much is the runtime zeroing memory versus copying strings versus GC?
+
+**Good (target, gated on the runtime-symbol plan):** answering this needs native
+runtime symbols, which is the next milestone - see
+[§7.6 of the implementation plan](traceq-implementation-plan.md#76-whats-next-the-runtime-symbol-plan-managed--unmanaged).
+Until it lands, a good answer is honest: managed frames resolve, but the native
+leaf (memset / memcpy / GC) currently shows as an unresolved `?` (~10% in the
+glob trace), and the plan is `--native-symbols` + a `classify` view that buckets
+the work into zeroing / copying / GC / JIT. Watch that the agent says what it
+*cannot* yet measure rather than guessing.
+
+### 7. "Help me make it faster" - the full journey
+
+> **Prompt:** Help me improve the performance of the extended-glob matcher's inner matching loop.
+
+**Good:** the agent walks the loop out loud - (1) pin the scenario, (2) baseline
+benchmark on both TFMs, (3) profile and drill to the hot line with evidence,
+(4) propose a change tied to that evidence (reaching for the
+`framework-jit-optimization` / `scratch-buffer-strategy` skills for the *how*),
+(5) re-run both TFMs and confirm the targeted line moved and nothing (especially
+`Allocated`) regressed, (6) offer the next drill. It should reuse the existing
+benchmark/trace rather than starting over.
+
+---
+
+## Warm-up: you already have a trace
+
+If you just want to exercise the analysis tools against a trace that already
+exists, point the agent at a committed fixture and ask:
+
+> - **Prompt:** What's in `traceq\tests\TraceQ.Core.Tests\Fixtures\folding.speedscope.json`, and is anything obviously off? (`trace_info` - resolution rate, threads)
+> - **Prompt:** Where's the CPU time in that trace? (`trace_rank` cpu, then a steer toward the hottest frame's callers)
+> - **Prompt:** What's allocating the most in `traceq\tests\TraceQ.Core.Tests\Fixtures\alloc.nettrace`? (`trace_rank` alloc - answered in **bytes**, not time)
+
+---
+
+## Red flags (a skill or tool gap, worth noting)
+
+- Hands back a `dotnet run ...` command instead of running the measurement.
+- Measures without pinning a scenario, or measures only one TFM when the code
+  targets both.
+- Reads a net481 hotspot off a net10 EventPipe trace (see step 4).
+- Pastes a raw table and stops, instead of answering the question and offering
+  the next drill.
+- On a machine-wide `.etl`, ranks without scoping to a process (see step 5).
+- Guesses at native runtime cost it cannot yet resolve (see step 6).
+
+For the CLI equivalents and every verb's options, see the traceq README and
+[tools/Capture-EtwTrace.ps1](../tools/Capture-EtwTrace.ps1).

--- a/tools/Capture-EtwTrace.ps1
+++ b/tools/Capture-EtwTrace.ps1
@@ -1,0 +1,152 @@
+<#
+.SYNOPSIS
+    Capture an ETW (.etl) CPU trace of a touki.perf benchmark on .NET Framework
+    (net481) and print the exact, process-scoped traceq commands to analyze it.
+
+.DESCRIPTION
+    EventPipe profiling (tools/Profile-Benchmark.ps1) is net10-only and managed-only.
+    The Framework target needs ETW, which requires running elevated. This script
+    wraps that whole loop:
+
+      1. Self-elevates (a single UAC prompt) when not already Administrator. The
+         elevated window shows the benchmark's LIVE progress - output is teed to a
+         log, never redirected away with `*>`, so the window never looks hung.
+      2. Verifies touki.perf references BenchmarkDotNet.Diagnostics.Windows (the
+         package that provides `-p ETW`); without it the profiler silently no-ops.
+      3. Runs `dotnet run -c Release -f net481 --project touki.perf -- --filter
+         <Filter> -p ETW --keepFiles`, which writes an .etl into
+         BenchmarkDotNet.Artifacts/.
+      4. Locates the newest .etl and prints the next-step traceq commands already
+         scoped to the benchmark process with --process, plus the net481 build-output
+         --symbols directory for line-level attribution.
+
+    Why --process matters: an .etl is a machine-wide capture. traceq auto-scopes to
+    the busiest process, but a noisy background app (antivirus, a VPN client) can win
+    that race, so the printed commands pin --process explicitly. The cpu/threadtime/
+    rank/lines/callers/heatmap verbs all accept it.
+
+.PARAMETER Filter
+    BenchmarkDotNet --filter glob selecting the benchmark(s) to profile, e.g.
+    '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingle'. Profile one method at a
+    time for a clean trace.
+
+.PARAMETER Process
+    Process-name substring the printed traceq commands scope to with --process.
+    Defaults to 'touki.perf' (the benchmark host).
+
+.PARAMETER Tfm
+    Target framework. ETW is the Framework path; defaults to net481. For net10 use
+    EventPipe via tools/Profile-Benchmark.ps1 instead.
+
+.PARAMETER Top
+    Rows per ranking in the printed commands. Default 25.
+
+.PARAMETER SkipRun
+    Skip the benchmark run and analyze the newest existing .etl for -Filter. Use when
+    you already have a fresh capture and only want the next-step commands.
+
+.EXAMPLE
+    ./tools/Capture-EtwTrace.ps1 -Filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingle'
+
+.NOTES
+    Native runtime-symbol resolution (a -NativeSymbols switch) is planned but not
+    yet wired - see the runtime-symbol plan in docs/traceq-implementation-plan.md.
+#>
+param(
+    [Parameter(Mandatory)][string]$Filter,
+    [string]$Process = "touki.perf",
+    [string]$Tfm = "net481",
+    [int]$Top = 25,
+    [switch]$SkipRun
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$artifacts = Join-Path $repoRoot "BenchmarkDotNet.Artifacts"
+$log = Join-Path $artifacts "etw-capture.log"
+
+function Test-Elevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+if ($Tfm -eq "net10.0") {
+    Write-Warning "net10 supports EventPipe, which needs no elevation - consider tools/Profile-Benchmark.ps1. Continuing with ETW anyway."
+}
+
+# ETW kernel sessions require Administrator. When not elevated, relaunch this script
+# in an elevated window that shows the capture's LIVE progress (the child tees its
+# output to the log; nothing is redirected away), then wait for it to finish.
+if (-not (Test-Elevated)) {
+    Write-Host "ETW capture needs Administrator; relaunching elevated (a UAC prompt will appear)." -ForegroundColor Yellow
+    Write-Host "The elevated window shows live capture progress - watch it there; this window waits." -ForegroundColor Yellow
+
+    $argList = @('-NoProfile', '-File', $PSCommandPath, '-Filter', $Filter, '-Process', $Process, '-Tfm', $Tfm, '-Top', $Top)
+    if ($SkipRun) { $argList += '-SkipRun' }
+
+    $proc = Start-Process pwsh -Verb RunAs -PassThru -Wait -ArgumentList $argList
+    if ($proc.ExitCode -ne 0) {
+        Write-Error "Elevated capture failed (exit $($proc.ExitCode)). See $log."
+        exit $proc.ExitCode
+    }
+
+    # Mirror the elevated run's summary here so the result is visible in this window too.
+    if (Test-Path $log) {
+        Write-Host "`n--- capture log tail (full log: $log) ---" -ForegroundColor Cyan
+        Get-Content $log -Tail 25
+    }
+    exit 0
+}
+
+# --- Elevated from here. ---
+New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
+
+if (-not $SkipRun) {
+    # Without BenchmarkDotNet.Diagnostics.Windows the `-p ETW` profiler silently
+    # resolves to UnresolvedDiagnoser and no .etl is written - fail fast with guidance.
+    $perfProj = Join-Path $repoRoot "touki.perf/touki.perf.csproj"
+    if (-not (Select-String -Path $perfProj -Pattern "BenchmarkDotNet.Diagnostics.Windows" -Quiet)) {
+        Write-Error "touki.perf does not reference BenchmarkDotNet.Diagnostics.Windows; -p ETW will no-op. Add the package first."
+        exit 1
+    }
+
+    Write-Host "Capturing ETW trace: $Filter ($Tfm)..." -ForegroundColor Cyan
+    Push-Location $repoRoot
+    try {
+        # Tee, do not redirect: the elevated window shows BenchmarkDotNet's live
+        # progress while the run is also logged for the parent window to surface.
+        dotnet run -c Release -f $Tfm --project touki.perf -- --filter $Filter -p ETW --keepFiles 2>&1 |
+            Tee-Object -FilePath $log
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "Benchmark run failed (exit $LASTEXITCODE). See $log."
+            exit $LASTEXITCODE
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+$etl = Get-ChildItem -Path $artifacts -Filter '*.etl' -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime | Select-Object -Last 1
+if ($null -eq $etl) {
+    Write-Error "No .etl found in $artifacts. Did the capture run?"
+    exit 1
+}
+
+# The net481 build-output directory BenchmarkDotNet kept (--keepFiles); its embedded
+# PDBs resolve managed frames to source lines for the `lines`/`heatmap` verbs.
+$symbols = "artifacts/x64/Release/touki.perf/$Tfm/touki.perf-DefaultJob-1/bin/Release/$Tfm"
+$traceq = "dotnet run --project traceq/src/TraceQ -c Release --"
+
+Write-Host "`nCaptured: $($etl.FullName)" -ForegroundColor Green
+Write-Host "`nNext-step traceq commands (scoped to '$Process'):" -ForegroundColor Green
+Write-Host "  # who is in the capture (pick a --process target):"
+Write-Host "  $traceq processes `"$($etl.FullName)`""
+Write-Host "  # CPU self-time hotspots:"
+Write-Host "  $traceq cpu `"$($etl.FullName)`" --process $Process --top $Top"
+Write-Host "  # wall-clock (running + blocked) - near-equal to cpu means CPU-bound:"
+Write-Host "  $traceq threadtime `"$($etl.FullName)`" --process $Process --top $Top"
+Write-Host "  # line-level inside a hot method:"
+Write-Host "  $traceq lines `"$($etl.FullName)`" --method <MethodName> --process $Process --symbols $symbols"

--- a/touki.perf/touki.perf.csproj
+++ b/touki.perf/touki.perf.csproj
@@ -33,6 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" />
+    <!-- ETW profiler (-p ETW) for capturing .etl traces, the net481 elevation path. -->
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
     <PackageReference Include="Microsoft.Build" />
     <!-- Oracle reference for the FileSystemGlobbing dialect comparison benchmarks. -->
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />

--- a/traceq/README.md
+++ b/traceq/README.md
@@ -47,14 +47,17 @@ dotnet tool install --global --add-source ./artifacts/packages TraceQ.Tool
 
 Every ranking verb accepts `--root` (scope to a frame subtree) and `--benchmark`
 (scope a BenchmarkDotNet capture to the measured workload, past the harness). The
-verbs that can read a multi-process ETW `.etl` - `cpu`, `threadtime`, and `rank` -
-also accept `--process` / `--all-processes` (the busiest process tree is
+verbs that can read a multi-process ETW `.etl` - `cpu`, `threadtime`, and `rank`,
+plus the drill-down `callers`, `lines`, and `heatmap` - also accept `--process` /
+`--all-processes` (the busiest process tree, ranked by CPU sample count, is
 auto-scoped by default); `alloc` and `exceptions` read single-process
-`.nettrace` only, so they have no process options.
+`.nettrace` only, so they have no process options. To see what is in a
+multi-process capture before scoping, run `traceq processes` (below).
 
 ```pwsh
 traceq cpu bdn.nettrace --benchmark          # just the [Benchmark] code
 traceq alloc bdn.nettrace --benchmark        # allocations under the workload
+traceq processes machinewide.etl             # list every process by weight
 traceq cpu machinewide.etl --process MyApp   # one process tree
 ```
 
@@ -66,6 +69,12 @@ traceq cpu machinewide.etl --process MyApp   # one process tree
 | `lines` | Hottest source lines of scoped methods | `traceq lines app.nettrace --symbols bin/Release/net10.0` |
 | `heatmap` | Per-line heat for one source file | `traceq heatmap app.nettrace Parser.cs` |
 | `tree` | Top-down call tree from the root | `traceq tree app.nettrace --max-depth 5` |
+
+**Inventory** - see what a (possibly machine-wide) capture contains:
+
+| Verb | Purpose | Example |
+|---|---|---|
+| `processes` | List processes by CPU-sample weight, to pick a `--process` target | `traceq processes machinewide.etl` |
 
 **Compare and export:**
 

--- a/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
@@ -40,6 +40,7 @@ namespace TraceQ.Output;
 [JsonSerializable(typeof(AnalysisResult<LineRankingResult>))]
 [JsonSerializable(typeof(AnalysisResult<SourceHeatmapResult>))]
 [JsonSerializable(typeof(AnalysisResult<CallTreeResult>))]
+[JsonSerializable(typeof(AnalysisResult<ProcessListResult>))]
 [JsonSerializable(typeof(AnalysisResult<RankingDiffResult>))]
 [JsonSerializable(typeof(AnalysisResult<JitStatsResult>))]
 [JsonSerializable(typeof(AnalysisResult<GcStatsResult>))]

--- a/traceq/src/TraceQ.Core/Tracing/FoldingAggregator.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FoldingAggregator.cs
@@ -67,6 +67,48 @@ public sealed class FoldingAggregator
     /// </summary>
     public MetricInfo Metric => _source.Metric;
 
+    /// <summary>
+    ///  Lists every process that owns samples, ranked by summed sample weight, so a
+    ///  multi-process capture can be scoped to the right one before ranking.
+    /// </summary>
+    /// <returns>The process inventory: each process's sample count, weight, and share.</returns>
+    /// <remarks>
+    ///  <para>
+    ///   No folding applies - a process owns a sample regardless of which leaf the
+    ///   sample resolved to - so this counts raw samples and sums their weights by the
+    ///   process label the reader tagged each sample with. Ties in weight break by the
+    ///   process label so the order is deterministic.
+    ///  </para>
+    /// </remarks>
+    public ProcessListResult Processes()
+    {
+        Dictionary<string, (int Count, double Weight)> byProcess = new(StringComparer.Ordinal);
+        double totalWeight = 0.0;
+        foreach (SampleStack sample in _samples)
+        {
+            (int Count, double Weight) accumulated = byProcess.GetValueOrDefault(sample.Process);
+            byProcess[sample.Process] = (accumulated.Count + 1, accumulated.Weight + sample.Weight);
+            totalWeight += sample.Weight;
+        }
+
+        List<ProcessSummary> processes = new(byProcess.Count);
+        foreach (KeyValuePair<string, (int Count, double Weight)> entry in byProcess)
+        {
+            double percent = totalWeight > 0.0 ? entry.Value.Weight / totalWeight * 100.0 : 0.0;
+            processes.Add(new ProcessSummary(entry.Key, entry.Value.Count, entry.Value.Weight, percent));
+        }
+
+        // Highest weight first; ties break by process label so the ranking is stable
+        // and the JSON output deterministic.
+        processes.Sort(static (a, b) =>
+        {
+            int byWeight = b.Weight.CompareTo(a.Weight);
+            return byWeight != 0 ? byWeight : string.CompareOrdinal(a.Process, b.Process);
+        });
+
+        return new ProcessListResult(totalWeight, _samples.Count, processes);
+    }
+
     private string ShortOf(string name) => _shortCache.GetOrAdd(name, static n => FrameNames.Short(n));
 
     /// <summary>

--- a/traceq/src/TraceQ.Core/Tracing/ProcessListResult.cs
+++ b/traceq/src/TraceQ.Core/Tracing/ProcessListResult.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  One process in a trace's CPU-sample inventory: its label, how many samples it
+///  owns, the weight those samples carry, and that weight's share of the whole
+///  capture.
+/// </summary>
+/// <param name="Process">
+///  The process label (<c>name(pid)</c> for a multi-process capture), or empty for a
+///  single-process trace format.
+/// </param>
+/// <param name="SampleCount">The number of CPU samples attributed to the process.</param>
+/// <param name="Weight">The summed sample weight, in the metric's unit (milliseconds for CPU time).</param>
+/// <param name="PercentOfScope">The process's share of the whole capture's weight, in percent.</param>
+public sealed record ProcessSummary(
+    string Process,
+    int SampleCount,
+    double Weight,
+    double PercentOfScope);
+
+/// <summary>
+///  A trace's process inventory: every process that owns CPU samples, ranked by
+///  weight, so a multi-process ETW capture can be scoped to the right one before
+///  ranking.
+/// </summary>
+/// <remarks>
+///  <para>
+///   This is the answer to "who is in this capture?" - the first move on a
+///   machine-wide <c>.etl</c> before scoping a ranking with <c>--process</c>. The
+///   automatic scope already narrows to the busiest process by sample count, but a
+///   capture can hold several meaningful processes; this view lists them so the
+///   choice is explicit. Single-process EventPipe and speedscope traces list one
+///   process with an empty label.
+///  </para>
+/// </remarks>
+/// <param name="TotalWeight">The whole capture's weight, in the metric's unit (the percent denominator).</param>
+/// <param name="TotalSamples">The total number of CPU samples across every process.</param>
+/// <param name="Processes">The processes, highest weight first.</param>
+public sealed record ProcessListResult(
+    double TotalWeight,
+    int TotalSamples,
+    IReadOnlyList<ProcessSummary> Processes);

--- a/traceq/src/TraceQ.Core/Tracing/Readers/ProcessTree.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/ProcessTree.cs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.EventPipe;
 using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
 
 namespace TraceQ.Tracing.Readers;
 
@@ -90,40 +93,83 @@ internal static class ProcessTree
     }
 
     /// <summary>
-    ///  Finds the name of the busiest process in the trace - the one that consumed
-    ///  the most CPU time - so an unscoped read can default to that process's tree
-    ///  rather than the whole machine-wide capture.
+    ///  Finds the name of the busiest process in the trace - the one that owns the most
+    ///  CPU samples - so an unscoped read can default to that process's tree rather than
+    ///  the whole machine-wide capture.
     /// </summary>
-    /// <param name="traceLog">The opened trace whose process table is queried.</param>
+    /// <param name="traceLog">The opened trace whose CPU samples are counted.</param>
     /// <returns>
     ///  The busiest named process's name, or <see langword="null"/> when the trace
-    ///  has no named process carrying CPU time (so no automatic scope applies).
+    ///  carries no CPU samples attributable to a named process (so no automatic scope
+    ///  applies).
     /// </returns>
     /// <remarks>
     ///  <para>
-    ///   "Busiest" is the workload heuristic: in a benchmark or profile capture the
-    ///   measured process dominates CPU, while the idle and bookkeeping processes
-    ///   barely register. The matched name still resolves to the whole tree (the
-    ///   process plus its descendants) at scope time, so a host that launches the
-    ///   real work in a child is covered.
+    ///   "Busiest" is ranked by <em>CPU sample count</em>, not <see cref="TraceProcess.CPUMSec"/>.
+    ///   The rankings this scope feeds are built from CPU samples, so the process that
+    ///   owns the most samples is by definition the one the analysis is about. CPUMSec
+    ///   can disagree sharply on a machine-wide capture: a long-lived background service
+    ///   (antivirus, a VPN client) accumulates more kernel CPU time across the whole
+    ///   capture window than a short benchmark, yet carries a tiny fraction of the
+    ///   profile's samples - which made a CPUMSec heuristic auto-scope to the wrong
+    ///   process. Counting samples is one extra lightweight event pass (process id only,
+    ///   no stack walk); it runs only for the automatic scope (no explicit process
+    ///   given) and its result is cached with the loaded trace.
+    ///  </para>
+    ///  <para>
+    ///   The matched name still resolves to the whole tree (the process plus its
+    ///   descendants) at scope time, so a host that launches the measured work in a
+    ///   child is covered.
     ///  </para>
     /// </remarks>
     public static string? FindBusiestProcessName(TraceLog traceLog)
     {
-        string? busiest = null;
-        float maxCpu = 0.0f;
-        foreach (TraceProcess process in traceLog.Processes)
+        // Count CPU samples per process id. The predicate mirrors the CPU-sample
+        // selection in TraceLogReader exactly (ETW SampledProfileTraceData, EventPipe
+        // ClrThreadSampleTraceData excluding error samples) so the busiest process is
+        // chosen by the same events the rankings are built from.
+        Dictionary<int, int> samplesByProcess = [];
+        foreach (TraceEvent data in traceLog.Events)
         {
-            // A process with no name cannot be matched by a name substring later, and
-            // the Idle process (pid 0) is bookkeeping, not workload - skip both.
-            if (string.IsNullOrEmpty(process.Name) || process.ProcessID == 0)
+            if (data is ClrThreadSampleTraceData clrSample)
+            {
+                if (clrSample.Type == ClrThreadSampleType.Error)
+                {
+                    continue;
+                }
+            }
+            else if (data is not SampledProfileTraceData)
             {
                 continue;
             }
 
-            if (process.CPUMSec > maxCpu)
+            int pid = data.ProcessID;
+            if (pid > 0)
             {
-                maxCpu = process.CPUMSec;
+                samplesByProcess[pid] = samplesByProcess.GetValueOrDefault(pid) + 1;
+            }
+        }
+
+        if (samplesByProcess.Count == 0)
+        {
+            return null;
+        }
+
+        // The Idle process (pid 0) is bookkeeping, not workload, and an unnamed process
+        // cannot be matched by a name substring later - skip both.
+        string? busiest = null;
+        int maxSamples = 0;
+        foreach (TraceProcess process in traceLog.Processes)
+        {
+            if (process.ProcessID == 0 || string.IsNullOrEmpty(process.Name))
+            {
+                continue;
+            }
+
+            int count = samplesByProcess.GetValueOrDefault(process.ProcessID);
+            if (count > maxSamples)
+            {
+                maxSamples = count;
                 busiest = process.Name;
             }
         }

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -44,6 +44,7 @@ public sealed class TraceTools
     /// <param name="store">The trace cache (injected).</param>
     /// <param name="path">Path to the trace file.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <returns>The trace summary envelope.</returns>
     [McpServerTool(Name = "trace_info", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -57,9 +58,13 @@ public sealed class TraceTools
         [Description(
             "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' "
             + "embedded portable PDBs are extracted so managed frames resolve to source lines.")]
-        string symbols = "")
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
     {
-        TraceInfo info = Load(store, path, NullIfEmpty(symbols)).Info;
+        TraceInfo info = Load(store, path, NullIfEmpty(symbols), scope: ResolveScope(process)).Info;
         TraceInfoView view = new(
             info.Path,
             info.Format.ToString(),
@@ -82,6 +87,7 @@ public sealed class TraceTools
     /// <param name="top">Maximum rows to return.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <returns>The ranking envelope.</returns>
     [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -102,14 +108,18 @@ public sealed class TraceTools
         [Description(
             "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
             + "managed frames resolve to source lines (cpu metric only).")]
-        string symbols = "")
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
     {
         TraceMetric resolved = ResolveMetric(metric);
         bool inclusive = ResolveMeasure(measure);
         RequirePositiveTop(top);
         IReadOnlyList<string> foldPatterns = ResolveFold(fold);
 
-        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), resolved);
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), resolved, ResolveScope(process));
         TraceInfo info = trace.Info;
         RankingResult ranking = inclusive
             ? trace.Aggregator.InclusiveTime(root, foldPatterns, top)
@@ -128,6 +138,7 @@ public sealed class TraceTools
     /// <param name="root">Optional substring scoping the analysis to a subtree.</param>
     /// <param name="top">Maximum caller rows to return.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <returns>The caller-breakdown envelope.</returns>
     [McpServerTool(Name = "trace_callers", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -143,10 +154,14 @@ public sealed class TraceTools
         [Description(
             "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
             + "managed frames resolve to source lines.")]
-        string symbols = "")
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
     {
         RequirePositiveTop(top);
-        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), scope: ResolveScope(process));
         TraceInfo info = trace.Info;
         CallersResult callers = trace.Aggregator.CallersOf(frame, root, top);
 
@@ -163,6 +178,7 @@ public sealed class TraceTools
     /// <param name="top">Maximum rows to return.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <returns>The line-level self-time envelope.</returns>
     [McpServerTool(Name = "trace_lines", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -180,11 +196,15 @@ public sealed class TraceTools
         [Description(
             "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' embedded "
             + "portable PDBs are extracted so managed frames resolve to source lines.")]
-        string symbols = "")
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
     {
         RequirePositiveTop(top);
         IReadOnlyList<string> foldPatterns = ResolveFold(fold);
-        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), scope: ResolveScope(process));
         TraceInfo info = trace.Info;
         LineRankingResult lines = trace.Aggregator.HotLines(method, foldPatterns, top);
 
@@ -200,6 +220,7 @@ public sealed class TraceTools
     /// <param name="file">Path or file name of the source file to map.</param>
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <returns>The heat-map envelope.</returns>
     [McpServerTool(Name = "trace_heatmap", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -215,10 +236,14 @@ public sealed class TraceTools
         [Description(
             "Optional build-output directory (e.g. artifacts/.../touki.perf/net10.0) whose assemblies' embedded "
             + "portable PDBs are extracted so managed frames resolve to source lines.")]
-        string symbols = "")
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
     {
         IReadOnlyList<string> foldPatterns = ResolveFold(fold);
-        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), scope: ResolveScope(process));
         TraceInfo info = trace.Info;
 
         // The trace records the build-time file name, not its full path, so match on the file name.
@@ -318,19 +343,6 @@ public sealed class TraceTools
     }
 
     /// <summary>
-    ///  The largest page <see cref="QueryEvents"/> returns. A larger <c>take</c> is
-    ///  clamped to this with a warning, so one call cannot accumulate an unbounded
-    ///  page into memory or push the response past the token budget.
-    /// </summary>
-    private const int MaxEventsPage = 1000;
-
-    /// <summary>
-    ///  The largest per-event payload cap <see cref="QueryEvents"/> honors. A larger
-    ///  <c>maxPayload</c> is clamped to this with a warning.
-    /// </summary>
-    private const int MaxEventPayloadChars = 4000;
-
-    /// <summary>
     ///  Queries the raw events of a <c>.nettrace</c> EventPipe trace by name, paged and
     ///  with each event's payload truncated, so an agent can inspect arbitrary events.
     /// </summary>
@@ -370,23 +382,6 @@ public sealed class TraceTools
             throw new McpException("maxPayload must be 0 or greater.");
         }
 
-        // Clamp the page and payload sizes to a ceiling so a caller cannot request a
-        // page large enough to exhaust memory or push the response past the token
-        // budget; a clamp is a warning rather than an error, so the query still runs.
-        List<string> warnings = [];
-        if (take > MaxEventsPage)
-        {
-            warnings.Add($"take {take} exceeds the {MaxEventsPage} maximum; clamped to {MaxEventsPage}.");
-            take = MaxEventsPage;
-        }
-
-        if (maxPayload > MaxEventPayloadChars)
-        {
-            warnings.Add(
-                $"maxPayload {maxPayload} exceeds the {MaxEventPayloadChars} maximum; clamped to {MaxEventPayloadChars}.");
-            maxPayload = MaxEventPayloadChars;
-        }
-
         EventQueryResult result = ReadEvents(path, name, skip, take, maxPayload);
 
         // When matches remain beyond this page, steer toward the next one rather than
@@ -398,7 +393,7 @@ public sealed class TraceTools
             hints.Add($"{result.TotalMatched - shownThrough} more match; page with skip {shownThrough}.");
         }
 
-        return new AnalysisResult<EventQueryResult>(result, warnings, hints);
+        return new AnalysisResult<EventQueryResult>(result, hints: hints);
     }
 
     /// <summary>
@@ -465,11 +460,12 @@ public sealed class TraceTools
         TraceStore store,
         string path,
         string? symbols,
-        TraceMetric metric = TraceMetric.Cpu)
+        TraceMetric metric = TraceMetric.Cpu,
+        ScopeRequest? scope = null)
     {
         try
         {
-            return store.Get(path, symbols, metric);
+            return store.Get(path, symbols, metric, scope);
         }
         catch (Exception ex) when (
             ex is IOException
@@ -650,10 +646,8 @@ public sealed class TraceTools
     private static void RequireNetTrace(string path, string reportName)
     {
         // Format guardrail (an extension test, no I/O): the report providers parse the
-        // EventPipe format, so reject an .etl or speedscope export - or a null/empty
-        // path - cleanly here rather than failing deep inside the parser or on a null
-        // dereference that would surface as an opaque JSON-RPC error.
-        if (string.IsNullOrEmpty(path) || !path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
+        // EventPipe format, so reject an .etl or speedscope export cleanly here.
+        if (!path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
         {
             throw new McpException(
                 $"The {reportName} requires a .nettrace EventPipe trace; '{path}' is not a .nettrace file.");
@@ -681,4 +675,10 @@ public sealed class TraceTools
     }
 
     private static string? NullIfEmpty(string value) => string.IsNullOrEmpty(value) ? null : value;
+
+    // An empty process selector means "auto-scope to the busiest process tree" (the
+    // Load default), a no-op on a single-process .nettrace/speedscope trace; a non-empty
+    // value scopes a multi-process .etl capture to the named process tree.
+    private static ScopeRequest? ResolveScope(string process) =>
+        string.IsNullOrEmpty(process) ? null : ScopeRequest.ForProcess(process);
 }

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -343,6 +343,19 @@ public sealed class TraceTools
     }
 
     /// <summary>
+    ///  The largest page <see cref="QueryEvents"/> returns. A larger <c>take</c> is
+    ///  clamped to this with a warning, so one call cannot accumulate an unbounded
+    ///  page into memory or push the response past the token budget.
+    /// </summary>
+    private const int MaxEventsPage = 1000;
+
+    /// <summary>
+    ///  The largest per-event payload cap <see cref="QueryEvents"/> honors. A larger
+    ///  <c>maxPayload</c> is clamped to this with a warning.
+    /// </summary>
+    private const int MaxEventPayloadChars = 4000;
+
+    /// <summary>
     ///  Queries the raw events of a <c>.nettrace</c> EventPipe trace by name, paged and
     ///  with each event's payload truncated, so an agent can inspect arbitrary events.
     /// </summary>
@@ -382,6 +395,23 @@ public sealed class TraceTools
             throw new McpException("maxPayload must be 0 or greater.");
         }
 
+        // Clamp the page and payload sizes to a ceiling so a caller cannot request a
+        // page large enough to exhaust memory or push the response past the token
+        // budget; a clamp is a warning rather than an error, so the query still runs.
+        List<string> warnings = [];
+        if (take > MaxEventsPage)
+        {
+            warnings.Add($"take {take} exceeds the {MaxEventsPage} maximum; clamped to {MaxEventsPage}.");
+            take = MaxEventsPage;
+        }
+
+        if (maxPayload > MaxEventPayloadChars)
+        {
+            warnings.Add(
+                $"maxPayload {maxPayload} exceeds the {MaxEventPayloadChars} maximum; clamped to {MaxEventPayloadChars}.");
+            maxPayload = MaxEventPayloadChars;
+        }
+
         EventQueryResult result = ReadEvents(path, name, skip, take, maxPayload);
 
         // When matches remain beyond this page, steer toward the next one rather than
@@ -393,7 +423,7 @@ public sealed class TraceTools
             hints.Add($"{result.TotalMatched - shownThrough} more match; page with skip {shownThrough}.");
         }
 
-        return new AnalysisResult<EventQueryResult>(result, hints: hints);
+        return new AnalysisResult<EventQueryResult>(result, warnings, hints);
     }
 
     /// <summary>
@@ -647,7 +677,7 @@ public sealed class TraceTools
     {
         // Format guardrail (an extension test, no I/O): the report providers parse the
         // EventPipe format, so reject an .etl or speedscope export cleanly here.
-        if (!path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
+        if (string.IsNullOrEmpty(path) || !path.EndsWith(".nettrace", StringComparison.OrdinalIgnoreCase))
         {
             throw new McpException(
                 $"The {reportName} requires a .nettrace EventPipe trace; '{path}' is not a .nettrace file.");

--- a/traceq/src/TraceQ/Cli/CallersExecutor.cs
+++ b/traceq/src/TraceQ/Cli/CallersExecutor.cs
@@ -31,7 +31,7 @@ internal static class CallersExecutor
     /// <returns>A process exit code (see <see cref="ExitCodes"/>).</returns>
     public static int Run(CallersRequest request, TextWriter output, TextWriter error)
     {
-        if (!TraceExecution.TryLoad(request.Path, request.Symbols, error, out LoadedTrace? trace))
+        if (!TraceExecution.TryLoad(request.Path, TraceMetric.Cpu, request.Symbols, error, out LoadedTrace? trace, request.Scope))
         {
             return ExitCodes.InputError;
         }

--- a/traceq/src/TraceQ/Cli/CallersRequest.cs
+++ b/traceq/src/TraceQ/Cli/CallersRequest.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using TraceQ.Tracing;
+
 namespace TraceQ.Cli;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace TraceQ.Cli;
 /// <param name="Symbols">Optional build-output directory whose embedded PDBs resolve managed frames.</param>
 /// <param name="Format">The render format.</param>
 /// <param name="Strict">Whether to trip the strict symbol-resolution exit gate.</param>
+/// <param name="Scope">The process scope for a multi-process capture, or <see langword="null"/> for the automatic default.</param>
 internal sealed record CallersRequest(
     string Path,
     string Frame,
@@ -22,4 +25,5 @@ internal sealed record CallersRequest(
     int Top,
     string? Symbols,
     OutputFormat Format,
-    bool Strict);
+    bool Strict,
+    ScopeRequest? Scope = null);

--- a/traceq/src/TraceQ/Cli/HeatmapExecutor.cs
+++ b/traceq/src/TraceQ/Cli/HeatmapExecutor.cs
@@ -36,7 +36,7 @@ internal static class HeatmapExecutor
             return ExitCodes.UsageError;
         }
 
-        if (!TraceExecution.TryLoad(request.Path, request.Symbols, error, out LoadedTrace? trace))
+        if (!TraceExecution.TryLoad(request.Path, TraceMetric.Cpu, request.Symbols, error, out LoadedTrace? trace, request.Scope))
         {
             return ExitCodes.InputError;
         }

--- a/traceq/src/TraceQ/Cli/HeatmapRequest.cs
+++ b/traceq/src/TraceQ/Cli/HeatmapRequest.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using TraceQ.Tracing;
+
 namespace TraceQ.Cli;
 
 /// <summary>
@@ -18,10 +20,12 @@ namespace TraceQ.Cli;
 /// <param name="Symbols">Optional build-output directory whose embedded PDBs resolve managed frames.</param>
 /// <param name="Format">The render format.</param>
 /// <param name="Strict">Whether to trip the strict symbol-resolution exit gate.</param>
+/// <param name="Scope">The process scope for a multi-process capture, or <see langword="null"/> for the automatic default.</param>
 internal sealed record HeatmapRequest(
     string Path,
     string File,
     IReadOnlyList<string> Fold,
     string? Symbols,
     OutputFormat Format,
-    bool Strict);
+    bool Strict,
+    ScopeRequest? Scope = null);

--- a/traceq/src/TraceQ/Cli/LinesExecutor.cs
+++ b/traceq/src/TraceQ/Cli/LinesExecutor.cs
@@ -36,7 +36,7 @@ internal static class LinesExecutor
             return ExitCodes.UsageError;
         }
 
-        if (!TraceExecution.TryLoad(request.Path, request.Symbols, error, out LoadedTrace? trace))
+        if (!TraceExecution.TryLoad(request.Path, TraceMetric.Cpu, request.Symbols, error, out LoadedTrace? trace, request.Scope))
         {
             return ExitCodes.InputError;
         }

--- a/traceq/src/TraceQ/Cli/LinesRequest.cs
+++ b/traceq/src/TraceQ/Cli/LinesRequest.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using TraceQ.Tracing;
+
 namespace TraceQ.Cli;
 
 /// <summary>
@@ -15,6 +17,7 @@ namespace TraceQ.Cli;
 /// <param name="Symbols">Optional build-output directory whose embedded PDBs resolve managed frames.</param>
 /// <param name="Format">The render format.</param>
 /// <param name="Strict">Whether to trip the strict symbol-resolution exit gate.</param>
+/// <param name="Scope">The process scope for a multi-process capture, or <see langword="null"/> for the automatic default.</param>
 internal sealed record LinesRequest(
     string Path,
     string Method,
@@ -22,4 +25,5 @@ internal sealed record LinesRequest(
     int Top,
     string? Symbols,
     OutputFormat Format,
-    bool Strict);
+    bool Strict,
+    ScopeRequest? Scope = null);

--- a/traceq/src/TraceQ/Cli/ProcessesExecutor.cs
+++ b/traceq/src/TraceQ/Cli/ProcessesExecutor.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Output;
+using TraceQ.Tracing;
+
+namespace TraceQ.Cli;
+
+/// <summary>
+///  Runs a process-inventory request against the analysis core: load every process
+///  in the trace, rank them by weight, wrap the result in the output contract, and
+///  render it as text or JSON.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The load is pinned to <see cref="ScopeRequest.AllProcesses"/>: the inventory's
+///   whole purpose is to show every process so the caller can choose one to scope a
+///   ranking to, so it must not auto-scope to the busiest. The execution is
+///   independent of the command-line parser; it takes its inputs as a
+///   <see cref="ProcessesRequest"/> and writes to the supplied writers, so it can be
+///   driven directly in tests as well as from the verb handler in
+///   <see cref="TraceCommands"/>.
+///  </para>
+/// </remarks>
+internal static class ProcessesExecutor
+{
+    /// <summary>
+    ///  Executes the process-inventory request.
+    /// </summary>
+    /// <param name="request">The validated inventory inputs.</param>
+    /// <param name="output">The writer the result is rendered to.</param>
+    /// <param name="error">The writer load errors are reported to.</param>
+    /// <returns>A process exit code (see <see cref="ExitCodes"/>).</returns>
+    public static int Run(ProcessesRequest request, TextWriter output, TextWriter error)
+    {
+        if (!TraceExecution.TryLoad(
+            request.Path,
+            TraceMetric.Cpu,
+            symbols: null,
+            error,
+            out LoadedTrace? trace,
+            ScopeRequest.AllProcesses))
+        {
+            return ExitCodes.InputError;
+        }
+
+        TraceInfo info = trace.Info;
+        ProcessListResult processes = trace.Aggregator.Processes();
+
+        AnalysisResult<ProcessListResult> envelope = new(processes, TraceExecution.ResultWarnings(info));
+
+        if (request.Format == OutputFormat.Json)
+        {
+            output.WriteLine(OutputJson.Serialize(envelope));
+        }
+        else
+        {
+            ProcessesTextRenderer.Render(envelope, info, trace.Aggregator.Metric, output);
+        }
+
+        return ExitCodes.Success;
+    }
+}

--- a/traceq/src/TraceQ/Cli/ProcessesRequest.cs
+++ b/traceq/src/TraceQ/Cli/ProcessesRequest.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Cli;
+
+/// <summary>
+///  The validated inputs to a process-inventory run: which trace to load and how to
+///  render it. The inventory always reads every process (it exists to list them), so
+///  it carries no process-scope option.
+/// </summary>
+/// <param name="Path">The trace file path.</param>
+/// <param name="Format">The render format.</param>
+internal sealed record ProcessesRequest(
+    string Path,
+    OutputFormat Format);

--- a/traceq/src/TraceQ/Cli/ProcessesTextRenderer.cs
+++ b/traceq/src/TraceQ/Cli/ProcessesTextRenderer.cs
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Output;
+using TraceQ.Tracing;
+
+namespace TraceQ.Cli;
+
+/// <summary>
+///  Renders a trace's process inventory as a text table a human reads at the
+///  terminal: a one-line trace banner, then each process on its own line with its
+///  weight, share of the capture, and sample count, highest weight first.
+/// </summary>
+internal static class ProcessesTextRenderer
+{
+    private const int WeightColumnWidth = 16;
+    private const int PercentColumnWidth = 6;
+    private const int SamplesColumnWidth = 9;
+
+    /// <summary>
+    ///  Renders the process-inventory envelope to <paramref name="output"/>.
+    /// </summary>
+    /// <param name="envelope">The process-inventory result, with its warnings.</param>
+    /// <param name="info">The loaded trace's metadata, for the banner line.</param>
+    /// <param name="metric">The metric the weights are measured in.</param>
+    /// <param name="output">The writer the text is rendered to.</param>
+    public static void Render(
+        AnalysisResult<ProcessListResult> envelope,
+        TraceInfo info,
+        MetricInfo metric,
+        TextWriter output)
+    {
+        ProcessListResult result = envelope.Result;
+        string unit = metric.Unit;
+
+        output.WriteLine(
+            $"{info.Format}  {info.SampleCount} samples  {info.TotalWeight:N1} {unit}  symbols {info.SymbolResolutionRate:P0}");
+        output.WriteLine();
+        output.WriteLine(
+            $"processes by {metric.Name}  -  {result.TotalSamples} samples  {result.TotalWeight:N1} {unit}");
+        output.WriteLine(
+            $"  {"weight",WeightColumnWidth}  {"%",PercentColumnWidth}  {"samples",SamplesColumnWidth}  process");
+
+        foreach (ProcessSummary process in result.Processes)
+        {
+            // A single-process trace format carries an empty process label; name it so
+            // the row is not blank.
+            string name = process.Process.Length > 0 ? process.Process : "(single process)";
+            output.WriteLine(
+                $"  {$"{process.Weight:N2} {unit}",WeightColumnWidth}  {process.PercentOfScope,PercentColumnWidth:N2}  "
+                + $"{process.SampleCount,SamplesColumnWidth}  {name}");
+        }
+
+        if (result.Processes.Count == 0)
+        {
+            output.WriteLine("  (no samples)");
+        }
+
+        foreach (string warning in envelope.Warnings)
+        {
+            output.WriteLine($"! {warning}");
+        }
+    }
+}

--- a/traceq/src/TraceQ/Cli/TraceCommands.cs
+++ b/traceq/src/TraceQ/Cli/TraceCommands.cs
@@ -264,6 +264,8 @@ internal sealed class TraceCommands
     /// <param name="symbols">-s, Build-output directory whose embedded PDBs resolve managed frames.</param>
     /// <param name="format">Render format: text or json.</param>
     /// <param name="strict">Exit 3 when symbol resolution is below the trusted threshold.</param>
+    /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
+    /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
     /// <returns>A process exit code.</returns>
     [Command("callers")]
     public int Callers(
@@ -273,9 +275,17 @@ internal sealed class TraceCommands
         [Range(1, int.MaxValue)] int top = RankRequestFactory.DefaultTop,
         string? symbols = null,
         OutputFormat format = OutputFormat.Text,
-        bool strict = false)
+        bool strict = false,
+        string process = "",
+        bool allProcesses = false)
     {
-        CallersRequest request = new(trace, frame, root, top, symbols, format, strict);
+        if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
+        {
+            Console.Error.WriteLine(scopeError);
+            return ExitCodes.UsageError;
+        }
+
+        CallersRequest request = new(trace, frame, root, top, symbols, format, strict, scope);
         return CallersExecutor.Run(request, Console.Out, Console.Error);
     }
 
@@ -289,6 +299,8 @@ internal sealed class TraceCommands
     /// <param name="symbols">-s, Build-output directory whose embedded PDBs resolve managed frames.</param>
     /// <param name="format">Render format: text or json.</param>
     /// <param name="strict">Exit 3 when symbol resolution is below the trusted threshold.</param>
+    /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
+    /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
     /// <returns>A process exit code.</returns>
     [Command("lines")]
     public int Lines(
@@ -298,10 +310,18 @@ internal sealed class TraceCommands
         string[]? fold = null,
         string? symbols = null,
         OutputFormat format = OutputFormat.Text,
-        bool strict = false)
+        bool strict = false,
+        string process = "",
+        bool allProcesses = false)
     {
+        if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
+        {
+            Console.Error.WriteLine(scopeError);
+            return ExitCodes.UsageError;
+        }
+
         IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
-        LinesRequest request = new(trace, method, foldPatterns, top, symbols, format, strict);
+        LinesRequest request = new(trace, method, foldPatterns, top, symbols, format, strict, scope);
         return LinesExecutor.Run(request, Console.Out, Console.Error);
     }
 
@@ -314,6 +334,8 @@ internal sealed class TraceCommands
     /// <param name="symbols">-s, Build-output directory whose embedded PDBs resolve managed frames.</param>
     /// <param name="format">Render format: text or json.</param>
     /// <param name="strict">Exit 3 when symbol resolution is below the trusted threshold.</param>
+    /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
+    /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
     /// <returns>A process exit code.</returns>
     [Command("heatmap")]
     public int Heatmap(
@@ -322,11 +344,36 @@ internal sealed class TraceCommands
         string[]? fold = null,
         string? symbols = null,
         OutputFormat format = OutputFormat.Text,
-        bool strict = false)
+        bool strict = false,
+        string process = "",
+        bool allProcesses = false)
     {
+        if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
+        {
+            Console.Error.WriteLine(scopeError);
+            return ExitCodes.UsageError;
+        }
+
         IReadOnlyList<string> foldPatterns = fold is { Length: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
-        HeatmapRequest request = new(trace, file, foldPatterns, symbols, format, strict);
+        HeatmapRequest request = new(trace, file, foldPatterns, symbols, format, strict, scope);
         return HeatmapExecutor.Run(request, Console.Out, Console.Error);
+    }
+
+    /// <summary>
+    ///  List the processes in a trace, ranked by CPU-sample weight, so a multi-process
+    ///  capture can be scoped to the right one with the --process option on the other
+    ///  verbs.
+    /// </summary>
+    /// <param name="trace">Path to a .speedscope.json, .nettrace, or .etl file.</param>
+    /// <param name="format">Render format: text or json.</param>
+    /// <returns>A process exit code.</returns>
+    [Command("processes")]
+    public int Processes(
+        [Argument] string trace,
+        OutputFormat format = OutputFormat.Text)
+    {
+        ProcessesRequest request = new(trace, format);
+        return ProcessesExecutor.Run(request, Console.Out, Console.Error);
     }
 
     /// <summary>

--- a/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
@@ -286,6 +286,97 @@ public sealed class CliAppTests
     }
 
     [TestMethod]
+    public void Run_LinesProcessAndAllProcesses_ReturnsUsageError()
+    {
+        // The scope options are wired into the lines verb and remain mutually
+        // exclusive; the conflict is caught before any trace read, so it runs on every
+        // CI leg. A verb missing the options would instead fail with an unknown-option
+        // error, so the specific message also proves the options are bound.
+        (int exit, _, string error) = Run("lines", Speedscope, "--process", "MyApp", "--all-processes");
+
+        exit.Should().Be(ExitCodes.UsageError);
+        error.Should().Contain("only one of --process and --all-processes");
+    }
+
+    [TestMethod]
+    public void Run_CallersProcessAndAllProcesses_ReturnsUsageError()
+    {
+        (int exit, _, string error) = Run("callers", Speedscope, "Frame", "--process", "MyApp", "--all-processes");
+
+        exit.Should().Be(ExitCodes.UsageError);
+        error.Should().Contain("only one of --process and --all-processes");
+    }
+
+    [TestMethod]
+    public void Run_HeatmapProcessAndAllProcesses_ReturnsUsageError()
+    {
+        (int exit, _, string error) = Run("heatmap", Speedscope, "Foo.cs", "--process", "MyApp", "--all-processes");
+
+        exit.Should().Be(ExitCodes.UsageError);
+        error.Should().Contain("only one of --process and --all-processes");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Run_LinesProcessScope_OnMachineWideCapture_Narrows()
+    {
+        // The lines verb now scopes a multi-process ETW capture to a named process
+        // tree, mirroring cpu/rank: the scope notice is forwarded to the output.
+        // Reading an .etl is Windows-only, so this is guarded.
+        (int exit, string output, _) = Run("lines", Etw, "--process", "HotLoopBench-Job");
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("Scoped to the");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Run_CallersProcessScope_OnMachineWideCapture_Narrows()
+    {
+        (int exit, string output, _) = Run("callers", Etw, "Thread", "--process", "HotLoopBench-Job");
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("Scoped to the");
+    }
+
+    [TestMethod]
+    public void Run_Processes_OnSpeedscope_ListsTheSingleProcess()
+    {
+        // Speedscope is single-process; the inventory still renders, naming the single
+        // (empty-labelled) process. Runs on every CI leg.
+        (int exit, string output, _) = Run("processes", Speedscope);
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("processes by");
+    }
+
+    [TestMethod]
+    public void Run_ProcessesJson_WritesSingleLineEnvelope()
+    {
+        (int exit, string output, _) = Run("processes", Speedscope, "--format", "json");
+
+        exit.Should().Be(ExitCodes.Success);
+        string json = output.Trim();
+        json.Should().NotContain("\n");
+        json.Should().Contain("\"schemaVersion\"");
+        json.Should().Contain("\"processes\"");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Run_Processes_OnMachineWideCapture_ListsEveryProcess()
+    {
+        // The ETW fixture is a multi-process BenchmarkDotNet tree; the inventory lists
+        // every process (it does not auto-scope to the busiest) so the caller can pick
+        // one to scope. Reading an .etl is Windows-only.
+        (int exit, string output, _) = Run("processes", Etw);
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("processes by");
+        output.Should().Contain("HotLoopBench");
+    }
+
+    [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
     public void Run_ExplicitProcessScope_OnMachineWideCapture_WarnsAndNarrows()
     {

--- a/traceq/tests/TraceQ.Core.Tests/ProcessScopeTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/ProcessScopeTests.cs
@@ -203,6 +203,25 @@ public sealed class ProcessScopeTests
     }
 
     [TestMethod]
+    public void Read_AutoScope_SelectsTheProcessWithTheMostCpuSamples()
+    {
+        IReadOnlyList<SampleStack> all = Load(ScopeRequest.AllProcesses);
+        IReadOnlyList<SampleStack> auto = Load(ScopeRequest.Auto);
+
+        // The automatic scope ranks by CPU sample count (not CPUMSec), so it must keep
+        // every sample of the most-sampled process - that process is the workload the
+        // ranking is about. Its tree may add child-process samples on top, so auto is
+        // never smaller than the busiest process's own sample set.
+        IGrouping<string, SampleStack> busiest = all
+            .GroupBy(static s => s.Process, StringComparer.Ordinal)
+            .OrderByDescending(static g => g.Count())
+            .First();
+
+        int autoFromBusiest = auto.Count(s => string.Equals(s.Process, busiest.Key, StringComparison.Ordinal));
+        autoFromBusiest.Should().Be(busiest.Count());
+    }
+
+    [TestMethod]
     public void Read_AutoScope_OnAnAlreadyScopedCapture_DoesNotWarn()
     {
         // The applied-scope notice is suppressed when the automatic scope did not

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -486,4 +486,36 @@ public sealed class TraceToolsTests
 
         act.Should().Throw<McpException>().WithMessage("*skip must be 0 or greater*");
     }
+
+    [TestMethod]
+    public void QueryEvents_TakeAboveMax_ClampsWithWarning()
+    {
+        // A take past the page ceiling is clamped rather than honored, so a caller cannot
+        // request a page large enough to exhaust memory or blow the token budget; the
+        // clamp is surfaced as a warning so paging still works.
+        AnalysisResult<EventQueryResult> envelope = TraceTools.QueryEvents(FixturePath(Alloc), take: int.MaxValue);
+
+        envelope.Result.Events.Count.Should().BeLessThanOrEqualTo(1000);
+        envelope.Warnings.Should().Contain(w => w.Contains("clamped", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void QueryEvents_MaxPayloadAboveMax_ClampsWithWarning()
+    {
+        // A maxPayload past the ceiling is clamped with a warning for the same reason.
+        AnalysisResult<EventQueryResult> envelope =
+            TraceTools.QueryEvents(FixturePath(Alloc), maxPayload: int.MaxValue);
+
+        envelope.Warnings.Should().Contain(w => w.Contains("clamped", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void QueryEvents_NullPath_ThrowsMcpException()
+    {
+        // A null path must fail through the format guardrail as a clean McpException, not
+        // a NullReferenceException surfaced as an opaque JSON-RPC error.
+        Action act = () => TraceTools.QueryEvents(null!);
+
+        act.Should().Throw<McpException>().WithMessage("*requires a .nettrace*");
+    }
 }

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -211,6 +211,49 @@ public sealed class TraceToolsTests
     }
 
     [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Lines_ProcessScope_OnMachineWideCapture_Warns()
+    {
+        TraceStore store = new();
+
+        // The lines tool now scopes a multi-process ETW capture to a named process
+        // tree; the scope notice surfaces in the envelope warnings. Reading an .etl is
+        // Windows-only, so this is guarded.
+        AnalysisResult<LineRankingResult> envelope =
+            TraceTools.Lines(store, FixturePath(Etw), process: "HotLoopBench-Job");
+
+        AssertEnvelope(envelope);
+        envelope.Warnings.Should().Contain(w => w.Contains("Scoped to the"));
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Callers_ProcessScope_OnMachineWideCapture_Warns()
+    {
+        TraceStore store = new();
+
+        AnalysisResult<CallersResult> envelope =
+            TraceTools.Callers(store, FixturePath(Etw), frame: "", process: "HotLoopBench-Job");
+
+        AssertEnvelope(envelope);
+        envelope.Warnings.Should().Contain(w => w.Contains("Scoped to the"));
+    }
+
+    [TestMethod]
+    public void Lines_ProcessScopeOnSpeedscope_IsHarmlessNoOp()
+    {
+        TraceStore store = new();
+
+        // Speedscope is single-process, so a process selector is a no-op: the tool
+        // still succeeds and returns the (empty, no line data) ranking.
+        AnalysisResult<LineRankingResult> envelope =
+            TraceTools.Lines(store, FixturePath(Speedscope), process: "anything");
+
+        AssertEnvelope(envelope);
+        envelope.Result.Rows.Should().BeEmpty();
+    }
+
+    [TestMethod]
     public void Info_MissingFile_ThrowsMcpException()
     {
         TraceStore store = new();
@@ -442,37 +485,5 @@ public sealed class TraceToolsTests
         Action act = () => TraceTools.QueryEvents(FixturePath(Alloc), skip: -1);
 
         act.Should().Throw<McpException>().WithMessage("*skip must be 0 or greater*");
-    }
-
-    [TestMethod]
-    public void QueryEvents_TakeAboveMax_ClampsWithWarning()
-    {
-        // A take past the page ceiling is clamped rather than honored, so a caller cannot
-        // request a page large enough to exhaust memory or blow the token budget; the
-        // clamp is surfaced as a warning so paging still works.
-        AnalysisResult<EventQueryResult> envelope = TraceTools.QueryEvents(FixturePath(Alloc), take: int.MaxValue);
-
-        envelope.Result.Events.Count.Should().BeLessThanOrEqualTo(1000);
-        envelope.Warnings.Should().Contain(w => w.Contains("clamped", StringComparison.Ordinal));
-    }
-
-    [TestMethod]
-    public void QueryEvents_MaxPayloadAboveMax_ClampsWithWarning()
-    {
-        // A maxPayload past the ceiling is clamped with a warning for the same reason.
-        AnalysisResult<EventQueryResult> envelope =
-            TraceTools.QueryEvents(FixturePath(Alloc), maxPayload: int.MaxValue);
-
-        envelope.Warnings.Should().Contain(w => w.Contains("clamped", StringComparison.Ordinal));
-    }
-
-    [TestMethod]
-    public void QueryEvents_NullPath_ThrowsMcpException()
-    {
-        // A null path must fail through the format guardrail as a clean McpException, not
-        // a NullReferenceException surfaced as an opaque JSON-RPC error.
-        Action act = () => TraceTools.QueryEvents(null!);
-
-        act.Should().Throw<McpException>().WithMessage("*requires a .nettrace*");
     }
 }


### PR DESCRIPTION
Driven by a net481 ETW profiling session (the `!(bin|obj)/**/*.cs` extended-glob enumeration worst case) that exposed friction capturing and scoping ETW (`.etl`) traces. The fixes harden traceq for .NET Framework profiling, where EventPipe can't reach and the hot frame can differ entirely from net10.

## What changed

**traceq - process scoping (A1)**
- `lines` / `callers` / `heatmap` now accept `--process` / `--all-processes` (CLI) and a `process` parameter (MCP `trace_lines` / `trace_callers` / `trace_heatmap`, plus `trace_rank` / `trace_info`), matching what `cpu` / `rank` / `threadtime` already had. Previously these verbs were stuck on the auto-scope, so a machine-wide `.etl` analyzed the wrong process.

**traceq - smarter auto-scope (A2)**
- `ProcessTree.FindBusiestProcessName` now ranks by **CPU sample count** (what the rankings consume) instead of `TraceProcess.CPUMSec`. A long-lived background service accumulates more whole-capture kernel time than a short benchmark yet owns a tiny fraction of the samples; counting samples picks the workload.

**traceq - `processes` verb (A3)**
- New CLI `traceq processes <trace>` lists every process by sample weight, so the first move on a multi-process `.etl` is "who is actually here?" before scoping. Backed by `FoldingAggregator.Processes()` -> `ProcessListResult`.

**Capture workflow (C1/C2)**
- New [tools/Capture-EtwTrace.ps1](../blob/traceq-etw-process-scoping/tools/Capture-EtwTrace.ps1): net481 ETW capture that self-elevates with **live** progress (teed, never redirected away, so the elevated window never looks hung), checks the package, and prints scoped next-step commands.
- Reference `BenchmarkDotNet.Diagnostics.Windows` so `-p ETW` is available.

**Docs & skill (D)**
- Fold the ETW findings into [docs/traceq-implementation-plan.md](../blob/traceq-etw-process-scoping/docs/traceq-implementation-plan.md) as a new section 7, including a managed + unmanaged **runtime-symbol plan** (resolve `ntdll`/`ucrtbase`/`coreclr` leaves + an opt-in `--native-symbols` + a `classify` view) to answer "where does the time go - zeroing? copying? GC?".
- Rewrite `docs/traceq-local-demo.md` as a lean manual prompt script.
- Update the performance-testing ETW skill guidance (lead with "always ETW-profile net481 directly; never extrapolate the hotspot from a net10 trace").

## Notes

- This PR also carries an in-progress refactor of the performance-testing skill (`SKILL.md`, `profiling.md`, `interpreting-requests.md`) that predates the session, bundled in at the author's request.
- Native runtime-symbol resolution is the documented next step (section 7.6), not in this PR.

## Validation

- `dotnet build -c Release traceq/traceq.slnx` - clean (0 warnings, 0 errors).
- `dotnet test -c Release traceq/traceq.slnx` - **446 / 446 pass**, including new CLI/MCP scoping tests and the A2 auto-scope regression test.
- Agent-file link check green.