### PR TITLE
traceq: native symbols, --no-fold, classify, and MCP/CLI surface parity

### DIFF
--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -5,6 +5,17 @@
         "microsoft-learn": {
             "type": "http",
             "url": "https://learn.microsoft.com/api/mcp"
+        },
+        // Local traceq trace-analysis server (incubating under traceq/). Points at the
+        // built Release DLL for fast startup and clean stdout; rebuild with
+        // `dotnet build traceq/src/TraceQ.Mcp/TraceQ.Mcp.csproj -c Release` and restart
+        // the server after changing traceq. See docs/traceq-local-demo.md.
+        "traceq": {
+            "type": "stdio",
+            "command": "dotnet",
+            "args": [
+                "${workspaceFolder}/traceq/src/TraceQ.Mcp/bin/Release/net10.0/TraceQ.Mcp.dll"
+            ]
         }
     }
 }

--- a/docs/performance-investigation-without-mcp.md
+++ b/docs/performance-investigation-without-mcp.md
@@ -1,8 +1,8 @@
-# Profiling without the `touki.mcp` server
+# Profiling without the `traceq` server
 
 The primary way to turn a captured benchmark trace into ranked hotspots and
 line-level attribution is the in-workspace
-[touki.mcp](../touki.mcp/touki.mcp.csproj) analyzer - see
+[traceq](../traceq/README.md) analyzer - see
 [performance-investigation.md](performance-investigation.md) sections 3a, 3f,
 and 6.
 
@@ -18,8 +18,8 @@ applies identically here; this doc only covers the script invocations.
 
 | Script | Role | MCP equivalent |
 | --- | --- | --- |
-| `tools/Profile-Benchmark.ps1` | Run a benchmark under EventPipe **and** print folded self/inclusive rankings in one command (net10.0-only; refuses net481). | capture with `dotnet run ... -p EP` + `analyze`/`hotspots_self`/`hotspots_inclusive` |
-| `tools/Get-TraceHotspots.ps1` | Aggregate an existing `.speedscope.json` into folded self/inclusive rankings; `-CallersOf <frame>` reports a frame's callers. | `hotspots_self` / `hotspots_inclusive` / `callers_of` |
+| `tools/Profile-Benchmark.ps1` | Run a benchmark under EventPipe **and** print folded self/inclusive rankings in one command (net10.0-only; refuses net481). | capture with `dotnet run ... -p EP` + the `cpu` verb / `trace_rank` |
+| `tools/Get-TraceHotspots.ps1` | Aggregate an existing `.speedscope.json` into folded self/inclusive rankings; `-CallersOf <frame>` reports a frame's callers. | `trace_rank` (self/inclusive) / `trace_callers` |
 | `tools/speedscope-to-flamegraph.ps1` | Render an inclusive flame-graph SVG. | none - use this, or drag the speedscope into <https://www.speedscope.app/> |
 
 ## One command: run + profile + ranked hotspots
@@ -58,6 +58,6 @@ mandatory before trusting any self-time number.
 ## Line-level attribution
 
 The scripts stop at the method. For line-level (`file:line`) attribution there
-is **no script fallback** - it requires the `touki.mcp` analyzer reading a
+is **no script fallback** - it requires the `traceq` analyzer reading a
 `.nettrace`/`.etl` with the matching PDB. See
 [performance-investigation.md](performance-investigation.md) section 3f.

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -36,7 +36,7 @@ flowchart TD
     B -->|"Is impl A faster than B?"| C[BenchmarkDotNet A/B<br/>MemoryDiagnoser + Baseline]
     B -->|"Does this allocate?"| D[BenchmarkDotNet<br/>MemoryDiagnoser - read Allocated]
     B -->|"Which method eats the time<br/>in a whole operation?"| E[Profiler: EventPipeProfiler<br/>or dotnet-trace -> speedscope]
-    B -->|"Which source LINE inside<br/>the hot method?"| M[touki.mcp hot_lines<br/>.nettrace + --symbols]
+    B -->|"Which source LINE inside<br/>the hot method?"| M[traceq lines<br/>.nettrace + --symbols]
     B -->|"Why is THIS loop slow<br/>on net481?"| F[DisassemblyDiagnoser<br/>compare net481 vs net10 asm]
     B -->|"Branch mispredicts / cache?"| G[HardwareCounters<br/>Windows + admin]
     C --> H[Read *.md report only]
@@ -58,7 +58,7 @@ Rule of thumb for picking the entry point:
 | "A vs B", "did my change regress?" | BenchmarkDotNet `[Benchmark]` + `Baseline` | low |
 | "Does X allocate? how much?" | BenchmarkDotNet `[MemoryDiagnoser]` | low |
 | "Where in a multi-method operation is the time?" | `[EventPipeProfiler]` or `dotnet-trace` | medium |
-| "Which source *line* inside the hot method?" | `touki.mcp` `hot_lines` (`.nettrace` + `--symbols`) | medium |
+| "Which source *line* inside the hot method?" | `traceq` `lines` (`.nettrace` + `--symbols`) | medium |
 | "Why does the JIT emit slow code here?" | `[DisassemblyDiagnoser]` | medium |
 | "Is it branch misprediction / cache misses?" | `[HardwareCounters]` (Win+admin) | medium |
 | "Does it leak / churn the GC over a long run?" | `dotnet-counters`, `dotnet-gcdump` | medium |
@@ -256,12 +256,12 @@ It writes a `.speedscope.json` (and `.nettrace`) under
 <https://www.speedscope.app/> (drag-drop, nothing to install) to get a flame
 graph. Cross-platform, works on Linux/macOS/Windows, **no admin required**.
 
-#### Capture a trace, then rank hotspots (touki.mcp)
+#### Capture a trace, then rank hotspots (traceq)
 
 Capturing the trace and *reading* it are two steps. Capture is a plain
 `dotnet run`; the ranked, artifact-folded self/inclusive hotspots come from the
-in-workspace [touki.mcp](../touki.mcp/touki.mcp.csproj) analyzer (section 6),
-which reads the trace BenchmarkDotNet just wrote - no GUI, no PerfView:
+in-workspace [traceq](../traceq/README.md) analyzer (section 6), which reads the
+trace BenchmarkDotNet just wrote - no GUI, no PerfView:
 
 ```powershell
 # 1. Run the benchmark under EventPipe (--keepFiles preserves the build so its
@@ -274,14 +274,15 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
     Sort-Object LastWriteTime | Select-Object -Last 1).FullName
 
 # 2. Folded self-time + inclusive-time rankings, scoped to a workload frame.
-dotnet run --project touki.mcp -c Release -- analyze $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+dotnet run --project traceq/src/TraceQ -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
 
 # Confirm what a folded JIT-helper artifact is attributable to:
-dotnet run --project touki.mcp -c Release -- analyze $trace --callers 'BulkMoveWithWriteBarrier'
+dotnet run --project traceq/src/TraceQ -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
 ```
 
-An agent that speaks MCP calls `hotspots_self` / `hotspots_inclusive` /
-`callers_of` directly on the same trace (section 6) instead of shelling out.
+An agent that speaks MCP calls `trace_rank` (with `measure: self|inclusive`) /
+`trace_callers` directly on the registered `traceq` server (section 6) instead
+of shelling out.
 
 > The committed PowerShell scripts (`Profile-Benchmark.ps1`,
 > `Get-TraceHotspots.ps1`) did this aggregation before the MCP server existed
@@ -291,7 +292,7 @@ An agent that speaks MCP calls `hotspots_self` / `hotspots_inclusive` /
 > [performance-investigation-without-mcp.md](performance-investigation-without-mcp.md).
 
 For line-level attribution on the same trace - which *source line* inside the
-ranked method dominates - hand the `.nettrace` to `touki.mcp` with `--lines`
+ranked method dominates - hand the `.nettrace` to `traceq` with the `lines` verb
 (section 3f). This has no script fallback.
 
 > **Reading the BenchmarkDotNet speedscope export - two traps.**
@@ -412,7 +413,7 @@ samples for a stable ranking. Levers that actually help, cheapest first:
   count already helps; an operation that runs for seconds (like the 25 s
   extglob enumeration here) yields thousands of samples and a stable tree.
 - **Fold the artifacts** (section 3a, Trap 2). This is the single biggest
-  accuracy win for *attribution* and costs nothing - the `touki.mcp` analyzer
+  accuracy win for *attribution* and costs nothing - the `traceq` analyzer
   (and the fallback scripts) do it by default.
 - **Split a suspect frame with `[MethodImpl(MethodImplOptions.NoInlining)]`.**
   If two methods are inlined together the sampler cannot tell them apart;
@@ -422,7 +423,7 @@ samples for a stable ranking. Levers that actually help, cheapest first:
   stdout - token-cheap for an agent, and it reads the same `.nettrace`.
 - **PerfView headless** (`PerfView /FoldPats=... stacks ...`) does the same fold
   the analyzer does, with richer grouping, when you already have PerfView. The
-  `touki.mcp` analyzer exists so the common case needs neither PerfView nor a
+  `traceq` analyzer exists so the common case needs neither PerfView nor a
   GUI.
 - **Want true CPU time and native frames?** EventPipe gives neither. On Windows
   use `[EtwProfiler]` (section 3b, admin). On Linux - including **WSL Ubuntu on
@@ -448,18 +449,18 @@ Stabilize the JIT **for clean attribution, not for absolute numbers**:
 - Do **not** chase JIT stability for a microbenchmark whose numbers you care
   about - measure those with the normal tiered harness.
 
-### 3f. Layer 2b - from the hot method down to the hot *line* (`touki.mcp`)
+### 3f. Layer 2b - from the hot method down to the hot *line* (`traceq`)
 
 The profilers above rank *methods*. The committed
-[touki.mcp](../touki.mcp/touki.mcp.csproj) project takes the same trace one
+[traceq](../traceq/README.md) project takes the same trace one
 level deeper: it reads the `.nettrace`/`.etl` through TraceEvent and attributes
 each leaf sample to the **source `file:line` that was executing**, so you can
 see which lines of a hot loop dominate. It is net10-only and runs two ways:
 
-- **Console front end** - `dotnet run --project touki.mcp -c Release -- analyze`.
-- **MCP server** - the same queries exposed as tools (`load_trace`,
-  `hotspots_self`, `hotspots_inclusive`, `callers_of`, `hot_lines`,
-  `list_threads`) for an agent that speaks MCP. See section 6.
+- **Console front end** - `dotnet run --project traceq/src/TraceQ -c Release -- <verb>`.
+- **MCP server** - the same queries exposed as tools (`trace_info`,
+  `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
+  registered `traceq` server for an agent that speaks MCP. See section 6.
 
 The top-down loop on a single captured trace:
 
@@ -475,15 +476,16 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
 $sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
 
 # 1. Method ranking (self + inclusive), JIT-helper artifacts folded.
-dotnet run --project touki.mcp -c Release -- analyze $trace --symbols $sym --top 20
+dotnet run --project traceq/src/TraceQ -c Release -- cpu $trace --symbols $sym --top 20
 
 # 2. Line ranking inside the dominant method.
-dotnet run --project touki.mcp -c Release -- analyze $trace --lines RunEngine --symbols $sym --top 30
+dotnet run --project traceq/src/TraceQ -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
 ```
 
-Console flags: `--root <substr>` scopes to a subtree, `--callers <substr>`
-reports a frame's callers, `--lines [<methodSubstr>]` switches to line-level,
-`--symbols <dir>` supplies PDBs, `--top N` caps rows.
+Verbs and flags: `cpu`/`rank` rank methods (`--root <substr>` scopes to a
+subtree), `callers <frame>` reports a frame's callers, `lines [--method
+<substr>]` is line-level, `heatmap <file>` overlays per-line heat; `--symbols
+<dir>` supplies PDBs and `--top N` caps rows.
 
 > **Embedded PDBs need `--symbols`.** `touki.dll` ships its portable PDB
 > *embedded* (`<DebugType>embedded</DebugType>`), and TraceEvent cannot read an
@@ -602,28 +604,33 @@ but unmatched depth. Pairs with `dotnet-trace`'s `.nettrace` output too.
 
 ## 6. MCP servers and programmatic API access
 
-### The in-workspace profiling MCP server: `touki.mcp`
+### The in-workspace profiling MCP server: `traceq`
 
-This workspace **does** ship a dedicated trace-analysis MCP server,
-[touki.mcp](../touki.mcp/touki.mcp.csproj) (net10-only). It reads the same
-`.nettrace`/`.etl` traces the diagnosers and `dotnet-trace` produce, folds the
-JIT-helper sampling artifacts (section 3a, Trap 2), and answers method- and
-line-level questions over MCP - so an agent that speaks MCP can drive the whole
-Layer 2 / Layer 2b loop without shelling out to the PowerShell scripts. It also
-has a console front end (`analyze`, section 3f).
+This workspace ships a dedicated trace-analysis MCP server,
+[traceq](../traceq/README.md) (net10-only), registered in
+[.vscode/mcp.json](../.vscode/mcp.json). It reads the same
+`.nettrace`/`.etl`/`.speedscope.json` traces the diagnosers and `dotnet-trace`
+produce, folds the JIT-helper sampling artifacts (section 3a, Trap 2), and
+answers method- and line-level questions over MCP - so an agent that speaks MCP
+can drive the whole Layer 2 / Layer 2b loop without shelling out to the
+PowerShell scripts. It also has a console front end (the CLI verbs, section 3f).
 
-Tools it exposes (all take a trace `path`):
+Tools it exposes (all take a trace `path`; `trace_rank` selects the family with
+`metric` and the measure with `measure`):
 
 | Tool | Answers |
 | --- | --- |
-| `load_trace(path, symbols)` | format / duration / sample count / symbol-resolution rate / threads. **Call first**; a rate below 0.8 means symbols are missing. |
-| `hotspots_self(path, rootFrame, fold, top)` | folded self-time ranking. |
-| `hotspots_inclusive(path, rootFrame, fold, top)` | folded inclusive-time ranking. |
-| `callers_of(path, frame, rootFrame, top)` | who calls a frame - confirms what a JIT-helper artifact is attributable to. |
-| `hot_lines(path, method, fold, top, symbols)` | **line-level** self-time, each leaf sample mapped to `file:line`. Needs `.nettrace`/`.etl` + `symbols`; speedscope yields nothing; `<no source>` = PDB not found. |
-| `list_threads(path)` | per-thread sample counts, to pick a `rootFrame` or spot idle thread-pool noise. |
+| `trace_info(path, symbols)` | format / total weight / sample count / symbol-resolution rate / per-thread counts / warnings. **Call first**; a rate below 0.8 means symbols are missing. Folds in the old per-thread listing. |
+| `trace_rank(path, metric, measure, root, fold, top, symbols)` | folded ranking by `metric` (cpu, alloc, exceptions, threadtime) and `measure` (self or inclusive). |
+| `trace_callers(path, frame, root, top)` | who calls a frame - confirms what a JIT-helper artifact is attributable to. |
+| `trace_lines(path, method, fold, top, symbols)` | **line-level** self-time, each leaf sample mapped to `file:line`. Needs `.nettrace`/`.etl` + `symbols`; speedscope yields nothing; `<no source>` = PDB not found. |
+| `trace_heatmap(path, file, fold, symbols)` | per-line self-time heat for one source file, ordered to overlay onto the source. |
+| `trace_diff(before, after, measure, root, fold, top)` | what got slower/faster between two traces. |
+| `trace_gc(path, top)` | GC counts, pauses, and heap summary (`.nettrace`). |
+| `trace_query_events(path, name, skip, take, maxPayload)` | raw event query by name, paged (`.nettrace`). |
+| `trace_export(path, output, format, name, symbols)` | write a speedscope / Chrome-trace flame-graph file. |
 
-`rootFrame` gotcha and symbol/`--keepFiles`/inlining caveats are the same as the
+The `root` gotcha and symbol/`--keepFiles`/inlining caveats are the same as the
 console form - see sections 3a and 3f.
 
 ### Research-oriented MCP/API surfaces
@@ -660,9 +667,9 @@ A concrete, token-efficient loop an agent should follow:
    `*-report-github.md`, quote only `Mean`/`Ratio`/`Allocated` for changed rows.
 6. **If the bottleneck is unclear**, attach `[EventPipeProfiler(CpuSampling)]`,
    capture a trace (`dotnet run ... --filter *<Subject>* -p EP --keepFiles` on
-   **net10.0**), then rank it with the `touki.mcp` analyzer
-   (`dotnet run --project touki.mcp -c Release -- analyze <trace> --root
-   <workload-frame>`, or the `hotspots_self`/`hotspots_inclusive` MCP tools; the
+   **net10.0**), then rank it with the `traceq` analyzer
+   (`dotnet run --project traceq/src/TraceQ -c Release -- cpu <trace> --root
+   <workload-frame>`, or the `trace_rank` MCP tool; the
    PowerShell scripts in
    [performance-investigation-without-mcp.md](performance-investigation-without-mcp.md)
    are the no-MCP fallback). **Fold the JIT-helper artifacts**
@@ -673,9 +680,9 @@ A concrete, token-efficient loop an agent should follow:
    EventPipe is net10.0-only; for net481 on-CPU attribution use `[EtwProfiler]`
    (admin) - see the per-TFM table in &sect;3.
 7. **If you need the hot *line*, not just the hot method**, feed the same
-   `.nettrace` to `touki.mcp`: `dotnet run --project touki.mcp -c Release --
-   analyze <trace> --lines <method> --symbols <build-dir> --top 30` (or the
-   `hot_lines` MCP tool). Capture with `--keepFiles` and point `--symbols` at
+   `.nettrace` to `traceq`: `dotnet run --project traceq/src/TraceQ -c Release --
+   lines <trace> --method <method> --symbols <build-dir> --top 30` (or the
+   `trace_lines` MCP tool). Capture with `--keepFiles` and point `--symbols` at
    BDN's surviving `...-DefaultJob-N/bin/Release/net10.0` so the PDB GUID
    matches; if the ranking collapses onto one or two call-site lines the callee
    is inlined - drill the non-inlined tail or add a temporary `NoInlining`. See
@@ -710,15 +717,15 @@ A/B + allocations ............ dotnet run -c Release -f <tfm> --project touki.pe
 Fast smoke ................... add --job short
 Read the result .............. BenchmarkDotNet.Artifacts/results/*-report-github.md
 Capture a trace .............. dotnet run -c Release -f net10.0 --project touki.perf -- --filter *X* -p EP --keepFiles
-Rank an existing trace ....... dotnet run --project touki.mcp -c Release -- analyze <trace> --root <workload-frame>
-                               folds JIT-helper artifacts + ranks self/inclusive. --callers <frame> = who calls it.
-No-MCP fallback scripts ...... ./tools/Profile-Benchmark.ps1 / Get-TraceHotspots.ps1 (see *-without-mcp.md)
+Rank an existing trace ....... dotnet run --project traceq/src/TraceQ -c Release -- cpu <trace> --root <workload-frame>
+                               folds JIT-helper artifacts + ranks self/inclusive. callers <frame> = who calls it.
+No-server fallback scripts ... ./tools/Profile-Benchmark.ps1 / Get-TraceHotspots.ps1 (see *-without-mcp.md)
 Flame-graph SVG .............. ./tools/speedscope-to-flamegraph.ps1   (or drag the speedscope into speedscope.app)
-Which source LINE? ........... dotnet run --project touki.mcp -c Release -- analyze <trace> --lines <method> --symbols <build-dir>
+Which source LINE? ........... dotnet run --project traceq/src/TraceQ -c Release -- lines <trace> --method <method> --symbols <build-dir>
                                net10 .nettrace/.etl + embedded PDB. Capture with --keepFiles; point --symbols
                                at BDN's ...-DefaultJob-N/bin/Release/net10.0 (PDB GUID must match the trace).
                                Inlined callee -> samples collapse on the call-site line; drill the tail. See 3f.
-touki.mcp as an MCP server ... tools: load_trace / hotspots_self / hotspots_inclusive / callers_of / hot_lines / list_threads
+traceq as an MCP server ...... tools: trace_info / trace_rank / trace_callers / trace_lines / trace_heatmap / trace_diff / trace_gc / trace_query_events / trace_export
 Where's the time? (in-harness) [EventPipeProfiler(EventPipeProfile.CpuSampling)] -> speedscope.app
                                net10.0 only (no admin); net481 needs [EtwProfiler] (admin) -> .etl
                                FOLD BulkMoveWithWriteBarrier/PollGC/CPU_TIME before reading self-time.

--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -264,8 +264,22 @@ Help is treated as a build artifact (**landed**): the README carries an examples
 > budget was re-measured (~4.4k tokens for nine tools) and the ceiling raised to 6000.
 > **Only the MCP Inspector smoke remains** (a manual check); `trace_trim` stays parked
 > with the `trim` verb.
+>
+> **Surface parity with the CLI (later pass).** The "rich family reports stay
+> CLI-first" stance below was revisited so an agent reaches the same analyses a human
+> does. Four tools joined the curated set - `trace_processes` (the process inventory),
+> `trace_tree` (the top-down call tree), `trace_classify` (the runtime work-category
+> breakdown), and `trace_jit` (the JIT report, a `.nettrace` report alongside
+> `trace_gc`) - taking it to **thirteen tools**. `alloc` and `exceptions` were already
+> reachable through `trace_rank`'s `metric` parameter, so the only analysis verbs that
+> stay CLI-only are the file-management verbs `convert` and `clean` (they manage the
+> on-disk ETLX cache rather than return an analysis, and `clean` deletes files - both
+> sit outside the read-only analysis contract). The output schemas put the
+> thirteen-tool surface at ~6.7k tokens (~520 each), so the schema-budget ceiling was
+> re-measured and raised to 8000 - still a bloat guard (a doubled description or a few
+> unplanned tools trips it), not a cap on legitimate parity.
 
-The eight tools (§5.2) re-cut over the same services: port touki.mcp's description text, apply the D5 consolidation (`trace_rank` with `metric`), fold `list_threads` into `trace_info`, add `trace_gc`/`trace_diff`/`trace_query_events`. The broadened surface (section 1A) raises the consolidation stakes, not the tool count: the **engine** tools take a `metric`/provider parameter, so `trace_rank(metric: cpu|threadtime|alloc|…)` is *one* tool spanning every family rather than one tool per family - the token budget below is what forces this. `trace_export` and `trace_trim` join the curated set (they are how an agent hands a human a flame graph or shrinks a trace); the rich family reports (`alloc`/`jit`/`exceptions`/`heap`) stay CLI-first and are promoted to MCP only when an eval task demands it (backlog O4). Annotations (`readOnlyHint` et al.), `outputSchema` + `structuredContent` where the C# SDK supports them, the server `instructions` field carrying the workflow summary, and `traceq mcp` hosting with stderr-only logging.
+The eight tools (§5.2) re-cut over the same services: port touki.mcp's description text, apply the D5 consolidation (`trace_rank` with `metric`), fold `list_threads` into `trace_info`, add `trace_gc`/`trace_diff`/`trace_query_events`. The broadened surface (section 1A) raises the consolidation stakes, not the tool count: the **engine** tools take a `metric`/provider parameter, so `trace_rank(metric: cpu|threadtime|alloc|…)` is *one* tool spanning every family rather than one tool per family - the token budget below is what forces this. `trace_export` and `trace_trim` join the curated set (they are how an agent hands a human a flame graph or shrinks a trace); the rich family reports were initially CLI-first and promoted to MCP only as eval tasks demanded (backlog O4), but the surface was later brought to parity with the analysis verbs (see the parity-pass update above), leaving only the `heap` family (future) and the file-management verbs `convert`/`clean` CLI-only. Annotations (`readOnlyHint` et al.), `outputSchema` + `structuredContent` where the C# SDK supports them, the server `instructions` field carrying the workflow summary, and `traceq mcp` hosting with stderr-only logging.
 
 Two CI checks born here and kept forever: the **stdout-purity test** (run the server under load, including a deliberately chatty logging provider, and assert nothing but JSON-RPC reaches stdout) and the **schema budget check** (serialize the tool list, fail above a token budget - ~4.4k tokens for the nine-tool surface once each tool advertises an output schema, with the ceiling set at 6000 to fit the curated set). Both landed in `tools/Test-McpServer.ps1`, which also runs a scripted `tools/call` round-trip. The MCP Inspector smoke is a manual check.
 
@@ -302,7 +316,7 @@ Build the §10 harness: headless Claude Code + Copilot CLI runners, the four arm
 
 ### Post-1.0 backlog (eval- and demand-gated, per design §13)
 
-`collect` verb (CLI-only, Windows-only, elevation-guarded — D11) · promote `alloc`/`jit`/`exceptions` to MCP when an eval task demands it (O4) · MCP Tasks for large-trace first load (O2) · MCP Apps flame-graph view (O3) · kernel ETW surface as a bounded expansion (O7) · Linux `perf`/LTTng ingestion · **net-mem provider** by factoring `GCHeapSimulator` into TraceEvent (Addendum A) · **heap-snapshot capture** via the HeapDump assembly or `dotnet-gcdump` (Addendum A) · **trigger-based + circular-buffer collection** (Addendum A) · **PMC / CPU-counter** capture and ranking (section 1A) · promote the retention / leak-diff family to MCP · richer interactive views (Perfetto deep-link, MCP Apps).
+`collect` verb (CLI-only, Windows-only, elevation-guarded — D11) · promote the `heap` family to MCP when an eval task demands it (O4; `alloc`/`exceptions` are reachable via `trace_rank`'s `metric`, and `jit`/`processes`/`tree`/`classify` shipped as `trace_jit`/`trace_processes`/`trace_tree`/`trace_classify`) · MCP Tasks for large-trace first load (O2) · MCP Apps flame-graph view (O3) · kernel ETW surface as a bounded expansion (O7) · Linux `perf`/LTTng ingestion · **net-mem provider** by factoring `GCHeapSimulator` into TraceEvent (Addendum A) · **heap-snapshot capture** via the HeapDump assembly or `dotnet-gcdump` (Addendum A) · **trigger-based + circular-buffer collection** (Addendum A) · **PMC / CPU-counter** capture and ranking (section 1A) · promote the retention / leak-diff family to MCP · richer interactive views (Perfetto deep-link, MCP Apps).
 
 ---
 

--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -6,10 +6,14 @@ its findings back into the tool - see [§7](#7-dogfooding-hardening-2026-06-10-e
 Shipped: process scoping on the line-level verbs and the MCP tools (A1), a
 sample-count busiest-process auto-scope (A2), a `processes` inventory verb (A3),
 the [tools/Capture-EtwTrace.ps1](../tools/Capture-EtwTrace.ps1) capture wrapper
-(C1), and the rewritten ETW skill (D). **What's next: the runtime-symbol plan
-([§7.6](#76-whats-next-the-runtime-symbol-plan-managed--unmanaged))** - resolve
-managed *and* unmanaged runtime symbols so a profile can say where time actually
-goes (zeroing memory? copying strings?), then resume the product milestones at
+(C1), and the rewritten ETW skill (D). **Managed runtime symbols: verified
+(2026-06-11)** - a probe of real captures confirmed .NET runtime/framework
+managed methods already resolve from the CLR rundown on both TFMs (net10 R2R at
+100%, net481 NGEN managed leaves resolve), pinned by a regression test; no
+managed-symbol work is needed (§7.6). **What's next: native runtime symbols
+([§7.6](#76-whats-next-the-runtime-symbol-plan-managed--unmanaged))** - the
+opt-in symbol-server path for the unmanaged ~10% (zeroing / copying / GC), so a
+profile can name where that time goes, then resume the product milestones at
 M3½ (promotion).
 **Progress (2026-06-09):** M0 complete (PR #182). M1's analysis core is complete and M2 (the CLI head) is the active milestone. M1 landings - core relocation merged (PR #183); provider/engine seam laid (`StackSampleSource` + `MetricInfo`); output-contract envelope landed (`AnalysisResult<T>` + compact, rounded, deterministic JSON with golden tests); symbol gate landed (`SymbolGate`; `--strict`/exit-3 deferred to M2); tier-2 LRU landed (`LruCache`); token budget landed (`OutputBudget`; truncation + text renderer deferred to M2); fixture corpus + parity harness landed for the net10 EventPipe half (PR #186); allocation provider landed (`AllocationProvider` reads `GCAllocationTick` into byte-weighted stacks ranked by the same metric-generic engine - `SampleStack.Weight`); GC-stats provider landed (`GcStatsProvider` reads `TraceGC` structured records, reusing the GC-verbose fixture). **ThreadTime landed (ETW):** the earlier EventPipe spike was a strictly worse CPU view (no `BLOCKED_TIME`, since EventPipe samples only running threads), but the net481 ETW capture carries context switches, so `ThreadTimeProvider` reconstructs each thread's running and blocked intervals into elapsed-millisecond stacks (`MetricInfo.ThreadTime`) the metric-generic engine ranks unchanged. Export engine verb landed (`SpeedscopeExporter` writes any provider's stacks to the speedscope sampled format, metric-aware unit). Filter/scope grammar subset landed (`ScopeFilter` include/exclude on frame names; sample-level time/process scoping deferred for model + fixture reasons). Diff engine verb landed (`RankingDiff` compares two rankings - provider-agnostic regression/improvement deltas). Group transform landed (`GroupTransform` collapses a matched module's frames into a `module!` box). Chromium export landed (`ChromiumExporter` writes any provider's stacks to the Chrome Trace Event Format). EventQuery provider landed (`EventQueryProvider` paginated raw-event query with payload cap). JitStats provider landed (`JitStatsProvider` per-method JIT compile-time / size / tier records, with a tuned `JitLoop` smoke fixture). Steering-hint taxonomy landed (`SteeringHints` turns a ranking, callers, or diff result into the canonical next-step nudge). The net481 ETW (`.etl`) corpus half landed: an `EtwLoop` benchmark captured under the ETW profiler with context-switch keywords, a process-tree relog `trim` (native-only; the managed-JIT limit and the physical-trim follow-up are captured in [traceq-etl-trimming.md](traceq-etl-trimming.md)), and a committed ~1 MB multi-process scenario fixture. Process-tree scoping landed (`ProcessScope` + read-time filtering in the ETL/EventPipe reader): a machine-wide capture is scoped losslessly to the workload process tree and its children at analysis time, resolving the workload's managed frames. The tier-1 ETLX disk cache is deferred with reason (TraceEvent already caches `.nettrace`/`.etl` -> `.etlx` on both paths; a custom cache adds nothing measurable without the elevated `.etl` half). ThreadTime landed over the ETW capture (`ThreadTimeProvider`: running + blocked intervals into elapsed-millisecond stacks). The O1 cross-machine hand-off spike passed: a Windows-converted `.etlx` resolves managed frames byte-identically on Ubuntu 26.04, so the hand-off is advertised (only the `.etl` -> `.etlx` conversion stays Windows-only). Exceptions provider landed (`ExceptionsProvider` reads `Exception/Start` events into count-weighted throw-site stacks). The text renderer (landed in M2) and the grouping altitude (`GroupTransform`, landed in M1) are no longer outstanding, so the only deferred M1 work is the sample-level time- and process-filter altitudes (M1 step 5, parked for want of fixture data - distinct from the read-time `ProcessScope`, which is already built). **M2 (CLI head):** the engine verbs `rank`/`cpu`/`callers`/`lines`/`heatmap`/`diff`/`tree`/`export` have merged (PRs #195-198); the fifth slice has wired the provider-selection seam (a `TraceMetric` selector threaded through `TraceStore` -> `TraceLoader`, which dispatches to each provider and synthesizes the `TraceInfo` for the non-CPU families) and lit up the three stack-source family shortcuts - `alloc`, `exceptions`, and `threadtime` - each selectable as `rank --metric <name>` or its own verb (PR #199), and added the three report verbs `gcstats` / `jitstats` / `events` (structured records rather than rankable stacks, each with its own executor and renderer), and wired the `--process` / `--all-processes` scope options onto the stack-ranking verbs (a `ScopeRequest` intent the loader resolves to a process tree, defaulting to the busiest process automatically). M2's verb surface is complete, and the CLI head is closed out: the `--benchmark` scope option (frame-based, presets the root to the BenchmarkDotNet workload wrapper) and the `convert` / `clean` file-op verbs landed, the CLI packages as a local `dotnet tool` (an exit criterion), and a CI help-lint guards the help/README contract. `heap` stays unbuilt (no provider yet, Addendum A capture work); `trim` stays parked (the relog rewrite resolves native frames only - see traceq-etl-trimming.md); the eval-task exit criterion rides the M5 harness. See the M2 section for detail.
 **Date:** 2026-06-04
@@ -483,13 +487,27 @@ artifact. The goal is to name that work.
 
 **Two symbol classes, two very different costs:**
 
-1. **Managed frames - already resolved, free.** JITted method names come from the
-   CLR rundown baked into every trace, so `System.*`, `Buffer.Memmove`,
-   `SpanHelpers.*`, and all touki methods already rank correctly on both TFMs with
-   no symbol server. The one gap is **precompiled images**: on net481 the
-   Framework assemblies are NGENed (need NGEN PDBs), and on net10 the runtime
-   ships ReadyToRun (R2R) - TraceEvent usually resolves R2R from the rundown, but
-   this must be verified, not assumed.
+1. **Managed frames - already resolved, free (VERIFIED 2026-06-11).** Method names
+   come from the CLR rundown baked into every trace, so `System.*`,
+   `Buffer.Memmove`, `SpanHelpers.*`, and all touki methods rank correctly on both
+   TFMs with no symbol server. The precompiled-image question - net481 NGEN and
+   net10 ReadyToRun (R2R) - is now **answered, not assumed**: a probe of real
+   captures showed net10 EventPipe resolves R2R framework methods at **100%**
+   (`System.String.Ctor`, `System.MemoryExtensions.IndexOf`,
+   `System.Reflection.*`), and a full net481 ETW capture resolves NGEN framework
+   methods (`System.Runtime.InteropServices.MemoryMarshal.GetReference`,
+   `System.Buffers.DefaultArrayPool...`, `System.IO.PathInternal.*`) - the only
+   unresolved leaves there are **native** (the ~10% `?`), not managed. So there is
+   **no managed-symbol work to do** for the captures traceq's profilers produce;
+   `Load_NetTrace_ResolvesDotNetRuntimeManagedMethods` pins net10 R2R resolution as
+   a regression guard. Two caveats: (a) a trace whose CLR rundown was **stripped**
+   (the committed, relog-trimmed `etw.etl` fixture resolves at ~1%) loses managed
+   names - that is a trimming artifact, not a resolution gap, and is why the net481
+   NGEN case is verified manually but not yet pinned by a committed fixture (it
+   needs a managed-resolving `.etl` release asset, per the fixture strategy);
+   (b) the aggregate resolution rate conflates managed and native, so a net481
+   capture can read "44%" while every managed leaf resolves - the `SymbolGate`
+   warning already hedges this ("managed-method rankings remain usable").
 2. **Native runtime frames - the missing 10%, needs a symbol server.** These are
    the frames that answer the question, and they live in unmanaged modules whose
    PDBs are on the **Microsoft public symbol server**
@@ -513,13 +531,16 @@ samples are fetched - bounding the download to what the trace actually hit, not
 every loaded DLL. The current offline, deterministic, local-PDB-only mode stays
 the **default**.
 
-**Phase 2 - precompiled-image PDBs.** For NGEN modules (net481), call
-`SymbolReader.GenerateNGenSymbolsForModule` during the read (TraceEvent
-regenerates the NGEN PDB from the native image locally; Windows-only). We
-confirmed BDN's `EtwProfiler` writes **no** `.etl.ngenpdb` folder, so
-analysis-time generation is the only path. For net10, verify R2R frames resolve
-from the rundown; if not, the R2R PDB comes from the same symbol server as the
-native modules.
+**Phase 2 - precompiled-image PDBs (managed names: not needed; see below).**
+The verification above settles this for the *managed* case: NGEN (net481) and R2R
+(net10) framework method **names already resolve from the CLR rundown**, so no
+`SymbolReader.GenerateNGenSymbolsForModule` call or R2R PDB fetch is required to
+get managed runtime symbols. NGEN-PDB generation only becomes relevant for two
+narrower needs that are not the current ask: **(a)** managed **line numbers**
+inside precompiled framework code (the rundown carries names, not source lines),
+and **(b)** rehydrating managed names from a capture whose rundown was stripped.
+Both are deferred until an eval task demands them; for now Phase 2 is a no-op for
+the "get managed runtime symbols" goal, which is already met.
 
 **Phase 3 - surface the work (the part that actually answers the question).**
 The default fold list *hides* exactly these frames: it folds `memmove`,

--- a/touki.perf/ValueStringBuilderFormattingPerf.cs
+++ b/touki.perf/ValueStringBuilderFormattingPerf.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text;
+using Touki.Text;
+
+namespace touki.perf;
+
+/// <summary>
+///  Head-to-head comparison of formatting a string with <see cref="Touki.Text.ValueStringBuilder"/>
+///  versus a plain <see cref="StringBuilder"/>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The scenario is a representative composite-format build: one literal-heavy format
+///   string with three holes of mixed types (a <see cref="string"/>, an <see cref="int"/>,
+///   and a <see cref="double"/>) producing a short result that fits inside the 256-char
+///   stack buffer. Both variants finish with <c>ToString()</c>, so each pays for the final
+///   result string; the difference is everything else.
+///  </para>
+///  <para>
+///   The plain <see cref="StringBuilder"/> path allocates the builder object, its internal
+///   char buffer, and one box per value-type argument (<see cref="StringBuilder.AppendFormat(string, object?, object?, object?)"/>
+///   takes <see cref="object"/> holes). The <see cref="Touki.Text.ValueStringBuilder"/> path keeps its
+///   working buffer on the stack and passes arguments through <see cref="Value"/>, which
+///   stores primitives inline, so it allocates only the final string.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+public class ValueStringBuilderFormattingPerf
+{
+    private const string Format = "User {0} has {1} points ({2:F1}% complete).";
+
+    private readonly string _name = "Jeremy";
+    private readonly int _score = 1234;
+    private readonly double _percent = 87.5;
+
+    [Benchmark(Baseline = true)]
+    public string StringBuilder_AppendFormat()
+    {
+        StringBuilder builder = new();
+        builder.AppendFormat(Format, _name, _score, _percent);
+        return builder.ToString();
+    }
+
+    [Benchmark]
+    public string ValueStringBuilder_AppendFormat()
+    {
+        ValueStringBuilder builder = new(stackalloc char[256]);
+        builder.AppendFormat(Format, _name, _score, _percent);
+        return builder.ToStringAndDispose();
+    }
+}

--- a/traceq/README.md
+++ b/traceq/README.md
@@ -87,6 +87,7 @@ traceq cpu app.etl --process MyApp --native-symbols   # name the GC/JIT/memcpy f
 | Verb | Purpose | Example |
 |---|---|---|
 | `processes` | List processes by CPU-sample weight, to pick a `--process` target | `traceq processes machinewide.etl` |
+| `classify` | Summarize CPU time by runtime work category (zeroing / copying / GC / ...) | `traceq classify app.etl --native-symbols` |
 
 **Compare and export:**
 

--- a/traceq/README.md
+++ b/traceq/README.md
@@ -61,6 +61,18 @@ traceq processes machinewide.etl             # list every process by weight
 traceq cpu machinewide.etl --process MyApp   # one process tree
 ```
 
+**Native runtime symbols.** Managed frames (including NGEN and ReadyToRun
+framework methods) resolve for free from the trace's CLR rundown. The *unmanaged*
+runtime frames - the GC, the JIT, `memset` / `memcpy`, write barriers - need PDBs
+from the Microsoft public symbol server, which `cpu` / `rank` fetch only when you
+opt in with `--native-symbols` (cached under `--symbol-cache`, default in the temp
+path). It is off by default so analysis stays offline and deterministic; the first
+run downloads, later runs hit the cache.
+
+```pwsh
+traceq cpu app.etl --process MyApp --native-symbols   # name the GC/JIT/memcpy frames
+```
+
 **Drill-down** - follow a ranking into detail:
 
 | Verb | Purpose | Example |

--- a/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
@@ -41,6 +41,7 @@ namespace TraceQ.Output;
 [JsonSerializable(typeof(AnalysisResult<SourceHeatmapResult>))]
 [JsonSerializable(typeof(AnalysisResult<CallTreeResult>))]
 [JsonSerializable(typeof(AnalysisResult<ProcessListResult>))]
+[JsonSerializable(typeof(AnalysisResult<ClassifyResult>))]
 [JsonSerializable(typeof(AnalysisResult<RankingDiffResult>))]
 [JsonSerializable(typeof(AnalysisResult<JitStatsResult>))]
 [JsonSerializable(typeof(AnalysisResult<GcStatsResult>))]

--- a/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
+++ b/traceq/src/TraceQ.Core/Output/TraceQJsonContext.cs
@@ -47,9 +47,11 @@ namespace TraceQ.Output;
 [JsonSerializable(typeof(AnalysisResult<EventQueryResult>))]
 [JsonSerializable(typeof(AnalysisResult<ExportResult>))]
 // Tool-parameter types the MCP head binds through these same options but that no result
-// type reaches transitively: the optional `fold` regex array. The scalar parameter types
-// (string, int) are already reached through the result records above.
+// type reaches transitively: the optional `fold` regex array, and `bool` (the
+// `nativeSymbols` tool parameter - no result record carries a bool). The other scalar
+// parameter types (string, int) are already reached through the result records above.
 [JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(bool))]
 internal sealed partial class TraceQJsonContext : JsonSerializerContext
 {
 }

--- a/traceq/src/TraceQ.Core/Server/TraceStore.cs
+++ b/traceq/src/TraceQ.Core/Server/TraceStore.cs
@@ -76,12 +76,18 @@ public sealed class TraceStore
     ///  cache keys on it for those metrics, so the same trace scoped two ways is cached
     ///  separately.
     /// </param>
+    /// <param name="symbolOptions">
+    ///  Optional native-symbol resolution. Consumed only by the CPU metric; the cache
+    ///  keys on it, so the same trace read with and without native symbols is cached
+    ///  separately. <see langword="null"/> is the managed-only offline default.
+    /// </param>
     /// <returns>The cached loaded trace.</returns>
     public LoadedTrace Get(
         string path,
         string? symbolsDirectory = null,
         TraceMetric metric = TraceMetric.Cpu,
-        ScopeRequest? scope = null)
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         string fullPath = Path.GetFullPath(path);
 
@@ -101,15 +107,22 @@ public sealed class TraceStore
             ? ScopeKey(scope)
             : "-";
 
+        // Only the CPU loader consumes symbolOptions (native resolution), so a trace
+        // read with native symbols caches separately from one without; the other
+        // metrics ignore it and share the "managed" fragment.
+        string symbolKey = metric == TraceMetric.Cpu
+            ? (symbolOptions ?? SymbolOptions.None).CacheKeyFragment()
+            : "managed";
+
         // Length-prefix the first path so the two components cannot be confused for a
         // different pair: '|' - like every other ASCII separator - is a legal POSIX
         // file-name character, so a plain "a|b" delimiter could collide ("a|b" + "c"
-        // versus "a" + "b|c"). The metric and scope prefixes keep a trace's distinct
-        // provider views and scopes from sharing one cache entry. Loading uses the
-        // normalized symbols path so a relative symbolsDirectory resolves exactly the
-        // way it was keyed.
-        string key = $"{(int)metric}:{scopeKey}:{fullPath.Length}|{fullPath}{fullSymbols}";
-        return _cache.GetOrAdd(key, _ => _loader.Load(fullPath, metric, fullSymbols, scope));
+        // versus "a" + "b|c"). The metric, scope, and symbol prefixes keep a trace's
+        // distinct provider views, scopes, and symbol modes from sharing one cache
+        // entry. Loading uses the normalized symbols path so a relative symbolsDirectory
+        // resolves exactly the way it was keyed.
+        string key = $"{(int)metric}:{scopeKey}:{symbolKey}:{fullPath.Length}|{fullPath}{fullSymbols}";
+        return _cache.GetOrAdd(key, _ => _loader.Load(fullPath, metric, fullSymbols, scope, symbolOptions));
     }
 
     // A stable cache-key fragment for a scope request: 'all' for all-processes, 'auto'

--- a/traceq/src/TraceQ.Core/Tracing/ClassifyResult.cs
+++ b/traceq/src/TraceQ.Core/Tracing/ClassifyResult.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  One runtime work category in a classification: its name, the self-time weight
+///  attributed to it, and that weight's share of the scoped total.
+/// </summary>
+/// <param name="Category">
+///  The category name (see <see cref="FrameCategories"/>): zeroing, copying,
+///  write-barrier, gc, jit, or other.
+/// </param>
+/// <param name="Weight">The summed self-time weight, in the metric's unit (milliseconds for CPU).</param>
+/// <param name="PercentOfScope">The category's share of the scoped total, in percent.</param>
+public sealed record CategoryRow(
+    string Category,
+    double Weight,
+    double PercentOfScope);
+
+/// <summary>
+///  A CPU profile summarized by runtime work category, answering "where did the time
+///  go - zeroing memory? copying strings? in the GC?" - the complement to a per-method
+///  ranking.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Each sample's self-time leaf is bucketed by <see cref="FrameCategories.Classify"/>
+///   and the categories are ranked by weight. The classification only distinguishes the
+///   runtime work once native symbols are resolved; without them the native leaves are
+///   the unresolved <c>?</c> frame and fall in <see cref="FrameCategories.Other"/>, so
+///   this view pairs naturally with the <c>--native-symbols</c> option. Folding is
+///   marker-only (the synthetic <c>CPU_TIME</c> markers), so the JIT-helper thunks the
+///   categories classify are not folded away.
+///  </para>
+/// </remarks>
+/// <param name="ScopeWeight">The scoped total, in the metric's unit (the percent denominator).</param>
+/// <param name="RootFrame">The root frame the classification was scoped to, or empty for the whole trace.</param>
+/// <param name="Categories">The categories, highest weight first.</param>
+public sealed record ClassifyResult(
+    double ScopeWeight,
+    string RootFrame,
+    IReadOnlyList<CategoryRow> Categories);

--- a/traceq/src/TraceQ.Core/Tracing/FoldingAggregator.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FoldingAggregator.cs
@@ -177,9 +177,68 @@ public sealed class FoldingAggregator
     }
 
     /// <summary>
-    ///  Computes the inclusive-time ranking, crediting each distinct non-folded
-    ///  frame on a stack once per sample.
+    ///  Classifies self-time by runtime work category - zeroing, copying, GC,
+    ///  write-barrier, JIT, or other - so a CPU profile can be summarized as "where did
+    ///  the time go: zeroing memory? copying strings? in the GC?".
     /// </summary>
+    /// <param name="rootFrame">Substring scoping the classification to a subtree, or empty for the whole trace.</param>
+    /// <returns>The categories, ranked by self-time weight.</returns>
+    /// <remarks>
+    ///  <para>
+    ///   The self-time leaf of each sample is found the same way <see cref="SelfTime"/>
+    ///   finds it, but folding is fixed to the synthetic sample markers only
+    ///   (<see cref="FrameNames.MarkerOnlyFoldPatterns"/>): the JIT-helper thunks the
+    ///   categories classify (memset / memcpy / write barriers) must not be folded away,
+    ///   or the work being classified would be folded into its managed caller and lost.
+    ///   The leaf is then bucketed by <see cref="FrameCategories.Classify"/>.
+    ///  </para>
+    /// </remarks>
+    public ClassifyResult Classify(string rootFrame)
+    {
+        Regex[] fold = FrameNames.CompileFoldPatterns(FrameNames.MarkerOnlyFoldPatterns);
+        Dictionary<string, double> byCategory = new(StringComparer.Ordinal);
+        double total = 0.0;
+
+        foreach (SampleStack sample in _samples)
+        {
+            IReadOnlyList<string> frames = sample.Frames;
+            int startIdx = ResolveStart(frames, rootFrame, out bool include);
+            if (!include || frames.Count == 0)
+            {
+                continue;
+            }
+
+            total += sample.Weight;
+
+            int leafIdx = frames.Count - 1;
+            while (leafIdx > startIdx && FrameNames.IsFolded(ShortOf(frames[leafIdx]), fold))
+            {
+                leafIdx--;
+            }
+
+            string category = FrameCategories.Classify(ShortOf(frames[leafIdx]));
+            byCategory.TryGetValue(category, out double current);
+            byCategory[category] = current + sample.Weight;
+        }
+
+        List<CategoryRow> rows = new(byCategory.Count);
+        foreach (KeyValuePair<string, double> entry in byCategory)
+        {
+            double percent = total > 0.0 ? entry.Value / total * 100.0 : 0.0;
+            rows.Add(new CategoryRow(entry.Key, entry.Value, percent));
+        }
+
+        // Highest weight first; ties break by category name so the ranking is stable
+        // and the JSON output deterministic.
+        rows.Sort(static (a, b) =>
+        {
+            int byWeight = b.Weight.CompareTo(a.Weight);
+            return byWeight != 0 ? byWeight : string.CompareOrdinal(a.Category, b.Category);
+        });
+
+        return new ClassifyResult(total, rootFrame, rows);
+    }
+
     /// <param name="rootFrame">Substring scoping the ranking to a subtree, or empty for the whole trace.</param>
     /// <param name="foldPatterns">Frame fold patterns.</param>
     /// <param name="top">Maximum number of rows to return.</param>

--- a/traceq/src/TraceQ.Core/Tracing/FrameCategories.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FrameCategories.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  Classifies a leaf frame into a runtime work category - zeroing, copying, GC,
+///  write-barrier, JIT, or "other" - so a CPU profile can be summarized as "where did
+///  the time go: zeroing memory? copying strings? in the GC?".
+/// </summary>
+/// <remarks>
+///  <para>
+///   The categories name the unmanaged runtime work that a per-method ranking either
+///   hides (folded into its managed caller) or scatters across many small frames.
+///   Classification is by frame-name substring, checked in a fixed priority order so a
+///   frame that could match two buckets lands in the more specific one: a
+///   <c>JIT_MemCpy</c> helper is <see cref="Copying"/>, not <see cref="Jit"/>, and
+///   <c>JIT_WriteBarrier</c> is <see cref="WriteBarrier"/>. Everything that matches no
+///   work pattern - managed methods, unresolved native frames - is <see cref="Other"/>.
+///  </para>
+///  <para>
+///   This is a heuristic over well-known runtime symbol names, not an exhaustive
+///   taxonomy; it is only meaningful once native symbols are resolved (otherwise the
+///   native leaves are the unresolved <c>?</c> frame and fall in <see cref="Other"/>).
+///  </para>
+/// </remarks>
+public static class FrameCategories
+{
+    /// <summary>Memory zeroing: <c>memset</c>, <c>RtlZeroMemory</c>, <c>JIT_MemSet</c>.</summary>
+    public const string Zeroing = "zeroing";
+
+    /// <summary>Memory copying: <c>memcpy</c>, <c>memmove</c>, <c>JIT_MemCpy</c>.</summary>
+    public const string Copying = "copying";
+
+    /// <summary>GC write barriers: <c>JIT_WriteBarrier</c>, <c>BulkMoveWithWriteBarrier</c>.</summary>
+    public const string WriteBarrier = "write-barrier";
+
+    /// <summary>Garbage collection: <c>gc_heap</c>, <c>WKS::</c> / <c>SVR::</c>, <c>JIT_New</c>.</summary>
+    public const string Gc = "gc";
+
+    /// <summary>Just-in-time compilation: <c>clrjit</c>, <c>CompileMethod</c>, other <c>JIT_</c> helpers.</summary>
+    public const string Jit = "jit";
+
+    /// <summary>Anything not matching a runtime work pattern: managed methods, unresolved frames.</summary>
+    public const string Other = "other";
+
+    // Each category is a set of case-insensitive substrings. Order is significant:
+    // the more specific memory/barrier operations are tested before the generic GC and
+    // JIT buckets so an overlapping helper (JIT_MemCpy, JIT_WriteBarrier, JIT_New) lands
+    // in the operation it actually performs rather than the generic "jit" bucket.
+    private static readonly (string Category, string[] Tokens)[] s_rules =
+    [
+        (Zeroing, ["memset", "rtlzeromemory", "zeromemory", "jit_memset", "memclr"]),
+        (Copying, ["memcpy", "memmove", "jit_memcpy", "wmemcpy"]),
+        (WriteBarrier, ["writebarrier"]),
+        (Gc, ["gc_heap", "wks::", "svr::", "gcheap", "jit_new", "jit_box", "sohallocate", "allocateobject"]),
+        (Jit, ["clrjit", "compilemethod", "jit_", "pollgc"])
+    ];
+
+    /// <summary>
+    ///  Classifies a (shortened) leaf frame name into a runtime work category.
+    /// </summary>
+    /// <param name="shortLeafName">The shortened leaf frame name.</param>
+    /// <returns>
+    ///  One of <see cref="Zeroing"/>, <see cref="Copying"/>, <see cref="WriteBarrier"/>,
+    ///  <see cref="Gc"/>, <see cref="Jit"/>, or <see cref="Other"/>.
+    /// </returns>
+    public static string Classify(string shortLeafName)
+    {
+        if (string.IsNullOrEmpty(shortLeafName))
+        {
+            return Other;
+        }
+
+        foreach ((string category, string[] tokens) in s_rules)
+        {
+            foreach (string token in tokens)
+            {
+                if (shortLeafName.Contains(token, StringComparison.OrdinalIgnoreCase))
+                {
+                    return category;
+                }
+            }
+        }
+
+        return Other;
+    }
+}

--- a/traceq/src/TraceQ.Core/Tracing/FrameNames.cs
+++ b/traceq/src/TraceQ.Core/Tracing/FrameNames.cs
@@ -54,6 +54,27 @@ public static partial class FrameNames
         "JIT_"
     ];
 
+    /// <summary>
+    ///  The minimal fold set: only the synthetic sample markers, not the JIT-helper
+    ///  thunks. Used by the <c>--no-fold</c> / <c>--raw</c> option so the native
+    ///  runtime leaves (the GC, <c>memset</c> / <c>memcpy</c>, write barriers) rank on
+    ///  their own instead of being folded into their managed caller.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The synthetic <c>CPU_TIME</c> / <c>UNMANAGED_CODE_TIME</c> leaf markers must
+    ///   stay folded even in "no fold" mode: every sample's self-time collapses onto
+    ///   that marker otherwise, which would report almost all time against one
+    ///   meaningless row rather than the real native leaves. So "no fold" means "fold
+    ///   only the markers", not "fold nothing".
+    ///  </para>
+    /// </remarks>
+    public static IReadOnlyList<string> MarkerOnlyFoldPatterns { get; } =
+    [
+        "CPU_TIME",
+        "UNMANAGED_CODE_TIME"
+    ];
+
     [GeneratedRegex(@"!([^(]+)")]
     private static partial Regex AfterModuleRegex();
 

--- a/traceq/src/TraceQ.Core/Tracing/Readers/ITraceReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/ITraceReader.cs
@@ -50,6 +50,17 @@ internal interface ITraceReader
     ///  is narrowed to an explicit name, the busiest process automatically, or every
     ///  process when opted out. Ignored by single-process formats (speedscope).
     /// </param>
+    /// <param name="symbolOptions">
+    ///  Optional native-symbol resolution. <see langword="null"/> or
+    ///  <see cref="SymbolOptions.None"/> resolves managed frames from the trace's
+    ///  rundown only (offline); <see cref="SymbolOptions.WithCache"/> additionally
+    ///  fetches native runtime PDBs from the public symbol server. Ignored by formats
+    ///  with no native frames (speedscope).
+    /// </param>
     /// <returns>The normalized samples and quality signals.</returns>
-    TraceReadResult Read(string path, string? symbolsDirectory = null, ScopeRequest? scope = null);
+    TraceReadResult Read(
+        string path,
+        string? symbolsDirectory = null,
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null);
 }

--- a/traceq/src/TraceQ.Core/Tracing/Readers/SpeedscopeReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/SpeedscopeReader.cs
@@ -29,10 +29,15 @@ internal sealed class SpeedscopeReader : ITraceReader
         path.EndsWith(".speedscope.json", StringComparison.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
-    public TraceReadResult Read(string path, string? symbolsDirectory = null, ScopeRequest? scope = null)
+    public TraceReadResult Read(
+        string path,
+        string? symbolsDirectory = null,
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         // A speedscope profile carries no process information, so process scoping does
-        // not apply; the parameter is accepted for interface uniformity.
+        // not apply; likewise it carries no native frames, so symbolOptions does not
+        // apply. Both parameters are accepted for interface uniformity.
         using FileStream stream = File.OpenRead(path);
         using JsonDocument document = JsonDocument.Parse(stream);
         JsonElement root = document.RootElement;

--- a/traceq/src/TraceQ.Core/Tracing/Readers/TraceLogReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/TraceLogReader.cs
@@ -48,7 +48,11 @@ internal abstract class TraceLogReader : ITraceReader
     protected abstract TraceLog OpenTraceLog(string path);
 
     /// <inheritdoc/>
-    public TraceReadResult Read(string path, string? symbolsDirectory = null, ScopeRequest? scope = null)
+    public TraceReadResult Read(
+        string path,
+        string? symbolsDirectory = null,
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         using TraceLog traceLog = OpenTraceLog(path);
 
@@ -81,6 +85,16 @@ internal abstract class TraceLogReader : ITraceReader
             else if (!string.IsNullOrEmpty(symbolsDirectory))
             {
                 symbolReader.SymbolPath = symbolsDirectory;
+            }
+
+            // Opt-in native runtime symbols: point the reader at the Microsoft public
+            // symbol server (a local cache fronting it) and resolve the unmanaged
+            // runtime modules - the GC, the JIT, memset/memcpy, write barriers - whose
+            // PDBs are not in the trace. Off by default so the common path stays offline
+            // and deterministic; managed frames resolve from the rundown regardless.
+            if (symbolOptions is { ResolveNativeRuntime: true })
+            {
+                ResolveNativeRuntimeSymbols(traceLog, symbolReader, symbolOptions);
             }
 
             // Resolve the scope intent (an explicit name, the busiest process under the
@@ -235,6 +249,97 @@ internal abstract class TraceLogReader : ITraceReader
 
         return new TraceReadResult(samples, resolutionRate, warnings);
     }
+
+    /// <summary>
+    ///  Points <paramref name="symbolReader"/> at the Microsoft public symbol server
+    ///  (fronted by a local cache) and resolves the names of the unmanaged runtime
+    ///  modules, so native runtime frames (the GC, the JIT, <c>memset</c> /
+    ///  <c>memcpy</c>, write barriers) carry method names instead of a bare module
+    ///  address.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Only the runtime/OS modules are looked up - <c>coreclr</c> / <c>clr</c>,
+    ///   <c>clrjit</c>, <c>ntdll</c>, <c>kernelbase</c>, <c>kernel32</c>,
+    ///   <c>ucrtbase</c>, <c>msvcrt</c> - rather than every loaded module, so the
+    ///   download is bounded to the frames a runtime profile actually needs. Each
+    ///   lookup is best-effort: a module whose PDB cannot be fetched (offline, or no
+    ///   published symbols) simply keeps its unresolved frames rather than failing the
+    ///   whole read.
+    ///  </para>
+    /// </remarks>
+    private static void ResolveNativeRuntimeSymbols(
+        TraceLog traceLog,
+        SymbolReader symbolReader,
+        SymbolOptions options)
+    {
+        string cacheDirectory = options.CacheDirectory ?? SymbolOptions.DefaultCacheDirectory;
+        Directory.CreateDirectory(cacheDirectory);
+
+        // The standard symbol-path form: a local downstream cache backed by the public
+        // server, so the first read downloads and later reads hit the cache. Preserve
+        // any path already set (the local build-output PDBs) by appending the server.
+        string serverPath = $"srv*{cacheDirectory}*https://msdl.microsoft.com/download/symbols";
+        symbolReader.SymbolPath = string.IsNullOrEmpty(symbolReader.SymbolPath)
+            ? serverPath
+            : $"{symbolReader.SymbolPath}{Path.PathSeparator}{serverPath}";
+
+        foreach (TraceModuleFile moduleFile in traceLog.ModuleFiles)
+        {
+            if (!IsRuntimeModule(moduleFile.Name))
+            {
+                continue;
+            }
+
+            try
+            {
+                traceLog.CodeAddresses.LookupSymbolsForModule(symbolReader, moduleFile);
+            }
+            catch (Exception)
+            {
+                // Best-effort: an unfetchable module keeps its unresolved frames rather
+                // than failing the read. Offline use and modules with no published PDB
+                // both land here.
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Whether <paramref name="moduleName"/> is one of the unmanaged .NET runtime or
+    ///  OS modules whose symbols answer "where did the native time go" (GC, JIT,
+    ///  memory operations), so native resolution can be bounded to them.
+    /// </summary>
+    private static bool IsRuntimeModule(string? moduleName)
+    {
+        if (string.IsNullOrEmpty(moduleName))
+        {
+            return false;
+        }
+
+        // Match the runtime/OS modules by name substring (case-insensitive); the
+        // module name carries no extension here. `clr` is matched exactly because it is
+        // a short token that would otherwise match unrelated names.
+        foreach (string token in s_runtimeModuleTokens)
+        {
+            if (moduleName.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return moduleName.Equals("clr", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static readonly string[] s_runtimeModuleTokens =
+    [
+        "coreclr",
+        "clrjit",
+        "ntdll",
+        "kernelbase",
+        "kernel32",
+        "ucrtbase",
+        "msvcrt"
+    ];
 
     /// <summary>
     ///  Resolves the source location (<c>file:line</c>) for a code address,

--- a/traceq/src/TraceQ.Core/Tracing/Readers/TraceLogReader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/Readers/TraceLogReader.cs
@@ -295,11 +295,13 @@ internal abstract class TraceLogReader : ITraceReader
             {
                 traceLog.CodeAddresses.LookupSymbolsForModule(symbolReader, moduleFile);
             }
-            catch (Exception)
+            catch (Exception ex) when (ex is not (OutOfMemoryException or AccessViolationException))
             {
                 // Best-effort: an unfetchable module keeps its unresolved frames rather
                 // than failing the read. Offline use and modules with no published PDB
-                // both land here.
+                // both land here. Fatal process-corruption conditions (out of memory,
+                // access violation) are allowed to surface rather than being masked as
+                // a merely-missing symbol.
             }
         }
     }

--- a/traceq/src/TraceQ.Core/Tracing/SymbolOptions.cs
+++ b/traceq/src/TraceQ.Core/Tracing/SymbolOptions.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+/// <summary>
+///  How a trace read should resolve <em>native</em> runtime symbols: the agent-facing
+///  intent the reader turns into a symbol-server path and per-module lookups.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Managed frames (including NGEN and ReadyToRun framework methods) resolve for
+///   free from the CLR rundown baked into every trace, so the default - 
+///   <see cref="None"/> - needs no symbol server and stays fully offline and
+///   deterministic. The unmanaged runtime frames (the GC, the JIT, <c>memset</c> /
+///   <c>memcpy</c>, write barriers) live in native modules - <c>coreclr</c>,
+///   <c>clrjit</c>, <c>ntdll</c>, <c>ucrtbase</c> - whose PDBs are not in the trace;
+///   resolving them requires fetching from the
+///   <see href="https://msdl.microsoft.com/download/symbols">Microsoft public symbol
+///   server</see>. That is opt-in (<see cref="WithCache"/>) because the first fetch
+///   hits the network and writes a local cache, which a default-offline analysis and
+///   CI must never do implicitly.
+///  </para>
+/// </remarks>
+public sealed class SymbolOptions
+{
+    private SymbolOptions(bool resolveNativeRuntime, string? cacheDirectory)
+    {
+        ResolveNativeRuntime = resolveNativeRuntime;
+        CacheDirectory = cacheDirectory;
+    }
+
+    /// <summary>
+    ///  The default: resolve managed frames from the trace's rundown only, never
+    ///  reaching a symbol server. Offline and deterministic.
+    /// </summary>
+    public static SymbolOptions None { get; } = new(resolveNativeRuntime: false, cacheDirectory: null);
+
+    /// <summary>
+    ///  Resolve native runtime frames from the Microsoft public symbol server, caching
+    ///  downloaded PDBs under <paramref name="cacheDirectory"/>.
+    /// </summary>
+    /// <param name="cacheDirectory">
+    ///  The local directory the symbol server caches downloaded PDBs in. When
+    ///  <see langword="null"/> or empty the reader uses a default under the temp path
+    ///  (<c>traceq-symbols</c>), so repeated reads reuse one cache.
+    /// </param>
+    /// <returns>The opt-in native-symbol options.</returns>
+    public static SymbolOptions WithCache(string? cacheDirectory = null) =>
+        new(resolveNativeRuntime: true, cacheDirectory: string.IsNullOrEmpty(cacheDirectory) ? null : cacheDirectory);
+
+    /// <summary>
+    ///  Whether to resolve native runtime frames from the public symbol server. When
+    ///  <see langword="false"/> only the trace's own rundown is consulted (managed
+    ///  frames), which is the offline default.
+    /// </summary>
+    public bool ResolveNativeRuntime { get; }
+
+    /// <summary>
+    ///  The local symbol-cache directory, or <see langword="null"/> to use the default
+    ///  under the temp path. Only consulted when <see cref="ResolveNativeRuntime"/> is
+    ///  <see langword="true"/>.
+    /// </summary>
+    public string? CacheDirectory { get; }
+
+    /// <summary>
+    ///  The default symbol-cache directory used when the caller does not supply one:
+    ///  <c>traceq-symbols</c> under the system temp path.
+    /// </summary>
+    public static string DefaultCacheDirectory => Path.Combine(Path.GetTempPath(), "traceq-symbols");
+
+    /// <summary>
+    ///  A stable cache-key fragment for this options value, so a trace read with native
+    ///  symbols is cached separately from one without.
+    /// </summary>
+    /// <returns>
+    ///  <c>native:&lt;cache&gt;</c> when native resolution is on, otherwise <c>managed</c>.
+    /// </returns>
+    public string CacheKeyFragment() =>
+        ResolveNativeRuntime ? $"native:{CacheDirectory ?? DefaultCacheDirectory}" : "managed";
+}

--- a/traceq/src/TraceQ.Core/Tracing/SymbolOptions.cs
+++ b/traceq/src/TraceQ.Core/Tracing/SymbolOptions.cs
@@ -47,8 +47,26 @@ public sealed class SymbolOptions
     ///  (<c>traceq-symbols</c>), so repeated reads reuse one cache.
     /// </param>
     /// <returns>The opt-in native-symbol options.</returns>
-    public static SymbolOptions WithCache(string? cacheDirectory = null) =>
-        new(resolveNativeRuntime: true, cacheDirectory: string.IsNullOrEmpty(cacheDirectory) ? null : cacheDirectory);
+    /// <exception cref="ArgumentException">
+    ///  <paramref name="cacheDirectory"/> contains <c>*</c>, which is the symbol-path
+    ///  element separator (<c>srv*&lt;cache&gt;*&lt;server&gt;</c>); allowing it would
+    ///  let the cache directory alter the effective symbol path.
+    /// </exception>
+    public static SymbolOptions WithCache(string? cacheDirectory = null)
+    {
+        // The cache directory is interpolated into a SymSrv path element of the form
+        // `srv*<cache>*https://...`; a `*` in the directory would split into extra path
+        // elements and corrupt that syntax, so reject it up front rather than letting it
+        // alter the effective symbol path.
+        if (cacheDirectory is not null && cacheDirectory.Contains('*'))
+        {
+            throw new ArgumentException(
+                "The symbol-cache directory cannot contain '*'; it is the symbol-path element separator.",
+                nameof(cacheDirectory));
+        }
+
+        return new(resolveNativeRuntime: true, cacheDirectory: string.IsNullOrEmpty(cacheDirectory) ? null : cacheDirectory);
+    }
 
     /// <summary>
     ///  Whether to resolve native runtime frames from the public symbol server. When

--- a/traceq/src/TraceQ.Core/Tracing/TraceLoader.cs
+++ b/traceq/src/TraceQ.Core/Tracing/TraceLoader.cs
@@ -68,6 +68,13 @@ public sealed class TraceLoader
     ///  (speedscope) and for the single-process EventPipe metrics (allocation,
     ///  exceptions).
     /// </param>
+    /// <param name="symbolOptions">
+    ///  Optional native-symbol resolution for the CPU metric. <see langword="null"/>
+    ///  or <see cref="SymbolOptions.None"/> resolves managed frames from the rundown
+    ///  only (offline); <see cref="SymbolOptions.WithCache"/> additionally fetches
+    ///  native runtime PDBs from the public symbol server. Consumed only by the CPU
+    ///  metric over a <see cref="TraceFormat.Etl"/> capture.
+    /// </param>
     /// <returns>The loaded trace.</returns>
     /// <exception cref="ArgumentException">
     ///  <paramref name="path"/> is <see langword="null"/>, empty, or not a valid file path.
@@ -83,7 +90,8 @@ public sealed class TraceLoader
         string path,
         TraceMetric metric,
         string? symbolsDirectory = null,
-        ScopeRequest? scope = null)
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         ArgumentException.ThrowIfNullOrEmpty(path);
 
@@ -99,7 +107,7 @@ public sealed class TraceLoader
 
         return metric switch
         {
-            TraceMetric.Cpu => LoadCpu(fullPath, reader, symbolsDirectory, scope),
+            TraceMetric.Cpu => LoadCpu(fullPath, reader, symbolsDirectory, scope, symbolOptions),
             TraceMetric.Allocations => LoadAllocations(fullPath, reader),
             TraceMetric.Exceptions => LoadExceptions(fullPath, reader),
             TraceMetric.ThreadTime => LoadThreadTime(fullPath, reader, scope),
@@ -115,9 +123,10 @@ public sealed class TraceLoader
         string fullPath,
         ITraceReader reader,
         string? symbolsDirectory,
-        ScopeRequest? scope)
+        ScopeRequest? scope,
+        SymbolOptions? symbolOptions)
     {
-        TraceReadResult result = reader.Read(fullPath, symbolsDirectory, scope);
+        TraceReadResult result = reader.Read(fullPath, symbolsDirectory, scope, symbolOptions);
         TraceInfo info = BuildInfo(
             fullPath,
             reader.Format,

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -88,6 +88,7 @@ public sealed class TraceTools
     /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
     /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
+    /// <param name="nativeSymbols">Resolve native runtime frames from the public symbol server (opt-in, network); cpu/.etl only.</param>
     /// <returns>The ranking envelope.</returns>
     [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -112,14 +113,19 @@ public sealed class TraceTools
         [Description(
             "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
             + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
-        string process = "")
+        string process = "",
+        [Description(
+            "Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server. "
+            + "Opt-in - it fetches over the network and caches locally. cpu metric over an .etl capture only; "
+            + "managed frames already resolve without it.")]
+        bool nativeSymbols = false)
     {
         TraceMetric resolved = ResolveMetric(metric);
         bool inclusive = ResolveMeasure(measure);
         RequirePositiveTop(top);
         IReadOnlyList<string> foldPatterns = ResolveFold(fold);
 
-        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), resolved, ResolveScope(process));
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), resolved, ResolveScope(process), ResolveSymbols(nativeSymbols));
         TraceInfo info = trace.Info;
         RankingResult ranking = inclusive
             ? trace.Aggregator.InclusiveTime(root, foldPatterns, top)
@@ -491,11 +497,12 @@ public sealed class TraceTools
         string path,
         string? symbols,
         TraceMetric metric = TraceMetric.Cpu,
-        ScopeRequest? scope = null)
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         try
         {
-            return store.Get(path, symbols, metric, scope);
+            return store.Get(path, symbols, metric, scope, symbolOptions);
         }
         catch (Exception ex) when (
             ex is IOException
@@ -711,4 +718,9 @@ public sealed class TraceTools
     // value scopes a multi-process .etl capture to the named process tree.
     private static ScopeRequest? ResolveScope(string process) =>
         string.IsNullOrEmpty(process) ? null : ScopeRequest.ForProcess(process);
+
+    // Opt-in native runtime symbol resolution; the default cache directory is used.
+    // Off resolves managed frames from the rundown only (offline).
+    private static SymbolOptions ResolveSymbols(bool nativeSymbols) =>
+        nativeSymbols ? SymbolOptions.WithCache() : SymbolOptions.None;
 }

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -20,7 +20,11 @@ namespace TraceQ.Mcp;
 ///  work-category breakdown, two-trace diffs, the garbage-collection and JIT reports,
 ///  and a raw event query across speedscope, EventPipe (<c>.nettrace</c>), and ETW
 ///  (<c>.etl</c>) inputs, plus export a flame graph to a file. Every tool but
-///  <c>trace_export</c> is read-only; <c>trace_export</c> writes a file.
+///  <c>trace_export</c> is read-only; <c>trace_export</c> writes a file. Two tools -
+///  <c>trace_rank</c> and <c>trace_classify</c> - reach the Microsoft public symbol
+///  server and write a local symbol cache when their opt-in <c>nativeSymbols</c> flag
+///  is set, so both carry the open-world hint; with the flag off (the default) they
+///  stay offline and read-only like the rest.
 /// </summary>
 /// <remarks>
 ///  <para>
@@ -91,7 +95,7 @@ public sealed class TraceTools
     /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <param name="nativeSymbols">Resolve native runtime frames from the public symbol server (opt-in, network); cpu/.etl only.</param>
     /// <returns>The ranking envelope.</returns>
-    [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "trace_rank", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true)]
     [Description(
         "Rank the hottest frames over a chosen provider metric. measure=self credits the executing leaf "
         + "(JIT-helper leaves folded into the real method that incurred them); measure=inclusive credits a "
@@ -579,7 +583,7 @@ public sealed class TraceTools
     /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
     /// <param name="nativeSymbols">Resolve native runtime frames from the public symbol server (opt-in, network); cpu/.etl only.</param>
     /// <returns>The classification envelope.</returns>
-    [McpServerTool(Name = "trace_classify", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [McpServerTool(Name = "trace_classify", ReadOnly = true, Idempotent = true, OpenWorld = true, UseStructuredContent = true)]
     [Description(
         "Bucket CPU self-time by runtime work category - zeroing, copying, write-barrier, GC, JIT, or other - to "
         + "answer 'where did the time go: zeroing memory? copying? in the GC?'. The categories are recognized from "

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -15,9 +15,10 @@ namespace TraceQ.Mcp;
 
 /// <summary>
 ///  The curated MCP tool surface over the TraceQ analysis core: load a trace and
-///  query its quality signals, folded self/inclusive rankings, immediate callers,
-///  line-level attribution, two-trace diffs, the garbage-collection report, and a
-///  raw event query across speedscope, EventPipe (<c>.nettrace</c>), and ETW
+///  query its quality signals, the process inventory, folded self/inclusive rankings,
+///  the top-down call tree, immediate callers, line-level attribution, a runtime
+///  work-category breakdown, two-trace diffs, the garbage-collection and JIT reports,
+///  and a raw event query across speedscope, EventPipe (<c>.nettrace</c>), and ETW
 ///  (<c>.etl</c>) inputs, plus export a flame graph to a file. Every tool but
 ///  <c>trace_export</c> is read-only; <c>trace_export</c> writes a file.
 /// </summary>
@@ -488,6 +489,165 @@ public sealed class TraceTools
     }
 
     /// <summary>
+    ///  Lists the processes a trace contains, ranked by CPU-sample weight, so a
+    ///  multi-process capture can be scoped to the right one before ranking.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <returns>The process-inventory envelope.</returns>
+    [McpServerTool(Name = "trace_processes", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description(
+        "List the processes a trace contains, ranked by CPU-sample weight. This is the first move on a "
+        + "machine-wide .etl capture: see who is in it, then scope the ranking and drill-down tools to one with "
+        + "their 'process' parameter. Reads every process - it does not auto-scope to the busiest. A single-process "
+        + ".nettrace or speedscope trace lists just its one process.")]
+    public static AnalysisResult<ProcessListResult> Processes(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path)
+    {
+        // The inventory's whole purpose is to reveal every process, so it opts out of
+        // the busiest-process auto-scope the ranking tools default to.
+        LoadedTrace trace = Load(store, path, symbols: null, TraceMetric.Cpu, ScopeRequest.AllProcesses);
+        TraceInfo info = trace.Info;
+        ProcessListResult processes = trace.Aggregator.Processes();
+
+        return new AnalysisResult<ProcessListResult>(processes, info.Warnings);
+    }
+
+    /// <summary>
+    ///  Returns the top-down call tree from the root into its callees, following the hot
+    ///  path down to the work that dominates it.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="root">Optional substring scoping the tree to a frame's subtree.</param>
+    /// <param name="maxDepth">Maximum frame levels below the root to expand.</param>
+    /// <param name="minPercent">Minimum share of the scoped total, in percent, a node must have to appear.</param>
+    /// <param name="fold">Optional fold patterns; defaults to the built-in JIT-helper list.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
+    /// <returns>The call-tree envelope.</returns>
+    [McpServerTool(Name = "trace_tree", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description(
+        "Top-down CPU call tree from a root frame into its callees, following the hot path down to the work that "
+        + "dominates it - the complement to trace_callers, which walks up. Each node carries its inclusive share; "
+        + "maxDepth caps how far below the root it expands and minPercent prunes nodes below a share of the scoped "
+        + "total so the tree stays to the meaningful paths. Scope to a subtree with root; omit it for the whole "
+        + "trace. JIT-helper leaves are folded into their caller.")]
+    public static AnalysisResult<CallTreeResult> Tree(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
+        [Description("Optional substring of a frame name to scope the tree to its subtree; omit for the whole trace.")] string root = "",
+        [Description("Maximum number of frame levels below the root to expand.")] int maxDepth = 10,
+        [Description("Minimum share of the scoped total, in percent, a node must have to appear.")] double minPercent = 1.0,
+        [Description("Optional regex fold patterns; omit to use the built-in JIT-helper defaults.")] string[]? fold = null,
+        [Description(
+            "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
+            + "managed frames resolve to source lines.")]
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
+    {
+        if (maxDepth < 0 || maxDepth > FoldingAggregator.MaxTreeDepth)
+        {
+            throw new McpException($"maxDepth must be in [0, {FoldingAggregator.MaxTreeDepth}].");
+        }
+
+        if (minPercent < 0)
+        {
+            throw new McpException("minPercent must be 0 or greater.");
+        }
+
+        IReadOnlyList<string> foldPatterns = ResolveFold(fold);
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), scope: ResolveScope(process));
+        TraceInfo info = trace.Info;
+        CallTreeResult tree = trace.Aggregator.CallTree(root, foldPatterns, maxDepth, minPercent);
+
+        return new AnalysisResult<CallTreeResult>(tree, info.Warnings);
+    }
+
+    /// <summary>
+    ///  Buckets CPU self-time by runtime work category - zeroing, copying, write-barrier,
+    ///  GC, JIT, or other - to answer where the time went at the machine level.
+    /// </summary>
+    /// <param name="store">The trace cache (injected).</param>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="root">Optional substring scoping the classification to a subtree.</param>
+    /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process .etl capture to one process tree.</param>
+    /// <param name="nativeSymbols">Resolve native runtime frames from the public symbol server (opt-in, network); cpu/.etl only.</param>
+    /// <returns>The classification envelope.</returns>
+    [McpServerTool(Name = "trace_classify", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description(
+        "Bucket CPU self-time by runtime work category - zeroing, copying, write-barrier, GC, JIT, or other - to "
+        + "answer 'where did the time go: zeroing memory? copying? in the GC?'. The categories are recognized from "
+        + "native runtime frames, so pair this with nativeSymbols=true on an .etl capture; without resolved native "
+        + "symbols the runtime leaves fall in 'other' and the breakdown understates the real cost. Scope to a "
+        + "subtree with root.")]
+    public static AnalysisResult<ClassifyResult> Classify(
+        TraceStore store,
+        [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
+        [Description("Optional substring of a frame name to scope the classification to its subtree.")] string root = "",
+        [Description(
+            "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
+            + "managed frames resolve to source lines.")]
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "",
+        [Description(
+            "Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server so "
+            + "they classify instead of falling in 'other'. Opt-in - it fetches over the network and caches "
+            + "locally. cpu over an .etl capture only.")]
+        bool nativeSymbols = false)
+    {
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), TraceMetric.Cpu, ResolveScope(process), ResolveSymbols(nativeSymbols));
+        TraceInfo info = trace.Info;
+        ClassifyResult classification = trace.Aggregator.Classify(root);
+
+        return new AnalysisResult<ClassifyResult>(classification, info.Warnings);
+    }
+
+    /// <summary>
+    ///  Returns the JIT-compilation report for a <c>.nettrace</c> EventPipe trace:
+    ///  the aggregate compile summary plus the costliest per-method records.
+    /// </summary>
+    /// <param name="path">Path to the trace file.</param>
+    /// <param name="top">Maximum per-method records to return, ranked by compile time.</param>
+    /// <returns>The JIT-report envelope.</returns>
+    [McpServerTool(Name = "trace_jit", ReadOnly = true, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
+    [Description(
+        "JIT-compilation report for a .nettrace EventPipe trace: the method count, total and mean compile time, "
+        + "and the per-method records capped to the 'top' costliest compiles. Use it to judge startup or first-call "
+        + "JIT cost - a startup trace can compile thousands of methods. The aggregate summary always reflects every "
+        + "method; only the per-method detail is capped. Requires a .nettrace trace; .etl and speedscope inputs are "
+        + "rejected.")]
+    public static AnalysisResult<JitStatsResult> Jit(
+        [Description("Path to a .nettrace EventPipe trace file.")] string path,
+        [Description("Maximum number of per-method records to return, ranked by compile time.")] int top = 25)
+    {
+        RequirePositiveTop(top);
+        JitStatsResult full = ReadJitStats(path);
+
+        // Keep the full aggregate summary, but cap the per-method detail to the
+        // costliest compiles so a startup trace's thousands of methods cannot blow
+        // the output budget.
+        List<string> warnings = [];
+        IReadOnlyList<JitMethodRecord> shown = full.Methods;
+        if (shown.Count > top)
+        {
+            shown = [.. shown.OrderByDescending(static m => m.CompileMs).Take(top)];
+            warnings.Add($"Showing the top {top} of {full.MethodCount} methods by compile time.");
+        }
+
+        JitStatsResult report = full with { Methods = shown };
+        return new AnalysisResult<JitStatsResult>(report, warnings);
+    }
+
+    /// <summary>
     ///  Loads the <paramref name="metric"/> view of the trace, mapping the loader's
     ///  failure modes to a clean <see cref="McpException"/> rather than letting an
     ///  opaque exception propagate to the client.
@@ -634,6 +794,32 @@ public sealed class TraceTools
         try
         {
             return new GcStatsProvider().Read(path);
+        }
+        catch (Exception ex) when (
+            ex is IOException
+            or UnauthorizedAccessException
+            or NotSupportedException
+            or InvalidOperationException
+            or FormatException
+            or ArgumentException)
+        {
+            // A missing, unreadable, or malformed .nettrace surfaces as a clean tool
+            // error rather than an unhandled exception.
+            throw new McpException(ex.Message);
+        }
+    }
+
+    /// <summary>
+    ///  Reads the JIT report for a <c>.nettrace</c> trace, applying the format guardrail
+    ///  and mapping the provider's failure modes to a clean <see cref="McpException"/>.
+    /// </summary>
+    private static JitStatsResult ReadJitStats(string path)
+    {
+        RequireNetTrace(path, "JIT report");
+
+        try
+        {
+            return new JitStatsProvider().Read(path);
         }
         catch (Exception ex) when (
             ex is IOException

--- a/traceq/src/TraceQ/Cli/ClassifyExecutor.cs
+++ b/traceq/src/TraceQ/Cli/ClassifyExecutor.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Output;
+using TraceQ.Tracing;
+
+namespace TraceQ.Cli;
+
+/// <summary>
+///  Runs a classify request against the analysis core: load the CPU view, bucket
+///  self-time by runtime work category, wrap the result in the output contract, and
+///  render it as text or JSON.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The execution is independent of the command-line parser; it takes its inputs as a
+///   <see cref="ClassifyRequest"/> and writes to the supplied writers, so it can be
+///   driven directly in tests as well as from the verb handler in
+///   <see cref="TraceCommands"/>.
+///  </para>
+/// </remarks>
+internal static class ClassifyExecutor
+{
+    /// <summary>
+    ///  Executes the classify request.
+    /// </summary>
+    /// <param name="request">The validated classify inputs.</param>
+    /// <param name="output">The writer the result is rendered to.</param>
+    /// <param name="error">The writer load errors are reported to.</param>
+    /// <returns>A process exit code (see <see cref="ExitCodes"/>).</returns>
+    public static int Run(ClassifyRequest request, TextWriter output, TextWriter error)
+    {
+        if (!TraceExecution.TryLoad(
+            request.Path, TraceMetric.Cpu, request.Symbols, error, out LoadedTrace? trace, request.Scope, request.SymbolOptions))
+        {
+            return ExitCodes.InputError;
+        }
+
+        TraceInfo info = trace.Info;
+        ClassifyResult classification = trace.Aggregator.Classify(request.Root);
+
+        AnalysisResult<ClassifyResult> envelope = new(classification, TraceExecution.ResultWarnings(info));
+
+        if (request.Format == OutputFormat.Json)
+        {
+            output.WriteLine(OutputJson.Serialize(envelope));
+        }
+        else
+        {
+            ClassifyTextRenderer.Render(envelope, info, trace.Aggregator.Metric, output);
+        }
+
+        return TraceExecution.StrictExit(info, request.Strict);
+    }
+}

--- a/traceq/src/TraceQ/Cli/ClassifyRequest.cs
+++ b/traceq/src/TraceQ/Cli/ClassifyRequest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Tracing;
+
+namespace TraceQ.Cli;
+
+/// <summary>
+///  The validated inputs to a classify run: which trace to load, how to scope it, how
+///  to resolve symbols, and how to render it.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Classification buckets CPU self-time by runtime work category, so it reads the
+///   CPU view and - like <c>cpu</c> - takes a process scope and native-symbol options
+///   (the categories only distinguish the native runtime work once its symbols
+///   resolve). Folding is fixed to marker-only inside the aggregator, so there is no
+///   fold option here.
+///  </para>
+/// </remarks>
+/// <param name="Path">The trace file path.</param>
+/// <param name="Root">Substring scoping the classification to a subtree, or empty for the whole trace.</param>
+/// <param name="Symbols">Optional build-output directory whose embedded PDBs resolve managed frames.</param>
+/// <param name="Format">The render format.</param>
+/// <param name="Strict">Whether to trip the strict symbol-resolution exit gate.</param>
+/// <param name="Scope">The process scope, or <see langword="null"/> for the automatic default.</param>
+/// <param name="SymbolOptions">Native-symbol resolution, or <see langword="null"/> for managed-only (the offline default).</param>
+internal sealed record ClassifyRequest(
+    string Path,
+    string Root,
+    string? Symbols,
+    OutputFormat Format,
+    bool Strict,
+    ScopeRequest? Scope = null,
+    SymbolOptions? SymbolOptions = null);

--- a/traceq/src/TraceQ/Cli/ClassifyTextRenderer.cs
+++ b/traceq/src/TraceQ/Cli/ClassifyTextRenderer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using TraceQ.Output;
+using TraceQ.Tracing;
+
+namespace TraceQ.Cli;
+
+/// <summary>
+///  Renders a runtime work-category classification as a text table: a one-line trace
+///  banner, then each category on its own line with its weight and share of scope,
+///  highest weight first.
+/// </summary>
+internal static class ClassifyTextRenderer
+{
+    private const int WeightColumnWidth = 16;
+    private const int PercentColumnWidth = 6;
+
+    /// <summary>
+    ///  Renders the classify envelope to <paramref name="output"/>.
+    /// </summary>
+    /// <param name="envelope">The classify result, with its warnings.</param>
+    /// <param name="info">The loaded trace's metadata, for the banner line.</param>
+    /// <param name="metric">The metric the weights are measured in.</param>
+    /// <param name="output">The writer the text is rendered to.</param>
+    public static void Render(
+        AnalysisResult<ClassifyResult> envelope,
+        TraceInfo info,
+        MetricInfo metric,
+        TextWriter output)
+    {
+        ClassifyResult result = envelope.Result;
+        string unit = metric.Unit;
+        string scope = result.RootFrame.Length > 0 ? $"scoped to '{result.RootFrame}'" : "whole trace";
+
+        output.WriteLine(
+            $"{info.Format}  {info.SampleCount} samples  {info.TotalWeight:N1} {unit}  symbols {info.SymbolResolutionRate:P0}");
+        output.WriteLine();
+        output.WriteLine($"{metric.Name} by work category  -  scope {result.ScopeWeight:N2} {unit}  ({scope})");
+        output.WriteLine($"  {"weight",WeightColumnWidth}  {"%",PercentColumnWidth}  category");
+
+        foreach (CategoryRow row in result.Categories)
+        {
+            output.WriteLine(
+                $"  {$"{row.Weight:N2} {unit}",WeightColumnWidth}  {row.PercentOfScope,PercentColumnWidth:N2}  {row.Category}");
+        }
+
+        if (result.Categories.Count == 0)
+        {
+            output.WriteLine("  (no samples in scope)");
+        }
+
+        foreach (string warning in envelope.Warnings)
+        {
+            output.WriteLine($"! {warning}");
+        }
+    }
+}

--- a/traceq/src/TraceQ/Cli/RankRequest.cs
+++ b/traceq/src/TraceQ/Cli/RankRequest.cs
@@ -29,6 +29,7 @@ namespace TraceQ.Cli;
 /// <param name="Symbols">Optional build-output directory whose embedded PDBs resolve managed frames.</param>
 /// <param name="Strict">Whether to trip the strict symbol-resolution exit gate.</param>
 /// <param name="Scope">The process scope (explicit name, automatic default, or all processes).</param>
+/// <param name="SymbolOptions">Native-symbol resolution, or <see langword="null"/> for managed-only (the offline default).</param>
 internal sealed record RankRequest(
     string Path,
     TraceMetric Metric,
@@ -39,4 +40,5 @@ internal sealed record RankRequest(
     OutputFormat Format,
     string? Symbols,
     bool Strict,
-    ScopeRequest? Scope = null);
+    ScopeRequest? Scope = null,
+    SymbolOptions? SymbolOptions = null);

--- a/traceq/src/TraceQ/Cli/RankRequestFactory.cs
+++ b/traceq/src/TraceQ/Cli/RankRequestFactory.cs
@@ -74,11 +74,26 @@ internal static class RankRequestFactory
         string? symbols,
         OutputFormat format,
         bool strict,
-        ScopeRequest? scope = null)
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         IReadOnlyList<string> foldPatterns = fold is { Count: > 0 } ? fold : FrameNames.DefaultFoldPatterns;
-        return new RankRequest(trace, metric, root, top, foldPatterns, measure, format, symbols, strict, scope);
+        return new RankRequest(
+            trace, metric, root, top, foldPatterns, measure, format, symbols, strict, scope, symbolOptions);
     }
+
+    /// <summary>
+    ///  Builds the native-symbol options from the two verb options: the
+    ///  <c>--native-symbols</c> opt-in and the optional <c>--symbol-cache</c> directory.
+    /// </summary>
+    /// <param name="nativeSymbols">Whether <c>--native-symbols</c> was set.</param>
+    /// <param name="symbolCache">The <c>--symbol-cache</c> directory, or empty for the default.</param>
+    /// <returns>
+    ///  <see cref="SymbolOptions.WithCache"/> when native resolution was requested,
+    ///  otherwise <see cref="SymbolOptions.None"/> (the offline managed-only default).
+    /// </returns>
+    public static SymbolOptions ResolveSymbolOptions(bool nativeSymbols, string symbolCache) =>
+        nativeSymbols ? SymbolOptions.WithCache(symbolCache) : SymbolOptions.None;
 
     /// <summary>
     ///  Builds the process-scope request from the two mutually exclusive verb options:

--- a/traceq/src/TraceQ/Cli/RankRequestFactory.cs
+++ b/traceq/src/TraceQ/Cli/RankRequestFactory.cs
@@ -96,6 +96,47 @@ internal static class RankRequestFactory
         nativeSymbols ? SymbolOptions.WithCache(symbolCache) : SymbolOptions.None;
 
     /// <summary>
+    ///  Resolves the effective leaf-fold patterns from the explicit <c>--fold</c>
+    ///  patterns and the <c>--no-fold</c> option, which are mutually exclusive.
+    /// </summary>
+    /// <param name="fold">The explicit <c>--fold</c> patterns, or <see langword="null"/>/empty when not given.</param>
+    /// <param name="noFold">
+    ///  Whether <c>--no-fold</c> was set: fold only the synthetic sample markers, so the
+    ///  native runtime leaves (GC, <c>memset</c> / <c>memcpy</c>, write barriers) rank
+    ///  on their own.
+    /// </param>
+    /// <param name="patterns">
+    ///  The resolved patterns on success: the explicit list, the marker-only list when
+    ///  <paramref name="noFold"/> is set, or <see langword="null"/> for the built-in
+    ///  default (which <see cref="Create"/> fills in).
+    /// </param>
+    /// <param name="errorMessage">The usage error when both options were given.</param>
+    /// <returns>
+    ///  <see langword="true"/> when the options are valid; otherwise <see langword="false"/>,
+    ///  and the caller should report <paramref name="errorMessage"/> as a usage error.
+    /// </returns>
+    public static bool TryResolveFold(
+        string[]? fold,
+        bool noFold,
+        out string[]? patterns,
+        [NotNullWhen(false)] out string? errorMessage)
+    {
+        bool hasFold = fold is { Length: > 0 };
+        if (hasFold && noFold)
+        {
+            patterns = null;
+            errorMessage = "Specify only one of --fold and --no-fold.";
+            return false;
+        }
+
+        // --no-fold folds only the synthetic markers; an explicit --fold wins; otherwise
+        // leave null so Create applies the built-in default fold list.
+        patterns = noFold ? [.. FrameNames.MarkerOnlyFoldPatterns] : fold;
+        errorMessage = null;
+        return true;
+    }
+
+    /// <summary>
     ///  Builds the process-scope request from the two mutually exclusive verb options:
     ///  an explicit <c>--process</c> name and the <c>--all-processes</c> opt-out.
     /// </summary>

--- a/traceq/src/TraceQ/Cli/RankingExecutor.cs
+++ b/traceq/src/TraceQ/Cli/RankingExecutor.cs
@@ -37,7 +37,7 @@ internal static class RankingExecutor
         }
 
         if (!TraceExecution.TryLoad(
-            request.Path, request.Metric, request.Symbols, error, out LoadedTrace? trace, request.Scope))
+            request.Path, request.Metric, request.Symbols, error, out LoadedTrace? trace, request.Scope, request.SymbolOptions))
         {
             return ExitCodes.InputError;
         }

--- a/traceq/src/TraceQ/Cli/TraceCommands.cs
+++ b/traceq/src/TraceQ/Cli/TraceCommands.cs
@@ -403,6 +403,53 @@ internal sealed class TraceCommands
     }
 
     /// <summary>
+    ///  Summarize CPU self-time by runtime work category - zeroing, copying, GC,
+    ///  write-barrier, JIT, or other - answering "where did the time go: zeroing memory?
+    ///  copying strings? in the GC?". Pair with --native-symbols so the native runtime
+    ///  work resolves; without it the native leaves fall in 'other'.
+    /// </summary>
+    /// <param name="trace">Path to a .speedscope.json, .nettrace, or .etl file.</param>
+    /// <param name="root">Substring scoping the classification to the subtree under a frame.</param>
+    /// <param name="symbols">-s, Build-output directory whose embedded PDBs resolve managed frames.</param>
+    /// <param name="format">Render format: text or json.</param>
+    /// <param name="strict">Exit 3 when symbol resolution is below the trusted threshold.</param>
+    /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
+    /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
+    /// <param name="benchmark">Scope to the BenchmarkDotNet measured-workload subtree (preset root); for BDN captures.</param>
+    /// <param name="nativeSymbols">Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server; opt-in, fetches over the network. .etl captures only.</param>
+    /// <param name="symbolCache">Local cache directory for downloaded native PDBs; omit for the default under the temp path.</param>
+    /// <returns>A process exit code.</returns>
+    [Command("classify")]
+    public int Classify(
+        [Argument] string trace,
+        string root = "",
+        string? symbols = null,
+        OutputFormat format = OutputFormat.Text,
+        bool strict = false,
+        string process = "",
+        bool allProcesses = false,
+        bool benchmark = false,
+        bool nativeSymbols = false,
+        string symbolCache = "")
+    {
+        if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
+        {
+            Console.Error.WriteLine(scopeError);
+            return ExitCodes.UsageError;
+        }
+
+        if (!RankRequestFactory.TryResolveRoot(root, benchmark, out string resolvedRoot, out string? rootError))
+        {
+            Console.Error.WriteLine(rootError);
+            return ExitCodes.UsageError;
+        }
+
+        SymbolOptions symbolOptions = RankRequestFactory.ResolveSymbolOptions(nativeSymbols, symbolCache);
+        ClassifyRequest request = new(trace, resolvedRoot, symbols, format, strict, scope, symbolOptions);
+        return ClassifyExecutor.Run(request, Console.Out, Console.Error);
+    }
+
+    /// <summary>
     ///  Compare two traces and report what got slower or faster between them.
     /// </summary>
     /// <param name="before">Path to the baseline .speedscope.json, .nettrace, or .etl file.</param>

--- a/traceq/src/TraceQ/Cli/TraceCommands.cs
+++ b/traceq/src/TraceQ/Cli/TraceCommands.cs
@@ -38,6 +38,7 @@ internal sealed class TraceCommands
     /// <param name="benchmark">Scope to the BenchmarkDotNet measured-workload subtree (preset root); for BDN captures.</param>
     /// <param name="nativeSymbols">Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server; opt-in, fetches over the network. .etl CPU captures only.</param>
     /// <param name="symbolCache">Local cache directory for downloaded native PDBs; omit for the default under the temp path.</param>
+    /// <param name="noFold">Fold only the synthetic sample markers, not the JIT-helper thunks, so native runtime leaves rank on their own. Mutually exclusive with --fold.</param>
     /// <returns>A process exit code.</returns>
     [Command("rank")]
     public int Rank(
@@ -54,7 +55,8 @@ internal sealed class TraceCommands
         bool allProcesses = false,
         bool benchmark = false,
         bool nativeSymbols = false,
-        string symbolCache = "")
+        string symbolCache = "",
+        bool noFold = false)
     {
         if (!RankRequestFactory.TryResolveMetric(metric, out TraceMetric resolved))
         {
@@ -75,9 +77,15 @@ internal sealed class TraceCommands
             return ExitCodes.UsageError;
         }
 
+        if (!RankRequestFactory.TryResolveFold(fold, noFold, out string[]? foldPatterns, out string? foldError))
+        {
+            Console.Error.WriteLine(foldError);
+            return ExitCodes.UsageError;
+        }
+
         SymbolOptions symbolOptions = RankRequestFactory.ResolveSymbolOptions(nativeSymbols, symbolCache);
         RankRequest request = RankRequestFactory.Create(
-            trace, resolved, measure, resolvedRoot, top, fold, symbols, format, strict, scope, symbolOptions);
+            trace, resolved, measure, resolvedRoot, top, foldPatterns, symbols, format, strict, scope, symbolOptions);
         return RankingExecutor.Run(request, Console.Out, Console.Error);
     }
 
@@ -101,6 +109,7 @@ internal sealed class TraceCommands
     /// <param name="benchmark">Scope to the BenchmarkDotNet measured-workload subtree (preset root); for BDN captures.</param>
     /// <param name="nativeSymbols">Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server; opt-in, fetches over the network. .etl CPU captures only.</param>
     /// <param name="symbolCache">Local cache directory for downloaded native PDBs; omit for the default under the temp path.</param>
+    /// <param name="noFold">Fold only the synthetic sample markers, not the JIT-helper thunks, so native runtime leaves rank on their own. Mutually exclusive with --fold.</param>
     /// <returns>A process exit code.</returns>
     [Command("cpu")]
     public int Cpu(
@@ -116,7 +125,8 @@ internal sealed class TraceCommands
         bool allProcesses = false,
         bool benchmark = false,
         bool nativeSymbols = false,
-        string symbolCache = "")
+        string symbolCache = "",
+        bool noFold = false)
     {
         if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
         {
@@ -130,9 +140,15 @@ internal sealed class TraceCommands
             return ExitCodes.UsageError;
         }
 
+        if (!RankRequestFactory.TryResolveFold(fold, noFold, out string[]? foldPatterns, out string? foldError))
+        {
+            Console.Error.WriteLine(foldError);
+            return ExitCodes.UsageError;
+        }
+
         SymbolOptions symbolOptions = RankRequestFactory.ResolveSymbolOptions(nativeSymbols, symbolCache);
         RankRequest request = RankRequestFactory.Create(
-            trace, TraceMetric.Cpu, measure, resolvedRoot, top, fold, symbols, format, strict, scope, symbolOptions);
+            trace, TraceMetric.Cpu, measure, resolvedRoot, top, foldPatterns, symbols, format, strict, scope, symbolOptions);
         return RankingExecutor.Run(request, Console.Out, Console.Error);
     }
 

--- a/traceq/src/TraceQ/Cli/TraceCommands.cs
+++ b/traceq/src/TraceQ/Cli/TraceCommands.cs
@@ -36,6 +36,8 @@ internal sealed class TraceCommands
     /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
     /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
     /// <param name="benchmark">Scope to the BenchmarkDotNet measured-workload subtree (preset root); for BDN captures.</param>
+    /// <param name="nativeSymbols">Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server; opt-in, fetches over the network. .etl CPU captures only.</param>
+    /// <param name="symbolCache">Local cache directory for downloaded native PDBs; omit for the default under the temp path.</param>
     /// <returns>A process exit code.</returns>
     [Command("rank")]
     public int Rank(
@@ -50,7 +52,9 @@ internal sealed class TraceCommands
         bool strict = false,
         string process = "",
         bool allProcesses = false,
-        bool benchmark = false)
+        bool benchmark = false,
+        bool nativeSymbols = false,
+        string symbolCache = "")
     {
         if (!RankRequestFactory.TryResolveMetric(metric, out TraceMetric resolved))
         {
@@ -71,8 +75,9 @@ internal sealed class TraceCommands
             return ExitCodes.UsageError;
         }
 
+        SymbolOptions symbolOptions = RankRequestFactory.ResolveSymbolOptions(nativeSymbols, symbolCache);
         RankRequest request = RankRequestFactory.Create(
-            trace, resolved, measure, resolvedRoot, top, fold, symbols, format, strict, scope);
+            trace, resolved, measure, resolvedRoot, top, fold, symbols, format, strict, scope, symbolOptions);
         return RankingExecutor.Run(request, Console.Out, Console.Error);
     }
 
@@ -94,6 +99,8 @@ internal sealed class TraceCommands
     /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
     /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
     /// <param name="benchmark">Scope to the BenchmarkDotNet measured-workload subtree (preset root); for BDN captures.</param>
+    /// <param name="nativeSymbols">Resolve native runtime frames (GC, JIT, memset/memcpy) from the Microsoft public symbol server; opt-in, fetches over the network. .etl CPU captures only.</param>
+    /// <param name="symbolCache">Local cache directory for downloaded native PDBs; omit for the default under the temp path.</param>
     /// <returns>A process exit code.</returns>
     [Command("cpu")]
     public int Cpu(
@@ -107,7 +114,9 @@ internal sealed class TraceCommands
         bool strict = false,
         string process = "",
         bool allProcesses = false,
-        bool benchmark = false)
+        bool benchmark = false,
+        bool nativeSymbols = false,
+        string symbolCache = "")
     {
         if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
         {
@@ -121,8 +130,9 @@ internal sealed class TraceCommands
             return ExitCodes.UsageError;
         }
 
+        SymbolOptions symbolOptions = RankRequestFactory.ResolveSymbolOptions(nativeSymbols, symbolCache);
         RankRequest request = RankRequestFactory.Create(
-            trace, TraceMetric.Cpu, measure, resolvedRoot, top, fold, symbols, format, strict, scope);
+            trace, TraceMetric.Cpu, measure, resolvedRoot, top, fold, symbols, format, strict, scope, symbolOptions);
         return RankingExecutor.Run(request, Console.Out, Console.Error);
     }
 

--- a/traceq/src/TraceQ/Cli/TraceExecution.cs
+++ b/traceq/src/TraceQ/Cli/TraceExecution.cs
@@ -93,11 +93,12 @@ internal static class TraceExecution
         string? symbols,
         TextWriter error,
         [NotNullWhen(true)] out LoadedTrace? trace,
-        ScopeRequest? scope = null)
+        ScopeRequest? scope = null,
+        SymbolOptions? symbolOptions = null)
     {
         try
         {
-            trace = new TraceStore().Get(path, symbols, metric, scope);
+            trace = new TraceStore().Get(path, symbols, metric, scope, symbolOptions);
             return true;
         }
         catch (Exception ex) when (

--- a/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
@@ -286,6 +286,18 @@ public sealed class CliAppTests
     }
 
     [TestMethod]
+    public void Run_NativeSymbolsOnSpeedscope_BindsAndIsHarmlessNoOp()
+    {
+        // --native-symbols binds on the cpu verb; speedscope carries no native frames,
+        // so it is a no-op that reaches no symbol server (offline-safe) and still
+        // renders the ranking. This proves the option is wired without a network fetch.
+        (int exit, string output, _) = Run("cpu", Speedscope, "--native-symbols");
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("CPU self-time");
+    }
+
+    [TestMethod]
     public void Run_LinesProcessAndAllProcesses_ReturnsUsageError()
     {
         // The scope options are wired into the lines verb and remain mutually

--- a/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
@@ -411,6 +411,31 @@ public sealed class CliAppTests
     }
 
     [TestMethod]
+    public void Run_Classify_OnSpeedscope_RendersCategoryTable()
+    {
+        // classify reads the CPU view and buckets self-time by runtime work category;
+        // on the speedscope fixture (no native frames) it renders the table with every
+        // leaf in 'other'. Runs on every CI leg.
+        (int exit, string output, _) = Run("classify", Speedscope);
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("by work category");
+        output.Should().Contain("other");
+    }
+
+    [TestMethod]
+    public void Run_ClassifyJson_WritesSingleLineEnvelope()
+    {
+        (int exit, string output, _) = Run("classify", Speedscope, "--format", "json");
+
+        exit.Should().Be(ExitCodes.Success);
+        string json = output.Trim();
+        json.Should().NotContain("\n");
+        json.Should().Contain("\"schemaVersion\"");
+        json.Should().Contain("\"categories\"");
+    }
+
+    [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
     public void Run_ExplicitProcessScope_OnMachineWideCapture_WarnsAndNarrows()
     {

--- a/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
@@ -298,6 +298,28 @@ public sealed class CliAppTests
     }
 
     [TestMethod]
+    public void Run_NoFold_BindsAndRenders()
+    {
+        // --no-fold binds on the cpu verb and folds only the synthetic markers; on the
+        // speedscope fixture it still renders a ranking.
+        (int exit, string output, _) = Run("cpu", Speedscope, "--no-fold");
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("CPU self-time");
+    }
+
+    [TestMethod]
+    public void Run_NoFoldAndFold_ReturnsUsageError()
+    {
+        // --no-fold and --fold are mutually exclusive; the conflict is caught before any
+        // ranking, so it runs on every CI leg.
+        (int exit, _, string error) = Run("cpu", Speedscope, "--no-fold", "--fold", "Helper");
+
+        exit.Should().Be(ExitCodes.UsageError);
+        error.Should().Contain("only one of --fold and --no-fold");
+    }
+
+    [TestMethod]
     public void Run_LinesProcessAndAllProcesses_ReturnsUsageError()
     {
         // The scope options are wired into the lines verb and remain mutually

--- a/traceq/tests/TraceQ.Cli.Tests/RankRequestFactoryTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/RankRequestFactoryTests.cs
@@ -154,4 +154,31 @@ public sealed class RankRequestFactoryTests
             .Should().BeFalse();
         error.Should().Contain("only one of --root and --benchmark");
     }
+
+    [TestMethod]
+    public void ResolveSymbolOptions_Default_IsManagedOnly()
+    {
+        // No --native-symbols: the offline managed-only default, so the CPU read never
+        // reaches a symbol server.
+        SymbolOptions options = RankRequestFactory.ResolveSymbolOptions(nativeSymbols: false, symbolCache: "");
+
+        options.Should().BeSameAs(SymbolOptions.None);
+    }
+
+    [TestMethod]
+    public void ResolveSymbolOptions_NativeSymbols_OptsInToNativeResolution()
+    {
+        SymbolOptions options = RankRequestFactory.ResolveSymbolOptions(nativeSymbols: true, symbolCache: "");
+
+        options.ResolveNativeRuntime.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void ResolveSymbolOptions_SymbolCache_IsCarriedThrough()
+    {
+        SymbolOptions options = RankRequestFactory.ResolveSymbolOptions(nativeSymbols: true, symbolCache: @"C:\sym");
+
+        options.ResolveNativeRuntime.Should().BeTrue();
+        options.CacheDirectory.Should().Be(@"C:\sym");
+    }
 }

--- a/traceq/tests/TraceQ.Cli.Tests/RankRequestFactoryTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/RankRequestFactoryTests.cs
@@ -181,4 +181,42 @@ public sealed class RankRequestFactoryTests
         options.ResolveNativeRuntime.Should().BeTrue();
         options.CacheDirectory.Should().Be(@"C:\sym");
     }
+
+    [TestMethod]
+    public void TryResolveFold_NoOptions_LeavesNullForTheBuiltInDefault()
+    {
+        // Neither --fold nor --no-fold: null patterns signal Create to apply the
+        // built-in default fold list.
+        RankRequestFactory.TryResolveFold(fold: null, noFold: false, out string[]? patterns, out string? error)
+            .Should().BeTrue();
+        error.Should().BeNull();
+        patterns.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void TryResolveFold_NoFold_FoldsOnlyTheSyntheticMarkers()
+    {
+        RankRequestFactory.TryResolveFold(fold: null, noFold: true, out string[]? patterns, out _)
+            .Should().BeTrue();
+        // Marker-only: the synthetic sample markers stay folded, but the JIT-helper
+        // thunks (Memmove, WriteBarrier, JIT_) do not, so native leaves rank raw.
+        patterns.Should().BeEquivalentTo(FrameNames.MarkerOnlyFoldPatterns);
+        patterns.Should().NotContain("JIT_");
+    }
+
+    [TestMethod]
+    public void TryResolveFold_ExplicitFold_IsPassedThrough()
+    {
+        RankRequestFactory.TryResolveFold(fold: ["MyHelper"], noFold: false, out string[]? patterns, out _)
+            .Should().BeTrue();
+        patterns.Should().BeEquivalentTo(["MyHelper"]);
+    }
+
+    [TestMethod]
+    public void TryResolveFold_BothOptions_IsAUsageError()
+    {
+        RankRequestFactory.TryResolveFold(fold: ["MyHelper"], noFold: true, out _, out string? error)
+            .Should().BeFalse();
+        error.Should().Contain("only one of --fold and --no-fold");
+    }
 }

--- a/traceq/tests/TraceQ.Core.Tests/FoldingAggregatorClassifyTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/FoldingAggregatorClassifyTests.cs
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class FoldingAggregatorClassifyTests
+{
+    private static FoldingAggregator Engine(IReadOnlyList<SampleStack> samples) =>
+        new(new StackSampleSource(MetricInfo.Cpu, samples));
+
+    private static Dictionary<string, double> ByCategory(ClassifyResult result)
+    {
+        Dictionary<string, double> map = new(StringComparer.Ordinal);
+        foreach (CategoryRow row in result.Categories)
+        {
+            map[row.Category] = row.Weight;
+        }
+
+        return map;
+    }
+
+    [TestMethod]
+    public void Classify_BucketsLeavesByRuntimeWorkCategory()
+    {
+        // Stacks are outermost-first; the leaf (last frame) is the self-time site.
+        FoldingAggregator engine = Engine(
+        [
+            new SampleStack(["MyApp.Run", "WKS::gc_heap::plan_phase"], 10.0, "1"),  // gc
+            new SampleStack(["MyApp.Run", "JIT_MemCpy"], 6.0, "1"),                 // copying
+            new SampleStack(["MyApp.Run", "ntdll!memset"], 4.0, "1"),               // zeroing
+            new SampleStack(["MyApp.Run", "MyApp.Work"], 5.0, "1")                  // other (managed)
+        ]);
+
+        ClassifyResult result = engine.Classify("");
+
+        result.ScopeWeight.Should().Be(25.0);
+        Dictionary<string, double> byCategory = ByCategory(result);
+        byCategory[FrameCategories.Gc].Should().Be(10.0);
+        byCategory[FrameCategories.Copying].Should().Be(6.0);
+        byCategory[FrameCategories.Other].Should().Be(5.0);
+        byCategory[FrameCategories.Zeroing].Should().Be(4.0);
+    }
+
+    [TestMethod]
+    public void Classify_RanksCategoriesByWeightWithPercentages()
+    {
+        FoldingAggregator engine = Engine(
+        [
+            new SampleStack(["MyApp.Run", "WKS::gc_heap::plan_phase"], 30.0, "1"),
+            new SampleStack(["MyApp.Run", "JIT_MemCpy"], 10.0, "1")
+        ]);
+
+        ClassifyResult result = engine.Classify("");
+
+        // Highest weight first; percentages are of the scoped total (40).
+        result.Categories[0].Category.Should().Be(FrameCategories.Gc);
+        result.Categories[0].PercentOfScope.Should().BeApproximately(75.0, 0.001);
+        result.Categories[1].Category.Should().Be(FrameCategories.Copying);
+        result.Categories[1].PercentOfScope.Should().BeApproximately(25.0, 0.001);
+    }
+
+    [TestMethod]
+    public void Classify_FoldsTheSyntheticMarkerToTheRealLeafBelowIt()
+    {
+        // The synthetic CPU_TIME marker is the leaf, but it is marker-folded, so the
+        // sample classifies by the real frame beneath it (the GC frame) rather than
+        // collapsing every marker sample into one meaningless bucket.
+        FoldingAggregator engine = Engine(
+        [
+            new SampleStack(["MyApp.Run", "WKS::gc_heap::plan_phase", "CPU_TIME"], 8.0, "1")
+        ]);
+
+        ClassifyResult result = engine.Classify("");
+
+        ByCategory(result).Should().ContainKey(FrameCategories.Gc);
+        ByCategory(result)[FrameCategories.Gc].Should().Be(8.0);
+    }
+
+    [TestMethod]
+    public void Classify_DoesNotFoldTheJitHelperThunks()
+    {
+        // Unlike the default fold list, classify must NOT fold Memmove / WriteBarrier /
+        // JIT_ helpers - those ARE the work being classified. A memcpy helper leaf stays
+        // the leaf and classifies as copying rather than folding into its managed caller.
+        FoldingAggregator engine = Engine(
+        [
+            new SampleStack(["MyApp.Run", "JIT_MemCpy"], 7.0, "1")
+        ]);
+
+        ClassifyResult result = engine.Classify("");
+
+        ByCategory(result).Should().ContainKey(FrameCategories.Copying);
+        ByCategory(result).Should().NotContainKey(FrameCategories.Other);
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/FrameCategoriesTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/FrameCategoriesTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+[TestClass]
+public sealed class FrameCategoriesTests
+{
+    [TestMethod]
+    [DataRow("memset", FrameCategories.Zeroing)]
+    [DataRow("ntdll!RtlZeroMemory", FrameCategories.Zeroing)]
+    [DataRow("JIT_MemSet", FrameCategories.Zeroing)]
+    [DataRow("memcpy", FrameCategories.Copying)]
+    [DataRow("ntdll!memmove", FrameCategories.Copying)]
+    [DataRow("JIT_MemCpy", FrameCategories.Copying)]
+    [DataRow("JIT_WriteBarrier", FrameCategories.WriteBarrier)]
+    [DataRow("BulkMoveWithWriteBarrier", FrameCategories.WriteBarrier)]
+    [DataRow("WKS::gc_heap::plan_phase", FrameCategories.Gc)]
+    [DataRow("SVR::gc_heap::mark_phase", FrameCategories.Gc)]
+    [DataRow("JIT_New", FrameCategories.Gc)]
+    [DataRow("clrjit!Compiler::compCompile", FrameCategories.Jit)]
+    [DataRow("coreclr!MethodDesc::CompileMethod", FrameCategories.Jit)]
+    [DataRow("PollGC", FrameCategories.Jit)]
+    [DataRow("Touki.Io.Globbing.CompiledGlobStrategy.RunEngine", FrameCategories.Other)]
+    [DataRow("System.SpanHelpers.IndexOf", FrameCategories.Other)]
+    [DataRow("?", FrameCategories.Other)]
+    [DataRow("", FrameCategories.Other)]
+    public void Classify_AssignsTheExpectedCategory(string frame, string expected)
+    {
+        FrameCategories.Classify(frame).Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void Classify_PrefersTheSpecificOperationOverTheGenericJitBucket()
+    {
+        // JIT_MemCpy / JIT_MemSet / JIT_WriteBarrier / JIT_New all start with "JIT_",
+        // but each must land in the operation it performs, not the generic "jit" bucket,
+        // because the work-type rules are checked before the generic jit rule.
+        FrameCategories.Classify("JIT_MemCpy").Should().Be(FrameCategories.Copying);
+        FrameCategories.Classify("JIT_MemSet").Should().Be(FrameCategories.Zeroing);
+        FrameCategories.Classify("JIT_WriteBarrier").Should().Be(FrameCategories.WriteBarrier);
+        FrameCategories.Classify("JIT_New").Should().Be(FrameCategories.Gc);
+
+        // A JIT_ helper that is none of those falls through to the generic jit bucket.
+        FrameCategories.Classify("JIT_Stelem_Ref").Should().Be(FrameCategories.Jit);
+    }
+
+    [TestMethod]
+    public void Classify_IsCaseInsensitive()
+    {
+        FrameCategories.Classify("MEMSET").Should().Be(FrameCategories.Zeroing);
+        FrameCategories.Classify("MemCpy").Should().Be(FrameCategories.Copying);
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/SymbolOptionsTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/SymbolOptionsTests.cs
@@ -49,6 +49,20 @@ public sealed class SymbolOptionsTests
     }
 
     [TestMethod]
+    [DataRow(@"C:\sym*evil")]
+    [DataRow("*")]
+    [DataRow(@"srv*c:\x*https://evil.example/symbols")]
+    public void WithCache_DirectoryWithStar_Throws(string dir)
+    {
+        // The cache directory is interpolated into a SymSrv path element
+        // (srv*<cache>*<server>), so a '*' would split into extra elements and could
+        // redirect the effective symbol path; it is rejected up front.
+        Action act = () => SymbolOptions.WithCache(dir);
+
+        act.Should().Throw<ArgumentException>().WithParameterName("cacheDirectory");
+    }
+
+    [TestMethod]
     public void DefaultCacheDirectory_IsUnderTheTempPath()
     {
         SymbolOptions.DefaultCacheDirectory.Should().Be(Path.Combine(Path.GetTempPath(), "traceq-symbols"));

--- a/traceq/tests/TraceQ.Core.Tests/SymbolOptionsTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/SymbolOptionsTests.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace TraceQ.Tracing;
+
+// SymbolOptions is the high-level native-symbol intent; its factories and cache-key
+// fragment are platform-agnostic (no trace read or network), so they run everywhere.
+// The actual native resolution is exercised manually against a real .etl with network;
+// it is not pinned by a committed fixture (the trimmed etw.etl carries no rundown).
+[TestClass]
+public sealed class SymbolOptionsTests
+{
+    [TestMethod]
+    public void None_IsManagedOnlyAndOffline()
+    {
+        SymbolOptions.None.ResolveNativeRuntime.Should().BeFalse();
+        SymbolOptions.None.CacheDirectory.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void WithCache_DefaultsToTheSharedTempCache()
+    {
+        SymbolOptions options = SymbolOptions.WithCache();
+
+        options.ResolveNativeRuntime.Should().BeTrue();
+        // A null cache directory means "use the default"; the reader resolves it to
+        // DefaultCacheDirectory, so the value stays null here by design.
+        options.CacheDirectory.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void WithCache_CarriesAnExplicitCacheDirectory()
+    {
+        SymbolOptions options = SymbolOptions.WithCache(@"C:\sym");
+
+        options.ResolveNativeRuntime.Should().BeTrue();
+        options.CacheDirectory.Should().Be(@"C:\sym");
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(null)]
+    public void WithCache_EmptyDirectory_FallsBackToTheDefault(string? dir)
+    {
+        // An empty or null directory is normalized to null so the reader uses the
+        // default cache, rather than treating "" as a real (cwd) path.
+        SymbolOptions.WithCache(dir).CacheDirectory.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void DefaultCacheDirectory_IsUnderTheTempPath()
+    {
+        SymbolOptions.DefaultCacheDirectory.Should().Be(Path.Combine(Path.GetTempPath(), "traceq-symbols"));
+    }
+
+    [TestMethod]
+    public void CacheKeyFragment_None_IsManaged()
+    {
+        // The managed-only default and native resolution must produce different cache
+        // keys so the same trace read both ways is cached separately.
+        SymbolOptions.None.CacheKeyFragment().Should().Be("managed");
+    }
+
+    [TestMethod]
+    public void CacheKeyFragment_Native_DiffersFromManagedAndCarriesTheCache()
+    {
+        string nativeKey = SymbolOptions.WithCache(@"C:\sym").CacheKeyFragment();
+
+        nativeKey.Should().NotBe("managed");
+        nativeKey.Should().Contain(@"C:\sym");
+    }
+
+    [TestMethod]
+    public void CacheKeyFragment_NativeWithDifferentCaches_Differ()
+    {
+        // Two native reads with distinct cache directories are distinct cache entries.
+        string a = SymbolOptions.WithCache(@"C:\a").CacheKeyFragment();
+        string b = SymbolOptions.WithCache(@"C:\b").CacheKeyFragment();
+
+        a.Should().NotBe(b);
+    }
+}

--- a/traceq/tests/TraceQ.Core.Tests/TraceLoaderTests.cs
+++ b/traceq/tests/TraceQ.Core.Tests/TraceLoaderTests.cs
@@ -82,6 +82,36 @@ public sealed class TraceLoaderTests
     }
 
     [TestMethod]
+    public void Load_NetTrace_ResolvesDotNetRuntimeManagedMethods()
+    {
+        TraceLoader loader = new();
+
+        LoadedTrace trace = loader.Load(FixturePath("alloc.nettrace"), TraceMetric.Allocations);
+
+        // The .NET runtime/framework managed methods on the stacks are ReadyToRun
+        // (R2R) precompiled images on modern .NET, not JITted - so this pins that
+        // precompiled managed frames resolve to qualified names from the EventPipe
+        // CLR rundown, with no symbol server and no local PDBs. A regression here
+        // (an unresolved BCL frame surfacing as "module!?" or "?") would silently
+        // degrade every managed ranking, so it is asserted directly rather than
+        // inferred from the aggregate resolution rate.
+        IEnumerable<string> allFrames = trace.Source.Samples.SelectMany(static s => s.Frames);
+
+        // The BCL namespace is `System.`; a resolved frame is a qualified
+        // `Namespace.Type.Method`, never the `?` / `module!?` unresolved placeholders.
+        allFrames.Should().Contain(
+            f => f.StartsWith("System.", StringComparison.Ordinal) && !f.EndsWith("!?", StringComparison.Ordinal),
+            because: "precompiled .NET runtime managed methods must resolve to names from the CLR rundown");
+
+        // A concrete BCL type the AllocLoop fixture exercises (it allocates strings),
+        // pinning that a specific runtime type resolves by name and not just that
+        // some `System.` frame happens to be present.
+        allFrames.Should().Contain(
+            f => f.Contains("System.String", StringComparison.Ordinal),
+            because: "the string allocations in the fixture must attribute to a named System.String method");
+    }
+
+    [TestMethod]
     public void Load_AllocationMetricOnSpeedscope_ThrowsNotSupported()
     {
         TraceLoader loader = new();

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceQ.Mcp.Tests.csproj
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceQ.Mcp.Tests.csproj
@@ -34,6 +34,9 @@
     <None Include="..\TraceQ.Core.Tests\Fixtures\exceptions.nettrace" Link="Fixtures\exceptions.nettrace">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\TraceQ.Core.Tests\Fixtures\jit.nettrace" Link="Fixtures\jit.nettrace">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="..\TraceQ.Core.Tests\Fixtures\etw.etl" Link="Fixtures\etw.etl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -16,6 +16,7 @@ public sealed class TraceToolsTests
     private const string Speedscope = "folding.speedscope.json";
     private const string Alloc = "alloc.nettrace";
     private const string Exceptions = "exceptions.nettrace";
+    private const string Jit = "jit.nettrace";
     private const string Etw = "etw.etl";
 
     private static string FixturePath(string name) =>
@@ -339,6 +340,117 @@ public sealed class TraceToolsTests
         AnalysisResult<GcStatsResult> envelope = TraceTools.Gc(FixturePath(Alloc), top: 1);
 
         envelope.Result.Gcs.Count.Should().BeLessThanOrEqualTo(1);
+    }
+
+    [TestMethod]
+    public void Processes_Speedscope_ListsTheSingleProcess()
+    {
+        TraceStore store = new();
+
+        AnalysisResult<ProcessListResult> envelope = TraceTools.Processes(store, FixturePath(Speedscope));
+
+        AssertEnvelope(envelope);
+        envelope.Result.Processes.Should().NotBeEmpty();
+        envelope.Result.TotalSamples.Should().BeGreaterThan(0);
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Processes_Etw_RanksEveryProcessByWeight()
+    {
+        TraceStore store = new();
+
+        AnalysisResult<ProcessListResult> envelope = TraceTools.Processes(store, FixturePath(Etw));
+
+        AssertEnvelope(envelope);
+        // The inventory reads every process rather than auto-scoping to the busiest,
+        // and reports them highest weight first.
+        envelope.Result.Processes.Should().NotBeEmpty();
+        envelope.Result.Processes.Should().BeInDescendingOrder(static p => p.Weight);
+    }
+
+    [TestMethod]
+    public void Tree_Speedscope_ReturnsRootedCallTree()
+    {
+        TraceStore store = new();
+
+        AnalysisResult<CallTreeResult> envelope = TraceTools.Tree(store, FixturePath(Speedscope));
+
+        AssertEnvelope(envelope);
+        envelope.Result.ScopeWeight.Should().BeGreaterThan(0.0);
+        envelope.Result.Root.Children.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public void Tree_NegativeMaxDepth_Throws()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Tree(store, FixturePath(Speedscope), maxDepth: -1);
+
+        act.Should().Throw<McpException>().WithMessage("*maxDepth*");
+    }
+
+    [TestMethod]
+    public void Tree_NegativeMinPercent_Throws()
+    {
+        TraceStore store = new();
+
+        Action act = () => TraceTools.Tree(store, FixturePath(Speedscope), minPercent: -1.0);
+
+        act.Should().Throw<McpException>().WithMessage("*minPercent*");
+    }
+
+    [TestMethod]
+    public void Classify_Speedscope_BucketsSelfTimeByCategory()
+    {
+        TraceStore store = new();
+
+        AnalysisResult<ClassifyResult> envelope = TraceTools.Classify(store, FixturePath(Speedscope));
+
+        AssertEnvelope(envelope);
+        envelope.Result.ScopeWeight.Should().BeGreaterThan(0.0);
+        envelope.Result.Categories.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    public void Jit_NetTrace_ReturnsCompileSummary()
+    {
+        AnalysisResult<JitStatsResult> envelope = TraceTools.Jit(FixturePath(Jit));
+
+        AssertEnvelope(envelope);
+        envelope.Result.MethodCount.Should().BeGreaterThan(0);
+        envelope.Result.Methods.Should().NotBeEmpty();
+        envelope.Result.TotalCompileMs.Should().BeGreaterThan(0.0);
+    }
+
+    [TestMethod]
+    public void Jit_NonNetTraceInput_ThrowsMcpException()
+    {
+        // The JIT report parses the EventPipe format; an .etl or speedscope is rejected
+        // up front by the extension guardrail.
+        Action act = () => TraceTools.Jit(FixturePath(Speedscope));
+
+        act.Should().Throw<McpException>().WithMessage("*requires a .nettrace*");
+    }
+
+    [TestMethod]
+    public void Jit_NonPositiveTop_Throws()
+    {
+        Action act = () => TraceTools.Jit(FixturePath(Jit), top: 0);
+
+        act.Should().Throw<McpException>().WithMessage("*top must be 1 or greater*");
+    }
+
+    [TestMethod]
+    public void Jit_Top_CapsPerMethodDetail()
+    {
+        // The aggregate summary always reflects every method, but the per-method detail
+        // list is capped to 'top' so a startup trace's thousands of methods cannot blow
+        // the output budget.
+        AnalysisResult<JitStatsResult> envelope = TraceTools.Jit(FixturePath(Jit), top: 1);
+
+        envelope.Result.Methods.Count.Should().BeLessThanOrEqualTo(1);
     }
 
     [TestMethod]

--- a/traceq/tools/Test-McpServer.ps1
+++ b/traceq/tools/Test-McpServer.ps1
@@ -31,16 +31,19 @@
   The build configuration whose MCP binary to exercise. Defaults to Release.
 
 .PARAMETER MaxSchemaTokens
-  The tool-list token budget. Defaults to 6000. Tokens are estimated at four
+  The tool-list token budget. Defaults to 8000. Tokens are estimated at four
   characters each; the check prints the measured characters and estimate so a
   regression is legible. The budget covers each tool's name, description, input
   schema, and (because the tools advertise structured content) its output schema -
-  everything the client puts in front of the model from tools/list.
+  everything the client puts in front of the model from tools/list. The ceiling is
+  a bloat guard, not a cap on legitimate surface: the 13 analysis tools measure
+  ~6,700 tokens (~520 each), so 8000 leaves modest headroom while still tripping on
+  a doubled description or a few unplanned tools.
 #>
 [CmdletBinding()]
 param(
     [string]$Configuration = 'Release',
-    [int]$MaxSchemaTokens = 6000
+    [int]$MaxSchemaTokens = 8000
 )
 
 $ErrorActionPreference = 'Stop'
@@ -119,13 +122,10 @@ $p.StandardInput.WriteLine($callRequest)
 $p.StandardInput.Flush()
 
 # Single async read pump with a hard overall deadline; do not break on a per-read
-# timeout because a cold server's first stdout line can take several seconds.
-# JSON-RPC responses may arrive out of order, so collect until BOTH the tools/list
-# (id 2) and the tools/call (id 3) responses have been seen rather than breaking on
-# id 3 alone - otherwise a tools/list that landed second would be missed and the
-# schema-budget check below would fail on an otherwise healthy server.
+# timeout because a cold server's first stdout line can take several seconds. The
+# tools/call response (id 3) is the last one expected, so reading until it arrives
+# collects the initialize, tools/list, and tools/call responses.
 $stdout = [System.Collections.Generic.List[string]]::new()
-$gotTools = $false
 $gotRoundTrip = $false
 $deadline = [DateTime]::UtcNow.AddSeconds(30)
 $pending = $p.StandardOutput.ReadLineAsync()
@@ -134,21 +134,17 @@ while ([DateTime]::UtcNow -lt $deadline) {
         $line = $pending.Result
         if ($null -eq $line) { break }
         $stdout.Add($line)
-        # Track the tools/list (id 2) and tools/call (id 3) responses by a real
-        # JSON-RPC id, not a substring (which would also match id 20, 30, ...). A
-        # non-JSON line is left for the purity check below to flag.
+        # Detect the final tools/call response by a real JSON-RPC id == 3, not a
+        # substring (which would also match id 30, 31, ...). A non-JSON line is left
+        # for the purity check below to flag.
         $trimmed = $line.Trim()
         if ($trimmed.Length -gt 0) {
             try {
                 $probe = [System.Text.Json.JsonDocument]::Parse($trimmed)
-                switch (Get-JsonRpcId $probe.RootElement) {
-                    2 { $gotTools = $true }
-                    3 { $gotRoundTrip = $true }
-                }
+                if ((Get-JsonRpcId $probe.RootElement) -eq 3) { $gotRoundTrip = $true; break }
             }
             catch { }
         }
-        if ($gotTools -and $gotRoundTrip) { break }
         $pending = $p.StandardOutput.ReadLineAsync()
     }
 }
@@ -166,12 +162,9 @@ if (-not $p.WaitForExit(5000)) {
 # failure output. Surfaced only on failure so a passing run stays quiet.
 $stderrOutput = $stderrTask.GetAwaiter().GetResult()
 
-if (-not ($gotTools -and $gotRoundTrip)) {
-    $missing = if (-not $gotTools -and -not $gotRoundTrip) { 'tools/list and tools/call' }
-        elseif (-not $gotTools) { 'tools/list' }
-        else { 'tools/call' }
+if (-not $gotRoundTrip) {
     throw (
-        "The server did not return the $missing response within the deadline.`n" +
+        "The server did not return the tools/call response within the deadline.`n" +
         "stdout:`n$($stdout -join "`n")`n" +
         "stderr:`n$stderrOutput")
 }

--- a/traceq/tools/Test-McpServer.ps1
+++ b/traceq/tools/Test-McpServer.ps1
@@ -127,6 +127,7 @@ $p.StandardInput.Flush()
 # collects the initialize, tools/list, and tools/call responses.
 $stdout = [System.Collections.Generic.List[string]]::new()
 $gotRoundTrip = $false
+$gotToolsList = $false
 $deadline = [DateTime]::UtcNow.AddSeconds(30)
 $pending = $p.StandardOutput.ReadLineAsync()
 while ([DateTime]::UtcNow -lt $deadline) {
@@ -134,14 +135,20 @@ while ([DateTime]::UtcNow -lt $deadline) {
         $line = $pending.Result
         if ($null -eq $line) { break }
         $stdout.Add($line)
-        # Detect the final tools/call response by a real JSON-RPC id == 3, not a
-        # substring (which would also match id 30, 31, ...). A non-JSON line is left
-        # for the purity check below to flag.
+        # Track the responses we need by real JSON-RPC id (not a substring, which would
+        # also match id 30, 31, ...): tools/list is id 2, the tools/call round-trip is
+        # id 3. JSON-RPC responses can arrive in any order, so wait for BOTH before
+        # stopping - breaking on id 3 alone could miss a later-arriving tools/list and
+        # silently skip the schema-budget check. A non-JSON line is left for the purity
+        # check below to flag.
         $trimmed = $line.Trim()
         if ($trimmed.Length -gt 0) {
             try {
                 $probe = [System.Text.Json.JsonDocument]::Parse($trimmed)
-                if ((Get-JsonRpcId $probe.RootElement) -eq 3) { $gotRoundTrip = $true; break }
+                $probeId = Get-JsonRpcId $probe.RootElement
+                if ($probeId -eq 2) { $gotToolsList = $true }
+                elseif ($probeId -eq 3) { $gotRoundTrip = $true }
+                if ($gotToolsList -and $gotRoundTrip) { break }
             }
             catch { }
         }


### PR DESCRIPTION
## Summary

Continues the traceq incubation (on top of #208): adds native runtime symbol resolution and brings the MCP tool surface to parity with the CLI.

### traceq
- **Verify managed runtime symbols** (`afdb3cb`): confirm .NET runtime managed frames resolve, pinned with a regression test.
- **Native runtime symbols** (`58a2387`): opt-in `--native-symbols` / `--symbol-cache` on `cpu`/`rank` resolves GC/JIT/memcpy frames from the Microsoft public symbol server (verified 44% -> 87% symbol resolution on a real net481 ETL).
- **`--no-fold`** (`32adc09`): rank raw native leaves without JIT-helper folding.
- **`classify` verb** (`bfb0127`): bucket CPU self-time by runtime work category (zeroing / copying / write-barrier / GC / JIT / other).
- **MCP/CLI parity** (`52ea602`): four new MCP tools - `trace_processes`, `trace_tree`, `trace_classify`, `trace_jit` - so an agent reaches the same analyses the CLI offers. The curated surface is now **13 tools** (~6.7k schema tokens); the schema-budget ceiling was raised 6000 -> 8000 with rationale. `alloc`/`exceptions` are already reachable through `trace_rank`'s `metric`; the only analysis verbs that stay CLI-only are the file-management verbs `convert`/`clean` (they manage the on-disk ETLX cache and `clean` deletes files - outside the read-only analysis contract).
- Register the local traceq MCP server in `.vscode/mcp.json` (`bc8390c`).

### Incidental (bundled by request)
- New `ValueStringBuilder` vs `StringBuilder` formatting benchmark in `touki.perf` (`0fd412a`).
- Update the performance-investigation walkthroughs to reference `traceq` (`d48927d`).

## Validation
- `dotnet build -c Release traceq/traceq.slnx` - clean (0 warnings).
- `dotnet test -c Release traceq/traceq.slnx` - 505/505 pass (+10 new MCP tests).
- MCP server check (stdout purity, `tools/call` round-trip, schema budget) - green.
- CLI help-lint - green (18 verbs).