### PR TITLE
Add NonCopyable / defensive-copy analyzers and dogfood them on touki

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -26,6 +26,7 @@ The "Disambiguation" section below records every known overlap.
 | [publish-release](./publish-release/SKILL.md) | "publish a new version", "release alpha.N", "ship a beta", "cut a release", "promote alpha to beta", "tag and publish" - choosing the right `Major.Minor.Patch`, alpha/beta/rc/stable channel, tag stream (`v*` vs `ts-v*`), and GitHub release notes | repo-specific | `pre-pr-self-review` |
 | [manage-skills](./manage-skills/SKILL.md) | "find a skill", "build a skill" / "create a skill" (checks for an existing one first), "update the skill", sync a local change upstream vs into an overlay; the find-first build path, tiered search, pull/push update flow | semi-portable | `agent-files-review` |
 | [roslyn-analyzers](./roslyn-analyzers/SKILL.md) | "write an analyzer", "create a Roslyn/diagnostic analyzer", "add an analyzer rule", "add a code fix", "enforce <convention> at build time", "flag <pattern> in code"; find-first check of existing `CA`/`IDE` rules, `BannedApiAnalyzers`, EditorConfig, Roslynator/StyleCop/Meziantou before authoring; `touki.analyzers` layout, packing into `KlutzyNinja.Touki`, statelessness/`IOperation` design, the `Microsoft.CodeAnalysis.Testing` harness, in-IDE perf budget | semi-portable | `performance-testing`, `security-review`, `pre-pr-self-review`, `create-pr` |
+| [il-copy-inspection](./il-copy-inspection/SKILL.md) | "find struct copies", "where does the compiler copy this struct", "is this a defensive copy", "check for boxing in IL", "did the compiler emit a copy", "confirm the analyzer's defensive-copy warning", "audit a `[NonCopyable]` type's copies after build"; reading emitted IL (`ildasm`/`ilspycmd`/Cecil/`MetadataReader`) for the `ldobj`/`stloc`/`ldloca` defensive-copy signature, `box`, by-value field/arg/return copies, and PDB offset-to-source mapping | semi-portable | `roslyn-analyzers`, `framework-jit-optimization`, `performance-testing`, `scratch-buffer-strategy` |
 
 **Portability** (mirrored from each skill's `metadata.portability`) marks how much
 a skill would need to change to be reused in another repo: `portable` (generic),
@@ -124,6 +125,24 @@ Both talk about "performance", but about different things:
 They share no harness and no budget. If the request is "make this analyzer faster
 to type against", it is `roslyn-analyzers`; if it is "make this method faster at
 run time", it is `performance-testing`.
+
+### `il-copy-inspection` vs `roslyn-analyzers` vs the perf skills
+
+"Find the struct copies" is ambiguous across four artifact layers. Route by what is
+being read:
+
+- **Predict copies from source, live in the IDE** &rarr; `roslyn-analyzers`
+  (the TOUKI0002-0004 defensive-copy / `[NonCopyable]` rules over `IOperation`).
+- **Read the compiler's emitted IL** for the actual `ldobj`/`box`/by-value copies
+  &rarr; `il-copy-inspection`. It is post-build and sees synthesized copies the
+  analyzer cannot.
+- **Read the JIT's machine code** (was the copy elided?) &rarr;
+  `framework-jit-optimization` + `[DisassemblyDiagnoser]`.
+- **Measure the runtime cost** (allocation / time) &rarr; `performance-testing`.
+
+`il-copy-inspection` never runs the code and never measures time; if a request needs
+a number, it belongs to `performance-testing`. The natural chain is analyzer
+prediction &rarr; IL confirmation &rarr; asm/runtime cost.
 
 ## Maintenance
 

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: il-copy-inspection
+description: Find struct value copies in a method's compiled IL - defensive copies, boxing, by-value field/argument/return copies - by reading the emitted bytecode rather than predicting from source. Use when asked to "find struct copies", "where does the compiler copy this struct", "is this a defensive copy", "check for boxing in IL", "did the compiler emit a copy here", "confirm the analyzer's defensive-copy warning", or "audit a [NonCopyable] type's copies after build". Post-build, ground-truth counterpart to the source-level `roslyn-analyzers` defensive-copy rules (TOUKI0002-0004): IL is post-lowering, so synthesized copies the analyzer cannot see are visible here. Not for wall-clock/allocation measurement (that is `performance-testing`) nor for JIT-emitted machine code (that is `framework-jit-optimization` + `DisassemblyDiagnoser`).
+metadata:
+    portability: semi-portable
+---
+
+# Inspecting IL for struct copies
+
+A struct copy is invisible in C# source but concrete in IL. This skill reads a
+method's **emitted bytecode** to find where the compiler actually copies a value
+type - defensive copies, boxing, and by-value field/argument/return copies - and
+maps each back to a source line. It is the ground-truth, post-build complement to
+the predictive, in-IDE `roslyn-analyzers` rules.
+
+## The four layers (where this sits)
+
+A struct copy can be reasoned about at four levels. Pick the layer that answers the
+question; they are complementary, not interchangeable.
+
+| Layer | Artifact | Tool / skill | What it tells you |
+| ----- | -------- | ------------ | ----------------- |
+| Source | `IOperation` (pre-lowering) | `roslyn-analyzers` (TOUKI0002-0004) | A copy is *predicted* from C# rules, live in the IDE |
+| **IL** | **compiled bytecode (post-lowering)** | **this skill** (`ildasm` / `ilspycmd` / Cecil) | **A copy was *emitted* by the C# compiler** |
+| Asm | JIT machine code | `framework-jit-optimization` + `DisassemblyDiagnoser` | Whether the JIT *kept* the copy or elided it |
+| Runtime | ETW / wall-clock | `performance-testing` + `traceq` | Whether the copy *costs* measurable time / allocation |
+
+The IL layer is uniquely able to see copies the **compiler synthesizes during
+lowering** - async / iterator state-machine field hoisting, closures, thunks -
+which have no source operation and are therefore out of reach for an analyzer. It
+is also the cheapest way to *confirm* a TOUKI0002/0003 prediction: if the IL has the
+defensive-copy signature, the analyzer was right.
+
+## Step 0 - is something already answering this?
+
+- **"Does my code have a defensive copy I can fix in the editor?"** -> the
+  `roslyn-analyzers` rules already flag the common cases live. Use this skill only
+  to (a) confirm a flagged case, or (b) find the synthesized copies the analyzer
+  documents as out of scope.
+- **"Is this copy actually costing me time / allocations?"** -> `performance-testing`
+  (boxing shows as `Allocated` under `[MemoryDiagnoser]`; a hot defensive copy shows
+  in a trace).
+- **"Did the JIT keep the copy?"** -> `framework-jit-optimization` /
+  `[DisassemblyDiagnoser]`. The C# compiler may emit an IL copy that the JIT then
+  elides, so IL presence is necessary but not sufficient for a runtime cost.
+- Otherwise, read the IL (below).
+
+## Workflow
+
+1. **Build Release with a portable PDB.** Optimized IL is what ships; Debug IL has
+   extra copies and spills. The PDB's sequence points are what map IL offsets back
+   to `file:line`. (`touki` already emits embedded portable PDBs - see
+   `<DebugType>embedded</DebugType>` in
+   [touki/touki.csproj](../../../touki/touki.csproj).)
+2. **Extract the method's IL.** Pick a tool from the table below. Disassemble the
+   single method of interest, not the whole assembly.
+3. **Match the copy patterns.** Scan the method body for the copy opcodes and the
+   defensive-copy temp signature. The full catalog - every opcode, the
+   `ldobj`/`stloc`/`ldloca`/`call` defensive sequence, `box`, `cpobj`, `ldfld` vs
+   `ldflda` - is in
+   [references/copy-opcodes.md](references/copy-opcodes.md).
+4. **Map IL offset to source.** Use the PDB sequence points (most disassemblers can
+   interleave source, e.g. `ilspycmd -il` with debug info, or read sequence points
+   via `System.Reflection.Metadata`) to attribute each copy to a line - the same
+   artifact-to-source drill the `performance-testing` skill does with `traceq`.
+5. **Report** the type copied, the mechanism (defensive / box / by-value), and the
+   source line. Distinguish *intended* copies (a documented value transfer) from
+   *unintended* ones; IL alone cannot, so use the source context.
+
+## Tool options
+
+| Tool | Good for | Note |
+| ---- | -------- | ---- |
+| `ilspycmd -il <dll>` ([ICSharpCode.ILSpyCmd](https://github.com/icsharpcode/ILSpy)) | One-method IL dump, scriptable | `dotnet tool install -g ilspycmd`; cross-platform |
+| `ildasm` | Quick Windows dump | Ships with the .NET SDK / VS; Windows-centric |
+| `Mono.Cecil` | Programmatic body walking, custom rules | Best when scripting a repeatable copy audit |
+| `System.Reflection.Metadata` (`MetadataReader`, `MethodBodyBlock`) | In-proc, no extra dependency, owns the PDB sequence-point mapping | Most code; the right base for an automated pass |
+
+For a repeatable, automated audit, `Mono.Cecil` or `System.Reflection.Metadata`
+walking the method body and matching the opcode patterns from the catalog is the
+durable choice; `ilspycmd` is the fastest manual spot-check.
+
+## Constraints
+
+- **Needs a build and a PDB.** Unlike an analyzer (source only), this requires
+  compiled output. No PDB means no source-line mapping - opcodes only.
+- **IL copy != runtime cost.** The JIT may elide an emitted copy. Confirm cost at
+  the asm or runtime layer before claiming a perf impact.
+- **Generics share IL.** A copy of `T` appears once in the shared body; the real
+  cost depends on the instantiation. Note the open generic, then reason per
+  value-type substitution.
+- **Intent is lost in IL.** A by-value copy that is a deliberate transfer looks
+  identical to an accidental one. Keep the source open to classify; this is the same
+  "unintended vs intended" limit the `roslyn-analyzers` defensive-copy docs call out.
+
+## Cross-skill
+
+- `roslyn-analyzers` - the source-level, predictive side (TOUKI0002-0004). This
+  skill confirms its predictions and covers the synthesized copies it cannot see.
+- `framework-jit-optimization` - the next layer down (asm); whether the JIT kept the
+  copy, and what to do about it on net481.
+- `performance-testing` - whether the copy costs measurable time / allocation.
+- `scratch-buffer-strategy` - many `[NonCopyable]` types are pooled buffers; this
+  skill audits whether one is being copied by value.
+
+## Disambiguation
+
+"Find the copies" is ambiguous across layers. Route by artifact: **predict from
+source, live** -> `roslyn-analyzers`; **read the compiler's emitted IL** -> this
+skill; **read the JIT's machine code** -> `framework-jit-optimization`; **measure
+the runtime cost** -> `performance-testing`. This skill never runs the code and
+never measures time - it reads static bytecode.

--- a/.agents/skills/il-copy-inspection/references/copy-opcodes.md
+++ b/.agents/skills/il-copy-inspection/references/copy-opcodes.md
@@ -1,0 +1,100 @@
+# IL copy opcode and pattern catalog
+
+Reference for the [il-copy-inspection](../SKILL.md) skill. The opcodes and patterns
+that correspond to a struct value copy in compiled IL, and how to tell each apart
+from its non-copying address-based counterpart.
+
+## The defensive-copy signature
+
+A *defensive copy* is the one the compiler inserts silently when a non-`readonly`
+instance member is invoked on a read-only struct location (an `in` parameter, a
+`readonly` field, a `ref readonly` local). It is the highest-value find because it
+is invisible in source. For `void M(in Pooled p) => p.Mutate();` where `Mutate` is
+not `readonly`, the compiler emits a **synthesized temporary**:
+
+```
+ldarg.1            // &p   - address of the in-parameter (no copy yet)
+ldobj      Pooled  // copy *p onto the stack
+stloc.0            // spill the copy into a compiler temp local
+ldloca.s   0       // &temp - address of the COPY
+call       instance void Pooled::Mutate()   // mutate the copy, then discard it
+```
+
+The tell is the **`ldobj` -> `stloc <temp>` -> `ldloca <temp>` -> `call instance`**
+chain on a receiver that started as an address (`ldarg`/`ldflda`/`ldsflda` of a
+read-only location). The mutation lands on the temp and is thrown away. Contrast the
+no-copy form, where a `readonly` member (or a mutable receiver) is called directly
+on the address with no intervening `ldobj`/`stloc`:
+
+```
+ldarg.1            // &p
+call       instance int32 Pooled::Peek()    // readonly member - no copy
+```
+
+## Explicit copy opcodes
+
+| Opcode | Meaning | Copy? |
+| ------ | ------- | ----- |
+| `ldobj <type>` | Load a value type from an address onto the stack | **Yes** - copies the value |
+| `stobj <type>` | Store a value type from the stack through an address | **Yes** |
+| `cpobj <type>` | Copy a value type from one address to another | **Yes** |
+| `box <type>` | Box a value type into a reference | **Yes** - copy + heap allocation |
+| `unbox.any <type>` | Unbox to a value on the stack | **Yes** - copies out |
+| `ldfld <field>` | Load a field **by value** | **Yes** when the field is a struct |
+| `ldflda <field>` | Load a field **address** | No - address, no copy |
+| `ldsfld` / `ldsflda` | Static field, by value / by address | `ldsfld` copies; `ldsflda` does not |
+| `ldloc` / `ldloca` | Local, by value / by address | `ldloc` of a struct copies; `ldloca` does not |
+| `ldarg` / `ldarga` | Argument, by value / by address | `ldarg` of a struct copies; `ldarga` does not |
+| `ldelem <type>` / `ldelema` | Array element, by value / by address | `ldelem` copies; `ldelema` does not |
+
+The recurring distinction is **value form vs address form**: the `...a` suffix
+(`ldflda`, `ldloca`, `ldarga`, `ldelema`, `ldsflda`) takes an address and does
+**not** copy. The non-`a` form of a struct loads a copy.
+
+## By-value argument / return / assignment
+
+- **By-value argument.** A struct pushed onto the stack (via `ldloc`/`ldfld`/etc.,
+  not `ldloca`) into a call whose parameter is not `ref`/`in`/`out` is copied into
+  the callee. The callee's signature (no `&` on the parameter type) confirms by-value.
+- **By-value return.** `ret` with a struct value on the stack returns a copy. A
+  method that returns `ref` puts an address on the stack instead - no copy.
+- **Assignment / field store.** `stfld`/`stloc`/`stsfld` of a struct value, or
+  `stobj`/`cpobj` through an address, copies into the destination.
+
+## Boxing
+
+`box <ValueType>` is the easiest copy to spot and almost always unintended for a
+resource-owning struct: it copies the value onto the GC heap. It appears whenever a
+value type is converted to `object`, an interface, or `dynamic`, or wrapped in
+`Nullable<T>` patterns. Boxing is also the one copy whose runtime cost (an
+allocation) is directly visible at the runtime layer via `[MemoryDiagnoser]`.
+
+## Caveats when reading IL
+
+- **Move vs copy is still inferred.** IL shows a copy opcode but not whether the
+  source value had another owner. A `ldloc`/`ldobj` feeding a `ret` may be a
+  deliberate transfer. Cross-reference the source line (via the PDB) before calling
+  it unintended - the same limit the source analyzer documents.
+- **The JIT may elide it.** `ldobj`/`stloc` of a small struct can be optimized away
+  by the JIT. IL presence proves the *compiler* copied; confirm a *runtime* cost at
+  the asm (`DisassemblyDiagnoser`) or trace layer.
+- **Generics emit shared IL.** The body of a generic method shows one copy of `T`;
+  whether `T` is a large struct, a small struct, or a reference type changes the
+  real cost. Record the open generic and reason per value-type instantiation.
+- **Debug vs Release.** Debug IL adds spills and temporaries that look like copies.
+  Always read optimized Release IL for a representative picture.
+- **Compiler-synthesized members.** Async/iterator state machines hoist captured
+  structs into generated fields; the copy lives in the `MoveNext` body, not the
+  user method. Disassemble the generated nested type to see it.
+
+## Mapping IL offset to source line
+
+Each IL instruction has an offset; the portable PDB's **sequence points** map offset
+ranges to `(document, startLine, startColumn)`. To attribute a copy:
+
+- With a disassembler: use a mode that interleaves source (`ilspycmd` with debug
+  info, ILSpy's "IL with C#").
+- Programmatically: open the PDB with `System.Reflection.Metadata.MetadataReader`,
+  read the method's `MethodDebugInformation.GetSequencePoints()`, and find the
+  sequence point whose IL range contains the copy opcode's offset. This is the same
+  offset-to-line mechanism a profiler uses, applied statically.

--- a/.agents/skills/il-copy-inspection/references/copy-opcodes.md
+++ b/.agents/skills/il-copy-inspection/references/copy-opcodes.md
@@ -12,7 +12,7 @@ instance member is invoked on a read-only struct location (an `in` parameter, a
 is invisible in source. For `void M(in Pooled p) => p.Mutate();` where `Mutate` is
 not `readonly`, the compiler emits a **synthesized temporary**:
 
-```
+```cil
 ldarg.1            // &p   - address of the in-parameter (no copy yet)
 ldobj      Pooled  // copy *p onto the stack
 stloc.0            // spill the copy into a compiler temp local
@@ -26,7 +26,7 @@ read-only location). The mutation lands on the temp and is thrown away. Contrast
 no-copy form, where a `readonly` member (or a mutable receiver) is called directly
 on the address with no intervening `ldobj`/`stloc`:
 
-```
+```cil
 ldarg.1            // &p
 call       instance int32 Pooled::Peek()    // readonly member - no copy
 ```

--- a/.agents/skills/roslyn-analyzers/SKILL.md
+++ b/.agents/skills/roslyn-analyzers/SKILL.md
@@ -50,11 +50,16 @@ The short version, in priority order:
 - [touki.analyzers.tests/](../../../touki.analyzers.tests/touki.analyzers.tests.csproj) -
   `net10.0` MSTest project. Every test project needs a local `.editorconfig`
   disabling `CS1591` (see the existing one).
+- [touki.analyzers.codefixes/](../../../touki.analyzers.codefixes/touki.analyzers.codefixes.csproj) -
+  the `CodeFixProvider`s. A **separate** assembly because a code fix references the
+  Roslyn Workspaces layer, which RS1022 forbids in the analyzer assembly. Only
+  needed when you ship fixes; see the code-fix section in [design.md](design.md).
 - The analyzer ships **inside** `KlutzyNinja.Touki`, not as its own package. The
   `_AddAnalyzersToPackage` target in
-  [touki/touki.csproj](../../../touki/touki.csproj) packs it to
-  `analyzers/dotnet/cs/`, and the `OutputItemType="Analyzer"` project reference in
-  the same file dogfoods it against touki's own sources.
+  [touki/touki.csproj](../../../touki/touki.csproj) packs both the analyzer and the
+  code-fix assemblies to `analyzers/dotnet/cs/`, and the `OutputItemType="Analyzer"`
+  project reference in the same file dogfoods the analyzers against touki's own
+  sources.
 
 ## Workflow
 
@@ -99,6 +104,10 @@ The short version, in priority order:
 - Validate library runtime perf (not analyzer perf) with `performance-testing`.
 - Run `pre-pr-self-review` before opening a PR; `create-pr` to publish.
 - If the analyzer parses or reinterprets untrusted input, run `security-review`.
+- For a rule about struct copies (like the TOUKI0002-0004 defensive-copy /
+  `[NonCopyable]` analyzers), `il-copy-inspection` is the post-build, ground-truth
+  counterpart: it reads emitted IL to confirm a prediction and to find the
+  compiler-synthesized copies an `IOperation`-based analyzer cannot see.
 
 ## Disambiguation
 

--- a/.agents/skills/roslyn-analyzers/design.md
+++ b/.agents/skills/roslyn-analyzers/design.md
@@ -21,7 +21,11 @@ The host creates one analyzer instance and reuses it across compilations, thread
 and (in the IDE) edits. Never store per-analysis state in an instance or static
 field. All state lives in locals inside the registered callbacks, or in
 per-compilation state captured by `RegisterCompilationStartAction` (see
-[performance.md](performance.md)).
+[performance.md](performance.md)). Storing a `Compilation` or `ISymbol` in a field
+is doubly wrong: besides the race, it **roots** that compilation's object graph
+across every later edit. Resolve well-known symbols at compilation start and capture
+them in the closure - see the rooting rule in
+[performance.md](performance.md#the-rooting-rule-capture-in-the-closure-never-in-a-field).
 
 In `Initialize`, always:
 
@@ -135,18 +139,59 @@ disagree, so this cannot be forgotten if you build before committing.
 
 A code fix is a separate type from the analyzer:
 
-- `[ExportCodeFixProvider(LanguageNames.CSharp)]` on a `CodeFixProvider`.
-- `FixableDiagnosticIds` returns the analyzer's ID(s).
+- `[ExportCodeFixProvider(LanguageNames.CSharp)]` plus `[Shared]` on a
+  `CodeFixProvider`.
+- `FixableDiagnosticIds` returns the analyzer's ID(s). Hardcode the id strings (a
+  stable public contract) rather than referencing the analyzer assembly - the
+  code fix lives in a different assembly (see below).
 - Implement `RegisterCodeFixesAsync`; compute the edit as an immutable
-  `Document`/`SyntaxNode` transformation and register a `CodeAction`.
+  `Document`/`Solution`/`SyntaxNode` transformation and register a `CodeAction`.
+  `SyntaxGenerator` (from `Microsoft.CodeAnalysis.Editing`) is the language-neutral
+  way to edit modifiers/declarations - e.g. `generator.WithModifiers(decl,
+  generator.GetModifiers(decl).WithIsReadOnly(true))`.
 - Override `GetFixAllProvider()` (usually `WellKnownFixAllProviders.BatchFixer`) so
   "fix all occurrences" works.
 - Use a stable, descriptive `equivalenceKey` on the `CodeAction` so FixAll can group
   identical fixes.
+- Only offer the fix when the target is editable - check
+  `member.DeclaringSyntaxReferences` is non-empty before registering, so the fix
+  does not appear on members defined in metadata.
 
-Code fixes live in the analyzer package and are validated with the code-fix verifier
-in [validation.md](validation.md). A fix that can change behavior (not just style)
-should be offered conservatively and covered by before/after tests.
+A fix that can change behavior (not just style) should be offered conservatively
+and covered by before/after tests ([validation.md](validation.md)).
+
+### Code fixes go in a SEPARATE assembly (RS1022)
+
+A `CodeFixProvider` references the Roslyn **Workspaces** layer
+(`Document`, `CodeAction`, `SyntaxGenerator`). **RS1022 forbids any reference to
+Workspaces types from an assembly that also contains a `DiagnosticAnalyzer`** -
+analyzers must stay Workspaces-free so they load in the command-line compiler. So
+a repo that ships code fixes needs a second project:
+
+- `touki.analyzers` - the `DiagnosticAnalyzer`s. References
+  `Microsoft.CodeAnalysis.CSharp`, `EnforceExtendedAnalyzerRules=true`.
+- [touki.analyzers.codefixes](../../../touki.analyzers.codefixes/touki.analyzers.codefixes.csproj) -
+  the `CodeFixProvider`s. `netstandard2.0`, signed, `IsPackable=false`,
+  `IncludeBuildOutput=false`. References
+  `Microsoft.CodeAnalysis.CSharp.Workspaces`. Do **not** set
+  `EnforceExtendedAnalyzerRules` and do **not** add
+  `Microsoft.CodeAnalysis.Analyzers` here - those are for the analyzer assembly.
+
+Both assemblies pack into `analyzers/dotnet/cs/` from the **same**
+`_AddAnalyzersToPackage` target (a second `MSBuild Targets="GetTargetPath"` call
+feeding the same `_PackageFiles` group). The command-line compiler loads the
+code-fix dll but never instantiates the provider (no analyzer in it), so the
+absence of Workspaces at build time is fine; the IDE supplies Workspaces when it
+offers the fix. This is the standard StyleCop/Roslynator split.
+
+**Packaging gotcha:** `MSBuild Targets="GetTargetPath"` returns the code-fix
+assembly path but does **not** build it, and nothing else in touki's graph builds
+it either (it is not an analyzer *of* touki). Add a build-ordering
+`ProjectReference` from `touki.csproj` to the code-fix project with
+`ReferenceOutputAssembly="false" PrivateAssets="all"` and **no**
+`OutputItemType="Analyzer"` (adding that would load Workspaces into the
+command-line compiler's analyzer context). Without the reference the pack fails
+with "Could not find a part of the path ...\touki.analyzers.codefixes\...".
 
 ## Checklist
 

--- a/.agents/skills/roslyn-analyzers/performance.md
+++ b/.agents/skills/roslyn-analyzers/performance.md
@@ -29,8 +29,9 @@ have a greater impact on performance."
 ## Cache well-known symbols once per compilation
 
 If your rule compares against specific types or members (e.g. "is this
-`System.Enum.HasFlag`"), do **not** resolve them inside the per-node callback.
-Resolve them once at compilation start and capture them:
+`System.Enum.HasFlag`", "does this type carry `[NonCopyable]`"), do **not** resolve
+them inside the per-node callback. Resolve them once at compilation start and
+capture them:
 
 ```csharp
 context.RegisterCompilationStartAction(static start =>
@@ -49,10 +50,57 @@ context.RegisterCompilationStartAction(static start =>
 });
 ```
 
+- **Resolve by metadata name, compare by symbol identity - never by string.**
+  `Compilation.GetTypeByMetadataName("Namespace.TypeName")` returns the
+  `INamedTypeSymbol` for a fully qualified CLR metadata name (or null on absence /
+  ambiguity). The official Roslyn analyzer tutorial is explicit: check types
+  through the semantic model and *"don't compare the string from `ToString()`."*
+  `ToString()` / `ToDisplayString()` allocate a fresh string on every call;
+  `SymbolEqualityComparer.Default.Equals(symbol, target)` is allocation-free.
 - `GetTypeByMetadataName` once per compilation, not once per node.
 - **Bail early**: if the type/API the rule is about is not referenced by the
-  compilation, register nothing and the analyzer costs ~zero on that project.
-- Compare symbols with `SymbolEqualityComparer.Default`, never by display string.
+  compilation, register nothing and the analyzer costs ~zero on that project. (Only
+  bail when *every* diagnostic needs the symbol; if one rule still fires without it,
+  pass the nullable symbol through and branch instead.)
+
+### Matching an attribute on a type
+
+To answer "is this type marked `[SomeAttribute]`?", resolve the attribute symbol
+once (above) and walk the candidate's already-materialized attribute list,
+comparing by identity:
+
+```csharp
+foreach (AttributeData attribute in type.GetAttributes())
+{
+    if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeSymbol))
+    {
+        return true;
+    }
+}
+```
+
+`GetAttributes()` returns the symbol's existing attribute array, so this iterate-
+and-compare is allocation-free - no dictionary, no string build. A
+`ConcurrentDictionary<INamedTypeSymbol, bool>` "cache" on top of this is usually
+overhead, not savings: the work it memoizes is already cheap, and the dictionary
+itself allocates. Reach for a memo only when a *profile* shows the lookup dominating.
+
+Matching the fully qualified metadata name (via `GetTypeByMetadataName`) is also
+stricter and safer than matching the attribute's *simple* name
+(`AttributeClass.Name == "SomeAttribute"`): simple-name matching silently accepts an
+unrelated same-named attribute in another namespace. Match the simple name only when
+you deliberately want consumers to be able to declare their own marker attribute.
+
+### The rooting rule: capture in the closure, never in a field
+
+A `Compilation` (and the symbols hanging off it) is a large object graph. The
+analyzer **instance is reused across compilations and edits**, so storing a
+`Compilation`, `ISymbol`, or symbol-keyed collection in a **static or instance
+field** of the analyzer roots that graph and leaks memory across edits. Capturing
+the resolved symbol in the `RegisterCompilationStartAction` lambda (as above) is the
+correct pattern: the closure lives only as long as that one compilation's analysis,
+so nothing is rooted afterward. The danger is the field, not the capture - a
+per-compilation local or closure is fine.
 
 ## Enable concurrency
 
@@ -106,4 +154,6 @@ dotnet build touki/touki.csproj -c Release -p:ReportAnalyzer=true -bl
 | Slow even where rule is irrelevant | No early bail | Resolve target symbol at compilation start; return if absent |
 | Time scales with file size | `DescendantNodes()` / tree walk | Register a narrower node/operation kind |
 | GC pressure during typing | LINQ / closures in callback | Direct loops, `static` lambdas, cached arrays |
+| GC pressure on type checks | `ToString()` / `ToDisplayString()` compares | Resolve once with `GetTypeByMetadataName`, compare via `SymbolEqualityComparer` |
+| Memory grows across edits | `Compilation`/`ISymbol` in a static/instance field | Capture per-compilation symbols in the closure, never a field |
 | Wrong results under parallelism | Shared mutable state | Remove it; keep state per-callback or per-compilation |

--- a/.agents/skills/roslyn-analyzers/validation.md
+++ b/.agents/skills/roslyn-analyzers/validation.md
@@ -46,6 +46,21 @@ you need exact span markup, code-fix verification, or controlled reference sets.
 Either way the test project is `net10.0` MSTest with AwesomeAssertions, and needs a
 local `.editorconfig` disabling `CS1591`.
 
+### Testing a code fix without the official harness
+
+If you skip `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing`, a code fix can still be
+exercised in-memory with an `AdhocWorkspace` (the test project references
+`Microsoft.CodeAnalysis.CSharp.Workspaces`):
+[touki.analyzers.tests/CodeFixTestHarness.cs](../../../touki.analyzers.tests/CodeFixTestHarness.cs)
+adds a `Document` to an ad-hoc project, runs the analyzer to get the diagnostic,
+calls `provider.RegisterCodeFixesAsync` with a `CodeFixContext` whose registration
+delegate captures the offered `CodeAction`s, then applies the first action via
+`action.GetOperationsAsync()` -> `ApplyChangesOperation.ChangedSolution` and returns
+the changed document's text to assert on. The test project also needs a project
+reference to `touki.analyzers.codefixes`. Pin the before/after source and assert the
+expected member gained `readonly`; test the fix on a **non-mutating** member, since
+"make readonly" on a genuinely mutating member would produce a compiler error.
+
 ## Coverage checklist
 
 For every rule, test all of:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="5.0.0-1.25277.114" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.2.3" />

--- a/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Offers a "Make '{member}' readonly" fix for the defensive-copy diagnostics (<c>TOUKI0002</c> and
+///  <c>TOUKI0003</c>). Marking the accessed instance member <see langword="readonly"/> is the usual remedy: it
+///  tells the compiler the member does not mutate, so no defensive copy is needed.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The fix is only offered when the member is declared in source. If the member actually mutates state, marking
+///   it <see langword="readonly"/> produces a compiler error the developer can act on; the analyzer cannot prove
+///   non-mutation cheaply, so it defers that judgment.
+///  </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MakeMemberReadonlyCodeFixProvider))]
+[Shared]
+public sealed class MakeMemberReadonlyCodeFixProvider : CodeFixProvider
+{
+    // Hardcoded to avoid a dependency on the analyzer assembly; these ids are a stable public contract.
+    private const string DefensiveCopyId = "TOUKI0002";
+    private const string NonCopyableDefensiveCopyId = "TOUKI0003";
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds =>
+        ImmutableArray.Create(DefensiveCopyId, NonCopyableDefensiveCopyId);
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SemanticModel? semanticModel =
+            await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        SyntaxNode? root =
+            await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (semanticModel is null || root is null)
+        {
+            return;
+        }
+
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            ISymbol? member = TryGetAccessedMember(node, semanticModel, context.CancellationToken);
+
+            // Only members declared in source can be edited.
+            if (member is null || member.DeclaringSyntaxReferences.IsEmpty)
+            {
+                continue;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: $"Make '{member.Name}' readonly",
+                    createChangedSolution: cancellationToken =>
+                        MakeMemberReadonlyAsync(context.Document.Project.Solution, member, cancellationToken),
+                    equivalenceKey: "MakeMemberReadonly"),
+                diagnostic);
+        }
+    }
+
+    private static ISymbol? TryGetAccessedMember(SyntaxNode node, SemanticModel semanticModel, CancellationToken cancellationToken)
+    {
+        // The diagnostic is reported on the receiver; the accessed member is on the enclosing access expression.
+        for (SyntaxNode? current = node; current is not null; current = current.Parent)
+        {
+            switch (current)
+            {
+                case InvocationExpressionSyntax invocation:
+                    return semanticModel.GetSymbolInfo(invocation, cancellationToken).Symbol;
+                case ElementAccessExpressionSyntax elementAccess:
+                    return semanticModel.GetSymbolInfo(elementAccess, cancellationToken).Symbol;
+                case MemberAccessExpressionSyntax memberAccess:
+                    return semanticModel.GetSymbolInfo(memberAccess, cancellationToken).Symbol;
+                case StatementSyntax:
+                    return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<Solution> MakeMemberReadonlyAsync(Solution solution, ISymbol member, CancellationToken cancellationToken)
+    {
+        Solution updatedSolution = solution;
+
+        foreach (SyntaxReference reference in member.DeclaringSyntaxReferences)
+        {
+            Document? document = updatedSolution.GetDocument(reference.SyntaxTree);
+            if (document is null)
+            {
+                continue;
+            }
+
+            SyntaxNode declaration = await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
+            SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            if (root is null)
+            {
+                continue;
+            }
+
+            SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
+            DeclarationModifiers modifiers = generator.GetModifiers(declaration);
+            if (modifiers.IsReadOnly)
+            {
+                continue;
+            }
+
+            SyntaxNode updatedDeclaration = generator.WithModifiers(declaration, modifiers.WithIsReadOnly(true));
+            updatedSolution = updatedSolution.WithDocumentSyntaxRoot(
+                document.Id,
+                root.ReplaceNode(declaration, updatedDeclaration));
+        }
+
+        return updatedSolution;
+    }
+}

--- a/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
@@ -64,6 +64,14 @@ public sealed class MakeMemberReadonlyCodeFixProvider : CodeFixProvider
                 continue;
             }
 
+            // A member-level 'readonly' modifier also applies to a property/indexer's set or init accessor, which is
+            // a compiler error even when the getter is non-mutating. Only offer the fix for read-only properties
+            // (get-only / expression-bodied); a getter-only readonly edit would be a future enhancement.
+            if (member is IPropertySymbol { SetMethod: not null })
+            {
+                continue;
+            }
+
             context.RegisterCodeFix(
                 CodeAction.Create(
                     title: $"Make '{member.Name}' readonly",

--- a/touki.analyzers.codefixes/touki.analyzers.codefixes.csproj
+++ b/touki.analyzers.codefixes/touki.analyzers.codefixes.csproj
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--
+      Code-fix providers reference the Roslyn Workspaces APIs, which must not live in the analyzer assembly
+      (RS1022). They ship in a separate assembly that is packed alongside the analyzer under analyzers/dotnet/cs
+      by the _AddAnalyzersToPackage target in touki/touki.csproj. netstandard2.0 so the IDE can load it.
+    -->
+    <TargetFramework>netstandard2.0</TargetFramework>
+
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Touki.Analyzers</RootNamespace>
+
+    <IsPackable>false</IsPackable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+
+    <!-- Not a security boundary, the strong name is for identity and ease of use from other signed assemblies. -->
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\klutzyninja.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Brings CodeFixProvider, Document, CodeAction, and SyntaxGenerator (and CodeAnalysis.CSharp transitively). -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Minimal in-memory harness that runs an analyzer over a snippet, applies a code fix to the first matching
+///  diagnostic, and returns the resulting source text.
+/// </summary>
+internal static class CodeFixTestHarness
+{
+    private static readonly Lazy<ImmutableArray<MetadataReference>> s_references = new(CreateReferences);
+
+    /// <summary>
+    ///  Runs <paramref name="analyzer"/> against <paramref name="source"/>, applies <paramref name="codeFix"/> to
+    ///  the first diagnostic with id <paramref name="diagnosticId"/>, and returns the fixed source. Returns the
+    ///  original source unchanged when no such diagnostic or fix is produced.
+    /// </summary>
+    public static async Task<string> ApplyFixAsync(
+        DiagnosticAnalyzer analyzer,
+        CodeFixProvider codeFix,
+        string source,
+        string diagnosticId)
+    {
+        using AdhocWorkspace workspace = new();
+        Project project = workspace
+            .AddProject("TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(s_references.Value)
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        Document document = project.AddDocument("Test.cs", source);
+
+        Compilation compilation = (await document.Project.GetCompilationAsync().ConfigureAwait(false))!;
+        CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer]);
+        ImmutableArray<Diagnostic> diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+
+        Diagnostic? target = diagnostics.FirstOrDefault(diagnostic => diagnostic.Id == diagnosticId);
+        if (target is null)
+        {
+            return source;
+        }
+
+        List<CodeAction> actions = [];
+        CodeFixContext fixContext = new(
+            document,
+            target,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+        await codeFix.RegisterCodeFixesAsync(fixContext).ConfigureAwait(false);
+
+        if (actions.Count == 0)
+        {
+            return source;
+        }
+
+        ImmutableArray<CodeActionOperation> operations =
+            await actions[0].GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+        ApplyChangesOperation applyChanges = operations.OfType<ApplyChangesOperation>().Single();
+        Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+        SourceText text = await changedDocument.GetTextAsync().ConfigureAwait(false);
+        return text.ToString();
+    }
+
+    private static ImmutableArray<MetadataReference> CreateReferences()
+    {
+        string trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
+
+        return
+        [
+            .. trustedAssemblies
+                .Split(Path.PathSeparator)
+                .Where(path => path.Length > 0)
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+        ];
+    }
+}

--- a/touki.analyzers.tests/DefensiveCopyAnalyzerTests.cs
+++ b/touki.analyzers.tests/DefensiveCopyAnalyzerTests.cs
@@ -1,0 +1,230 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class DefensiveCopyAnalyzerTests
+{
+    // Sample types shared by the snippets below. The marker attribute is declared as Touki.NonCopyableAttribute so
+    // it matches the fully qualified name the analyzer resolves (the test compilation has no reference to touki).
+    private const string Types = """
+        using System;
+        using Touki;
+
+        namespace Touki
+        {
+            [AttributeUsage(AttributeTargets.Struct)]
+            sealed class NonCopyableAttribute : Attribute { }
+        }
+
+        [NonCopyable]
+        struct Pooled
+        {
+            private int _value;
+            public void Mutate() => _value++;
+            public readonly int Peek() => _value;
+            public int Prop => _value;
+        }
+
+        struct Plain
+        {
+            private int _value;
+            public void Mutate() => _value++;
+        }
+
+        readonly struct ReadOnlyPlain
+        {
+            public void Method() { }
+        }
+
+        """;
+
+    private static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source) =>
+        AnalyzerTestHarness.GetDiagnosticsAsync(new DefensiveCopyAnalyzer(), source);
+
+    [TestMethod]
+    public async Task NonReadonlyMethod_OnInParameterOfNonCopyable_ReportsTOUKI0003()
+    {
+        string source = Types + """
+            class C
+            {
+                void M(in Pooled p) => p.Mutate();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId);
+    }
+
+    [TestMethod]
+    public async Task NonReadonlyMethod_OnInParameterOfPlainStruct_ReportsTOUKI0002()
+    {
+        string source = Types + """
+            class C
+            {
+                void M(in Plain p) => p.Mutate();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(DefensiveCopyAnalyzer.DefensiveCopyId);
+    }
+
+    [TestMethod]
+    public async Task NonReadonlyMethod_OnReadonlyField_OutsideConstructor_Reports()
+    {
+        string source = Types + """
+            struct Holder
+            {
+                private readonly Plain _p;
+                public void Use() => _p.Mutate();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(DefensiveCopyAnalyzer.DefensiveCopyId);
+    }
+
+    [TestMethod]
+    public async Task NonReadonlyMethod_OnReadonlyField_InsideConstructor_ReportsNothing()
+    {
+        string source = Types + """
+            struct Holder
+            {
+                private readonly Plain _p;
+                public Holder(int x)
+                {
+                    _p = default;
+                    _p.Mutate();
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task NonReadonlyProperty_OnInParameter_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                int M(in Pooled p) => p.Prop;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId);
+    }
+
+    [TestMethod]
+    public async Task ReadonlyMember_OnInParameter_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                int M(in Pooled p) => p.Peek();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ReadonlyStruct_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                void M(in ReadOnlyPlain p) => p.Method();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task NonReadonlyMethod_OnByValueParameter_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                void M(Pooled p) => p.Mutate();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task NonReadonlyMethod_OnRefReadonlyLocal_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                static Pooled s_pooled;
+
+                void M()
+                {
+                    ref readonly Pooled p = ref s_pooled;
+                    p.Mutate();
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId);
+    }
+
+    [TestMethod]
+    public async Task GeneratedCode_ReportsNothing()
+    {
+        string source = """
+            // <auto-generated/>
+            using System;
+            using Touki;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+
+            [NonCopyable]
+            struct Pooled
+            {
+                private int _value;
+                public void Mutate() => _value++;
+            }
+
+            class C
+            {
+                void M(in Pooled p) => p.Mutate();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/MakeMemberReadonlyCodeFixTests.cs
+++ b/touki.analyzers.tests/MakeMemberReadonlyCodeFixTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class MakeMemberReadonlyCodeFixTests
+{
+    private const string Types = """
+        using System;
+        using Touki;
+
+        namespace Touki
+        {
+            [AttributeUsage(AttributeTargets.Struct)]
+            sealed class NonCopyableAttribute : Attribute { }
+        }
+
+        [NonCopyable]
+        struct Pooled
+        {
+            private int _value;
+            public int Prop => _value;
+            public int Read() => _value;
+        }
+
+        """;
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnNonMutatingProperty_AddsReadonly()
+    {
+        string source = Types + """
+            class C
+            {
+                int M(in Pooled p) => p.Prop;
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            source,
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId).ConfigureAwait(false);
+
+        fixedSource.Should().Contain("public readonly int Prop => _value;");
+    }
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnNonMutatingMethod_AddsReadonly()
+    {
+        string source = Types + """
+            class C
+            {
+                int M(in Pooled p) => p.Read();
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            source,
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId).ConfigureAwait(false);
+
+        fixedSource.Should().Contain("public readonly int Read() => _value;");
+    }
+}

--- a/touki.analyzers.tests/MakeMemberReadonlyCodeFixTests.cs
+++ b/touki.analyzers.tests/MakeMemberReadonlyCodeFixTests.cs
@@ -64,4 +64,41 @@ public class MakeMemberReadonlyCodeFixTests
 
         fixedSource.Should().Contain("public readonly int Read() => _value;");
     }
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnPropertyWithSetter_OffersNoFix()
+    {
+        // A member-level 'readonly' would also mark the setter readonly, which is a compiler error. The fix must
+        // not be offered here, so ApplyFixAsync returns the source unchanged.
+        const string source = """
+            using System;
+            using Touki;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+
+            [NonCopyable]
+            struct Pooled
+            {
+                private int _value;
+                public int Prop { get => _value; set => _value = value; }
+            }
+
+            class C
+            {
+                int M(in Pooled p) => p.Prop;
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            source,
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
 }

--- a/touki.analyzers.tests/NonCopyableByValueAnalyzerTests.cs
+++ b/touki.analyzers.tests/NonCopyableByValueAnalyzerTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class NonCopyableByValueAnalyzerTests
+{
+    // A non-ref [NonCopyable] struct so boxing, fields, and by-value passing are all legal (not blocked by the
+    // ref-struct rules), letting each by-value path be exercised directly. The marker attribute is declared as
+    // Touki.NonCopyableAttribute so it matches the fully qualified name the analyzer resolves.
+    private const string Types = """
+        using System;
+        using Touki;
+
+        namespace Touki
+        {
+            [AttributeUsage(AttributeTargets.Struct)]
+            sealed class NonCopyableAttribute : Attribute { }
+        }
+
+        [NonCopyable]
+        struct Pooled
+        {
+            public int Value;
+        }
+
+        struct Plain
+        {
+            public int Value;
+        }
+
+        """;
+
+    private static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source) =>
+        AnalyzerTestHarness.GetDiagnosticsAsync(new NonCopyableByValueAnalyzer(), source);
+
+    [TestMethod]
+    public async Task ByValueArgument_OfNonCopyable_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                static void Take(Pooled p) { }
+                static void M(Pooled p) => Take(p);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(NonCopyableByValueAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task RefArgument_OfNonCopyable_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                static void Take(ref Pooled p) { }
+                static void M(ref Pooled p) => Take(ref p);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task FreshlyCreatedArgument_IsMoveNotCopy_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                static void Take(Pooled p) { }
+                static void M() => Take(new Pooled());
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task ByValueReturn_OfNonCopyable_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                static Pooled M(Pooled p) => p;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(NonCopyableByValueAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AssignmentFromLocation_OfNonCopyable_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                static void M(Pooled a)
+                {
+                    Pooled b = default;
+                    b = a;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(NonCopyableByValueAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task DeclarationFromLocation_OfNonCopyable_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                static void M(Pooled a)
+                {
+                    Pooled b = a;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(NonCopyableByValueAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task RefLocalAlias_OfNonCopyable_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                static void M(ref Pooled a)
+                {
+                    ref Pooled b = ref a;
+                    b.Value = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Boxing_OfNonCopyable_Reports()
+    {
+        string source = Types + """
+            class C
+            {
+                static object M(Pooled p) => p;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(NonCopyableByValueAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task NonCopyableField_InCopyableStruct_Reports()
+    {
+        string source = Types + """
+            struct Container
+            {
+                public Pooled Buffer;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Should().ContainSingle().Subject;
+        diagnostic.Id.Should().Be(NonCopyableByValueAnalyzer.DiagnosticId);
+
+        // The field case must not advise "pass by ref/in" (you cannot pass a field by ref to fix it); it advises
+        // marking the containing type [NonCopyable] instead.
+        string message = diagnostic.GetMessage();
+        message.Should().Contain("[NonCopyable]");
+        message.Should().NotContain("pass it by 'ref' or 'in'");
+    }
+
+    [TestMethod]
+    public async Task ByValueArgument_OfPlainStruct_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                static void Take(Plain p) { }
+                static void M(Plain p) => Take(p);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/NonCopyableByValueAnalyzerTests.cs
+++ b/touki.analyzers.tests/NonCopyableByValueAnalyzerTests.cs
@@ -102,6 +102,39 @@ public class NonCopyableByValueAnalyzerTests
     }
 
     [TestMethod]
+    public async Task RefReadonlyReturn_OfNonCopyable_ReportsNothing()
+    {
+        // A 'ref readonly' return hands back the original location, not a copy.
+        string source = Types + """
+            class C
+            {
+                static Pooled s_pooled;
+                static ref readonly Pooled M() => ref s_pooled;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task RefReturn_OfNonCopyable_ReportsNothing()
+    {
+        string source = Types + """
+            class C
+            {
+                static Pooled s_pooled;
+                static ref Pooled M() => ref s_pooled;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
     public async Task AssignmentFromLocation_OfNonCopyable_Reports()
     {
         string source = Types + """

--- a/touki.analyzers.tests/touki.analyzers.tests.csproj
+++ b/touki.analyzers.tests/touki.analyzers.tests.csproj
@@ -27,6 +27,8 @@
     <PackageReference Include="AwesomeAssertions" />
     <!-- Roslyn APIs used by the in-memory test harness to run the analyzer. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
+    <!-- Workspaces APIs used by the in-memory code-fix harness (AdhocWorkspace, CodeAction). -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
     <!-- Enables the MTP runner's TRX report option used by CI. -->
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" PrivateAssets="all" />
@@ -37,6 +39,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\touki.analyzers\touki.analyzers.csproj" />
+    <ProjectReference Include="..\touki.analyzers.codefixes\touki.analyzers.codefixes.csproj" />
   </ItemGroup>
 
 </Project>

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -5,3 +5,6 @@
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TOUKI0001 | Usage | Warning | Use 'is null' / 'is not null' for null comparisons
+TOUKI0002 | Reliability | Hidden | Defensive copy of a struct
+TOUKI0003 | Reliability | Warning | Defensive copy of a [NonCopyable] struct
+TOUKI0004 | Reliability | Warning | By-value copy of a [NonCopyable] struct

--- a/touki.analyzers/CopyAnalysis.cs
+++ b/touki.analyzers/CopyAnalysis.cs
@@ -1,0 +1,213 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Shared, language-agnostic helpers for reasoning about struct value copies over <see cref="IOperation"/> trees.
+/// </summary>
+/// <remarks>
+///  <para>
+///   These helpers encode the <em>conservative approximation</em> that both <see cref="DefensiveCopyAnalyzer"/>
+///   and <see cref="NonCopyableByValueAnalyzer"/> share. The fundamental constraint is timing: an analyzer runs on
+///   the bound-but-not-lowered operation tree, whereas the compiler emits the actual struct copies (the
+///   <c>ldobj</c> / <c>stloc</c> / <c>ldloca</c> defensive-copy sequence, <c>box</c>, <c>cpobj</c>) only during
+///   later lowering. There is no public Roslyn signal for "a copy was emitted here", so these helpers reconstruct
+///   the copy from C# language rules instead of observing it.
+///  </para>
+///  <para>
+///   The practical rule throughout: when a construct cannot be classified with confidence, return the
+///   non-reporting answer. A missed copy (false negative) is preferable to a spurious warning (false positive)
+///   that trains users to disable the rule. The synthesized copies that never appear in the operation tree
+///   (async / iterator hoisting, closures, thunks) are out of scope by construction and are the domain of a
+///   complementary IL-inspection pass rather than these helpers.
+///  </para>
+/// </remarks>
+internal static class CopyAnalysis
+{
+    /// <summary>
+    ///  The canonical CLR metadata name of the attribute that marks a value type as non-copyable. Resolve it once
+    ///  per compilation with <see cref="Compilation.GetTypeByMetadataName(string)"/> and compare candidate types'
+    ///  attributes against the resulting symbol by identity.
+    /// </summary>
+    public const string NonCopyableAttributeMetadataName = "Touki.NonCopyableAttribute";
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="type"/> is a value type annotated with the
+    ///  <paramref name="nonCopyableAttribute"/> symbol (matched by identity, i.e. the fully qualified
+    ///  <c>Touki.NonCopyableAttribute</c>).
+    /// </summary>
+    public static bool IsNonCopyable(ITypeSymbol? type, INamedTypeSymbol nonCopyableAttribute)
+    {
+        if (type is not { IsValueType: true })
+        {
+            return false;
+        }
+
+        // GetAttributes() returns the symbol's already-materialized attribute list; iterating it and comparing the
+        // AttributeClass by symbol identity is allocation-free, unlike building and comparing ToDisplayString().
+        foreach (AttributeData attribute in type.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, nonCopyableAttribute))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Returns <see langword="true"/> for a struct type where accessing a non-readonly instance member can force a
+    ///  defensive copy. <see langword="readonly"/> structs never need a defensive copy, and non-structs (enums,
+    ///  type parameters, classes) are excluded.
+    /// </summary>
+    public static bool IsCopyableStruct(ITypeSymbol? type) =>
+        type is { IsValueType: true, IsReadOnly: false, TypeKind: TypeKind.Struct };
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if accessing <paramref name="member"/> on a read-only receiver forces a
+    ///  defensive copy, i.e. the member is a non-static instance member that is not <see langword="readonly"/>.
+    /// </summary>
+    public static bool MemberForcesDefensiveCopy(ISymbol member)
+    {
+        if (member.IsStatic)
+        {
+            return false;
+        }
+
+        return member switch
+        {
+            IMethodSymbol method => !method.IsReadOnly,
+            IPropertySymbol property => property.GetMethod is { IsReadOnly: false },
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    ///  Determines whether <paramref name="receiver"/> is a read-only location, returning the reason if so.
+    /// </summary>
+    public static bool TryGetReadOnlyReason(IOperation? receiver, ISymbol containingSymbol, out ReadOnlyReason reason)
+    {
+        reason = default;
+        switch (receiver)
+        {
+            case IParameterReferenceOperation parameter:
+                switch (parameter.Parameter.RefKind)
+                {
+                    case RefKind.In:
+                        reason = ReadOnlyReason.InParameter;
+                        return true;
+                    case RefKind.RefReadOnlyParameter:
+                        reason = ReadOnlyReason.RefReadOnlyParameter;
+                        return true;
+                    default:
+                        return false;
+                }
+
+            case IFieldReferenceOperation field:
+                if (field.Field.IsReadOnly && !IsInsideInitializingConstructor(field.Field, containingSymbol))
+                {
+                    reason = field.Field.IsStatic ? ReadOnlyReason.StaticReadOnlyField : ReadOnlyReason.ReadOnlyField;
+                    return true;
+                }
+
+                // A non-readonly field is itself read-only only when reached through a read-only location (e.g. a
+                // field of an 'in' parameter). This recursion handles one level of receiver chain; it does not
+                // model a value-returning property in the middle of the chain (that return is its own copy), which
+                // is one of the documented partial-coverage cases - a missed copy rather than a false positive.
+                return field.Instance is not null && TryGetReadOnlyReason(field.Instance, containingSymbol, out reason);
+
+            case ILocalReferenceOperation local when local.Local.RefKind == RefKind.RefReadOnly:
+                reason = ReadOnlyReason.RefReadOnlyLocal;
+                return true;
+
+            case IInvocationOperation invocation when invocation.TargetMethod.ReturnsByRefReadonly:
+                reason = ReadOnlyReason.RefReadOnlyReturn;
+                return true;
+
+            case IPropertyReferenceOperation property when property.Property.ReturnsByRefReadonly:
+                reason = ReadOnlyReason.RefReadOnlyReturn;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    /// <summary>
+    ///  Describes a <see cref="ReadOnlyReason"/> for a diagnostic message.
+    /// </summary>
+    public static string Describe(ReadOnlyReason reason) => reason switch
+    {
+        ReadOnlyReason.InParameter => "'in' parameter",
+        ReadOnlyReason.RefReadOnlyParameter => "'ref readonly' parameter",
+        ReadOnlyReason.ReadOnlyField => "readonly field",
+        ReadOnlyReason.StaticReadOnlyField => "static readonly field",
+        ReadOnlyReason.RefReadOnlyLocal => "'ref readonly' local",
+        ReadOnlyReason.RefReadOnlyReturn => "'ref readonly' return value",
+        _ => "read-only location",
+    };
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="value"/> reads an existing storage location, so using it
+    ///  by value duplicates that location (a copy). A value produced fresh (a <see langword="new"/> expression, a
+    ///  factory call, <see langword="default"/>) is treated as a move and returns <see langword="false"/>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is the move-vs-copy heuristic. C# has no move semantics, so "is this a copy?" is decided by the shape
+    ///   of the source expression: a reference to a local, parameter, field, or array element names a storage
+    ///   location that survives the operation, hence reading it by value duplicates it. Anything else - a
+    ///   constructor or factory result, <see langword="default"/>, a value already on the evaluation stack - is a
+    ///   freshly produced value with no other owner, so consuming it is a move, not a copy. The list of "location"
+    ///   operations is intentionally narrow; an unrecognized shape is treated as a move (false negative) rather than
+    ///   risking a false positive on a deliberate transfer.
+    ///  </para>
+    /// </remarks>
+    public static bool IsCopyOfExistingLocation(IOperation value) => Unwrap(value) switch
+    {
+        ILocalReferenceOperation => true,
+        IParameterReferenceOperation => true,
+        IFieldReferenceOperation => true,
+        IArrayElementReferenceOperation => true,
+        _ => false,
+    };
+
+    private static IOperation Unwrap(IOperation operation)
+    {
+        while (true)
+        {
+            switch (operation)
+            {
+                case IConversionOperation { IsImplicit: true, OperatorMethod: null } conversion:
+                    operation = conversion.Operand;
+                    break;
+                case IParenthesizedOperation parenthesized:
+                    operation = parenthesized.Operand;
+                    break;
+                default:
+                    return operation;
+            }
+        }
+    }
+
+    private static bool IsInsideInitializingConstructor(IFieldSymbol field, ISymbol containingSymbol)
+    {
+        if (containingSymbol is not IMethodSymbol method)
+        {
+            return false;
+        }
+
+        bool isMatchingConstructor = field.IsStatic
+            ? method.MethodKind == MethodKind.StaticConstructor
+            : method.MethodKind == MethodKind.Constructor;
+
+        return isMatchingConstructor
+            && SymbolEqualityComparer.Default.Equals(method.ContainingType, field.ContainingType);
+    }
+}

--- a/touki.analyzers/DefensiveCopyAnalyzer.cs
+++ b/touki.analyzers/DefensiveCopyAnalyzer.cs
@@ -1,0 +1,171 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports defensive copies of structs: accessing a non-readonly instance member through a read-only location
+///  (an <see langword="in"/> parameter, a <see langword="readonly"/> field, a <see langword="ref"/>
+///  <see langword="readonly"/> local, etc.) silently copies the struct, runs the member against the copy, and
+///  discards it.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Two diagnostics are produced. <c>TOUKI0002</c> fires on any struct and defaults to
+///   <see cref="DiagnosticSeverity.Hidden"/> because it is high volume. <c>TOUKI0003</c> fires only on types marked
+///   <c>[NonCopyable]</c> and defaults to <see cref="DiagnosticSeverity.Warning"/>. A given copy is reported by
+///   exactly one of them so the two never overlap on the same location.
+///  </para>
+///  <para>
+///   <b>Constraints and limitations.</b> This analyzer is a deliberately conservative source-level approximation,
+///   not an exact accounting of the copies the compiler emits. It runs over the bound-but-not-lowered
+///   <see cref="IOperation"/> tree, which is <em>before</em> the C# compiler lowers a defensive copy into its
+///   <c>ldobj</c>/<c>stloc</c>/<c>ldloca</c> IL sequence. It therefore <em>predicts</em> a copy from the language
+///   rules (a read-only receiver plus a non-<see langword="readonly"/>, non-static member) rather than observing
+///   the emitted copy. The consequences:
+///  </para>
+///  <para>
+///   - <b>Invisible / synthesized copies are not seen.</b> Copies the compiler introduces during lowering with no
+///   corresponding source operation - async / iterator state-machine field hoisting, captured-variable closures,
+///   and compiler thunks - are unreachable here. Detecting those requires inspecting emitted IL.
+///  </para>
+///  <para>
+///   - <b>Read-only-location detection is partial.</b> The receiver is classified by
+///   <see cref="CopyAnalysis.TryGetReadOnlyReason"/>, which recognizes <see langword="in"/> /
+///   <see langword="ref"/> <see langword="readonly"/> parameters, <see langword="readonly"/> fields (outside their
+///   declaring constructor), <see langword="ref"/> <see langword="readonly"/> locals, and members that return by
+///   <see langword="ref"/> <see langword="readonly"/>. Long receiver chains through value-returning members are not
+///   fully tracked, so some real defensive copies are missed (a false negative is preferred over a false positive).
+///  </para>
+///  <para>
+///   - <b>Concrete structs only.</b> A generic type parameter that is later substituted with a struct is not
+///   analyzed here; the rule fires on concrete struct receivers.
+///  </para>
+///  <para>
+///   When in doubt the analyzer stays silent. A complementary source-IL inspection workflow (the
+///   <c>il-copy-inspection</c> agent skill) reads emitted IL to cover the synthesized-copy class this analyzer
+///   cannot, and to confirm a prediction made here.
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class DefensiveCopyAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The diagnostic id for a defensive copy of any struct.</summary>
+    public const string DefensiveCopyId = "TOUKI0002";
+
+    /// <summary>The diagnostic id for a defensive copy of a <c>[NonCopyable]</c> struct.</summary>
+    public const string NonCopyableDefensiveCopyId = "TOUKI0003";
+
+    private const string HelpLinkUri = "https://github.com/JeremyKuhne/touki";
+
+    private static readonly DiagnosticDescriptor s_defensiveCopy = new(
+        id: DefensiveCopyId,
+        title: "Defensive copy of a struct",
+        messageFormat: "A defensive copy of '{0}' is created because non-readonly member '{1}' is accessed on a read-only {2}; mutations are discarded",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Hidden,
+        isEnabledByDefault: true,
+        description: "Accessing a non-readonly instance member through a read-only location copies the struct, runs the member against the copy, then discards it.",
+        helpLinkUri: HelpLinkUri);
+
+    private static readonly DiagnosticDescriptor s_nonCopyableDefensiveCopy = new(
+        id: NonCopyableDefensiveCopyId,
+        title: "Defensive copy of a non-copyable struct",
+        messageFormat: "'{0}' is marked [NonCopyable]; accessing non-readonly member '{1}' on a read-only {2} creates a defensive copy",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A type marked [NonCopyable] must not be copied. Accessing a non-readonly member through a read-only location creates a discarded defensive copy.",
+        helpLinkUri: HelpLinkUri);
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics =
+        ImmutableArray.Create(s_defensiveCopy, s_nonCopyableDefensiveCopy);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static start =>
+        {
+            // Resolve the marker attribute once per compilation by its fully qualified metadata name. Capturing it
+            // in the closure (rather than a static/instance field) keeps the symbol scoped to this compilation, so
+            // it cannot root the Compilation across edits. A null result means the attribute is not referenced, so
+            // no type is [NonCopyable] and every defensive copy is reported as the generic TOUKI0002.
+            INamedTypeSymbol? nonCopyable =
+                start.Compilation.GetTypeByMetadataName(CopyAnalysis.NonCopyableAttributeMetadataName);
+            start.RegisterOperationAction(c => AnalyzeInvocation(c, nonCopyable), OperationKind.Invocation);
+            start.RegisterOperationAction(c => AnalyzePropertyReference(c, nonCopyable), OperationKind.PropertyReference);
+        });
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol? nonCopyable)
+    {
+        IInvocationOperation invocation = (IInvocationOperation)context.Operation;
+        AnalyzeAccess(context, nonCopyable, invocation.Instance, invocation.TargetMethod);
+    }
+
+    private static void AnalyzePropertyReference(OperationAnalysisContext context, INamedTypeSymbol? nonCopyable)
+    {
+        IPropertyReferenceOperation reference = (IPropertyReferenceOperation)context.Operation;
+
+        // A write through the setter on a read-only location is a compile error, not a defensive copy.
+        if (IsAssignmentTarget(reference))
+        {
+            return;
+        }
+
+        AnalyzeAccess(context, nonCopyable, reference.Instance, reference.Property);
+    }
+
+    private static void AnalyzeAccess(
+        OperationAnalysisContext context,
+        INamedTypeSymbol? nonCopyable,
+        IOperation? instance,
+        ISymbol member)
+    {
+        if (instance is null || !CopyAnalysis.IsCopyableStruct(instance.Type))
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.MemberForcesDefensiveCopy(member))
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.TryGetReadOnlyReason(instance, context.ContainingSymbol, out ReadOnlyReason reason))
+        {
+            return;
+        }
+
+        ITypeSymbol receiverType = instance.Type!;
+        bool isNonCopyable = nonCopyable is not null && CopyAnalysis.IsNonCopyable(receiverType, nonCopyable);
+        DiagnosticDescriptor rule = isNonCopyable ? s_nonCopyableDefensiveCopy : s_defensiveCopy;
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            rule,
+            instance.Syntax.GetLocation(),
+            receiverType.Name,
+            member.Name,
+            CopyAnalysis.Describe(reason)));
+    }
+
+    private static bool IsAssignmentTarget(IOperation operation) => operation.Parent switch
+    {
+        ISimpleAssignmentOperation assignment => assignment.Target == operation,
+        ICompoundAssignmentOperation compound => compound.Target == operation,
+        ICoalesceAssignmentOperation coalesce => coalesce.Target == operation,
+        IIncrementOrDecrementOperation => true,
+        _ => false,
+    };
+}

--- a/touki.analyzers/NonCopyableByValueAnalyzer.cs
+++ b/touki.analyzers/NonCopyableByValueAnalyzer.cs
@@ -1,0 +1,231 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports copies of a <c>[NonCopyable]</c> value: passing it by value, returning it by value, assigning it from
+///  an existing location, boxing it, or storing it as a field of a copyable struct. Such a type owns a resource
+///  that must not be duplicated, so it should be passed by <see langword="ref"/> / <see langword="in"/> instead.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <b>Move vs copy heuristic.</b> C# has no concept of a "move", so the analyzer distinguishes a copy from a
+///   move structurally via <see cref="CopyAnalysis.IsCopyOfExistingLocation"/>: a value <em>read from an existing
+///   storage location</em> (a local, parameter, field, or array element) is treated as a copy, while a value
+///   produced fresh (a <see langword="new"/> expression, a factory/method result, or <see langword="default"/>)
+///   is treated as a move and is not reported. This is an approximation; it can miss a copy whose source is an
+///   unusual expression shape, and a caller can suppress a deliberate transfer with
+///   <c>[SuppressMessage]</c>.
+///  </para>
+///  <para>
+///   <b>Reported copy mechanisms:</b> by-value argument (parameter <see cref="RefKind.None"/>), by-value return
+///   (method does not return by <see langword="ref"/>), simple assignment and variable initialization from a
+///   location, boxing conversion to a reference type, and a <c>[NonCopyable]</c>-typed field declared in a
+///   <em>copyable</em> struct (copying the outer struct shallow-copies the field).
+///  </para>
+///  <para>
+///   <b>Constraints and limitations.</b> Like its companion <see cref="DefensiveCopyAnalyzer"/>, this is a
+///   conservative source-level approximation over the bound <see cref="IOperation"/> tree, not an exact IL copy
+///   accounting. Known gaps, each a deliberate false negative:
+///  </para>
+///  <para>
+///   - <b>Not covered:</b> auto-property backing copies, <see cref="System.Nullable{T}"/> wrapping,
+///   deconstruction / tuple-element copies, <c>foreach</c> over a by-value struct enumerable, and copies the
+///   compiler synthesizes during lowering (async / iterator hoisting, closures) which have no source operation.
+///  </para>
+///  <para>
+///   - <b>User-defined conversions are skipped</b> (they invoke an operator rather than copying the value),
+///   so an implicit operator such as <c>BufferScope&lt;T&gt;</c>'s conversion to <see cref="System.Span{T}"/> is
+///   intentionally not flagged.
+///  </para>
+///  <para>
+///   - <b>Most paths are unreachable for a <see langword="ref"/> struct.</b> A <see langword="ref"/> struct
+///   (the common <c>[NonCopyable]</c> case, e.g. a pooled buffer) cannot be boxed, stored in a non-ref-struct
+///   field, or hoisted into an async state machine by language rule, so those reports never arise for it; the
+///   live cases for a ref struct are by-value argument, return, assignment, and local initialization.
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>The diagnostic id reported by this analyzer.</summary>
+    public const string DiagnosticId = "TOUKI0004";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "By-value copy of a non-copyable struct",
+        messageFormat: "'{0}' is marked [NonCopyable] and is copied by value ({1})",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A type marked [NonCopyable] owns a resource that must not be duplicated. Pass it by reference rather than copying it by value.",
+        helpLinkUri: "https://github.com/JeremyKuhne/touki");
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static start =>
+        {
+            // Every diagnostic from this analyzer requires the [NonCopyable] attribute, so if the compilation does
+            // not reference it there is nothing to analyze - register no actions and the analyzer costs ~nothing.
+            // Capturing the symbol in the closure (not a static field) avoids rooting the Compilation across edits.
+            if (start.Compilation.GetTypeByMetadataName(CopyAnalysis.NonCopyableAttributeMetadataName) is not { } nonCopyable)
+            {
+                return;
+            }
+
+            start.RegisterOperationAction(c => AnalyzeArgument(c, nonCopyable), OperationKind.Argument);
+            start.RegisterOperationAction(c => AnalyzeReturn(c, nonCopyable), OperationKind.Return);
+            start.RegisterOperationAction(c => AnalyzeAssignment(c, nonCopyable), OperationKind.SimpleAssignment);
+            start.RegisterOperationAction(c => AnalyzeVariableDeclarator(c, nonCopyable), OperationKind.VariableDeclarator);
+            start.RegisterOperationAction(c => AnalyzeConversion(c, nonCopyable), OperationKind.Conversion);
+            start.RegisterSymbolAction(c => AnalyzeField(c, nonCopyable), SymbolKind.Field);
+        });
+    }
+
+    private static void AnalyzeArgument(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
+    {
+        IArgumentOperation argument = (IArgumentOperation)context.Operation;
+
+        // Only by-value passing copies; ref / in / out pass the original location.
+        if (argument.Parameter is not { RefKind: RefKind.None } parameter)
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.IsNonCopyable(argument.Value.Type, nonCopyable) || !CopyAnalysis.IsCopyOfExistingLocation(argument.Value))
+        {
+            return;
+        }
+
+        Report(context, argument.Value, argument.Value.Type!, $"argument to parameter '{parameter.Name}'; pass it by 'ref' or 'in' instead");
+    }
+
+    private static void AnalyzeReturn(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
+    {
+        IReturnOperation operation = (IReturnOperation)context.Operation;
+        if (operation.ReturnedValue is not { } value)
+        {
+            return;
+        }
+
+        // A by-ref return hands back the original location, not a copy.
+        if (context.ContainingSymbol is IMethodSymbol { ReturnsByRef: true })
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.IsNonCopyable(value.Type, nonCopyable) || !CopyAnalysis.IsCopyOfExistingLocation(value))
+        {
+            return;
+        }
+
+        Report(context, value, value.Type!, "return value; return by 'ref' to hand back the original");
+    }
+
+    private static void AnalyzeAssignment(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
+    {
+        ISimpleAssignmentOperation assignment = (ISimpleAssignmentOperation)context.Operation;
+
+        // A ref assignment (x = ref y) rebinds an alias and does not copy.
+        if (assignment.IsRef)
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.IsNonCopyable(assignment.Value.Type, nonCopyable) || !CopyAnalysis.IsCopyOfExistingLocation(assignment.Value))
+        {
+            return;
+        }
+
+        Report(context, assignment.Value, assignment.Value.Type!, "assignment; bind the target by 'ref' to alias the original");
+    }
+
+    private static void AnalyzeVariableDeclarator(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
+    {
+        IVariableDeclaratorOperation declarator = (IVariableDeclaratorOperation)context.Operation;
+
+        // A ref local (ref var x = ref y) aliases the original and does not copy.
+        if (declarator.Symbol.RefKind != RefKind.None)
+        {
+            return;
+        }
+
+        if (declarator.Initializer?.Value is not { } value)
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.IsNonCopyable(value.Type, nonCopyable) || !CopyAnalysis.IsCopyOfExistingLocation(value))
+        {
+            return;
+        }
+
+        Report(context, value, value.Type!, $"local '{declarator.Symbol.Name}'; declare it 'ref' to alias the original");
+    }
+
+    private static void AnalyzeConversion(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
+    {
+        IConversionOperation conversion = (IConversionOperation)context.Operation;
+
+        // User-defined conversions call an operator; they are not a boxing copy of the value.
+        if (conversion.OperatorMethod is not null)
+        {
+            return;
+        }
+
+        if (!CopyAnalysis.IsNonCopyable(conversion.Operand.Type, nonCopyable))
+        {
+            return;
+        }
+
+        // Boxing converts a value type to a reference type (object, an interface, or dynamic).
+        if (conversion.Type is { IsReferenceType: true })
+        {
+            Report(context, conversion, conversion.Operand.Type!, "boxing conversion; do not convert it to object, an interface, or dynamic");
+        }
+    }
+
+    private static void AnalyzeField(SymbolAnalysisContext context, INamedTypeSymbol nonCopyable)
+    {
+        IFieldSymbol field = (IFieldSymbol)context.Symbol;
+        if (field.IsImplicitlyDeclared || !CopyAnalysis.IsNonCopyable(field.Type, nonCopyable))
+        {
+            return;
+        }
+
+        // Copying a struct shallow-copies its fields. Flag a non-copyable field of a copyable struct; if the
+        // containing type is itself non-copyable, its own copies are reported elsewhere.
+        INamedTypeSymbol container = field.ContainingType;
+        if (container.TypeKind != TypeKind.Struct || CopyAnalysis.IsNonCopyable(container, nonCopyable))
+        {
+            return;
+        }
+
+        foreach (Location location in field.Locations)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                s_rule,
+                location,
+                field.Type.Name,
+                $"field '{field.Name}'; mark the containing type [NonCopyable] or make this a 'ref' field"));
+        }
+    }
+
+    private static void Report(OperationAnalysisContext context, IOperation location, ITypeSymbol type, string mechanism) =>
+        context.ReportDiagnostic(Diagnostic.Create(s_rule, location.Syntax.GetLocation(), type.Name, mechanism));
+}

--- a/touki.analyzers/NonCopyableByValueAnalyzer.cs
+++ b/touki.analyzers/NonCopyableByValueAnalyzer.cs
@@ -123,8 +123,8 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // A by-ref return hands back the original location, not a copy.
-        if (context.ContainingSymbol is IMethodSymbol { ReturnsByRef: true })
+        // A by-ref (or ref readonly) return hands back the original location, not a copy.
+        if (context.ContainingSymbol is IMethodSymbol { ReturnsByRef: true } or IMethodSymbol { ReturnsByRefReadonly: true })
         {
             return;
         }
@@ -222,7 +222,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
                 s_rule,
                 location,
                 field.Type.Name,
-                $"field '{field.Name}'; mark the containing type [NonCopyable] or make this a 'ref' field"));
+                $"field '{field.Name}'; mark the containing type [NonCopyable] or avoid storing it by value"));
         }
     }
 

--- a/touki.analyzers/ReadOnlyReason.cs
+++ b/touki.analyzers/ReadOnlyReason.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Why a receiver location is read-only, and therefore why accessing a non-readonly member through it forces a
+///  defensive copy.
+/// </summary>
+internal enum ReadOnlyReason
+{
+    /// <summary>An <see langword="in"/> parameter.</summary>
+    InParameter,
+
+    /// <summary>A <see langword="ref"/> <see langword="readonly"/> parameter.</summary>
+    RefReadOnlyParameter,
+
+    /// <summary>An instance <see langword="readonly"/> field accessed outside its declaring constructor.</summary>
+    ReadOnlyField,
+
+    /// <summary>A <see langword="static"/> <see langword="readonly"/> field.</summary>
+    StaticReadOnlyField,
+
+    /// <summary>A <see langword="ref"/> <see langword="readonly"/> local.</summary>
+    RefReadOnlyLocal,
+
+    /// <summary>A member that returns by <see langword="ref"/> <see langword="readonly"/>.</summary>
+    RefReadOnlyReturn,
+}

--- a/touki.slnx
+++ b/touki.slnx
@@ -28,6 +28,9 @@
   <Project Path="sample/sample.csproj">
     <Platform Project="x64" />
   </Project>
+  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj">
+    <Platform Project="x64" />
+  </Project>
   <Project Path="touki.analyzers.tests/touki.analyzers.tests.csproj">
     <Platform Project="x64" />
   </Project>

--- a/touki/.editorconfig
+++ b/touki/.editorconfig
@@ -1,0 +1,9 @@
+# Touki dogfoods its own analyzers (touki.analyzers, wired via OutputItemType="Analyzer"
+# in touki.csproj). TOUKI0002 (defensive copy of any struct) ships Hidden because it is
+# high volume for consumers; for touki's own sources we raise it to a suggestion so new
+# defensive copies stay visible to maintainers. It stays below warning on purpose: some
+# defensive copies come from BCL structs whose members are not readonly on net472 and are
+# only avoidable by decomposing/caching, so this must not break the build under
+# TreatWarningsAsErrors. TOUKI0003/TOUKI0004 keep their default Warning severity.
+[*.cs]
+dotnet_diagnostic.TOUKI0002.severity = suggestion

--- a/touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs
+++ b/touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs
@@ -8,8 +8,11 @@ namespace System.Diagnostics;
 ///  Provides an interpolated string handler for <see cref="Debug.Assert(bool)"/> that only formats when the assert fails.
 /// </summary>
 // Only invoked from Debug.Assert overloads, which are [Conditional("DEBUG")] and unreachable in Release coverage runs.
+// Owns a ValueStringBuilder (itself [NonCopyable]); copying the handler would copy the builder, so it propagates the
+// constraint. The compiler only ever uses an interpolated string handler by ref, so this is free here.
 [InterpolatedStringHandler]
 [ExcludeFromCodeCoverage]
+[Touki.NonCopyable]
 public ref struct AssertInterpolatedStringHandler
 {
     private ValueStringBuilder _builder;

--- a/touki/Framework/Polyfills/System.Runtime.CompilerServices/DefaultInterpolatedStringHandler.cs
+++ b/touki/Framework/Polyfills/System.Runtime.CompilerServices/DefaultInterpolatedStringHandler.cs
@@ -15,7 +15,10 @@ namespace System.Runtime.CompilerServices;
 ///  Simple default implementation of an interpolated string handler
 ///  that uses a <see cref="ValueStringBuilder"/> to build the string.
 /// </summary>
+// Owns a ValueStringBuilder (itself [NonCopyable]); copying the handler would copy the builder and double-free its
+// pooled array. The compiler only ever uses an interpolated string handler by ref, so this constraint is free here.
 [InterpolatedStringHandler]
+[NonCopyable]
 public ref struct DefaultInterpolatedStringHandler
 {
     private ValueStringBuilder _builder;

--- a/touki/Touki/Buffers/BufferScope.cs
+++ b/touki/Touki/Buffers/BufferScope.cs
@@ -8,6 +8,7 @@ namespace Touki.Buffers;
 ///  Allows renting a buffer from <see cref="ArrayPool{T}"/> with a using statement. Can be used directly as if it
 ///  were a <see cref="Span{T}"/>.
 /// </summary>
+[NonCopyable]
 public ref struct BufferScope<T>
 {
     private T[]? _array;

--- a/touki/Touki/Collections/ArraySegmentEnumerator.cs
+++ b/touki/Touki/Collections/ArraySegmentEnumerator.cs
@@ -11,7 +11,13 @@ namespace Touki.Collections;
 /// </summary>
 public struct ArraySegmentEnumerator<T> : IEnumerator<T>
 {
-    private readonly ArraySegment<T> _segment;
+    // The segment is decomposed into its parts rather than stored as an ArraySegment<T> field. On .NET Framework
+    // ArraySegment<T>.Array/Offset/Count are not readonly members, so accessing them through a readonly struct
+    // field forces a defensive copy of the whole segment on every access - in the per-element MoveNext hot path.
+    // Storing the array reference and two ints sidesteps that entirely (and is free on modern .NET as well).
+    private readonly T[] _array;
+    private readonly int _offset;
+    private readonly int _count;
     private int _index;
     private T _current;
 
@@ -22,7 +28,9 @@ public struct ArraySegmentEnumerator<T> : IEnumerator<T>
     internal ArraySegmentEnumerator(ArraySegment<T> segment)
     {
         ArgumentNullException.ThrowIfNull(segment.Array, nameof(segment));
-        _segment = segment;
+        _array = segment.Array;
+        _offset = segment.Offset;
+        _count = segment.Count;
         _index = 0;
         _current = default!;
     }
@@ -47,15 +55,14 @@ public struct ArraySegmentEnumerator<T> : IEnumerator<T>
     /// </returns>
     public bool MoveNext()
     {
-        if ((uint)_index < (uint)_segment.Count)
+        if ((uint)_index < (uint)_count)
         {
-            // .NET Framework doesn't have a public indexer method, would otherwise have to cast.
-            _current = _segment.Array![_index + _segment.Offset];
+            _current = _array[_index + _offset];
             _index++;
             return true;
         }
 
-        _index = _segment.Count + 1;
+        _index = _count + 1;
         _current = default!;
         return false;
     }

--- a/touki/Touki/Collections/RefCountedCache.Scope.cs
+++ b/touki/Touki/Collections/RefCountedCache.Scope.cs
@@ -17,6 +17,10 @@ public abstract partial class RefCountedCache<TValue, TCacheEntryData, TKey>
 #if DEBUG
     public class Scope : DisposalTracking.Tracker, IDisposable
 #else
+    // Ref-counts a CacheEntry: the entry constructor calls AddRef and Dispose calls Release. Copying the scope by
+    // value would duplicate the single logical reference without an extra AddRef, so disposing both copies would
+    // Release twice and corrupt the count. In DEBUG it is a class (a reference type, already non-copyable).
+    [NonCopyable]
     public readonly ref struct Scope
 #endif
     {

--- a/touki/Touki/NonCopyableAttribute.cs
+++ b/touki/Touki/NonCopyableAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki;
+
+/// <summary>
+///  Marks a value type as "non-copyable": copying an instance by value is a likely bug because the type owns a
+///  resource (a pooled or manually managed buffer, a handle, a lock) that must not be duplicated.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The Touki analyzers (<c>TOUKI0003</c> and <c>TOUKI0004</c>) report defensive copies and by-value copies of
+///   types annotated with this attribute. A type is recognized by the attribute's simple name
+///   (<c>NonCopyableAttribute</c>) in any namespace, so a consumer that cannot reference this type may declare its
+///   own attribute with the same name and get the same analysis.
+///  </para>
+///  <para>
+///   Applying this attribute does not change runtime behavior; it only drives static analysis. Prefer passing
+///   annotated values by <see langword="ref"/>, <see langword="in"/>, or <see langword="ref"/>
+///   <see langword="readonly"/> rather than by value.
+///  </para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.GenericParameter, AllowMultiple = false, Inherited = false)]
+public sealed class NonCopyableAttribute : Attribute
+{
+}

--- a/touki/Touki/NonCopyableAttribute.cs
+++ b/touki/Touki/NonCopyableAttribute.cs
@@ -11,9 +11,9 @@ namespace Touki;
 /// <remarks>
 ///  <para>
 ///   The Touki analyzers (<c>TOUKI0003</c> and <c>TOUKI0004</c>) report defensive copies and by-value copies of
-///   types annotated with this attribute. A type is recognized by the attribute's simple name
-///   (<c>NonCopyableAttribute</c>) in any namespace, so a consumer that cannot reference this type may declare its
-///   own attribute with the same name and get the same analysis.
+///   types annotated with this attribute. A type is recognized by this attribute's fully qualified name,
+///   <c>Touki.NonCopyableAttribute</c>; a marker attribute of the same simple name in a different namespace is not
+///   recognized.
 ///  </para>
 ///  <para>
 ///   Applying this attribute does not change runtime behavior; it only drives static analysis. Prefer passing

--- a/touki/Touki/Text/ValueStringBuilder.AppendInterpolatedStringHandler.cs
+++ b/touki/Touki/Text/ValueStringBuilder.AppendInterpolatedStringHandler.cs
@@ -12,6 +12,7 @@ public ref partial struct ValueStringBuilder
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     [InterpolatedStringHandler]
+    [NonCopyable]
     public ref struct InterpolatedStringHandler
     {
         private ValueStringBuilder _builder;

--- a/touki/Touki/Text/ValueStringBuilder.cs
+++ b/touki/Touki/Text/ValueStringBuilder.cs
@@ -33,6 +33,7 @@ namespace Touki.Text;
 ///  </para>
 /// </remarks>
 [InterpolatedStringHandler]
+[NonCopyable]
 public ref partial struct ValueStringBuilder
 {
     private const int GuessedLengthPerHole = 11;

--- a/touki/touki.csproj
+++ b/touki/touki.csproj
@@ -154,10 +154,22 @@
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"
                       PrivateAssets="all" />
+    <!--
+      Build-ordering only (no OutputItemType, so it is not loaded as an analyzer during touki's build): ensures the
+      code-fix assembly exists for the _AddAnalyzersToPackage target to pack.
+    -->
+    <ProjectReference Include="..\touki.analyzers.codefixes\touki.analyzers.codefixes.csproj"
+                      ReferenceOutputAssembly="false"
+                      PrivateAssets="all" />
   </ItemGroup>
 
   <Target Name="_AddAnalyzersToPackage" BeforeTargets="GenerateNuspec">
     <MSBuild Projects="..\touki.analyzers\touki.analyzers.csproj"
+             Targets="GetTargetPath"
+             Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=netstandard2.0">
+      <Output TaskParameter="TargetOutputs" ItemName="_ToukiAnalyzerAssembly" />
+    </MSBuild>
+    <MSBuild Projects="..\touki.analyzers.codefixes\touki.analyzers.codefixes.csproj"
              Targets="GetTargetPath"
              Properties="Configuration=$(Configuration);Platform=$(Platform);TargetFramework=netstandard2.0">
       <Output TaskParameter="TargetOutputs" ItemName="_ToukiAnalyzerAssembly" />


### PR DESCRIPTION
## Summary

Adds three Roslyn analyzers that detect struct value copies, a public `[NonCopyable]` attribute, a code fix, and the post-build IL-inspection skill - then dogfoods the analyzers on touki itself, which surfaced one real defensive copy.

Implements the plan in `roslyn/docs/proposals/noncopyable-defensive-copy-analyzers.md`, adapted to this repo's `TOUKI####` IDs and `touki.analyzers` layout.

## Analyzers (`touki.analyzers`)

| ID | Rule | Default severity |
|----|------|------------------|
| `TOUKI0002` | Defensive copy of any struct (non-readonly member on a read-only location) | Hidden |
| `TOUKI0003` | Defensive copy of a `[NonCopyable]` struct | Warning |
| `TOUKI0004` | By-value copy of a `[NonCopyable]` struct (argument / return / assignment / boxing / field of a copyable struct) | Warning |

- `Touki.NonCopyableAttribute` is **public** and matched by fully qualified metadata name (resolved once per compilation, captured in the compilation-start closure - no rooting).
- Each analyzer documents its constraints in source: a conservative `IOperation`-based (pre-lowering) approximation that favors false negatives; compiler-synthesized copies (async/iterator hoisting, closures) are out of scope.
- A separate `touki.analyzers.codefixes` assembly (RS1022 forbids Workspaces references in an analyzer assembly) provides a "make member readonly" fix. Both assemblies pack into `KlutzyNinja.Touki` under `analyzers/dotnet/cs/`.

## Dogfooding on touki

The analyzers run on touki's own sources (`OutputItemType="Analyzer"`). The effectiveness pass found **one real issue and zero false positives**:

- `ArraySegmentEnumerator` stored a `readonly ArraySegment<T>` and read its `Array`/`Offset`/`Count` - which are **not** `readonly` members on net472 - forcing a per-element defensive copy in `MoveNext`. Decomposed the field into `array`/`offset`/`count` to remove it.

Marked the resource-owning structs `[NonCopyable]`: `BufferScope<T>`, `ValueStringBuilder`, `RefCountedCache.Scope` (Release `ref struct` branch only), and the three interpolated-string handlers that own a `ValueStringBuilder` field. `touki/.editorconfig` raises `TOUKI0002` to `suggestion` for touki's own code (kept below `warning` so unavoidable BCL-on-net472 cases don't break the build); `TOUKI0003`/`TOUKI0004` keep their default `Warning`.

## Skills

- New `il-copy-inspection` skill - the post-build, ground-truth IL counterpart (reads emitted `ldobj`/`box`/by-value copies, sees the synthesized copies the analyzer can't).
- Expanded `roslyn-analyzers` with the code-fix-assembly split, attribute-matching, and symbol-rooting guidance.

## Validation

- Whole solution builds clean on both TFMs (net10.0, net472); 0 warnings.
- 30 analyzer + code-fix tests pass (Debug and Release).
- Changed-type tests (`ArraySegmentEnumerator`, `ValueStringBuilder`, `RefCountedCache`, interpolated handlers) pass on both TFMs.
- Agent-file validator and link checker pass.

Note: a full Windows `touki.tests` run reports a handful of `Assert.Inconclusive` results for the Unix-only globbing oracle suites (platform-guarded; run for real via WSL) - unrelated to this change.
