### PR TITLE
Make TOUKI0004 messages descriptive, not over-prescriptive

### DIFF
--- a/touki.analyzers/NonCopyableByValueAnalyzer.cs
+++ b/touki.analyzers/NonCopyableByValueAnalyzer.cs
@@ -65,7 +65,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
         category: "Reliability",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "A type marked [NonCopyable] owns a resource that must not be duplicated. Pass it by reference rather than copying it by value.",
+        description: "A type marked [NonCopyable] owns a resource that must not be duplicated. Where feasible pass or alias it by reference ('ref'/'in'/'ref readonly'); otherwise redesign so the value is not copied by value.",
         helpLinkUri: "https://github.com/JeremyKuhne/touki");
 
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
@@ -112,7 +112,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Report(context, argument.Value, argument.Value.Type!, $"argument to parameter '{parameter.Name}'; pass it by 'ref' or 'in' instead");
+        Report(context, argument.Value, argument.Value.Type!, $"as an argument to parameter '{parameter.Name}'");
     }
 
     private static void AnalyzeReturn(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
@@ -134,7 +134,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Report(context, value, value.Type!, "return value; return by 'ref' to hand back the original");
+        Report(context, value, value.Type!, "as a return value");
     }
 
     private static void AnalyzeAssignment(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
@@ -152,7 +152,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Report(context, assignment.Value, assignment.Value.Type!, "assignment; bind the target by 'ref' to alias the original");
+        Report(context, assignment.Value, assignment.Value.Type!, "via assignment");
     }
 
     private static void AnalyzeVariableDeclarator(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
@@ -175,7 +175,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Report(context, value, value.Type!, $"local '{declarator.Symbol.Name}'; declare it 'ref' to alias the original");
+        Report(context, value, value.Type!, $"into local '{declarator.Symbol.Name}'");
     }
 
     private static void AnalyzeConversion(OperationAnalysisContext context, INamedTypeSymbol nonCopyable)
@@ -196,7 +196,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
         // Boxing converts a value type to a reference type (object, an interface, or dynamic).
         if (conversion.Type is { IsReferenceType: true })
         {
-            Report(context, conversion, conversion.Operand.Type!, "boxing conversion; do not convert it to object, an interface, or dynamic");
+            Report(context, conversion, conversion.Operand.Type!, "via a boxing conversion");
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the post-merge review of #211. The Copilot reviewer flagged that the per-mechanism text in the `TOUKI0004` diagnostic message over-prescribed `ref`-based remedies that aren't legal or applicable in many of the cases the analyzer flags (returning a local, assigning to a field/property/array element, a non-alias local).

## Change

`NonCopyableByValueAnalyzer` message text is now purely **descriptive** for each mechanism, and the (hedged) remedy lives in the descriptor `description`:

| Mechanism | Before | After |
|-----------|--------|-------|
| argument | "argument to parameter 'p'; pass it by 'ref' or 'in' instead" | "as an argument to parameter 'p'" |
| return | "return value; return by 'ref' to hand back the original" | "as a return value" |
| assignment | "assignment; bind the target by 'ref' to alias the original" | "via assignment" |
| local | "local 'x'; declare it 'ref' to alias the original" | "into local 'x'" |
| boxing | "boxing conversion; do not convert it to object…" | "via a boxing conversion" |

The descriptor `description` now reads: *"A type marked [NonCopyable] owns a resource that must not be duplicated. Where feasible pass or alias it by reference ('ref'/'in'/'ref readonly'); otherwise redesign so the value is not copied by value."*

(The field-case message keeps its "mark the containing type [NonCopyable]" hint, which is always valid.)

## Validation

- 33 analyzer/code-fix tests pass in Release (tests assert on diagnostic `Id`, unaffected by message wording).

Addresses the three open review threads on #211.
