### PR TITLE
Re-pin framework-jit-optimization core to commons v0.6.0

### DIFF
--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -3,10 +3,10 @@ description: Optimize hot-path code for the `net481` (.NET Framework) target in 
 license: MIT
 metadata:
     github-path: skills/framework-jit-optimization
-    github-pinned: v0.3.0
-    github-ref: refs/tags/v0.3.0
+    github-pinned: v0.6.0
+    github-ref: refs/tags/v0.6.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 428c10165d3481855b1a0477c715f7bace02e89d
+    github-tree-sha: 854e92f1efe594bc805617ebdb1fc7a38dcad3aa
     portability: semi-portable
 name: framework-jit-optimization
 ---

--- a/.agents/skills/framework-jit-optimization/overlay.md
+++ b/.agents/skills/framework-jit-optimization/overlay.md
@@ -98,8 +98,8 @@ Pull upstream changes to the core (and its `references/`) with
 `gh skill update framework-jit-optimization` (review the diff, re-pin). Keep
 touki-specific additions in this file, not in the core.
 
-Note: [modern-net.md](modern-net.md) and [cross-tfm-codegen.md](cross-tfm-codegen.md)
-were added to the core locally and have not yet been pushed to the
-[agent-skills commons](https://github.com/JeremyKuhne/agent-skills). Until they are,
-`gh skill update` will show them as drift - push them upstream and re-pin rather
-than reverting.
+The [modern-net.md](modern-net.md) and [cross-tfm-codegen.md](cross-tfm-codegen.md)
+sibling pages originated here and were upstreamed to the
+[agent-skills commons](https://github.com/JeremyKuhne/agent-skills) in
+[PR #1](https://github.com/JeremyKuhne/agent-skills/pull/1); the vendored core is
+pinned to `v0.6.0`, which includes them. No pending divergence remains.


### PR DESCRIPTION
Re-pins the vendored `framework-jit-optimization` skill core to commons `v0.6.0`.

The `modern-net.md` and `cross-tfm-codegen.md` sibling pages (added in #213) were
upstreamed to the [agent-skills commons](https://github.com/JeremyKuhne/agent-skills)
in [PR #1](https://github.com/JeremyKuhne/agent-skills/pull/1) and released as
`v0.6.0`. This bumps the provenance pin so the vendored core matches its upstream
again.

## Changes

- **`SKILL.md`** - bump the provenance pin: `v0.3.0` / tree-sha `428c101` ->
  `v0.6.0` / tree-sha `854e92f`. The core content is byte-identical to commons
  `v0.6.0` (verified), so `gh skill update` now reports no drift.
- **`overlay.md`** - replace the stale "added locally, not yet pushed" note with a
  record that the pages were upstreamed in commons PR #1 and the core is pinned to
  `v0.6.0`; no pending divergence remains.

Docs-only; agent-file validation and the link check pass.