### PR TITLE
Scope traceq export to a process; add hands-free flame-graph viewers

### DIFF
--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-testing
-description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project, and translate a user's outcome-shaped performance question into a measurement. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `traceq` trace analyzer), evaluating allocations / memory usage, or when a user asks how long something takes, how much memory it uses, where time is spent, or to help make a method faster - which this skill turns into a scenario, a benchmark, and a drill-down.
+description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project, and translate a user's outcome-shaped performance question into a measurement. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `traceq` trace analyzer), visualizing a trace as an interactive flame graph in speedscope or Perfetto, evaluating allocations / memory usage, or when a user asks how long something takes, how much memory it uses, where time is spent, or to help make a method faster - which this skill turns into a scenario, a benchmark, and a drill-down.
 metadata:
   portability: semi-portable
 ---
@@ -116,7 +116,15 @@ sharplab, BenchmarkDotNet's `[DisassemblyDiagnoser]` / `[HardwareCounters]`, the
 - [running.md](running.md) - the `-f <tfm>` requirement, filtering to a class or
   method, the interactive picker, and useful switches.
 - [profiling.md](profiling.md) - capturing an EventPipe trace and drilling it
-  with the `traceq` analyzer from operation to method to line.
+  with the `traceq` analyzer from operation to method to line, and *reading* the
+  line ranking (prologue-dominated = call-count-bound; a helper recurring across
+  branches = the real target).
+- [graphical-viewers.md](graphical-viewers.md) - the *optional* last step:
+  handing a human an interactive flame graph in speedscope or Perfetto. When a
+  graphical view is worth offering (and when the direct `trace_lines` /
+  `trace_heatmap` drill is the better answer), which viewer to pick, how to launch
+  it hands-free with the right view active, and how to guide the user once it is
+  open.
 - [interpreting-results.md](interpreting-results.md) - before/after discipline on
   both TFMs, reading the memory columns, and the tuple-swap exception.
 - [reading-codegen.md](reading-codegen.md) - seeing the C# lowering, IL, and JIT

--- a/.agents/skills/performance-testing/graphical-viewers.md
+++ b/.agents/skills/performance-testing/graphical-viewers.md
@@ -1,0 +1,127 @@
+# Handing off an interactive flame graph: speedscope and Perfetto
+
+Detail for the [performance-testing](SKILL.md) skill. The rest of
+[profiling.md](profiling.md) is about the *direct* drill - `trace_rank`,
+`trace_lines`, `trace_heatmap` - which is almost always the right answer. This
+page is about the *optional* last resort: opening the trace in a rich interactive
+flame-graph viewer for a human.
+
+## Reach for the direct drill first
+
+The traceq tools answer "where is the time" at line precision, in text, with no
+viewer literacy required - so they are the practical default, and the thing to
+offer before a graphical viewer:
+
+- **"Which method dominates?"** -> `trace_rank` (method self-time ranking).
+- **"Which line is hot?"** -> `trace_lines` (per-`file:line` self-time, scoped to
+  a method).
+- **"Show the hot lines on the source."** -> `trace_heatmap` (per-line heat
+  overlaid on one source file).
+- **"What calls this frame?"** -> `trace_callers`.
+
+These are faster to run, quote exact numbers, fold the JIT-helper artifacts, and
+need no explanation. **Recommend them before suggesting a rich viewer.** A user
+who asked "why is this slow" wants the hot line, not a tour of a flame-graph UI.
+
+## When a graphical view is actually worth it
+
+Offer one only when the *shape* of the data - not a single number - is the
+insight, or the user wants to explore interactively. Good moments:
+
+- **The call-tree shape is the story.** Wide-vs-deep, unexpected recursion, a fan
+  of many shallow callers - a flame graph shows this at a glance where a ranked
+  table flattens it.
+- **Making a divergence legible to a human.** The EventPipe-vs-ETW attribution
+  flip (profiling.md, reason 4) is far more convincing shown as two flame graphs
+  side by side than as two tables: `ProduceAlternative` is a sliver under
+  `RunEngine` in the EventPipe profile and a wide frame in the ETW one.
+- **Exploring an unfamiliar method** whose call structure you do not yet know -
+  clicking down the hot path interactively beats guessing `--method` filters.
+- **Handing a visual to someone else** (a PR reviewer, an issue) who will not run
+  traceq.
+
+If none of those apply, stay in the direct drill.
+
+## Pick the viewer by export format
+
+traceq's `export` writes either format; the viewer follows from it. **Scope a
+machine-wide `.etl` when you export** - pass `--process <name>` (CLI) or the
+`process` argument (the `trace_export` MCP tool), exactly as the ranking verbs
+do, or the export captures whichever process was busiest (a background app, not
+the benchmark).
+
+| | speedscope | Perfetto |
+|---|---|---|
+| Export format | `speedscope` (the default) | `chromium` (`--format chromium`) |
+| Weight | light; 1 file, fast | heavy; 10-45x larger JSON |
+| Best view | **Left Heavy** (merged hotspots) + Sandwich (caller/callee) | timeline, multi-track, SQL queries |
+| Deep-link control | view only (no frame scope) | rich `startupCommands` (pin/expand/query) |
+| Right when | quick hotspot shape, the EventPipe/ETW flip | wall-clock/timeline questions, SQL drilldowns |
+
+For a CPU hotspot question - which is the usual case here - **speedscope is the
+better fit**: lighter, and its Left Heavy view is exactly the merged-hotspot
+picture. Perfetto earns its weight only when the question turns to wall-clock
+timeline, concurrency, or SQL over the trace.
+
+## Launch hands-free, with the right view already active
+
+Both openers serve the file from a one-shot loopback HTTP listener with the CORS
+header the web app requires, open the deep link in the default browser, serve the
+file once, then exit. Nothing is uploaded; the trace stays on `127.0.0.1`. They
+use different ports (speedscope 9002, Perfetto 9001), so both can be open at once
+for a side-by-side.
+
+```powershell
+# speedscope, opening straight into Left Heavy (the hotspot view).
+./tools/Open-SpeedscopeTrace.ps1 BenchmarkDotNet.Artifacts/flamegraphs/<name>.speedscope.json
+# -View sandwich | time-ordered to open in a different mode.
+
+# Perfetto, expanding + pinning the aggregate track so you land on the flame.
+./tools/Open-PerfettoTrace.ps1 BenchmarkDotNet.Artifacts/flamegraphs/<name>.perfetto.json
+```
+
+The fully offline speedscope alternative is `npx -y speedscope <file>`: it embeds
+the profile in a self-contained temp HTML and opens it, but **cannot set the
+initial view** (it always opens in Time Order). Use the script when you want Left
+Heavy on load; use `npx` when you want a single self-contained file with no local
+server.
+
+Why a server at all: neither web app can `fetch` a `file://` path, so a
+self-contained `file://` HTML does not work for loading-by-URL. The scripts
+reproduce Perfetto's own `open_trace_in_ui` approach - a loopback server plus a
+deep link - which a browser allows because `127.0.0.1` is a trustworthy origin.
+
+## Guide the user once it is open - these UIs assume knowledge
+
+**speedscope** opens in **Left Heavy** (the opener sets `view=left-heavy`): stacks
+are merged and sorted by weight, so the widest top frame is the hotspot. Tell the
+user to:
+
+- click a frame to zoom into its subtree (Escape zooms back out);
+- switch to **Sandwich** (top-left mode toggle) and click a function to see its
+  callers above and callees below - the visual form of `trace_callers`;
+- use the search box (the magnifier) to filter frames by name - this is a UI
+  control, not a URL parameter, so it cannot be preset.
+
+**Perfetto** shows the flame graph under the pinned `traceq` track (the opener
+expands and pins it). Tell the user to:
+
+- drag-select a time region, then read the per-frame breakdown in the bottom
+  tab;
+- use the **Query (SQL)** tab for ad-hoc rankings - but note the caveat below.
+
+## Caveats that will mislead if unsaid
+
+- **Perfetto slice durations are inclusive, not self-time.** traceq's chromium
+  export reconstructs begin/end slices from the samples, so a frame's `dur` (and
+  any `SUM(dur)` SQL) is inclusive of its callees. For self-time, trust
+  `trace_rank` / `trace_lines` - do not read a Perfetto SQL sum as self-time.
+- **traceq exports a single aggregate track.** The engine's rankings aggregate
+  across threads, so the flame graph is one synthetic thread named by the
+  export's `--name` (default `traceq`), not the real per-thread timeline. It is a
+  flame graph, not a scheduling view.
+- **speedscope cannot deep-link a scope** - only the view. To focus a frame the
+  user clicks it; there is no preset frame filter.
+- **A flame graph is not the source of truth for a number.** It is for *shape*
+  and *exploration*; quote the hot line/percentage from the traceq drill, which
+  folds the sampling artifacts the raw flame graph still shows.

--- a/.agents/skills/performance-testing/interpreting-requests.md
+++ b/.agents/skills/performance-testing/interpreting-requests.md
@@ -18,7 +18,7 @@ them through it; do not hand back a tool and a shrug.
 |---|---|---|
 | "How long does X take?" / "Is X fast enough?" | a latency number for a real scenario | benchmark the scenario, report `Mean` + error on both TFMs ([authoring](authoring.md), [running](running.md)) |
 | "How much memory does X use?" / "Does X allocate?" | bytes per operation | `[MemoryDiagnoser]` benchmark, report `Allocated` on both TFMs ([interpreting-results](interpreting-results.md)) |
-| "Where is the time spent?" / "Why is X slow?" | the hot method or line | profile a trace (EventPipe on net10, **ETW on net481**), rank -> callers -> lines ([profiling](profiling.md)) |
+| "Where is the time spent?" / "Why is X slow?" | the hot method or line | profile a trace (EventPipe on net10, **ETW on net481**), rank -> callers -> lines; if a thin driver/wrapper tops the net10 ranking, cross-check under ETW - inlining can misattribute self-time to the host ([profiling](profiling.md)) |
 | "What's allocating?" / "What's the GC doing?" | the hot alloc site / GC pressure | the allocation or GC view of a trace ([profiling](profiling.md)) |
 | "Make X faster" / "improve this method" | a *verified* improvement | the full loop below: scenario -> baseline -> profile -> change -> re-measure |
 | "Did my change help / regress anything?" | a before/after delta | baseline before, re-run after, diff both TFMs ([interpreting-results](interpreting-results.md)) |
@@ -105,10 +105,21 @@ yet. Offer it:
   pooled / `stackalloc` version and measure it?"
 - After a **hot spot** -> "Want me to try `<specific change the evidence
   suggests>` and measure whether it helps?"
+- After a **hot spot whose call-tree *shape* is the interesting part** (deep
+  recursion, a fan of shallow callers, or you want to show the EventPipe-vs-ETW
+  flip visually) -> "Want me to open this as an interactive flame graph in
+  speedscope so you can explore it?" Offer this *after* the line-level answer, not
+  instead of it - the `trace_lines` / `trace_heatmap` drill is the more practical
+  result. See [graphical-viewers.md](graphical-viewers.md).
 - After a **shallow line/heat map** (too few samples to attribute per line) ->
   "EventPipe sampled too coarsely to pin the hot lines; want me to re-capture
   under ETW (~1 kHz) for a deeper heat map?" See
   [profiling.md](profiling.md) - "When line attribution is too sparse".
+- After a **net10 method ranking topped by a driver/wrapper frame** (its body is
+  mostly a call into a loop) -> "EventPipe may be crediting an inlined callee's
+  time to its host; want me to re-capture under ETW - which resolves the inlinee -
+  and diff the two?" See [profiling.md](profiling.md) - reason 4 under "Capturing
+  under ETW". Lengthening the run will not fix this; only ETW reattributes it.
 - After an **improvement** -> "Want me to push the scenario harder (larger input,
   worst case), or check whether the win holds on the other TFM?"
 - After a **surprising divergence** -> "The net481 path is 3x slower here; want me
@@ -126,6 +137,14 @@ yet. Offer it:
   the Framework JIT inlines far less, so the hot frame can move entirely. Profile
   net481 directly under ETW rather than reading its hotspot off the net10 EventPipe
   trace (see [profiling](profiling.md)).
+- **Trusting the net10 EventPipe *method* ranking under heavy inlining.** It
+  credits an inlined callee's self-time to its physical host, so a thin
+  driver/wrapper can top the ranking while the real hot loop reads near-zero -
+  the same hotspot move, this time between *capture methods* on one TFM. Verified
+  flip on one binary (same PDB GUID): `ProduceAlternative` collected 98 EventPipe
+  leaf samples vs 11,516 ETW for the same op.
+  Cross-check under ETW when a wrapper tops the ranking; duration will not fix
+  it (see [profiling](profiling.md), reason 4).
 - **A single Mean with no error bars or allocation column.** Sub-microsecond
   deltas on this machine are noise; trust `Allocated` and deltas outside
   `Error`/`StdDev` ([interpreting-results](interpreting-results.md)).

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -44,7 +44,7 @@ Things that bite, kept short - full rationale in
 sections 3a (methods) and 3f (lines):
 
 - **EventPipe is net10.0-only** - net481 has no EventPipe, so profile it under
-  ETW instead (see [Capturing under ETW](#capturing-under-etw-net481-denser-samples-native-frames)
+  ETW instead (see [Capturing under ETW](#capturing-under-etw-net481-inlining-accurate-attribution-denser-samples-native-frames)
   and [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1)); never
   read a net481 hotspot off a net10 trace. EventPipe's CPU sampler is also fixed
   at **~100 Hz** and **net10 cannot raise it**

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -63,15 +63,22 @@ sections 3a (methods) and 3f (lines):
   build** - `touki.dll` ships its PDB embedded, and the symbols build's GUID
   must match the trace (hence `--keepFiles`). A wrong dir resolves frames to
   `<no source>` or is rejected with a GUID mismatch.
-- **Line attribution stops at inlined boundaries** - a fully-inlined callee
-  collapses onto its caller's call-site line. If the ranking piles onto one or
-  two call-site lines, scope `--method` to the callee (`--method ExtGlobEngine`)
-  or add a temporary `[MethodImpl(MethodImplOptions.NoInlining)]`.
+- **Inlining attribution differs by profiler, and it corrupts the *method*
+  ranking - not just the line view.** EventPipe's managed walker credits a
+  fully-inlined callee's self-time to its *physical host* method (and, in the
+  line view, collapses it onto the host's call-site line); BDN's ETW
+  `EtwProfiler` resolves it back to the inlinee. So a fully-inlined callee can
+  read near-zero on the EventPipe *method* ranking while its host tops it. If the
+  top self-frames are thin drivers/wrappers, suspect this and cross-check under
+  ETW (reason 4 below). Scoping `--method` to the callee or a temporary
+  `[MethodImpl(MethodImplOptions.NoInlining)]` also exposes it, but NoInlining
+  changes codegen (it can force a ref-struct engine to materialize per call), so
+  treat it as a probe, not a measurement.
 
-## Capturing under ETW (net481, denser samples, native frames)
+## Capturing under ETW (net481, inlining-accurate attribution, denser samples, native frames)
 
 EventPipe is net10-only and managed-only. Reach for an ETW (`.etl`) capture in
-three situations - the first is the one that bites hardest:
+four situations - the first two bite hardest:
 
 1. **Profiling net481 at all.** The Framework target has no EventPipe, so ETW is
    the only profiler - and the net481 hotspot can differ *completely* from net10,
@@ -86,6 +93,23 @@ three situations - the first is the one that bites hardest:
 3. **Line attribution is too sparse** - kernel CPU sampling is ~1 kHz, ~10x
    EventPipe's fixed ~100 Hz, so a short hot path spreads across more source lines
    (escalation detail below).
+4. **Method attribution under heavy inlining - even on net10.** EventPipe's
+   managed walker credits a fully-inlined callee's self-time to its *physical
+   host* method; BDN's ETW `EtwProfiler` (TraceEvent + the CLR inline map)
+   resolves it to the real inlinee. This is *not* a net481-only effect and *not*
+   a density effect - it reorders the net10 method ranking on the same binary.
+   Proven A/B (same PDB GUID, same net10 scenario, only the capture method
+   differs): `ExtGlobEngine.ProduceAlternative` collected just **98** leaf
+   samples in the EventPipe trace versus **11,516** in the ETW trace of the same
+   op - a ~117x attribution gap - while EventPipe parked 99.76 % of the engine's
+   self-time on two host call/setup lines (`RunEngine` :385 and
+   `RunEngineDirectory` :410) that ETW spread across `ProduceAlternative`'s real
+   body. **Signal in the `.nettrace`:** a thin
+   driver/wrapper method tops the self-time ranking while the inner loop you
+   expect to be hot reads near-zero. **Duration cannot fix this** - more samples
+   give a more confident wrong answer; only ETW (or reading the host's source /
+   a temporary NoInlining probe) corrects it. When you escalate, keep both
+   captures: the EventPipe-to-ETW flip *is* the evidence.
 
 **Capture it with one command.** [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1)
 self-elevates (one UAC prompt), shows the benchmark's **live** progress in the
@@ -111,6 +135,34 @@ other CPU consumers before capturing, or scope explicitly.
 running *and* blocked - while `cpu` is on-CPU time. When they agree closely the
 work is CPU-bound (the glob example: 56.45 % cpu vs 56.46 % threadtime - no
 blocking); when `threadtime` is much larger the frame is waiting on I/O or a lock.
+
+### Is EventPipe enough, or escalate to ETW?
+
+EventPipe is the right *first* capture on net10: unelevated, one command, and its
+method ranking locates the hot *region*. Treat it as triage, then decide whether
+to trust it or escalate. Three cases, two different fixes:
+
+- **Density - are there enough samples?** EventPipe samples each managed thread at
+  a fixed **~100 Hz**, so coverage is a function of *total* capture time (BDN
+  repeats the op across many iterations), not single-op latency. Rules of thumb
+  from this machine: a frame needs roughly **>=200-300 samples** for a trustworthy
+  self-%, and **>=1,000 samples** - about **~10 s of cumulative time in that
+  frame** at 100 Hz - before its *line* view spreads usefully. `trace_info`
+  reports the total count; multiply by the frame's self-% to see whether it clears
+  the bar. Under BDN's repetition you almost always clear the *method* bar; for a
+  short hot path you usually miss the *line* bar.
+- **Sparse but *correct* - the tree points at the right method, just thin.**
+  Lengthen the measured work (a larger input or the long-running scenario) or
+  capture ETW for ~10x density. **Lengthening the scenario is the right lever
+  here**, and the cheapest.
+- **Misattributed - a driver/wrapper tops the ranking (reason 4 above).**
+  Lengthening does **nothing**; it only sharpens a wrong answer. ETW is the fix.
+  This is the distinction that matters: **duration cures sparsity, never
+  misattribution.** Tell them apart by reading the top self-frame's source - if
+  its body is mostly a call into a loop, its self-time is borrowed from an
+  inlinee, and only ETW (or a NoInlining probe) will hand it back.
+
+The line-level escalation ladder below refines the first two cases.
 
 ### When line attribution is too sparse
 
@@ -141,3 +193,53 @@ The older `Profile-Benchmark.ps1` / `Get-TraceHotspots.ps1` scripts predate the
 analyzer and remain as a no-MCP fallback (plus `speedscope-to-flamegraph.ps1`
 for SVG) in
 [docs/performance-investigation-without-mcp.md](../../../docs/performance-investigation-without-mcp.md).
+
+## Reading the line ranking - what the heat *shape* means
+
+A correct, dense line ranking (a method's own `trace_lines`, or `trace_heatmap`
+over its file) still has to be *interpreted*. Two shapes recur and point at
+opposite levers - say which one you see, not just the top line:
+
+- **The method's entry/prologue line dominates its own ranking -> it is called
+  too often, not doing too much per call.** A method's first source line carries
+  the prologue and the first (bounds-checked) field/argument access, so when it
+  tops the method's *own* line ranking - and the next few field-bind lines pile in
+  behind it - the cost is *invocation count*, not any one computation. Worked
+  example: in `ProduceAlternative` (the negation backtracker) line 1006
+  (`ref Frame frame = ref _frames[frameIdx]`, the prologue) was **39 %** of the
+  method and the field binds on the next lines brought the entry preamble to
+  **~50 %**. The lever is calling it fewer times (prune dead candidates earlier),
+  not shaving its body. A *body*-line hotspot points the opposite way - optimize
+  that computation.
+- **A callee that recurs hot across several branches beats any single top line.**
+  Scan the ranking for the same helper at multiple `file:line`s and sum them - one
+  fix lands on every site. Same example: `CopyRanges` (the per-frame range
+  snapshot) appeared at three call sites summing above most single lines, so a
+  cheaper snapshot/restore is a better target than the single hottest line.
+
+A `:0` or `<no source>` row is self-time the PDB could not map to a line (a
+compiler-synthesized region, or a missing symbol), not a real line 0 - treat it as
+unattributed, not a hotspot.
+
+**Before trusting an *existing* trace, confirm the source has not moved since the
+capture.** Compare the hot file's last-commit date
+(`git log -1 --format=%ci -- <file>`) to the trace's timestamp; if the source
+changed after the capture the line numbers are stale - recapture rather than read
+them. (Reusing a still-matching trace is the right call - it skips a recapture -
+but only after this check.)
+
+## Handing off an interactive flame graph (optional)
+
+The drills above - `trace_rank`, `trace_lines`, `trace_heatmap` - are the
+practical answer to "where is the time" and should be offered first: they are
+line-precise, fold the sampling artifacts, and need no viewer literacy. When the
+*shape* of the call tree is the insight, or a human wants to explore the trace
+interactively (or see the EventPipe-vs-ETW attribution flip side by side),
+`trace_export` writes a flame graph for speedscope or Perfetto, and
+[tools/Open-SpeedscopeTrace.ps1](../../../tools/Open-SpeedscopeTrace.ps1) /
+[tools/Open-PerfettoTrace.ps1](../../../tools/Open-PerfettoTrace.ps1) open it in
+the browser hands-free with the right view already active. See
+[graphical-viewers.md](graphical-viewers.md) for when it is worth offering, which
+viewer to pick, and how to guide the user once it is open. Scope a machine-wide
+`.etl` on export with `--process <name>` (or the `process` MCP argument), the
+same as the ranking verbs.

--- a/tools/Open-PerfettoTrace.ps1
+++ b/tools/Open-PerfettoTrace.ps1
@@ -1,0 +1,219 @@
+<#
+.SYNOPSIS
+    Open a Chrome-trace / Perfetto trace file in the Perfetto UI with the trace
+    already loaded - no manual "Open trace file" step.
+
+.DESCRIPTION
+    The Perfetto UI (https://ui.perfetto.dev) cannot fetch a trace from a file://
+    path, so a self-contained local HTML (the trick the speedscope CLI uses) does
+    not work for it. Instead Perfetto supports a deep link that fetches the trace
+    over HTTP:
+
+        https://ui.perfetto.dev/#!/?url=http://127.0.0.1:9001/<file>
+
+    This script reproduces Perfetto's own tools/open_trace_in_ui helper in
+    PowerShell: it serves the trace from a one-shot local HTTP listener on
+    127.0.0.1:9001 with the CORS header the UI requires, opens the deep link in the
+    default browser, serves the file when the UI fetches it, then shuts the listener
+    down. Nothing is uploaded anywhere - the trace stays on the loopback interface.
+
+    Port 9001 is not arbitrary: it is the HTTP+RPC port the Perfetto UI's content
+    security policy whitelists, so the fetch is only allowed from that port without
+    enabling the UI's "Relax CSP" flag.
+
+    The input must be a Chrome Trace Event Format file (what `traceq export --format
+    chromium` writes) or a native Perfetto proto trace. A speedscope export is NOT a
+    Perfetto format - open those with the speedscope CLI instead.
+
+.PARAMETER Path
+    Path to the trace file to serve (Chrome-trace JSON or Perfetto proto).
+
+.PARAMETER Origin
+    The Perfetto UI origin. Defaults to https://ui.perfetto.dev; use
+    http://localhost:10000 for a local Perfetto devserver.
+
+.PARAMETER Port
+    The loopback port to serve from. Defaults to 9001 (the only port the Perfetto
+    UI CSP allows without the Relax-CSP flag).
+
+.PARAMETER TimeoutSeconds
+    Hard cap on how long the listener stays up waiting for the first fetch. After
+    the trace is served once the listener stays up only briefly (for tab reloads)
+    and then exits. Defaults to 300.
+
+.PARAMETER PinTrack
+    Regex of track name(s) to pin to the top of the timeline once the trace loads,
+    via the stable dev.perfetto.PinTracksByRegex startup command. Defaults to
+    'traceq' - the single aggregate track traceq's chromium export emits (named by
+    the export's --name). Pass '' to skip pinning.
+
+.PARAMETER NoExpand
+    Skip the default dev.perfetto.ExpandTracksByRegex '.*' startup command. By
+    default every track group is expanded on load so the flame graph is visible
+    immediately instead of collapsed under a process row.
+
+.PARAMETER StartupCommands
+    One or more raw Perfetto startup-command JSON objects (e.g.
+    '{"id":"dev.perfetto.RunQueryAndShowTab","args":["SELECT ..."]}') to run after
+    the trace loads, overriding the default expand/pin commands. See
+    https://perfetto.dev/docs/visualization/commands-automation-reference for the
+    stable command surface.
+
+.PARAMETER NoOpenBrowser
+    Print the deep link instead of launching the browser (useful for testing).
+
+.EXAMPLE
+    ./tools/Open-PerfettoTrace.ps1 BenchmarkDotNet.Artifacts/flamegraphs/net10-etl-scoped.perfetto.json
+
+.NOTES
+    Companion to the speedscope path: tools/Open-SpeedscopeTrace.ps1 opens a
+    speedscope flame graph hands-free with a chosen view (e.g. Left Heavy).
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Path,
+    [string]$Origin = "https://ui.perfetto.dev",
+    [int]$Port = 9001,
+    [int]$TimeoutSeconds = 300,
+    [string]$PinTrack = "traceq",
+    [switch]$NoExpand,
+    [string[]]$StartupCommands,
+    [switch]$NoOpenBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Error "Trace file not found: $Path"
+    exit 1
+}
+
+$full = (Resolve-Path -LiteralPath $Path).Path
+$fname = [System.IO.Path]::GetFileName($full)
+$encoded = [System.Uri]::EscapeDataString($fname)
+
+# Strip any path/query from the origin so the CORS allow-origin is just scheme://host.
+$originUri = [System.Uri]$Origin
+$allowOrigin = "{0}://{1}" -f $originUri.Scheme, $originUri.Authority
+$deepLink = "$allowOrigin/#!/?url=http://127.0.0.1:$Port/$encoded&referrer=open_trace_in_ui"
+
+# Build the startup commands that configure the view once the trace loads. By
+# default expand every track group (so the flame is visible, not collapsed under a
+# process row) and pin the aggregate track to the top. Raw -StartupCommands, when
+# given, replace the defaults entirely.
+$commandObjects = @()
+if ($PSBoundParameters.ContainsKey('StartupCommands') -and $StartupCommands.Count -gt 0) {
+    foreach ($raw in $StartupCommands) {
+        $commandObjects += ($raw | ConvertFrom-Json)
+    }
+}
+else {
+    if (-not $NoExpand) {
+        $commandObjects += [pscustomobject]@{ id = 'dev.perfetto.ExpandTracksByRegex'; args = @('.*') }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($PinTrack)) {
+        $commandObjects += [pscustomobject]@{ id = 'dev.perfetto.PinTracksByRegex'; args = @($PinTrack) }
+    }
+}
+
+if ($commandObjects.Count -gt 0) {
+    # ConvertTo-Json unwraps a single-element array, so force array brackets when needed.
+    $commandsJson = ConvertTo-Json -InputObject $commandObjects -Depth 6 -Compress
+    if ($commandObjects.Count -eq 1) {
+        $commandsJson = "[$commandsJson]"
+    }
+
+    $deepLink += "&startupCommands=" + [System.Uri]::EscapeDataString($commandsJson)
+}
+
+$listener = [System.Net.HttpListener]::new()
+$listener.Prefixes.Add("http://127.0.0.1:$Port/")
+try {
+    $listener.Start()
+}
+catch [System.Net.HttpListenerException] {
+    Write-Error ("Could not bind http://127.0.0.1:$Port/ - $($_.Exception.Message). " +
+        "Port $Port may be in use by a trace_processor server or a previous run.")
+    exit 1
+}
+
+Write-Host "Serving $fname on http://127.0.0.1:$Port/ (CORS origin $allowOrigin)" -ForegroundColor Cyan
+if ($NoOpenBrowser) {
+    Write-Host "Open in browser: $deepLink" -ForegroundColor Yellow
+}
+else {
+    Write-Host "Opening Perfetto UI with the trace preloaded..." -ForegroundColor Green
+    Start-Process $deepLink | Out-Null
+}
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$served = 0
+$task = $null
+try {
+    while ((Get-Date) -lt $deadline) {
+        if ($null -eq $task) {
+            $task = $listener.GetContextAsync()
+        }
+
+        # Poll the pending accept so the deadline is still checked while idle; the
+        # same task is reused across iterations so no accept operation leaks.
+        if (-not $task.Wait(1000)) {
+            continue
+        }
+
+        $context = $task.Result
+        $task = $null
+        $request = $context.Request
+        $response = $context.Response
+        try {
+            $response.Headers["Access-Control-Allow-Origin"] = $allowOrigin
+            $response.Headers["Cache-Control"] = "no-cache"
+
+            $requestPath = [System.Uri]::UnescapeDataString($request.Url.AbsolutePath)
+            if ($request.HttpMethod -eq "OPTIONS") {
+                # Preflight (only sent if the UI ever makes a non-simple request).
+                $response.Headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
+                $response.Headers["Access-Control-Allow-Headers"] = "*"
+                $response.StatusCode = 204
+            }
+            elseif (($request.HttpMethod -in "GET", "HEAD") -and $requestPath -eq "/$fname") {
+                $bytes = [System.IO.File]::ReadAllBytes($full)
+                $response.ContentType = "application/json"
+                $response.ContentLength64 = $bytes.Length
+                if ($request.HttpMethod -eq "GET") {
+                    $response.OutputStream.Write($bytes, 0, $bytes.Length)
+                }
+
+                $served++
+                Write-Host ("Served {0} ({1:N0} bytes)" -f $fname, $bytes.Length) -ForegroundColor Green
+            }
+            else {
+                $response.StatusCode = 404
+            }
+        }
+        finally {
+            $response.Close()
+        }
+
+        # Once the UI has fetched the trace it lives in browser memory; keep the
+        # listener up only a short grace window so a tab reload still works, then exit.
+        if ($served -eq 1) {
+            $grace = (Get-Date).AddSeconds(60)
+            if ($grace -lt $deadline) {
+                $deadline = $grace
+            }
+        }
+    }
+}
+finally {
+    $listener.Stop()
+    $listener.Close()
+}
+
+if ($served -eq 0) {
+    Write-Warning "The Perfetto UI never fetched the trace before the timeout. Was the browser blocked?"
+    exit 2
+}
+
+Write-Host "Done - trace delivered to the Perfetto UI." -ForegroundColor Cyan

--- a/tools/Open-PerfettoTrace.ps1
+++ b/tools/Open-PerfettoTrace.ps1
@@ -179,7 +179,12 @@ try {
             }
             elseif (($request.HttpMethod -in "GET", "HEAD") -and $requestPath -eq "/$fname") {
                 $bytes = [System.IO.File]::ReadAllBytes($full)
-                $response.ContentType = "application/json"
+
+                # A Chrome-trace export is JSON; a native Perfetto capture (.pftrace,
+                # .perfetto-trace, .pb) is a binary proto. Label the payload accordingly
+                # so the Content-Type matches what is actually served.
+                $isJson = [System.IO.Path]::GetExtension($fname).ToLowerInvariant() -eq ".json"
+                $response.ContentType = if ($isJson) { "application/json" } else { "application/octet-stream" }
                 $response.ContentLength64 = $bytes.Length
                 if ($request.HttpMethod -eq "GET") {
                     $response.OutputStream.Write($bytes, 0, $bytes.Length)

--- a/tools/Open-SpeedscopeTrace.ps1
+++ b/tools/Open-SpeedscopeTrace.ps1
@@ -1,0 +1,191 @@
+<#
+.SYNOPSIS
+    Open a speedscope flame graph in the browser with the profile already loaded
+    AND a chosen view active (default: Left Heavy) - no manual load, no manual
+    view toggle.
+
+.DESCRIPTION
+    The `npx speedscope <file>` CLI auto-loads a profile but always opens in the
+    default Time Order view; it gives no way to pick the view it opens in. The
+    speedscope app does support a `view` hash parameter, but only when it controls
+    the URL - which the CLI does not expose.
+
+    This script takes the same approach as the Perfetto opener: it serves the
+    profile from a one-shot local HTTP listener with the CORS header speedscope.app
+    requires, then opens
+
+        https://www.speedscope.app/#profileURL=http://127.0.0.1:<port>/<file>&view=left-heavy&title=<name>
+
+    speedscope fetches the profile over loopback and applies the requested view on
+    load. Nothing is uploaded; the profile stays on the loopback interface, and a
+    browser permits the https app to fetch http://127.0.0.1 because loopback is a
+    trustworthy origin.
+
+    The three views map to speedscope's modes:
+      - time-ordered : the default chronological flame chart
+      - left-heavy   : stacks merged and sorted by weight (the hotspot view) [default]
+      - sandwich     : the per-function caller/callee table
+
+    The input must be a speedscope-format profile (what `traceq export` writes by
+    default, or `--format speedscope`). A Chrome-trace / Perfetto export is NOT a
+    speedscope profile - open those with tools/Open-PerfettoTrace.ps1.
+
+.PARAMETER Path
+    Path to the speedscope profile (.speedscope.json) to serve.
+
+.PARAMETER View
+    The speedscope view to open in: time-ordered, left-heavy, or sandwich.
+    Defaults to left-heavy.
+
+.PARAMETER Origin
+    The speedscope app origin. Defaults to https://www.speedscope.app.
+
+.PARAMETER Port
+    The loopback port to serve from. Defaults to 9002 (the Perfetto opener uses
+    9001).
+
+.PARAMETER Title
+    The profile title shown in the speedscope tab. Defaults to the file name.
+
+.PARAMETER TimeoutSeconds
+    Hard cap on how long the listener stays up waiting for the first fetch.
+    Defaults to 300.
+
+.PARAMETER NoOpenBrowser
+    Print the deep link instead of launching the browser (useful for testing).
+
+.EXAMPLE
+    ./tools/Open-SpeedscopeTrace.ps1 BenchmarkDotNet.Artifacts/flamegraphs/net10-nettrace.speedscope.json
+
+.EXAMPLE
+    ./tools/Open-SpeedscopeTrace.ps1 trace.speedscope.json -View sandwich
+
+.NOTES
+    The fully offline alternative is `npx -y speedscope <file>`, which embeds the
+    profile in a self-contained temp HTML but cannot set the initial view.
+    Companion: tools/Open-PerfettoTrace.ps1 for Chrome-trace / Perfetto exports.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$Path,
+    [ValidateSet("time-ordered", "left-heavy", "sandwich")]
+    [string]$View = "left-heavy",
+    [string]$Origin = "https://www.speedscope.app",
+    [int]$Port = 9002,
+    [string]$Title,
+    [int]$TimeoutSeconds = 300,
+    [switch]$NoOpenBrowser
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Path)) {
+    Write-Error "Profile file not found: $Path"
+    exit 1
+}
+
+$full = (Resolve-Path -LiteralPath $Path).Path
+$fname = [System.IO.Path]::GetFileName($full)
+if ([string]::IsNullOrWhiteSpace($Title)) {
+    $Title = $fname
+}
+
+# Strip any path/query from the origin so the CORS allow-origin is just scheme://host.
+$originUri = [System.Uri]$Origin
+$allowOrigin = "{0}://{1}" -f $originUri.Scheme, $originUri.Authority
+
+$profileUrl = "http://127.0.0.1:$Port/$([System.Uri]::EscapeDataString($fname))"
+$deepLink = "$allowOrigin/#profileURL=$([System.Uri]::EscapeDataString($profileUrl))" +
+    "&view=$View" +
+    "&title=$([System.Uri]::EscapeDataString($Title))"
+
+$listener = [System.Net.HttpListener]::new()
+$listener.Prefixes.Add("http://127.0.0.1:$Port/")
+try {
+    $listener.Start()
+}
+catch [System.Net.HttpListenerException] {
+    Write-Error ("Could not bind http://127.0.0.1:$Port/ - $($_.Exception.Message). " +
+        "Port $Port may be in use by a previous run.")
+    exit 1
+}
+
+Write-Host "Serving $fname on http://127.0.0.1:$Port/ (CORS origin $allowOrigin)" -ForegroundColor Cyan
+if ($NoOpenBrowser) {
+    Write-Host "Open in browser: $deepLink" -ForegroundColor Yellow
+}
+else {
+    Write-Host "Opening speedscope ($View view) with the profile preloaded..." -ForegroundColor Green
+    Start-Process $deepLink | Out-Null
+}
+
+$deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+$served = 0
+$task = $null
+try {
+    while ((Get-Date) -lt $deadline) {
+        if ($null -eq $task) {
+            $task = $listener.GetContextAsync()
+        }
+
+        # Poll the pending accept so the deadline is still checked while idle; the
+        # same task is reused across iterations so no accept operation leaks.
+        if (-not $task.Wait(1000)) {
+            continue
+        }
+
+        $context = $task.Result
+        $task = $null
+        $request = $context.Request
+        $response = $context.Response
+        try {
+            $response.Headers["Access-Control-Allow-Origin"] = $allowOrigin
+            $response.Headers["Cache-Control"] = "no-cache"
+
+            $requestPath = [System.Uri]::UnescapeDataString($request.Url.AbsolutePath)
+            if ($request.HttpMethod -eq "OPTIONS") {
+                # Preflight (only sent if speedscope ever makes a non-simple request).
+                $response.Headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
+                $response.Headers["Access-Control-Allow-Headers"] = "*"
+                $response.StatusCode = 204
+            }
+            elseif (($request.HttpMethod -in "GET", "HEAD") -and $requestPath -eq "/$fname") {
+                $bytes = [System.IO.File]::ReadAllBytes($full)
+                $response.ContentType = "application/json"
+                $response.ContentLength64 = $bytes.Length
+                if ($request.HttpMethod -eq "GET") {
+                    $response.OutputStream.Write($bytes, 0, $bytes.Length)
+                }
+
+                $served++
+                Write-Host ("Served {0} ({1:N0} bytes)" -f $fname, $bytes.Length) -ForegroundColor Green
+            }
+            else {
+                $response.StatusCode = 404
+            }
+        }
+        finally {
+            $response.Close()
+        }
+
+        # Once speedscope has fetched the profile it lives in browser memory; keep the
+        # listener up only a short grace window so a tab reload still works, then exit.
+        if ($served -eq 1) {
+            $grace = (Get-Date).AddSeconds(60)
+            if ($grace -lt $deadline) {
+                $deadline = $grace
+            }
+        }
+    }
+}
+finally {
+    $listener.Stop()
+    $listener.Close()
+}
+
+if ($served -eq 0) {
+    Write-Warning "speedscope never fetched the profile before the timeout. Was the browser blocked?"
+    exit 2
+}
+
+Write-Host "Done - profile delivered to speedscope ($View view)." -ForegroundColor Cyan

--- a/traceq/src/TraceQ.Mcp/TraceTools.cs
+++ b/traceq/src/TraceQ.Mcp/TraceTools.cs
@@ -447,6 +447,7 @@ public sealed class TraceTools
     /// <param name="format">The flame-graph format: <c>speedscope</c> or <c>chromium</c>.</param>
     /// <param name="name">The profile name embedded in the flame graph, shown in the viewer.</param>
     /// <param name="symbols">Optional build-output directory supplying embedded PDBs for line resolution.</param>
+    /// <param name="process">Optional process-name substring scoping a multi-process <c>.etl</c> to one process tree.</param>
     /// <returns>The export-confirmation envelope.</returns>
     [McpServerTool(Name = "trace_export", ReadOnly = false, Idempotent = true, OpenWorld = false, UseStructuredContent = true)]
     [Description(
@@ -454,8 +455,9 @@ public sealed class TraceTools
         + "off a visual. format=speedscope (the default) opens at speedscope.app; format=chromium writes the Chrome "
         + "Trace Event Format for chrome://tracing or the Perfetto UI. 'output' is the file path to write (required; "
         + "unlike the query tools this writes a file rather than returning the data, and overwrites an existing file "
-        + "at that path). The whole sample source is exported - no folding, scoping, or ranking. The response "
-        + "confirms the path, format, and byte count.")]
+        + "at that path). The whole sample source is exported - no folding or ranking. Pass 'process' to scope a "
+        + "machine-wide .etl to one process tree (as the ranking tools do); omit it to auto-scope to the busiest. "
+        + "The response confirms the path, format, and byte count.")]
     public static AnalysisResult<ExportResult> Export(
         TraceStore store,
         [Description("Path to a .speedscope.json, .nettrace, or .etl trace file.")] string path,
@@ -465,7 +467,11 @@ public sealed class TraceTools
         [Description(
             "Optional build-output directory whose assemblies' embedded portable PDBs are extracted so "
             + "managed frames resolve to source lines.")]
-        string symbols = "")
+        string symbols = "",
+        [Description(
+            "Optional process-name substring scoping a multi-process .etl capture to one process tree; omit "
+            + "to auto-scope to the busiest. Ignored for single-process .nettrace/speedscope traces.")]
+        string process = "")
     {
         bool chromium = ResolveExportFormat(format);
 
@@ -474,7 +480,7 @@ public sealed class TraceTools
             throw new McpException("output is required: the file path to write the flame graph to.");
         }
 
-        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols));
+        LoadedTrace trace = Load(store, path, NullIfEmpty(symbols), scope: ResolveScope(process));
         TraceInfo info = trace.Info;
 
         string exported = chromium

--- a/traceq/src/TraceQ/Cli/ExportExecutor.cs
+++ b/traceq/src/TraceQ/Cli/ExportExecutor.cs
@@ -14,10 +14,11 @@ namespace TraceQ.Cli;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   Export is a raw conversion of the whole sample source, so it takes no folding,
-///   scoping, or ranking options. Any symbol-resolution warning is written to the
-///   error writer rather than mixed into the flame-graph output, keeping the written
-///   JSON clean for the viewer.
+///   Export is a raw conversion of the sample source, so it takes no folding or
+///   ranking options; it does honor process scoping, so a machine-wide <c>.etl</c>
+///   can be narrowed to one process tree (as the ranking verbs do). Any
+///   symbol-resolution or scoping warning is written to the error writer rather than
+///   mixed into the flame-graph output, keeping the written JSON clean for the viewer.
 ///  </para>
 /// </remarks>
 internal static class ExportExecutor
@@ -31,7 +32,7 @@ internal static class ExportExecutor
     /// <returns>A process exit code (see <see cref="ExitCodes"/>).</returns>
     public static int Run(ExportRequest request, TextWriter output, TextWriter error)
     {
-        if (!TraceExecution.TryLoad(request.Path, request.Symbols, error, out LoadedTrace? trace))
+        if (!TraceExecution.TryLoad(request.Path, TraceMetric.Cpu, request.Symbols, error, out LoadedTrace? trace, request.Scope))
         {
             return ExitCodes.InputError;
         }

--- a/traceq/src/TraceQ/Cli/ExportRequest.cs
+++ b/traceq/src/TraceQ/Cli/ExportRequest.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using TraceQ.Tracing;
+
 namespace TraceQ.Cli;
 
 /// <summary>
@@ -13,9 +15,14 @@ namespace TraceQ.Cli;
 /// <param name="Output">The output file path, or <see langword="null"/> to write to standard output.</param>
 /// <param name="Symbols">Optional build-output directory whose embedded PDBs resolve managed frames.</param>
 /// <param name="Name">The profile name shown in the viewer.</param>
+/// <param name="Scope">
+///  The process scope: an explicit process tree, every process, or the automatic
+///  busiest-process default for a machine-wide <c>.etl</c>.
+/// </param>
 internal sealed record ExportRequest(
     string Path,
     ExportFormat Format,
     string? Output,
     string? Symbols,
-    string Name);
+    string Name,
+    ScopeRequest Scope);

--- a/traceq/src/TraceQ/Cli/TraceCommands.cs
+++ b/traceq/src/TraceQ/Cli/TraceCommands.cs
@@ -515,6 +515,8 @@ internal sealed class TraceCommands
     /// <param name="output">-o, Output file path; omit to write to standard output.</param>
     /// <param name="symbols">-s, Build-output directory whose embedded PDBs resolve managed frames.</param>
     /// <param name="name">Profile name shown in the viewer.</param>
+    /// <param name="process">Scope to the process tree whose name contains this; omit to auto-scope to the busiest.</param>
+    /// <param name="allProcesses">Read every process instead of auto-scoping to the busiest (multi-process captures).</param>
     /// <returns>A process exit code.</returns>
     [Command("export")]
     public int Export(
@@ -522,9 +524,17 @@ internal sealed class TraceCommands
         ExportFormat format = ExportFormat.Speedscope,
         string? output = null,
         string? symbols = null,
-        string name = "traceq")
+        string name = "traceq",
+        string process = "",
+        bool allProcesses = false)
     {
-        ExportRequest request = new(trace, format, output, symbols, name);
+        if (!RankRequestFactory.TryResolveScope(process, allProcesses, out ScopeRequest scope, out string? scopeError))
+        {
+            Console.Error.WriteLine(scopeError);
+            return ExitCodes.UsageError;
+        }
+
+        ExportRequest request = new(trace, format, output, symbols, name, scope);
         return ExportExecutor.Run(request, Console.Out, Console.Error);
     }
 

--- a/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/CliAppTests.cs
@@ -659,6 +659,34 @@ public sealed class CliAppTests
         exit.Should().Be(ExitCodes.Success);
         output.Should().Contain("--format");
         output.Should().Contain("--output");
+        output.Should().Contain("--process");
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Run_ExportProcessScope_OnMachineWideCapture_Narrows()
+    {
+        // The export verb scopes a multi-process ETW capture to a named process tree,
+        // mirroring cpu/rank/lines. The scope notice goes to the error stream so the
+        // exported JSON on stdout stays clean for a viewer. Reading an .etl is
+        // Windows-only, so this is guarded.
+        (int exit, string output, string error) = Run("export", Etw, "--process", "HotLoopBench-Job");
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("speedscope.app/file-format-schema");
+        error.Should().Contain("Scoped to the");
+    }
+
+    [TestMethod]
+    public void Run_ExportProcessAndAllProcesses_IsUsageError()
+    {
+        // The two scope options are mutually exclusive, matching the ranking verbs. The
+        // check runs before the trace loads, so the single-process speedscope fixture
+        // exercises it on every CI leg.
+        (int exit, _, string error) = Run("export", Speedscope, "--process", "x", "--all-processes");
+
+        exit.Should().Be(ExitCodes.UsageError);
+        error.Should().Contain("only one of --process and --all-processes");
     }
 
     [TestMethod]

--- a/traceq/tests/TraceQ.Cli.Tests/ExportExecutorTests.cs
+++ b/traceq/tests/TraceQ.Cli.Tests/ExportExecutorTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using TraceQ.Tracing;
+
 namespace TraceQ.Cli;
 
 [TestClass]
@@ -12,12 +14,15 @@ public sealed class ExportExecutorTests
 
     private static string Speedscope => FixturePath("folding.speedscope.json");
 
+    private static string Etw => FixturePath("etw.etl");
+
     private static ExportRequest Request(
         string path,
         ExportFormat format = ExportFormat.Speedscope,
         string? output = null,
-        string name = "traceq") =>
-        new(path, format, output, Symbols: null, name);
+        string name = "traceq",
+        ScopeRequest? scope = null) =>
+        new(path, format, output, Symbols: null, name, scope ?? ScopeRequest.Auto);
 
     private static (int Exit, string Out, string Error) Run(ExportRequest request)
     {
@@ -95,6 +100,22 @@ public sealed class ExportExecutorTests
 
         exit.Should().Be(ExitCodes.InputError);
         error.Should().NotBeEmpty();
+    }
+
+    [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Run_EtwScopedToProcess_WritesProfileAndWarns()
+    {
+        // Scoping the export to a named process tree narrows a machine-wide .etl, just
+        // as the ranking verbs do. The scope notice goes to the error writer so the
+        // flame-graph JSON on the output writer stays clean for a viewer. Reading an
+        // .etl is Windows-only, so this is guarded.
+        (int exit, string output, string error) =
+            Run(Request(Etw, scope: ScopeRequest.ForProcess("HotLoopBench-Job")));
+
+        exit.Should().Be(ExitCodes.Success);
+        output.Should().Contain("speedscope.app/file-format-schema");
+        error.Should().Contain("Scoped to the");
     }
 
     [TestMethod]

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -548,7 +548,7 @@ public sealed class TraceToolsTests
     }
 
     [TestMethod]
-    public void Export_ProcessScopeOnSpeedscope_IsHarmlessNoOp()
+    public void Export_ProcessScope_OnSpeedscope_IsHarmlessNoOp()
     {
         TraceStore store = new();
         string outputPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.speedscope.json");

--- a/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
+++ b/traceq/tests/TraceQ.Mcp.Tests/TraceToolsTests.cs
@@ -520,6 +520,60 @@ public sealed class TraceToolsTests
     }
 
     [TestMethod]
+    [OSCondition(OperatingSystems.Windows)]
+    public void Export_ProcessScope_OnMachineWideCapture_Warns()
+    {
+        TraceStore store = new();
+        string outputPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.speedscope.json");
+
+        try
+        {
+            // The export tool now scopes a multi-process ETW capture to a named process
+            // tree, mirroring the ranking tools; the scope notice surfaces in the envelope
+            // warnings. Reading an .etl is Windows-only, so this is guarded.
+            AnalysisResult<ExportResult> envelope =
+                TraceTools.Export(store, FixturePath(Etw), outputPath, process: "HotLoopBench-Job");
+
+            File.Exists(outputPath).Should().BeTrue();
+            AssertEnvelope(envelope);
+            envelope.Warnings.Should().Contain(w => w.Contains("Scoped to the"));
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Export_ProcessScopeOnSpeedscope_IsHarmlessNoOp()
+    {
+        TraceStore store = new();
+        string outputPath = Path.Combine(Path.GetTempPath(), $"{Path.GetRandomFileName()}.speedscope.json");
+
+        try
+        {
+            // Speedscope is single-process, so a process selector is a no-op: the export
+            // still succeeds and writes the file.
+            AnalysisResult<ExportResult> envelope =
+                TraceTools.Export(store, FixturePath(Speedscope), outputPath, process: "anything");
+
+            File.Exists(outputPath).Should().BeTrue();
+            AssertEnvelope(envelope);
+            envelope.Result.Format.Should().Be("speedscope");
+        }
+        finally
+        {
+            if (File.Exists(outputPath))
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+
+    [TestMethod]
     public void Export_UnknownFormat_Throws()
     {
         TraceStore store = new();


### PR DESCRIPTION
## Summary

Three related improvements to the `traceq` trace-analysis workflow and the `performance-testing` skill, all arising from a glob-enumeration profiling investigation.

### traceq: process-scoped `export`

`export` was the only CPU verb that could not scope a machine-wide `.etl` to one process, so it captured whichever process was busiest (e.g. the editor) instead of the benchmark. This adds `--process` / `--all-processes` to the CLI `export` verb and a `process` argument to the `trace_export` MCP tool, mirroring `cpu` / `rank` / `lines`. Scoping a real ETL to `touki.perf` cut noise (6.1 -> 4.1 MB) and doubled symbol resolution (19% -> 33%). Covered by new CLI- and MCP-surface tests (513 traceq tests pass).

### tools: hands-free flame-graph viewers

- `tools/Open-SpeedscopeTrace.ps1` - serves a speedscope profile from a one-shot loopback HTTP listener and opens speedscope.app with the profile loaded and a chosen view active (default **Left Heavy**). Fills the gap the offline `npx speedscope` CLI cannot (it always opens in Time Order).
- `tools/Open-PerfettoTrace.ps1` - same loopback approach for a Chrome-trace/Perfetto export, opening the Perfetto UI with the `traceq` track expanded and pinned via `startupCommands`. Reproduces Perfetto's own `open_trace_in_ui`.

Both serve once then self-exit; nothing is uploaded (the trace stays on `127.0.0.1`).

### performance-testing skill

- **EventPipe-vs-ETW inlining attribution** (`profiling.md`): a fully-inlined callee's self-time is credited to its *physical host* method on an EventPipe `.nettrace` but to the real *inlinee* under ETW. Proven on one binary: `ProduceAlternative` drew **98** EventPipe leaf samples vs **11,516** under ETW. Duration cannot fix this - only ETW (or a NoInlining probe) reattributes it.
- **`graphical-viewers.md`** (new sub-page): when a rich interactive viewer is worth offering vs the direct `trace_lines` / `trace_heatmap` drill (drill first), which viewer to pick by export format, how to launch hands-free, and how to guide the user once it is open - plus the caveats (Perfetto slice `dur` is inclusive, single aggregate track, speedscope has no scope deep-link).
- **Reading the line ranking** (`profiling.md`): a prologue-dominated method ranking means *called too often* (call-count-bound), and a helper recurring across branches beats any single top line - with a trace-freshness check before reusing an existing capture.

## Testing

- `dotnet test traceq/traceq.slnx -c Release` - 513 passed, 0 failed.
- `tools/Validate-AgentFiles.ps1` passes.

## Not included

`docs/perf-analyzer-proposals.md` is intentionally excluded from this PR per the request.
