### PR TITLE
Make LICENSE classify as MIT; add NOTICE and SECURITY.md

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The MIT License (MIT)
+MIT License
 
 Copyright (c) 2025 Jeremy W. Kuhne and contributors
 
@@ -10,11 +10,7 @@ copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software unless it is used for .NET
-Foundation projects, in which case attribution is only needed in commit and
-pull request text. Other Microsoft projects (open or closed) may also follow
-the .NET Foundation exclusion as long as it was included in pull requests created
-when the author is employed by Microsoft.
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,23 @@
+touki
+Copyright (c) 2025 Jeremy W. Kuhne and contributors
+
+This product is licensed under the MIT License (see LICENSE).
+
+Third-party components redistributed with this project are attributed separately
+in THIRD-PARTY-NOTICES.TXT.
+
+Additional permission granted by the copyright holder
+-----------------------------------------------------
+
+In addition to the permissions granted by the MIT License, Jeremy W. Kuhne, as
+the copyright holder, grants the following relaxation of the attribution
+requirement (the requirement that the copyright and permission notice be
+included in all copies or substantial portions of the Software):
+
+  When this software is used in .NET Foundation projects, attribution is only
+  needed in commit and pull request text. Other Microsoft projects (open or
+  closed) may also follow this .NET Foundation exclusion as long as it was
+  included in pull requests created when the author is employed by Microsoft.
+
+This is an additional permission only: it grants more latitude than the MIT
+License and removes none of the rights the MIT License already provides.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-touki
+Touki
 Copyright (c) 2025 Jeremy W. Kuhne and contributors
 
 This product is licensed under the MIT License (see LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ Include, as far as you can:
 - steps to reproduce, ideally with a minimal code sample or input;
 - any known workaround.
 
-touki is a low-level library whose APIs parse and transform untrusted input -
+Touki is a low-level library whose APIs parse and transform untrusted input -
 glob and extended-glob patterns, format strings, path strings, and spans of
 bytes/chars. Parsing and decoding issues triggered by crafted input - crashes,
 unbounded allocation, catastrophic backtracking, or other denial-of-service
@@ -24,8 +24,9 @@ shapes - are in scope, on both the .NET 10 and .NET Framework 4.7.2 targets.
 
 ## Supported versions
 
-Fixes are applied to the latest release from the `main` branch. There is no
-long-term back-port stream; upgrade to the newest `KlutzyNinja.Touki` /
+Security fixes land on the `main` branch and ship in the next release. Only the
+latest released version line is supported; there is no long-term back-port
+stream, so upgrade to the newest `KlutzyNinja.Touki` /
 `KlutzyNinja.Touki.TestSupport` release to pick up a security fix.
 
 ## Response

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately - not in public issues.
+
+Use GitHub's private vulnerability reporting: open the **Security** tab of this
+repository and choose **Report a vulnerability**, or go directly to
+<https://github.com/JeremyKuhne/touki/security/advisories/new>. This opens a
+private advisory visible only to the maintainer.
+
+Include, as far as you can:
+
+- a description of the issue and its impact;
+- the version (NuGet package or commit) affected;
+- steps to reproduce, ideally with a minimal code sample or input;
+- any known workaround.
+
+touki is a low-level library whose APIs parse and transform untrusted input -
+glob and extended-glob patterns, format strings, path strings, and spans of
+bytes/chars. Parsing and decoding issues triggered by crafted input - crashes,
+unbounded allocation, catastrophic backtracking, or other denial-of-service
+shapes - are in scope, on both the .NET 10 and .NET Framework 4.7.2 targets.
+
+## Supported versions
+
+Fixes are applied to the latest release from the `main` branch. There is no
+long-term back-port stream; upgrade to the newest `KlutzyNinja.Touki` /
+`KlutzyNinja.Touki.TestSupport` release to pick up a security fix.
+
+## Response
+
+This is an open-source project maintained on a best-effort basis. You can expect
+an initial acknowledgement; please allow a reasonable window for a fix before any
+public disclosure.


### PR DESCRIPTION
Brings touki's license metadata and security policy in line with the conventions just applied to the filtrace repo.

## Changes

- **`LICENSE`** - replaced with the canonical SPDX MIT text so GitHub classifies it as **MIT**. It was showing as "Other" because the .NET Foundation attribution-exclusion clause was appended inline to the MIT body. Both packages already declare `PackageLicenseExpression=MIT` and do **not** pack the license file, so this only makes the repo file agree with the metadata consumers already see - nothing in the shipped packages changes.
- **`NOTICE`** (new) - preserves the .NET Foundation exclusion **verbatim**, restated as a standalone additional grant from the copyright holder (adds permission beyond MIT, removes none of MIT's rights). Cross-references `THIRD-PARTY-NOTICES.TXT`, which keeps its distinct role of attributing redistributed third-party code.
- **`SECURITY.md`** (new) - private vulnerability reporting via GitHub advisories. The untrusted-input parsing surface (glob / extended-glob patterns, format strings, path strings, byte/char spans) and DoS shapes (crashes, unbounded allocation, catastrophic backtracking) are called out as in scope on both the net10 and net481 targets.

## Notes

- The MIT badge appears once this lands on `main`.
- Mirrors the same change made in the filtrace repo for consistency.