### PR TITLE
Migrate traceq docs and skills to filtrace

### DIFF
--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -23,7 +23,7 @@ question; they are complementary, not interchangeable.
 | Source | `IOperation` (pre-lowering) | `roslyn-analyzers` (TOUKI0002-0004) | A copy is *predicted* from C# rules, live in the IDE |
 | **IL** | **compiled bytecode (post-lowering)** | **this skill** (`ildasm` / `ilspycmd` / Cecil) | **A copy was *emitted* by the C# compiler** |
 | Asm | JIT machine code | `framework-jit-optimization` + `DisassemblyDiagnoser` | Whether the JIT *kept* the copy or elided it |
-| Runtime | ETW / wall-clock | `performance-testing` + `traceq` | Whether the copy *costs* measurable time / allocation |
+| Runtime | ETW / wall-clock | `performance-testing` + `filtrace` | Whether the copy *costs* measurable time / allocation |
 
 The IL layer is uniquely able to see copies the **compiler synthesizes during
 lowering** - async / iterator state-machine field hoisting, closures, thunks -
@@ -62,7 +62,7 @@ defensive-copy signature, the analyzer was right.
 4. **Map IL offset to source.** Use the PDB sequence points (most disassemblers can
    interleave source, e.g. `ilspycmd -il` with debug info, or read sequence points
    via `System.Reflection.Metadata`) to attribute each copy to a line - the same
-   artifact-to-source drill the `performance-testing` skill does with `traceq`.
+   artifact-to-source drill the `performance-testing` skill does with `filtrace`.
 5. **Report** the type copied, the mechanism (defensive / box / by-value), and the
    source line. Distinguish *intended* copies (a documented value transfer) from
    *unintended* ones; IL alone cannot, so use the source context.

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-testing
-description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project, and translate a user's outcome-shaped performance question into a measurement. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `traceq` trace analyzer), visualizing a trace as an interactive flame graph in speedscope or Perfetto, evaluating allocations / memory usage, or when a user asks how long something takes, how much memory it uses, where time is spent, or to help make a method faster - which this skill turns into a scenario, a benchmark, and a drill-down.
+description: Author and run BenchmarkDotNet performance tests in the `touki.perf` project, and translate a user's outcome-shaped performance question into a measurement. Use when adding new benchmarks, running existing ones, comparing implementations, profiling to find which method dominates a benchmark, drilling from a benchmark down to the hot source line (via the `filtrace` trace analyzer), visualizing a trace as an interactive flame graph in speedscope or Perfetto, evaluating allocations / memory usage, or when a user asks how long something takes, how much memory it uses, where time is spent, or to help make a method faster - which this skill turns into a scenario, a benchmark, and a drill-down.
 metadata:
   portability: semi-portable
 ---
@@ -116,7 +116,7 @@ sharplab, BenchmarkDotNet's `[DisassemblyDiagnoser]` / `[HardwareCounters]`, the
 - [running.md](running.md) - the `-f <tfm>` requirement, filtering to a class or
   method, the interactive picker, and useful switches.
 - [profiling.md](profiling.md) - capturing an EventPipe trace and drilling it
-  with the `traceq` analyzer from operation to method to line, and *reading* the
+  with the `filtrace` analyzer from operation to method to line, and *reading* the
   line ranking (prologue-dominated = call-count-bound; a helper recurring across
   branches = the real target).
 - [graphical-viewers.md](graphical-viewers.md) - the *optional* last step:

--- a/.agents/skills/performance-testing/graphical-viewers.md
+++ b/.agents/skills/performance-testing/graphical-viewers.md
@@ -8,7 +8,7 @@ flame-graph viewer for a human.
 
 ## Reach for the direct drill first
 
-The traceq tools answer "where is the time" at line precision, in text, with no
+The filtrace tools answer "where is the time" at line precision, in text, with no
 viewer literacy required - so they are the practical default, and the thing to
 offer before a graphical viewer:
 
@@ -38,13 +38,13 @@ insight, or the user wants to explore interactively. Good moments:
 - **Exploring an unfamiliar method** whose call structure you do not yet know -
   clicking down the hot path interactively beats guessing `--method` filters.
 - **Handing a visual to someone else** (a PR reviewer, an issue) who will not run
-  traceq.
+  filtrace.
 
 If none of those apply, stay in the direct drill.
 
 ## Pick the viewer by export format
 
-traceq's `export` writes either format; the viewer follows from it. **Scope a
+filtrace's `export` writes either format; the viewer follows from it. **Scope a
 machine-wide `.etl` when you export** - pass `--process <name>` (CLI) or the
 `process` argument (the `trace_export` MCP tool), exactly as the ranking verbs
 do, or the export captures whichever process was busiest (a background app, not
@@ -103,7 +103,7 @@ user to:
 - use the search box (the magnifier) to filter frames by name - this is a UI
   control, not a URL parameter, so it cannot be preset.
 
-**Perfetto** shows the flame graph under the pinned `traceq` track (the opener
+**Perfetto** shows the flame graph under the pinned `filtrace` track (the opener
 expands and pins it). Tell the user to:
 
 - drag-select a time region, then read the per-frame breakdown in the bottom
@@ -112,16 +112,16 @@ expands and pins it). Tell the user to:
 
 ## Caveats that will mislead if unsaid
 
-- **Perfetto slice durations are inclusive, not self-time.** traceq's chromium
+- **Perfetto slice durations are inclusive, not self-time.** filtrace's chromium
   export reconstructs begin/end slices from the samples, so a frame's `dur` (and
   any `SUM(dur)` SQL) is inclusive of its callees. For self-time, trust
   `trace_rank` / `trace_lines` - do not read a Perfetto SQL sum as self-time.
-- **traceq exports a single aggregate track.** The engine's rankings aggregate
+- **filtrace exports a single aggregate track.** The engine's rankings aggregate
   across threads, so the flame graph is one synthetic thread named by the
-  export's `--name` (default `traceq`), not the real per-thread timeline. It is a
+  export's `--name` (default `filtrace`), not the real per-thread timeline. It is a
   flame graph, not a scheduling view.
 - **speedscope cannot deep-link a scope** - only the view. To focus a frame the
   user clicks it; there is no preset frame filter.
 - **A flame graph is not the source of truth for a number.** It is for *shape*
-  and *exploration*; quote the hot line/percentage from the traceq drill, which
+  and *exploration*; quote the hot line/percentage from the filtrace drill, which
   folds the sampling artifacts the raw flame graph still shows.

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -4,9 +4,9 @@ Detail for the [performance-testing](SKILL.md) skill.
 
 To find where a benchmark spends its time - optimizing a hot path or chasing a
 regression - capture an EventPipe CPU trace on `net10.0`, then drill it with the
-in-workspace [traceq](../../../traceq/README.md) analyzer. It reads the trace
-through TraceEvent, folds the JIT-helper sampling artifacts, and ranks by method
-or by source `file:line`. traceq is registered as an MCP server in
+standalone [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer. It reads
+the trace through TraceEvent, folds the JIT-helper sampling artifacts, and ranks
+by method or by source `file:line`. filtrace is registered as an MCP server in
 [.vscode/mcp.json](../../../.vscode/mcp.json), so **an agent calls its tools
 directly** - `trace_info` first, then `trace_rank` / `trace_callers` /
 `trace_lines` / `trace_heatmap`. The equivalent CLI verbs (below) are the manual
@@ -24,14 +24,19 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
 # The exact build BDN profiled - its PDB GUID matches the trace:
 $sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
 
+# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), cloned
+# beside touki at ../filtrace; run it from that checkout. Once filtrace is
+# published to NuGet, `dotnet tool install -g KlutzyNinja.Filtrace` lets you call
+# `filtrace <verb>` directly instead. (The MCP tools above need neither.)
+
 # Method ranking, scoped to a workload frame (which method owns the self-time).
-dotnet run --project traceq/src/TraceQ -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
 
 # Line ranking inside the dominant method (which lines of its hot loop dominate).
-dotnet run --project traceq/src/TraceQ -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
+dotnet run --project ../filtrace/src/Filtrace -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
 
 # Who calls a folded JIT-helper artifact, to confirm what it's attributable to.
-dotnet run --project traceq/src/TraceQ -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
+dotnet run --project ../filtrace/src/Filtrace -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
 ```
 
 The MCP tools map onto those verbs one-to-one: `trace_rank` (with
@@ -116,18 +121,18 @@ self-elevates (one UAC prompt), shows the benchmark's **live** progress in the
 elevated window (output is teed, never redirected with `*>`, so it never looks
 hung), checks that the `BenchmarkDotNet.Diagnostics.Windows` package is
 referenced - without it `-p ETW` silently no-ops - and prints the exact,
-process-scoped next-step traceq commands:
+process-scoped next-step filtrace commands:
 
 ```powershell
 ./tools/Capture-EtwTrace.ps1 -Filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingle'
 ```
 
-**An `.etl` is a machine-wide capture - scope it to your process.** traceq
+**An `.etl` is a machine-wide capture - scope it to your process.** filtrace
 auto-scopes to the busiest process *by CPU sample count* (the quantity the
 rankings consume), which is normally the benchmark; but a noisy background app
 (antivirus, a VPN client) can own enough samples to win, so pass `--process <name>`
 to pin it. **Every CPU verb takes it** - `cpu`, `rank`, `threadtime`, `lines`,
-`callers`, `heatmap` (and the matching `trace_*` MCP tools). `traceq processes
+`callers`, `heatmap` (and the matching `trace_*` MCP tools). `filtrace processes
 <etl>` lists every process by weight so you can choose the right target. Quiesce
 other CPU consumers before capturing, or scope explicitly.
 

--- a/docs/performance-investigation-without-mcp.md
+++ b/docs/performance-investigation-without-mcp.md
@@ -1,8 +1,8 @@
-# Profiling without the `traceq` server
+# Profiling without the `filtrace` MCP server
 
 The primary way to turn a captured benchmark trace into ranked hotspots and
-line-level attribution is the in-workspace
-[traceq](../traceq/README.md) analyzer - see
+line-level attribution is the standalone
+[filtrace](https://github.com/JeremyKuhne/filtrace) analyzer - see
 [performance-investigation.md](performance-investigation.md) sections 3a, 3f,
 and 6.
 
@@ -58,6 +58,6 @@ mandatory before trusting any self-time number.
 ## Line-level attribution
 
 The scripts stop at the method. For line-level (`file:line`) attribution there
-is **no script fallback** - it requires the `traceq` analyzer reading a
+is **no script fallback** - it requires the `filtrace` analyzer reading a
 `.nettrace`/`.etl` with the matching PDB. See
 [performance-investigation.md](performance-investigation.md) section 3f.

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -36,7 +36,7 @@ flowchart TD
     B -->|"Is impl A faster than B?"| C[BenchmarkDotNet A/B<br/>MemoryDiagnoser + Baseline]
     B -->|"Does this allocate?"| D[BenchmarkDotNet<br/>MemoryDiagnoser - read Allocated]
     B -->|"Which method eats the time<br/>in a whole operation?"| E[Profiler: EventPipeProfiler<br/>or dotnet-trace -> speedscope]
-    B -->|"Which source LINE inside<br/>the hot method?"| M[traceq lines<br/>.nettrace + --symbols]
+    B -->|"Which source LINE inside<br/>the hot method?"| M[filtrace lines<br/>.nettrace + --symbols]
     B -->|"Why is THIS loop slow<br/>on net481?"| F[DisassemblyDiagnoser<br/>compare net481 vs net10 asm]
     B -->|"Branch mispredicts / cache?"| G[HardwareCounters<br/>Windows + admin]
     C --> H[Read *.md report only]
@@ -58,7 +58,7 @@ Rule of thumb for picking the entry point:
 | "A vs B", "did my change regress?" | BenchmarkDotNet `[Benchmark]` + `Baseline` | low |
 | "Does X allocate? how much?" | BenchmarkDotNet `[MemoryDiagnoser]` | low |
 | "Where in a multi-method operation is the time?" | `[EventPipeProfiler]` or `dotnet-trace` | medium |
-| "Which source *line* inside the hot method?" | `traceq` `lines` (`.nettrace` + `--symbols`) | medium |
+| "Which source *line* inside the hot method?" | `filtrace` `lines` (`.nettrace` + `--symbols`) | medium |
 | "Why does the JIT emit slow code here?" | `[DisassemblyDiagnoser]` | medium |
 | "Is it branch misprediction / cache misses?" | `[HardwareCounters]` (Win+admin) | medium |
 | "Does it leak / churn the GC over a long run?" | `dotnet-counters`, `dotnet-gcdump` | medium |
@@ -256,11 +256,11 @@ It writes a `.speedscope.json` (and `.nettrace`) under
 <https://www.speedscope.app/> (drag-drop, nothing to install) to get a flame
 graph. Cross-platform, works on Linux/macOS/Windows, **no admin required**.
 
-#### Capture a trace, then rank hotspots (traceq)
+#### Capture a trace, then rank hotspots (filtrace)
 
 Capturing the trace and *reading* it are two steps. Capture is a plain
 `dotnet run`; the ranked, artifact-folded self/inclusive hotspots come from the
-in-workspace [traceq](../traceq/README.md) analyzer (section 6), which reads the
+standalone [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer (section 6), which reads the
 trace BenchmarkDotNet just wrote - no GUI, no PerfView:
 
 ```powershell
@@ -274,14 +274,14 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
     Sort-Object LastWriteTime | Select-Object -Last 1).FullName
 
 # 2. Folded self-time + inclusive-time rankings, scoped to a workload frame.
-dotnet run --project traceq/src/TraceQ -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
 
 # Confirm what a folded JIT-helper artifact is attributable to:
-dotnet run --project traceq/src/TraceQ -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
+dotnet run --project ../filtrace/src/Filtrace -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
 ```
 
 An agent that speaks MCP calls `trace_rank` (with `measure: self|inclusive`) /
-`trace_callers` directly on the registered `traceq` server (section 6) instead
+`trace_callers` directly on the registered `filtrace` server (section 6) instead
 of shelling out.
 
 > The committed PowerShell scripts (`Profile-Benchmark.ps1`,
@@ -292,7 +292,7 @@ of shelling out.
 > [performance-investigation-without-mcp.md](performance-investigation-without-mcp.md).
 
 For line-level attribution on the same trace - which *source line* inside the
-ranked method dominates - hand the `.nettrace` to `traceq` with the `lines` verb
+ranked method dominates - hand the `.nettrace` to `filtrace` with the `lines` verb
 (section 3f). This has no script fallback.
 
 > **Reading the BenchmarkDotNet speedscope export - two traps.**
@@ -413,7 +413,7 @@ samples for a stable ranking. Levers that actually help, cheapest first:
   count already helps; an operation that runs for seconds (like the 25 s
   extglob enumeration here) yields thousands of samples and a stable tree.
 - **Fold the artifacts** (section 3a, Trap 2). This is the single biggest
-  accuracy win for *attribution* and costs nothing - the `traceq` analyzer
+  accuracy win for *attribution* and costs nothing - the `filtrace` analyzer
   (and the fallback scripts) do it by default.
 - **Split a suspect frame with `[MethodImpl(MethodImplOptions.NoInlining)]`.**
   If two methods are inlined together the sampler cannot tell them apart;
@@ -423,7 +423,7 @@ samples for a stable ranking. Levers that actually help, cheapest first:
   stdout - token-cheap for an agent, and it reads the same `.nettrace`.
 - **PerfView headless** (`PerfView /FoldPats=... stacks ...`) does the same fold
   the analyzer does, with richer grouping, when you already have PerfView. The
-  `traceq` analyzer exists so the common case needs neither PerfView nor a
+  `filtrace` analyzer exists so the common case needs neither PerfView nor a
   GUI.
 - **Want true CPU time and native frames?** EventPipe gives neither. On Windows
   use `[EtwProfiler]` (section 3b, admin). On Linux - including **WSL Ubuntu on
@@ -449,18 +449,18 @@ Stabilize the JIT **for clean attribution, not for absolute numbers**:
 - Do **not** chase JIT stability for a microbenchmark whose numbers you care
   about - measure those with the normal tiered harness.
 
-### 3f. Layer 2b - from the hot method down to the hot *line* (`traceq`)
+### 3f. Layer 2b - from the hot method down to the hot *line* (`filtrace`)
 
-The profilers above rank *methods*. The committed
-[traceq](../traceq/README.md) project takes the same trace one
+The profilers above rank *methods*. The standalone
+[filtrace](https://github.com/JeremyKuhne/filtrace) project takes the same trace one
 level deeper: it reads the `.nettrace`/`.etl` through TraceEvent and attributes
 each leaf sample to the **source `file:line` that was executing**, so you can
 see which lines of a hot loop dominate. It is net10-only and runs two ways:
 
-- **Console front end** - `dotnet run --project traceq/src/TraceQ -c Release -- <verb>`.
+- **Console front end** - `dotnet run --project ../filtrace/src/Filtrace -c Release -- <verb>`.
 - **MCP server** - the same queries exposed as tools (`trace_info`,
   `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
-  registered `traceq` server for an agent that speaks MCP. See section 6.
+  registered `filtrace` server for an agent that speaks MCP. See section 6.
 
 The top-down loop on a single captured trace:
 
@@ -476,10 +476,10 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
 $sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
 
 # 1. Method ranking (self + inclusive), JIT-helper artifacts folded.
-dotnet run --project traceq/src/TraceQ -c Release -- cpu $trace --symbols $sym --top 20
+dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu $trace --symbols $sym --top 20
 
 # 2. Line ranking inside the dominant method.
-dotnet run --project traceq/src/TraceQ -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
+dotnet run --project ../filtrace/src/Filtrace -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
 ```
 
 Verbs and flags: `cpu`/`rank` rank methods (`--root <substr>` scopes to a
@@ -604,10 +604,10 @@ but unmatched depth. Pairs with `dotnet-trace`'s `.nettrace` output too.
 
 ## 6. MCP servers and programmatic API access
 
-### The in-workspace profiling MCP server: `traceq`
+### The profiling MCP server: `filtrace`
 
-This workspace ships a dedicated trace-analysis MCP server,
-[traceq](../traceq/README.md) (net10-only), registered in
+This workspace registers a dedicated trace-analysis MCP server,
+[filtrace](https://github.com/JeremyKuhne/filtrace) (net10-only), in
 [.vscode/mcp.json](../.vscode/mcp.json). It reads the same
 `.nettrace`/`.etl`/`.speedscope.json` traces the diagnosers and `dotnet-trace`
 produce, folds the JIT-helper sampling artifacts (section 3a, Trap 2), and
@@ -667,8 +667,8 @@ A concrete, token-efficient loop an agent should follow:
    `*-report-github.md`, quote only `Mean`/`Ratio`/`Allocated` for changed rows.
 6. **If the bottleneck is unclear**, attach `[EventPipeProfiler(CpuSampling)]`,
    capture a trace (`dotnet run ... --filter *<Subject>* -p EP --keepFiles` on
-   **net10.0**), then rank it with the `traceq` analyzer
-   (`dotnet run --project traceq/src/TraceQ -c Release -- cpu <trace> --root
+   **net10.0**), then rank it with the `filtrace` analyzer
+   (`dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu <trace> --root
    <workload-frame>`, or the `trace_rank` MCP tool; the
    PowerShell scripts in
    [performance-investigation-without-mcp.md](performance-investigation-without-mcp.md)
@@ -680,7 +680,7 @@ A concrete, token-efficient loop an agent should follow:
    EventPipe is net10.0-only; for net481 on-CPU attribution use `[EtwProfiler]`
    (admin) - see the per-TFM table in &sect;3.
 7. **If you need the hot *line*, not just the hot method**, feed the same
-   `.nettrace` to `traceq`: `dotnet run --project traceq/src/TraceQ -c Release --
+   `.nettrace` to `filtrace`: `dotnet run --project ../filtrace/src/Filtrace -c Release --
    lines <trace> --method <method> --symbols <build-dir> --top 30` (or the
    `trace_lines` MCP tool). Capture with `--keepFiles` and point `--symbols` at
    BDN's surviving `...-DefaultJob-N/bin/Release/net10.0` so the PDB GUID
@@ -717,15 +717,15 @@ A/B + allocations ............ dotnet run -c Release -f <tfm> --project touki.pe
 Fast smoke ................... add --job short
 Read the result .............. BenchmarkDotNet.Artifacts/results/*-report-github.md
 Capture a trace .............. dotnet run -c Release -f net10.0 --project touki.perf -- --filter *X* -p EP --keepFiles
-Rank an existing trace ....... dotnet run --project traceq/src/TraceQ -c Release -- cpu <trace> --root <workload-frame>
+Rank an existing trace ....... dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu <trace> --root <workload-frame>
                                folds JIT-helper artifacts + ranks self/inclusive. callers <frame> = who calls it.
 No-server fallback scripts ... ./tools/Profile-Benchmark.ps1 / Get-TraceHotspots.ps1 (see *-without-mcp.md)
 Flame-graph SVG .............. ./tools/speedscope-to-flamegraph.ps1   (or drag the speedscope into speedscope.app)
-Which source LINE? ........... dotnet run --project traceq/src/TraceQ -c Release -- lines <trace> --method <method> --symbols <build-dir>
+Which source LINE? ........... dotnet run --project ../filtrace/src/Filtrace -c Release -- lines <trace> --method <method> --symbols <build-dir>
                                net10 .nettrace/.etl + embedded PDB. Capture with --keepFiles; point --symbols
                                at BDN's ...-DefaultJob-N/bin/Release/net10.0 (PDB GUID must match the trace).
                                Inlined callee -> samples collapse on the call-site line; drill the tail. See 3f.
-traceq as an MCP server ...... tools: trace_info / trace_rank / trace_callers / trace_lines / trace_heatmap / trace_diff / trace_gc / trace_query_events / trace_export
+filtrace as an MCP server .... tools: trace_info / trace_rank / trace_callers / trace_lines / trace_heatmap / trace_diff / trace_gc / trace_query_events / trace_export
 Where's the time? (in-harness) [EventPipeProfiler(EventPipeProfile.CpuSampling)] -> speedscope.app
                                net10.0 only (no admin); net481 needs [EtwProfiler] (admin) -> .etl
                                FOLD BulkMoveWithWriteBarrier/PollGC/CPU_TIME before reading self-time.

--- a/docs/traceq-etl-trimming.md
+++ b/docs/traceq-etl-trimming.md
@@ -1,5 +1,11 @@
 # traceq ETL trimming - state and follow-up
 
+> **Historical record.** Refers to `traceq`, the trace analyzer since promoted to
+> the standalone **`filtrace`** repository
+> ([github.com/JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)).
+> The `traceq/...` paths below are from the in-touki incubation phase. Kept as a
+> design record; the narrative is not rewritten.
+
 Status: parked (2026-06-07). This document captures the full state of the
 physical ETW trace-trimming investigation so it can be picked up later. The
 lossless analysis-time alternative (process-tree scoping in the ETL reader) is

--- a/docs/traceq-implementation-plan.md
+++ b/docs/traceq-implementation-plan.md
@@ -1,5 +1,13 @@
 # `traceq` implementation plan
 
+> **Historical record.** This plan tracked the design and extraction of the
+> `traceq` trace analyzer, which shipped and was promoted on 2026-06-14 to its
+> own standalone repository as **`filtrace`**
+> ([github.com/JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)).
+> The `traceq/...` paths and the `traceq` / `TraceQ` names below describe the
+> in-touki incubation phase; see the filtrace repo for the final form. Kept here
+> as the decision record - the narrative is intentionally not rewritten.
+
 **Status:** Active — Q1–Q3 resolved (§6)
 **Dogfooding hardening (2026-06-10):** A real net481 ETW profiling session folded
 its findings back into the tool - see [§7](#7-dogfooding-hardening-2026-06-10-etw-capture-process-scoping-and-the-runtime-symbol-plan).

--- a/docs/traceq-local-demo.md
+++ b/docs/traceq-local-demo.md
@@ -120,9 +120,9 @@ benchmark/trace rather than starting over.
 If you just want to exercise the analysis tools against a trace that already
 exists, point the agent at a committed fixture and ask:
 
-> - **Prompt:** What's in `..\filtrace\tests\Filtrace.Core.Tests\Fixtures\folding.speedscope.json`, and is anything obviously off? (`trace_info` - resolution rate, threads)
+> - **Prompt:** What's in `../filtrace/tests/Filtrace.Core.Tests/Fixtures/folding.speedscope.json`, and is anything obviously off? (`trace_info` - resolution rate, threads)
 > - **Prompt:** Where's the CPU time in that trace? (`trace_rank` cpu, then a steer toward the hottest frame's callers)
-> - **Prompt:** What's allocating the most in `..\filtrace\tests\Filtrace.Core.Tests\Fixtures\alloc.nettrace`? (`trace_rank` alloc - answered in **bytes**, not time)
+> - **Prompt:** What's allocating the most in `../filtrace/tests/Filtrace.Core.Tests/Fixtures/alloc.nettrace`? (`trace_rank` alloc - answered in **bytes**, not time)
 
 ---
 

--- a/docs/traceq-local-demo.md
+++ b/docs/traceq-local-demo.md
@@ -1,6 +1,6 @@
-# traceq manual demo - user-oriented prompts
+# filtrace manual demo - user-oriented prompts
 
-A short, manual follow-along for exercising **traceq** from Copilot Chat the way
+A short, manual follow-along for exercising **filtrace** from Copilot Chat the way
 a real touki developer actually talks to it: outcome questions - "how long does
 this take?", "how much does it allocate?", "where's the time going?", "make this
 faster?" - not tool-by-tool instructions.
@@ -16,16 +16,17 @@ faster?" - not tool-by-tool instructions.
 
 ## Setup (one time)
 
-Build the MCP server and register it, then start it from the Command Palette
-(*MCP: List Servers* -> `traceq` -> *Start Server*):
+filtrace lives in its own repo (github.com/JeremyKuhne/filtrace), cloned beside
+touki at `../filtrace`. Build the MCP server and register it, then start it from
+the Command Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*):
 
 ```pwsh
-dotnet build traceq/src/TraceQ.Mcp/TraceQ.Mcp.csproj -c Release
+dotnet build ../filtrace/src/Filtrace.Mcp/Filtrace.Mcp.csproj -c Release
 ```
 
 The server entry lives in [.vscode/mcp.json](../.vscode/mcp.json) (rebuild the
-DLL and restart the server after changing traceq). Confirm nine `trace_*` tools
-register in the chat tool picker.
+DLL and restart the server after changing filtrace). Confirm the 13 `trace_*`
+tools register in the chat tool picker.
 
 ---
 
@@ -81,7 +82,7 @@ glob case it was: a method that was ~1.5% on net10 was ~56% on net481. A bare
 
 > **Prompt:** That ETW capture is machine-wide. How do I make sure we're looking at the benchmark and not something else running on my box?
 
-**Good:** the agent runs `traceq processes <etl>` to list the processes by weight,
+**Good:** the agent runs `filtrace processes <etl>` to list the processes by weight,
 then scopes every later query with `--process touki.perf` (or the right name).
 It should explain that an `.etl` is machine-wide, that the auto-scope picks the
 most-sampled process, and that a noisy background app can otherwise steal the
@@ -119,9 +120,9 @@ benchmark/trace rather than starting over.
 If you just want to exercise the analysis tools against a trace that already
 exists, point the agent at a committed fixture and ask:
 
-> - **Prompt:** What's in `traceq\tests\TraceQ.Core.Tests\Fixtures\folding.speedscope.json`, and is anything obviously off? (`trace_info` - resolution rate, threads)
+> - **Prompt:** What's in `..\filtrace\tests\Filtrace.Core.Tests\Fixtures\folding.speedscope.json`, and is anything obviously off? (`trace_info` - resolution rate, threads)
 > - **Prompt:** Where's the CPU time in that trace? (`trace_rank` cpu, then a steer toward the hottest frame's callers)
-> - **Prompt:** What's allocating the most in `traceq\tests\TraceQ.Core.Tests\Fixtures\alloc.nettrace`? (`trace_rank` alloc - answered in **bytes**, not time)
+> - **Prompt:** What's allocating the most in `..\filtrace\tests\Filtrace.Core.Tests\Fixtures\alloc.nettrace`? (`trace_rank` alloc - answered in **bytes**, not time)
 
 ---
 
@@ -136,5 +137,6 @@ exists, point the agent at a committed fixture and ask:
 - On a machine-wide `.etl`, ranks without scoping to a process (see step 5).
 - Guesses at native runtime cost it cannot yet resolve (see step 6).
 
-For the CLI equivalents and every verb's options, see the traceq README and
+For the CLI equivalents and every verb's options, see the
+[filtrace README](https://github.com/JeremyKuhne/filtrace) and
 [tools/Capture-EtwTrace.ps1](../tools/Capture-EtwTrace.ps1).

--- a/tools/Capture-EtwTrace.ps1
+++ b/tools/Capture-EtwTrace.ps1
@@ -1,7 +1,7 @@
 <#
 .SYNOPSIS
     Capture an ETW (.etl) CPU trace of a touki.perf benchmark on .NET Framework
-    (net481) and print the exact, process-scoped traceq commands to analyze it.
+    (net481) and print the exact, process-scoped filtrace commands to analyze it.
 
 .DESCRIPTION
     EventPipe profiling (tools/Profile-Benchmark.ps1) is net10-only and managed-only.
@@ -16,11 +16,11 @@
       3. Runs `dotnet run -c Release -f net481 --project touki.perf -- --filter
          <Filter> -p ETW --keepFiles`, which writes an .etl into
          BenchmarkDotNet.Artifacts/.
-      4. Locates the newest .etl and prints the next-step traceq commands already
+      4. Locates the newest .etl and prints the next-step filtrace commands already
          scoped to the benchmark process with --process, plus the net481 build-output
          --symbols directory for line-level attribution.
 
-    Why --process matters: an .etl is a machine-wide capture. traceq auto-scopes to
+    Why --process matters: an .etl is a machine-wide capture. filtrace auto-scopes to
     the busiest process, but a noisy background app (antivirus, a VPN client) can win
     that race, so the printed commands pin --process explicitly. The cpu/threadtime/
     rank/lines/callers/heatmap verbs all accept it.
@@ -31,7 +31,7 @@
     time for a clean trace.
 
 .PARAMETER Process
-    Process-name substring the printed traceq commands scope to with --process.
+    Process-name substring the printed filtrace commands scope to with --process.
     Defaults to 'touki.perf' (the benchmark host).
 
 .PARAMETER Tfm
@@ -138,15 +138,18 @@ if ($null -eq $etl) {
 # The net481 build-output directory BenchmarkDotNet kept (--keepFiles); its embedded
 # PDBs resolve managed frames to source lines for the `lines`/`heatmap` verbs.
 $symbols = "artifacts/x64/Release/touki.perf/$Tfm/touki.perf-DefaultJob-1/bin/Release/$Tfm"
-$traceq = "dotnet run --project traceq/src/TraceQ -c Release --"
+# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), cloned beside
+# touki at ../filtrace. Once it is published to NuGet (dotnet tool install -g
+# KlutzyNinja.Filtrace) the printed commands become just `filtrace <verb> ...`.
+$filtrace = "dotnet run --project ../filtrace/src/Filtrace -c Release --"
 
 Write-Host "`nCaptured: $($etl.FullName)" -ForegroundColor Green
-Write-Host "`nNext-step traceq commands (scoped to '$Process'):" -ForegroundColor Green
+Write-Host "`nNext-step filtrace commands (scoped to '$Process'):" -ForegroundColor Green
 Write-Host "  # who is in the capture (pick a --process target):"
-Write-Host "  $traceq processes `"$($etl.FullName)`""
+Write-Host "  $filtrace processes `"$($etl.FullName)`""
 Write-Host "  # CPU self-time hotspots:"
-Write-Host "  $traceq cpu `"$($etl.FullName)`" --process $Process --top $Top"
+Write-Host "  $filtrace cpu `"$($etl.FullName)`" --process $Process --top $Top"
 Write-Host "  # wall-clock (running + blocked) - near-equal to cpu means CPU-bound:"
-Write-Host "  $traceq threadtime `"$($etl.FullName)`" --process $Process --top $Top"
+Write-Host "  $filtrace threadtime `"$($etl.FullName)`" --process $Process --top $Top"
 Write-Host "  # line-level inside a hot method:"
-Write-Host "  $traceq lines `"$($etl.FullName)`" --method <MethodName> --process $Process --symbols $symbols"
+Write-Host "  $filtrace lines `"$($etl.FullName)`" --method <MethodName> --process $Process --symbols $symbols"

--- a/tools/Open-PerfettoTrace.ps1
+++ b/tools/Open-PerfettoTrace.ps1
@@ -21,7 +21,7 @@
     security policy whitelists, so the fetch is only allowed from that port without
     enabling the UI's "Relax CSP" flag.
 
-    The input must be a Chrome Trace Event Format file (what `traceq export --format
+    The input must be a Chrome Trace Event Format file (what `filtrace export --format
     chromium` writes) or a native Perfetto proto trace. A speedscope export is NOT a
     Perfetto format - open those with the speedscope CLI instead.
 
@@ -44,7 +44,7 @@
 .PARAMETER PinTrack
     Regex of track name(s) to pin to the top of the timeline once the trace loads,
     via the stable dev.perfetto.PinTracksByRegex startup command. Defaults to
-    'traceq' - the single aggregate track traceq's chromium export emits (named by
+    'filtrace' - the single aggregate track filtrace's chromium export emits (named by
     the export's --name). Pass '' to skip pinning.
 
 .PARAMETER NoExpand
@@ -75,7 +75,7 @@ param(
     [string]$Origin = "https://ui.perfetto.dev",
     [int]$Port = 9001,
     [int]$TimeoutSeconds = 300,
-    [string]$PinTrack = "traceq",
+    [string]$PinTrack = "filtrace",
     [switch]$NoExpand,
     [string[]]$StartupCommands,
     [switch]$NoOpenBrowser

--- a/tools/Open-SpeedscopeTrace.ps1
+++ b/tools/Open-SpeedscopeTrace.ps1
@@ -26,7 +26,7 @@
       - left-heavy   : stacks merged and sorted by weight (the hotspot view) [default]
       - sandwich     : the per-function caller/callee table
 
-    The input must be a speedscope-format profile (what `traceq export` writes by
+    The input must be a speedscope-format profile (what `filtrace export` writes by
     default, or `--format speedscope`). A Chrome-trace / Perfetto export is NOT a
     speedscope profile - open those with tools/Open-PerfettoTrace.ps1.
 


### PR DESCRIPTION
Completes the traceq -> filtrace promotion on the documentation side. The code was removed in #217 (traceq subtree) and #218 (touki.mcp); this updates the prose and agent surfaces that still referenced the tool by its old name and old in-repo paths. **No content is lost** - the touki-owned profiling workflow stays in touki; only the tool pointer moves to the standalone [filtrace](https://github.com/JeremyKuhne/filtrace) repo.

## Load-bearing (agent surfaces + tool scripts)

- **performance-testing skill** (`SKILL.md` description, `profiling.md`, `graphical-viewers.md`): the analyzer is now `filtrace`. CLI examples run from the sibling checkout (`../filtrace/src/Filtrace`) with a note that a published `KlutzyNinja.Filtrace` tool makes `filtrace <verb>` work directly. The MCP path is unchanged - the `trace_*` tool names are preserved and the server is the `filtrace` entry already in `.vscode/mcp.json`.
- **il-copy-inspection skill**: the two cross-references to the profiling drill now name filtrace.
- **tools/Capture-EtwTrace.ps1, Open-PerfettoTrace.ps1, Open-SpeedscopeTrace.ps1**: generated/printed commands and the export naming now use filtrace.

## Docs rewritten in place

- **performance-investigation.md**: filtrace throughout (sections 3a/3e/3f, the section 6 MCP-server description, the playbook, the quick-reference card); dangling `../traceq/README.md` links now point at the filtrace GitHub repo.
- **performance-investigation-without-mcp.md**: retitled/re-pointed; the touki-owned fallback scripts it documents are unchanged.
- **traceq-local-demo.md**: rewritten for filtrace (sibling MCP build path, warm-up fixtures under `../filtrace/tests`, tool count corrected 9 -> 13).

## History docs - annotated only, narrative preserved

- **traceq-implementation-plan.md, traceq-etl-trimming.md**: a top-of-file note records the promotion to filtrace; the `traceq/...` paths and the narrative are intentionally left as the decision record. `skills-improvement-plan.md` and `etl-mcp-server-plan.md` are untouched (planning history, no broken paths).

## Verified against the real filtrace repo

- filtrace's `export --name` default changed `traceq` -> `filtrace`, so `Open-PerfettoTrace.ps1`'s `$PinTrack` default is updated to `filtrace` (a `traceq` default would pin a nonexistent track).
- The MCP server exposes **13** `trace_*` tools (corrected a stale "nine").

## Checks

- Agent-file validator (`tools/Validate-AgentFiles.ps1`): passes.
- All three edited PowerShell scripts parse.
- No dangling `traceq/` paths remain outside the annotated history docs; no trailing whitespace / tabs in changed files.