### PR TITLE
Consume published filtrace 0.1.0 packages instead of local source

### DIFF
--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -24,19 +24,18 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
 # The exact build BDN profiled - its PDB GUID matches the trace:
 $sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
 
-# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), cloned
-# beside touki at ../filtrace; run it from that checkout. Once filtrace is
-# published to NuGet, `dotnet tool install -g KlutzyNinja.Filtrace` lets you call
-# `filtrace <verb>` directly instead. (The MCP tools above need neither.)
+# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), published
+# to NuGet. Install once with `dotnet tool install -g KlutzyNinja.Filtrace`, then
+# call `filtrace <verb>` directly. (The MCP tools above need no install.)
 
 # Method ranking, scoped to a workload frame (which method owns the self-time).
-dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+filtrace cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
 
 # Line ranking inside the dominant method (which lines of its hot loop dominate).
-dotnet run --project ../filtrace/src/Filtrace -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
+filtrace lines $trace --method RunEngine --symbols $sym --top 30
 
 # Who calls a folded JIT-helper artifact, to confirm what it's attributable to.
-dotnet run --project ../filtrace/src/Filtrace -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
+filtrace callers $trace 'BulkMoveWithWriteBarrier'
 ```
 
 The MCP tools map onto those verbs one-to-one: `trace_rank` (with

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -6,17 +6,17 @@
             "type": "http",
             "url": "https://learn.microsoft.com/api/mcp"
         },
-        // Local filtrace trace-analysis server. filtrace was promoted out of this
-        // repo into its own sibling repository (github.com/JeremyKuhne/filtrace,
-        // cloned alongside touki at ../filtrace). Points at the built Release DLL
-        // for fast startup and clean stdout; rebuild with
-        // `dotnet build ../filtrace/src/Filtrace.Mcp/Filtrace.Mcp.csproj -c Release`
-        // and restart the server after changing filtrace.
+        // filtrace trace-analysis MCP server, consumed from the published
+        // KlutzyNinja.Filtrace.Mcp package (github.com/JeremyKuhne/filtrace).
+        // `dnx` (the .NET 10 SDK tool runner) downloads and runs the package on
+        // demand; `--yes` auto-confirms the one-time download. No local clone or
+        // build required - restart the server after filtrace publishes a new version.
         "filtrace": {
             "type": "stdio",
-            "command": "dotnet",
+            "command": "dnx",
             "args": [
-                "${workspaceFolder}/../filtrace/src/Filtrace.Mcp/bin/Release/net10.0/Filtrace.Mcp.dll"
+                "KlutzyNinja.Filtrace.Mcp",
+                "--yes"
             ]
         }
     }

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -274,10 +274,10 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
     Sort-Object LastWriteTime | Select-Object -Last 1).FullName
 
 # 2. Folded self-time + inclusive-time rankings, scoped to a workload frame.
-dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+filtrace cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
 
 # Confirm what a folded JIT-helper artifact is attributable to:
-dotnet run --project ../filtrace/src/Filtrace -c Release -- callers $trace 'BulkMoveWithWriteBarrier'
+filtrace callers $trace 'BulkMoveWithWriteBarrier'
 ```
 
 An agent that speaks MCP calls `trace_rank` (with `measure: self|inclusive`) /
@@ -457,7 +457,8 @@ level deeper: it reads the `.nettrace`/`.etl` through TraceEvent and attributes
 each leaf sample to the **source `file:line` that was executing**, so you can
 see which lines of a hot loop dominate. It is net10-only and runs two ways:
 
-- **Console front end** - `dotnet run --project ../filtrace/src/Filtrace -c Release -- <verb>`.
+- **Console front end** - `filtrace <verb>` (install once with
+  `dotnet tool install -g KlutzyNinja.Filtrace`).
 - **MCP server** - the same queries exposed as tools (`trace_info`,
   `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
   registered `filtrace` server for an agent that speaks MCP. See section 6.
@@ -476,10 +477,10 @@ $trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
 $sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
 
 # 1. Method ranking (self + inclusive), JIT-helper artifacts folded.
-dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu $trace --symbols $sym --top 20
+filtrace cpu $trace --symbols $sym --top 20
 
 # 2. Line ranking inside the dominant method.
-dotnet run --project ../filtrace/src/Filtrace -c Release -- lines $trace --method RunEngine --symbols $sym --top 30
+filtrace lines $trace --method RunEngine --symbols $sym --top 30
 ```
 
 Verbs and flags: `cpu`/`rank` rank methods (`--root <substr>` scopes to a
@@ -668,8 +669,7 @@ A concrete, token-efficient loop an agent should follow:
 6. **If the bottleneck is unclear**, attach `[EventPipeProfiler(CpuSampling)]`,
    capture a trace (`dotnet run ... --filter *<Subject>* -p EP --keepFiles` on
    **net10.0**), then rank it with the `filtrace` analyzer
-   (`dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu <trace> --root
-   <workload-frame>`, or the `trace_rank` MCP tool; the
+   (`filtrace cpu <trace> --root <workload-frame>`, or the `trace_rank` MCP tool; the
    PowerShell scripts in
    [performance-investigation-without-mcp.md](performance-investigation-without-mcp.md)
    are the no-MCP fallback). **Fold the JIT-helper artifacts**
@@ -680,8 +680,8 @@ A concrete, token-efficient loop an agent should follow:
    EventPipe is net10.0-only; for net481 on-CPU attribution use `[EtwProfiler]`
    (admin) - see the per-TFM table in &sect;3.
 7. **If you need the hot *line*, not just the hot method**, feed the same
-   `.nettrace` to `filtrace`: `dotnet run --project ../filtrace/src/Filtrace -c Release --
-   lines <trace> --method <method> --symbols <build-dir> --top 30` (or the
+   `.nettrace` to `filtrace`: `filtrace lines <trace> --method <method>
+   --symbols <build-dir> --top 30` (or the
    `trace_lines` MCP tool). Capture with `--keepFiles` and point `--symbols` at
    BDN's surviving `...-DefaultJob-N/bin/Release/net10.0` so the PDB GUID
    matches; if the ranking collapses onto one or two call-site lines the callee
@@ -717,11 +717,11 @@ A/B + allocations ............ dotnet run -c Release -f <tfm> --project touki.pe
 Fast smoke ................... add --job short
 Read the result .............. BenchmarkDotNet.Artifacts/results/*-report-github.md
 Capture a trace .............. dotnet run -c Release -f net10.0 --project touki.perf -- --filter *X* -p EP --keepFiles
-Rank an existing trace ....... dotnet run --project ../filtrace/src/Filtrace -c Release -- cpu <trace> --root <workload-frame>
+Rank an existing trace ....... filtrace cpu <trace> --root <workload-frame>
                                folds JIT-helper artifacts + ranks self/inclusive. callers <frame> = who calls it.
 No-server fallback scripts ... ./tools/Profile-Benchmark.ps1 / Get-TraceHotspots.ps1 (see *-without-mcp.md)
 Flame-graph SVG .............. ./tools/speedscope-to-flamegraph.ps1   (or drag the speedscope into speedscope.app)
-Which source LINE? ........... dotnet run --project ../filtrace/src/Filtrace -c Release -- lines <trace> --method <method> --symbols <build-dir>
+Which source LINE? ........... filtrace lines <trace> --method <method> --symbols <build-dir>
                                net10 .nettrace/.etl + embedded PDB. Capture with --keepFiles; point --symbols
                                at BDN's ...-DefaultJob-N/bin/Release/net10.0 (PDB GUID must match the trace).
                                Inlined callee -> samples collapse on the call-site line; drill the tail. See 3f.

--- a/docs/traceq-local-demo.md
+++ b/docs/traceq-local-demo.md
@@ -16,17 +16,11 @@ faster?" - not tool-by-tool instructions.
 
 ## Setup (one time)
 
-filtrace lives in its own repo (github.com/JeremyKuhne/filtrace), cloned beside
-touki at `../filtrace`. Build the MCP server and register it, then start it from
-the Command Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*):
-
-```pwsh
-dotnet build ../filtrace/src/Filtrace.Mcp/Filtrace.Mcp.csproj -c Release
-```
-
-The server entry lives in [.vscode/mcp.json](../.vscode/mcp.json) (rebuild the
-DLL and restart the server after changing filtrace). Confirm the 13 `trace_*`
-tools register in the chat tool picker.
+filtrace is published to NuGet (github.com/JeremyKuhne/filtrace). The MCP server
+entry in [.vscode/mcp.json](../.vscode/mcp.json) runs it on demand via `dnx` (the
+.NET 10 SDK tool runner) - no clone or build required. Start it from the Command
+Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*) and confirm the 13
+`trace_*` tools register in the chat tool picker.
 
 ---
 
@@ -118,7 +112,9 @@ benchmark/trace rather than starting over.
 ## Warm-up: you already have a trace
 
 If you just want to exercise the analysis tools against a trace that already
-exists, point the agent at a committed fixture and ask:
+exists, point the agent at any trace you have and ask. The examples below use
+filtrace's own committed test fixtures, so they assume the filtrace repo is
+checked out at `../filtrace`; substitute any `.nettrace` / `.speedscope.json`:
 
 > - **Prompt:** What's in `../filtrace/tests/Filtrace.Core.Tests/Fixtures/folding.speedscope.json`, and is anything obviously off? (`trace_info` - resolution rate, threads)
 > - **Prompt:** Where's the CPU time in that trace? (`trace_rank` cpu, then a steer toward the hottest frame's callers)

--- a/tools/Capture-EtwTrace.ps1
+++ b/tools/Capture-EtwTrace.ps1
@@ -138,10 +138,10 @@ if ($null -eq $etl) {
 # The net481 build-output directory BenchmarkDotNet kept (--keepFiles); its embedded
 # PDBs resolve managed frames to source lines for the `lines`/`heatmap` verbs.
 $symbols = "artifacts/x64/Release/touki.perf/$Tfm/touki.perf-DefaultJob-1/bin/Release/$Tfm"
-# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), cloned beside
-# touki at ../filtrace. Once it is published to NuGet (dotnet tool install -g
-# KlutzyNinja.Filtrace) the printed commands become just `filtrace <verb> ...`.
-$filtrace = "dotnet run --project ../filtrace/src/Filtrace -c Release --"
+# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), published to
+# NuGet. Install once with `dotnet tool install -g KlutzyNinja.Filtrace`; the printed
+# commands below then run as `filtrace <verb> ...`.
+$filtrace = "filtrace"
 
 Write-Host "`nCaptured: $($etl.FullName)" -ForegroundColor Green
 Write-Host "`nNext-step filtrace commands (scoped to '$Process'):" -ForegroundColor Green


### PR DESCRIPTION
Switches touki from consuming filtrace as a sibling source checkout to the published NuGet packages, now that filtrace `0.1.0` is live (`KlutzyNinja.Filtrace` CLI + `KlutzyNinja.Filtrace.Mcp` MCP server).

## What changed

- **`.vscode/mcp.json`** - the `filtrace` MCP server now launches via `dnx KlutzyNinja.Filtrace.Mcp --yes` (the .NET 10 SDK tool runner downloads + runs on demand) instead of pointing at a locally built `../filtrace/.../Filtrace.Mcp.dll`. No clone or Release build required.
- **`.agents/skills/performance-testing/profiling.md`, `docs/performance-investigation.md`, `tools/Capture-EtwTrace.ps1`** - CLI invocations change from `dotnet run --project ../filtrace/src/Filtrace -c Release -- <verb>` to `filtrace <verb>` (after `dotnet tool install -g KlutzyNinja.Filtrace`). These docs already anticipated the switch with a "once filtrace is published" note.
- **`docs/traceq-local-demo.md`** - the one-time setup runs the published MCP server via `dnx` rather than building from source; the warm-up prompts note their sample fixtures assume a filtrace checkout.

## Validation

- `filtrace --version` -> `0.1.0` (global tool installs and runs).
- `dnx KlutzyNinja.Filtrace.Mcp --yes` starts the stdio server cleanly ("(filtrace) transport reading messages").
- Agent-files validator passes.
- Swept the repo: no source-coupled `../filtrace` build/run references remain.