### PR TITLE
Vendor the filtrace agent skill from the filtrace repo

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -14,7 +14,8 @@ The "Disambiguation" section below records every known overlap.
 | ----- | ---------------- | ----------- | ---------------- |
 | [polyfill-dotnet-api](./polyfill-dotnet-api/SKILL.md) | "polyfill", "backport", "add a span overload for net472/net481", "make API X available downlevel", missing-on-net472-present-on-net10 | repo-specific | `pre-pr-self-review`, `performance-testing`, `framework-jit-optimization`, `create-pr` |
 | [framework-jit-optimization](./framework-jit-optimization/SKILL.md) | hot-path tuning for `net481` in `touki/Framework/`, generic specialization, scalar/unrolled vs BCL delegation, net481 RyuJIT regressions; the `net10` counterpart (vectorization, intrinsics, struct-generic, devirtualization); cross-TFM codegen (arithmetic/branchless lowering, struct layout, allocation anti-patterns) | semi-portable | `performance-testing`, `il-copy-inspection` |
-| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations, reading the generated code (sharplab/`[DisassemblyDiagnoser]`/`[HardwareCounters]`/`DOTNET_JitDisasm*`) | semi-portable | `framework-jit-optimization`, `scratch-buffer-strategy`, `il-copy-inspection` |
+| [performance-testing](./performance-testing/SKILL.md) | authoring/running BenchmarkDotNet benchmarks in `touki.perf`, comparing implementations, evaluating allocations, reading the generated code (sharplab/`[DisassemblyDiagnoser]`/`[HardwareCounters]`/`DOTNET_JitDisasm*`) | semi-portable | `filtrace`, `framework-jit-optimization`, `scratch-buffer-strategy`, `il-copy-inspection` |
+| [filtrace](./filtrace/SKILL.md) | "where's the time/memory in this trace or benchmark", which method or source line is hot, why a run regressed vs a baseline, what a captured `.nettrace`/`.etl` holds, rank / drill / diff / export a CPU / alloc / exception / GC / JIT / thread-time profile, profiling net481 via ETW | vendored (tool repo) + overlay | `performance-testing` (via [overlay](./filtrace/overlay.md)) |
 | [scratch-buffer-strategy](./scratch-buffer-strategy/SKILL.md) | choosing a scratch-buffer strategy (zeroed `stackalloc` vs `[SkipLocalsInit]` vs `BufferScope<T>` vs `ArrayPool` rental), "should I rent or stackalloc?", net481/net10 size crossovers, weighing `[SkipLocalsInit]` | vendored (portable core) + overlay | `performance-testing`, `framework-jit-optimization` (via [overlay](./scratch-buffer-strategy/overlay.md)) |
 | [pre-pr-self-review](./pre-pr-self-review/SKILL.md) | self-review checklist before opening or pushing a PR; missing tests, unchecked length sums, empty-span foot-guns, TFM phrasing | semi-portable | `create-pr`, `polyfill-dotnet-api` |
 | [security-review](./security-review/SKILL.md) | "assess for security vulnerabilities", "do a security review", "check for ReDoS / DoS", "audit untrusted input handling"; any member accepting caller-supplied data, any use of `unsafe` / `Unsafe.*` / `MemoryMarshal.*` / `Marshal.*`, or any BCL API whose name or doc says "unsafe" / "caller must" - abusive-input handling, length / integer overflow, allocation and algorithmic DoS, caller-validated preconditions, argument validation | vendored (portable core) + overlay | `pre-pr-self-review`, `performance-testing` (via [overlay](./security-review/overlay.md)) |
@@ -35,7 +36,11 @@ a skill would need to change to be reused in another repo: `portable` (generic),
 `vendored (portable core) + overlay` is a pinned copy of a portable core from the
 [agent-skills commons](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in its `SKILL.md`) paired with a local `overlay.md`
-that carries the touki-specific cross-references and example links. Do not
+that carries the touki-specific cross-references and example links.
+`vendored (tool repo) + overlay` is the same pattern pinned to a tool's own repo
+instead of the commons: `filtrace` is a copy of the skill shipped by the
+standalone [JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)
+analyzer, re-vendored from there rather than the commons. Do not
 hand-edit a vendored core; `gh skill update` tracks it against upstream. See the
 sharing roadmap in
 [docs/skills-improvement-plan.md](../../docs/skills-improvement-plan.md).
@@ -107,6 +112,21 @@ Both mention "evaluating allocations", but they answer different questions:
   a decision, not a measurement.
 - **How do I measure a buffer/allocation cost** (author a benchmark, add
   `[MemoryDiagnoser]`, read `Allocated`) &rarr; `performance-testing`.
+
+### `performance-testing` vs `filtrace`
+
+Both describe "where's the time / which method is hot", but they sit on opposite
+sides of a hand-off:
+
+- **Author or run a benchmark, capture a touki trace, and interpret the result**
+  (the `-p EP --keepFiles` recipe, the EventPipe-vs-ETW divergence, reading the
+  line ranking) &rarr; `performance-testing`.
+- **Drive the filtrace analyzer over an existing trace** - the `cpu` / `rank` /
+  `callers` / `lines` / `diff` / `export` verbs and `trace_*` tools, the symbol
+  gate, the trap catalog &rarr; `filtrace`.
+
+The usual flow is `performance-testing` to produce the trace, then `filtrace` to
+rank and drill it.
 
 Use `scratch-buffer-strategy` to pick the design; use `performance-testing` to
 verify it on both TFMs.

--- a/.agents/skills/filtrace/SKILL.md
+++ b/.agents/skills/filtrace/SKILL.md
@@ -5,10 +5,10 @@ compatibility: Pairs with the filtrace MCP server (the KlutzyNinja.Filtrace.Mcp 
 license: MIT
 metadata:
   github-path: .agents/skills/filtrace
-  github-pinned: 10481a3e84c82b2cd7fa7709eadbf3afbbf45727
+  github-pinned: 04fd8573ef801b98aeb77442642aca9180f0a49e
   github-ref: refs/heads/main
   github-repo: https://github.com/JeremyKuhne/filtrace
-  github-tree-sha: e0b5c675e3c3fa57158cc3dbec619675173d6dd2
+  github-tree-sha: f75c6b3147d52a5782e715c2b9578e439cbd9455
   portability: repo-specific
 ---
 
@@ -83,7 +83,7 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 | Verb | Does |
 |---|---|
 | `diff <before> <after>` | what got slower/faster between two traces |
-| `export --format <speedscope\|chromium>` | write a flame graph for a viewer |
+| `export --format <fmt>` | write a flame graph for a viewer - `speedscope` or `chromium` |
 
 **Structured reports** (EventPipe `.nettrace`):
 

--- a/.agents/skills/filtrace/SKILL.md
+++ b/.agents/skills/filtrace/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: filtrace
+description: Analyze .NET CPU, allocation, exception, GC, JIT, and wall-clock (thread-time) traces - .nettrace, .etl, and speedscope captures - with the filtrace CLI or MCP server. Use when a user asks where time or memory goes in a trace or benchmark, which method or source line is hot, why a run regressed against a baseline, what a captured .nettrace / .etl contains, or to rank / drill / diff / export a profile - including profiling .NET Framework (net481) via ETW, where an EventPipe ranking would mislead.
+compatibility: Pairs with the filtrace MCP server (the KlutzyNinja.Filtrace.Mcp package, run via `dnx`) for in-agent tool calls; otherwise shells out to the filtrace CLI (the KlutzyNinja.Filtrace global tool). Either head provides the same analysis, so the skill degrades gracefully to whichever is installed.
+license: MIT
+metadata:
+  github-path: .agents/skills/filtrace
+  github-pinned: 10481a3e84c82b2cd7fa7709eadbf3afbbf45727
+  github-ref: refs/heads/main
+  github-repo: https://github.com/JeremyKuhne/filtrace
+  github-tree-sha: e0b5c675e3c3fa57158cc3dbec619675173d6dd2
+  portability: repo-specific
+---
+
+# Analyzing .NET traces with filtrace
+
+filtrace ranks, drills into, diffs, and exports CPU / allocation / exception /
+GC / JIT / thread-time profiles from `.nettrace`, `.etl`, and speedscope
+captures, from both modern .NET and .NET Framework. It is a command-line tool and
+an MCP server - there is no GUI. Output is dense text by default, or compact JSON
+(`--format json`). It runs on .NET 10 but reads traces from any runtime.
+
+This skill is the *how*; the full reference is single-sourced in
+[docs/workflow.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/workflow.md)
+and [docs/traps.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/traps.md).
+
+## The workflow: orient -> rank -> drill -> compare
+
+Almost every investigation is the same four moves:
+
+1. **Orient.** Read the trace's format, sample count, and symbol-resolution rate
+   first - `filtrace processes <trace>` or the `trace_info` tool. A
+   symbol-resolution rate **below 0.8** means managed frames are missing and the
+   rankings cannot be trusted; pass `--symbols <build-output-dir>` (the directory
+   holding your portable PDBs) before reading further.
+2. **Rank.** Find the hottest frames by the metric that matches the question -
+   `cpu`, `alloc`, `exceptions`, or `threadtime` (or `rank --metric <m>`).
+   Self-time finds the leaf that burns the resource; inclusive-time finds the
+   subtree that drives it.
+3. **Drill.** Follow the hot frame into detail: `callers <frame>` (who calls it),
+   `lines` / `heatmap <file>` (which source lines), or `tree` (what it calls).
+4. **Compare.** `diff <before> <after>` to see what regressed or improved, or
+   `export --format speedscope` to hand a human a flame graph.
+
+```pwsh
+filtrace cpu app.nettrace                    # 1-2. orient + rank self-time
+filtrace callers app.nettrace MyApp.Parse    # 3. who drives the hot frame
+filtrace lines app.nettrace --symbols bin/Release/net10.0   # 3. hot source lines
+filtrace diff before.nettrace after.nettrace # 4. what changed
+```
+
+<!-- filtrace:begin verbs -->
+### CLI verbs
+
+**Rank** - find the hottest frames by a metric:
+
+| Verb | Ranks | Reads |
+|---|---|---|
+| `rank --metric <m>` | any metric (`cpu`, `alloc`, `exceptions`, `threadtime`) | per metric |
+| `cpu` | CPU self/inclusive time | `.nettrace`, `.etl`, `.speedscope.json` |
+| `alloc` | bytes allocated, by site | `.nettrace` |
+| `exceptions` | throw sites, by count | `.nettrace` |
+| `threadtime` | wall-clock (running + blocked) | `.etl` (Windows) |
+
+**Drill** - follow a ranking into detail:
+
+| Verb | Shows |
+|---|---|
+| `callers <frame>` | immediate callers of a frame |
+| `lines` | hottest source lines of the scoped methods |
+| `heatmap <file>` | per-line heat for one source file |
+| `tree` | top-down call tree from the root |
+
+**Inventory** - see what a (possibly machine-wide) capture holds:
+
+| Verb | Shows |
+|---|---|
+| `processes` | processes by CPU-sample weight, to pick a `--process` target |
+| `classify` | CPU time by runtime work category (zeroing / copying / GC / JIT) |
+
+**Compare and export:**
+
+| Verb | Does |
+|---|---|
+| `diff <before> <after>` | what got slower/faster between two traces |
+| `export --format <speedscope\|chromium>` | write a flame graph for a viewer |
+
+**Structured reports** (EventPipe `.nettrace`):
+
+| Verb | Reports |
+|---|---|
+| `gcstats` | GC counts, pauses, heap summary |
+| `jitstats` | JIT method count, compile time, sizes |
+| `events --name <n>` | raw events by name, paged |
+
+**File ops** - manage the ETLX conversion cache TraceEvent keeps beside a trace:
+
+| Verb | Does |
+|---|---|
+| `convert` | build the ETLX cache up front |
+| `clean` | remove the ETLX cache to force a rebuild |
+<!-- filtrace:end verbs -->
+
+Run `filtrace <verb> --help` for the full option set of any verb.
+
+## Scope and symbols
+
+- **Scope to one process.** The stack verbs that read a multi-process `.etl`
+  (`cpu`, `threadtime`, `rank`, `callers`, `lines`, `heatmap`, `tree`, `classify`)
+  auto-scope to the busiest process tree. Run `processes` first to see the
+  capture, then `--process <name>` to override, or `--all-processes` to widen.
+  `alloc` / `exceptions` read a single-process `.nettrace` and have no process
+  options.
+- **Scope to the benchmark.** For a BenchmarkDotNet capture, `--benchmark` presets
+  the root to the measured-workload wrapper so the harness and warmup do not
+  dominate the ranking.
+- **Symbols.** Managed frames (including NGEN and ReadyToRun framework methods)
+  resolve for free from the trace's CLR rundown. `--symbols <dir>` resolves your
+  own managed frames and source lines; `--native-symbols` (CPU `.etl` only,
+  opt-in, network) names the unmanaged GC / JIT / `memcpy` frames that otherwise
+  show as a `?` leaf.
+
+## Traps
+
+The recurring ways a .NET trace investigation goes wrong:
+
+<!-- filtrace:begin traps -->
+## Trap catalog
+
+1. **Profile .NET Framework with ETW, never extrapolate from an EventPipe trace.**
+   EventPipe (`.nettrace`) is modern-.NET-only and managed-only. The net10
+   EventPipe ranking actively *misleads* for `net481`: weaker Framework inlining
+   relocates the hot frame, so a method that is 1.5% self-time on the EventPipe
+   trace can be 56% on the ETW (`.etl`) capture of the same workload. Capture
+   net481 under ETW (`threadtime` / `cpu` over an `.etl`) and rank that.
+
+2. **Trust the symbol-resolution rate before the rankings.** A rate below **0.8**
+   (surfaced by `trace_info` / the load warning) means managed frames are missing
+   and the names are unreliable - pass `--symbols <build-output-dir>`. Caveat: the
+   aggregate rate conflates managed and native frames, so a net481 ETW capture can
+   read low while every *managed* leaf resolves correctly; the warning hedges this
+   ("managed-method rankings remain usable").
+
+3. **On a machine-wide `.etl`, confirm the process before scoping.** filtrace
+   auto-scopes to the busiest process tree ranked by **CPU-sample count** (a
+   long-lived background service wins a wall-clock race but owns few samples), and
+   that default is usually right - but run `processes` first to see what is in the
+   capture, then pass `--process <name>` if the auto-pick is wrong.
+
+4. **BenchmarkDotNet captures include the harness.** A raw ranking of a BDN trace
+   is dominated by the orchestrator and warmup iterations, not your `[Benchmark]`.
+   Pass `--benchmark` to preset the root to the measured-workload wrapper so only
+   the measured code is ranked.
+
+5. **Native runtime frames need `--native-symbols`.** Without it, the unmanaged
+   ~10% of a trace - GC, JIT, `memset` / `memcpy`, write barriers - shows as an
+   unresolved `?` leaf. Opt in (CPU `.etl` only; fetches PDBs from the Microsoft
+   public symbol server, cached locally) to name it, then `classify` to get the
+   zeroing-vs-copying-vs-GC-vs-JIT split. It is off by default so analysis stays
+   offline and deterministic.
+
+6. **Self-time and inclusive-time answer different questions.** Self-time finds
+   the leaf that burns the resource; inclusive-time finds the subtree that drives
+   it. Ranking by the wrong measure hides the frame you want - start with self for
+   "what is hot", switch to inclusive for "what is responsible".
+
+7. **Reading an `.etl` is Windows-only.** The ETW -> ETLX conversion needs
+   Windows; once converted, the `.etlx` resolves managed frames and analyzes
+   identically on any OS ("convert on Windows, analyze anywhere"). The CLI/MCP
+   `.etl` paths are guarded and report a clean error off Windows.
+
+8. **The default fold list hides runtime leaves on purpose.** It folds
+   `memmove`, write-barriers, and GC-poll helpers into their managed caller -
+   right for "which method is hot", wrong for "what kind of work dominates". Use
+   `--no-fold` (or `classify`) to let the native leaves rank on their own.
+<!-- filtrace:end traps -->
+
+## CLI or MCP
+
+The two heads expose the same analysis:
+
+- **CLI** - `dotnet tool install -g KlutzyNinja.Filtrace`, then `filtrace <verb>`.
+- **MCP server** - `dnx KlutzyNinja.Filtrace.Mcp` over stdio, exposing thirteen
+  `trace_*` tools (`trace_info`, `trace_rank`, `trace_callers`, `trace_lines`,
+  `trace_heatmap`, `trace_tree`, `trace_processes`, `trace_classify`,
+  `trace_diff`, `trace_export`, `trace_gc`, `trace_jit`, `trace_query_events`).
+  Each returns one envelope: a `schemaVersion`, a `warnings` list, next-step
+  `hints`, and the typed result.
+
+See [docs/workflow.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/workflow.md)
+for the full verb/tool reference and the MCP config snippet, and
+[docs/traps.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/traps.md) for
+the trap catalog.

--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -1,0 +1,46 @@
+# Touki overlay - filtrace
+
+Repo-specific companion to the vendored [filtrace](SKILL.md) skill. The `SKILL.md`
+is a **pinned copy** of the agent skill shipped by the standalone
+[JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace) trace analyzer (see
+the `metadata.github-*` provenance in `SKILL.md`'s frontmatter). filtrace is a
+*tool-shipped skill*: its canonical home is the tool's own repo (single-sourced
+from filtrace `docs/`), not the
+[agent-skills commons](https://github.com/JeremyKuhne/agent-skills). Do not
+hand-edit the core - re-vendor it from filtrace instead. Everything
+touki-specific lives here.
+
+## How touki consumes filtrace
+
+filtrace ships as published NuGet packages; touki uses both heads:
+
+- **MCP server** - registered in [.vscode/mcp.json](../../../.vscode/mcp.json) as
+  `dnx KlutzyNinja.Filtrace.Mcp`, exposing the thirteen `trace_*` tools an agent
+  calls directly. No clone or build required.
+- **CLI** - `dotnet tool install -g KlutzyNinja.Filtrace`, then `filtrace <verb>`.
+
+The skill body's "full reference" links point at filtrace's `docs/workflow.md`
+and `docs/traps.md` as absolute `https://github.com/JeremyKuhne/filtrace` URLs:
+the load-bearing verb and trap catalogs are embedded in the skill body, so those
+links are supplementary and resolve from anywhere.
+
+## Cross-references (touki side)
+
+- [`performance-testing`](../performance-testing/SKILL.md) - the touki skill that
+  *delegates* trace-driving to filtrace. It owns the touki-specific half: how to
+  capture a benchmark trace (`-p EP --keepFiles`, where the symbols build is),
+  the EventPipe-vs-ETW attribution divergence, and reading the line ranking. For
+  the filtrace verb/tool reference and trap catalog it points here.
+- [profiling.md](../performance-testing/profiling.md) and
+  [graphical-viewers.md](../performance-testing/graphical-viewers.md) - the touki
+  capture recipes and viewer launchers that drive filtrace.
+- [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) - the touki
+  net481 ETW capture wrapper that prints scoped `filtrace` next-step commands.
+
+## Updating
+
+Re-vendor from filtrace when its skill changes: copy
+`.agents/skills/filtrace/SKILL.md` from the filtrace repo, re-add this provenance
+block (bump `github-pinned` / `github-tree-sha` to the new commit), and keep
+touki-specific notes here, not in the core. When filtrace cuts a release whose
+package carries the updated skill, prefer pinning to that tag.

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -33,6 +33,10 @@ the *how*; that page is the *what to measure and why*.
 
 **Related skills:**
 
+- [`filtrace`](../filtrace/SKILL.md) - the trace analyzer this skill drives for
+  profiling: the full verb / tool reference (`cpu` / `rank` / `callers` / `lines`
+  / `diff`, the `trace_*` MCP tools) and the trap catalog.
+  [profiling.md](profiling.md) captures the trace; filtrace ranks and drills it.
 - [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - reasons
   to add a polyfill (and therefore a benchmark) in the first place.
 - [`framework-jit-optimization`](../framework-jit-optimization/SKILL.md) -

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -1,6 +1,8 @@
 # Profiling a benchmark: from operation to method to line
 
-Detail for the [performance-testing](SKILL.md) skill.
+Detail for the [performance-testing](SKILL.md) skill. For the full filtrace
+verb / tool reference and trap catalog, see the [`filtrace`](../filtrace/SKILL.md)
+skill; this page is the touki capture recipe and how to read the result.
 
 To find where a benchmark spends its time - optimizing a hot path or chasing a
 regression - capture an EventPipe CPU trace on `net10.0`, then drill it with the

--- a/docs/skills-improvement-plan.md
+++ b/docs/skills-improvement-plan.md
@@ -17,6 +17,23 @@ consumers, [`JeremyKuhne/madowaku`](https://github.com/JeremyKuhne/madowaku)
 (a merge) and [`JeremyKuhne/thirtytwo`](https://github.com/JeremyKuhne/thirtytwo)
 (greenfield). Authored 2026-06-04; last updated 2026-06-06.
 
+**Update 2026-06-15 - the `traceq` seam is cleared.** The trace tooling was
+promoted out of touki into the standalone
+[`filtrace`](https://github.com/JeremyKuhne/filtrace) repo, published to NuGet
+(`KlutzyNinja.Filtrace` CLI + `KlutzyNinja.Filtrace.Mcp` server, `0.1.0`), and
+touki migrated onto the packages (touki #220). filtrace **ships its own agent
+skill**, which adds a third skill source beyond born-local and the commons: a
+**tool-shipped skill** whose canonical home is the tool's own repo
+(single-sourced from filtrace `docs/`), vendored into consumers exactly like a
+commons core but re-vendored from the tool repo rather than the commons. touki
+now vendors it at
+[.agents/skills/filtrace/](../.agents/skills/filtrace/SKILL.md) (pinned, with a
+touki [overlay](../.agents/skills/filtrace/overlay.md)), and `performance-testing`
+delegates trace-driving to it instead of re-documenting the verbs. What remains of
+Phase 4 is the `performance-testing` BenchmarkDotNet core extraction into the
+commons - its profiling half now points at the vendored `filtrace` skill, not the
+retired `touki.mcp`.
+
 This plan answers three questions about the agent skills under
 [.agents/skills/](../.agents/skills/):
 
@@ -1017,6 +1034,7 @@ applies. thirtytwo answers assume its scaffolding is stood up first (Phase 8).
 | `agent-files-review` | semi-portable | universal | yes | yes | yes |
 | `manage-skills` (section 3) | semi-portable | universal | yes (built) | yes | yes |
 | `performance-testing` | semi-portable | universal, project-gated (`<root>.perf`) | overlay | overlay | bootstrap |
+| `filtrace` (from filtrace) | vendored (tool repo) | dotnet-profiling | yes | yes | yes |
 | `scratch-buffer-strategy` | semi-portable | dotnet-perf | yes | yes | yes |
 | `framework-jit-optimization` | semi-portable | dotnet-framework | yes | yes | marginal |
 | `polyfill-dotnet-api` | repo-specific (small core) | dotnet-framework-polyfill | yes | yes | marginal |


### PR DESCRIPTION
Vendors the agent skill shipped by the standalone [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer into touki, so `performance-testing` delegates trace-driving to it instead of re-documenting filtrace's verbs and tools.

## Context

filtrace was promoted out of touki, published to NuGet (`0.1.0`), and touki migrated onto the packages (#220). filtrace ships its own skill (single-sourced from its `docs/`). This is the `performance-testing` half of the skills roadmap's `traceq` seam: consume filtrace's skill **from filtrace** rather than keeping a drifting copy here.

## What this adds

- **`.agents/skills/filtrace/SKILL.md`** (new) - vendored verbatim from filtrace `@10481a3` with `github-*` provenance + `license: MIT` frontmatter. Pinned to the post-[filtrace#11](https://github.com/JeremyKuhne/filtrace/pull/11) commit, where the skill's `docs/` reference links were made absolute `https://` URLs - so they are exempt from touki's relative-link gate and nothing dangles.
- **`.agents/skills/filtrace/overlay.md`** (new) - the touki overlay: how touki consumes filtrace (`dnx KlutzyNinja.Filtrace.Mcp` + the CLI), cross-references, and re-vendor instructions. touki-specific notes live here, never in the vendored core.
- **`performance-testing` (`SKILL.md` + `profiling.md`)** - delegate the filtrace verb/tool reference and trap catalog to the vendored skill; `profiling.md` stays the touki capture recipe and result-interpretation half (the EventPipe-vs-ETW divergence, the worked example).
- **`.agents/skills/README.md`** - inventory row, a `vendored (tool repo)` legend entry (a third skill source beside born-local and the commons), and a `performance-testing` vs `filtrace` disambiguation entry.
- **`docs/skills-improvement-plan.md`** - records the `traceq` seam cleared and the tool-shipped-skill source.

## Validation

- `tools/Validate-AgentFiles.ps1` passes.
- `tools/Test-AgentFileLinks.ps1` passes - all relative links resolve across 70 agent files (the vendored skill's full-reference links are absolute filtrace URLs, exempt by design).