### PR TITLE
Fold polyfill-layout.md into the polyfill-dotnet-api skill

### DIFF
--- a/.agents/skills/polyfill-dotnet-api/SKILL.md
+++ b/.agents/skills/polyfill-dotnet-api/SKILL.md
@@ -90,6 +90,9 @@ TFM-phrasing foot-guns are in [gotchas.md](gotchas.md).
 - [gotchas.md](gotchas.md) - empty-span pinning, the net481 `Unsafe.As`
   sign-extension bug, native `Random.NextBytes`, process-local `HashCode`,
   and net472-vs-net481 phrasing.
+- [references/polyfill-layout.md](references/polyfill-layout.md) - the
+  user-facing package layout, the new-type list, and the `extern alias`
+  disambiguation recipe.
 
 ## Examples in this repo
 

--- a/.agents/skills/polyfill-dotnet-api/design-rules.md
+++ b/.agents/skills/polyfill-dotnet-api/design-rules.md
@@ -87,12 +87,12 @@ The exception is when the polyfill defines a **new type** in `System.*`
 A future Microsoft polyfill for that exact type collides (CS0436/CS0433)
 and callers need `extern alias`. The recipe and the list of new-type
 polyfills lives in
-[docs/polyfill-layout.md](../../../docs/polyfill-layout.md). Prefer
+[references/polyfill-layout.md](references/polyfill-layout.md). Prefer
 extension members over new `System.*` types when feasible.
 
 Touki's stated commitment is to **defer to Microsoft-shipped polyfills
 when they ship**: a future Touki release will reference the official
 package and remove (or thin-forward) the duplicate type, so callers
 upgrade automatically. See
-[docs/polyfill-layout.md](../../../docs/polyfill-layout.md) for the
+[references/polyfill-layout.md](references/polyfill-layout.md) for the
 user-facing version of that policy.

--- a/.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md
+++ b/.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md
@@ -6,7 +6,7 @@ source code compiles and runs on both targets.
 
 ## Where the polyfills live
 
-All polyfills live under [touki/Framework/Polyfills/](../touki/Framework/Polyfills/),
+All polyfills live under [touki/Framework/Polyfills/](../../../../touki/Framework/Polyfills/),
 organized into one folder per BCL namespace:
 
 ```text
@@ -33,7 +33,7 @@ the BCL namespace means callers reach the polyfill through the same
 Anything outside `Polyfills/` is **not** a polyfill of public BCL
 surface - it is either Touki-specific functionality
 (under `touki/Framework/Touki/`) or shared library code (under
-[touki/Touki/](../touki/Touki/)).
+[touki/Touki/](../../../../touki/Touki/)).
 
 ## How polyfill members coexist with future BCL members
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -301,9 +301,9 @@ catch a mistake.
   prefer Microsoft-shipped packages, then PolySharp source-gen for compiler
   attributes, and only hand-roll under
   `touki/Framework/Polyfills/<BclNamespace>/` as a last resort. See
-  [docs/polyfill-layout.md](../docs/polyfill-layout.md) for the layout rules
-  (namespace = BCL namespace; Touki-specific code stays under
-  `touki/Framework/Touki/...`) and the `extern alias` recipe.
+  [references/polyfill-layout.md](../.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md)
+  for the layout rules (namespace = BCL namespace; Touki-specific code stays
+  under `touki/Framework/Touki/...`) and the `extern alias` recipe.
 
 ## Path-specific instructions
 

--- a/.github/instructions/polyfills.instructions.md
+++ b/.github/instructions/polyfills.instructions.md
@@ -41,5 +41,5 @@ skill. Headline:
 3. Hand-rolled polyfill in this directory - **last resort**, only with
    a real caller. Don't polyfill for completeness.
 
-See [docs/polyfill-layout.md](../../docs/polyfill-layout.md) for the
-user-facing description and the `extern alias` recipe for type-name conflicts.
+See [references/polyfill-layout.md](../../.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md)
+for the user-facing description and the `extern alias` recipe for type-name conflicts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -300,9 +300,9 @@ catch a mistake.
   prefer Microsoft-shipped packages, then PolySharp source-gen for compiler
   attributes, and only hand-roll under
   `touki/Framework/Polyfills/<BclNamespace>/` as a last resort. See
-  [docs/polyfill-layout.md](docs/polyfill-layout.md) for the layout rules
-  (namespace = BCL namespace; Touki-specific code stays under
-  `touki/Framework/Touki/...`) and the `extern alias` recipe.
+  [references/polyfill-layout.md](.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md)
+  for the layout rules (namespace = BCL namespace; Touki-specific code stays
+  under `touki/Framework/Touki/...`) and the `extern alias` recipe.
 
 ## Path-specific instructions
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Some of the design goals include:
 - `MSBuildEnumerator` for MSBuild-style glob enumeration with no
   allocations until a match is produced
 - Polyfills for many modern .NET BCL APIs on .NET Framework 4.7.2 (see the
-  [polyfill layout doc](docs/polyfill-layout.md) for the full list)
+  [polyfill layout doc](.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md) for the full list)
 - A `DisposableBase` with double-disposal protection and disposal
   tracking helpers for diagnosing leaks
 - Much more!
@@ -41,7 +41,7 @@ Some of the design goals include:
 - [Low-Allocation Collections](docs/collections.md)
 - [Buffers, Span Readers, and Span Writers](docs/buffers.md)
 - [IO Helpers (globs, paths, temp folders, stream formatting)](docs/io.md)
-- [.NET Framework Polyfill Layout & Disambiguation](docs/polyfill-layout.md)
+- [.NET Framework Polyfill Layout & Disambiguation](.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md)
 - [Span Performance on .NET Framework (net472+)](.agents/skills/framework-jit-optimization/references/framework-span-performance.md)
 - [ArrayPool vs Stack Scratch Buffers (net481/net10)](.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md)
 


### PR DESCRIPTION
Executes **Phase 3a** of the docs -> skills migration plan: folds
`docs/polyfill-layout.md` into the local `polyfill-dotnet-api` skill.

## What changed

- Moved `docs/polyfill-layout.md` ->
  `.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md` (git tracks it
  as a 97% rename). This matches the established repo pattern where the README
  "Overviews" list points directly at a skill's `references/` file - the same
  treatment as `framework-span-performance.md` and `arraypool-performance.md`.
- Repointed every inbound link: `README.md` (x2), `AGENTS.md` (+ regenerated the
  `.github/copilot-instructions.md` mirror), `.github/instructions/polyfills.instructions.md`,
  and the skill's `design-rules.md` (x2).
- Listed the reference in the skill's Sub-pages (`SKILL.md`).
- Deleted the `docs/` copy.

## Note on the disposition

The doc is user-facing (a README "Overviews" entry; the instructions file calls it
"the user-facing description"). I still folded + deleted rather than leaving a
`docs/` stub, because the repo already sends README readers into skill
`references/` files for two other entries, so this is consistent. Easy to restore a
thin `docs/` redirect stub if preferred.

## Validation

- `tools/Validate-AgentFiles.ps1` - pass (frontmatter, mirror, whitespace).
- `tools/Test-AgentFileLinks.ps1` - pass (82 files, all relative links resolve).
- Full-repo grep confirms no remaining reference to the old `docs/polyfill-layout.md`
  path.
- Docs/skills-only change; no C# touched.
