### PR TITLE
Docs cleanups: annotate the fuzz plan; note the EventPipe thunk artifact in the filtrace overlay

### DIFF
--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -37,6 +37,21 @@ links are supplementary and resolve from anywhere.
 - [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) - the touki
   net481 ETW capture wrapper that prints scoped `filtrace` next-step commands.
 
+## Touki note - a concrete Trap #8 hit
+
+The core's **Trap #8** already covers this: filtrace folds JIT-helper thunks
+(`memmove`, write-barriers, GC-poll) into their managed caller **by default**, so
+its ranking does not surface the artifact below - only a *raw / unfolded*
+EventPipe view (or a third-party viewer) does. Recorded here as the touki data
+point behind that trap: a pre-filtrace `CpuSampling` trace of touki's extglob
+enumeration read `System.Buffer.BulkMoveWithWriteBarrier` at 93% inclusive - a
+sampling artifact that really belonged to the two engine loop bodies calling it.
+The sharp tell: a write-barrier variant over a **ref-free** struct is impossible
+(it needs `RuntimeHelpers.IsReferenceOrContainsReferences<T>()`), so it cannot be
+a real call; attribute it to the caller with `callers`. Full writeup:
+[docs/dotnet-perf-discoveries.md](../../../docs/dotnet-perf-discoveries.md)
+section 8.
+
 ## Updating
 
 Re-vendor from filtrace when its skill changes: copy

--- a/docs/fuzz-testing-plan.md
+++ b/docs/fuzz-testing-plan.md
@@ -8,6 +8,35 @@
 > repository's [AGENTS.md](../AGENTS.md) "Working with the user on changes"
 > contract.
 
+## Implementation status (as of 2026-07-01)
+
+This plan is **fully implemented** and has since grown past its original scope.
+The [`touki.fuzz`](../touki.fuzz/) harness targets `net10.0;net481` and is
+excluded from the normal test run; the reusable instrument/run/crash-promotion
+workflow now lives in the [`fuzz-testing`](../.agents/skills/fuzz-testing/SKILL.md)
+skill.
+
+- **Phase 1** (project standup; `SpanReader`/`SpanWriter` on net10) - **DONE**.
+  `SpanReaderTarget` / `SpanWriterTarget`, the `corpus/` + `crashes/` layout,
+  `Install-FuzzPrereqs.ps1`, and the harness README all shipped.
+- **Phase 2** (net481 runs) - **DONE**. The harness multi-targets `net481`; the
+  net481 Release `Unsafe.As` sign-extension divergence this phase was meant to
+  hunt is pinned in
+  `touki.tests/Framework/Regressions/UnsafeAsAggressiveInliningRegressionTests.cs`.
+- **Phase 3** (RLE encode/decode) - **DONE**. `RunLengthTarget` covers the
+  round-trip, length-invariant, and malformed-decode scenarios.
+- **Phase 4** (promote findings to `touki.tests`) - **DONE / ongoing**. Glob
+  fuzzing found real catastrophic-backtracking and stack-overflow DoS bugs, now
+  pinned as deterministic cross-TFM cases in
+  `touki.tests/Touki/Io/Globbing/GlobSpecificationTests.Security.cs`.
+- **Cross-cutting skill** - **DONE**. The
+  [`fuzz-testing`](../.agents/skills/fuzz-testing/SKILL.md) skill is the
+  documented entry point for both engines and the crash-to-regression loop.
+- **Beyond the original plan:** added `StringSegmentTarget`,
+  `ValueStringBuilderTarget`, and `GlobSpecificationTarget`.
+
+The phase narratives below are retained as the historical record of the rollout.
+
 ## Guiding decisions
 
 - **SharpFuzz works cross-TFM.** The package targets `netstandard2.0`, so a


### PR DESCRIPTION
Two small docs/skills cleanups from the docs -> skills migration plan (Phase 5
plus the Phase 2 assessment follow-up).

## 1. Annotate the fuzz-testing plan with implementation status

[docs/fuzz-testing-plan.md](docs/fuzz-testing-plan.md) gains an "Implementation
status" section: the plan is fully implemented and exceeded. Phases 1-4 and the
cross-cutting `fuzz-testing` skill are done - `touki.fuzz` targets
`net10.0;net481`, the net481 `Unsafe.As` divergence Phase 2 hunted is pinned in
`UnsafeAsAggressiveInliningRegressionTests`, glob-fuzzing DoS findings are pinned
in `GlobSpecificationTests.Security.cs`, and the harness added `StringSegment`,
`ValueStringBuilder`, and `GlobSpecification` targets beyond the original
SpanReader/SpanWriter/RLE scope.

## 2. Note the EventPipe helper-thunk artifact in the filtrace overlay

[.agents/skills/filtrace/overlay.md](.agents/skills/filtrace/overlay.md) records
the touki data point behind the filtrace core's **Trap #8** (which already folds
`memmove` / write-barriers / GC-poll thunks into their caller by default): a raw
pre-filtrace `CpuSampling` view of extglob enumeration once read 93%
`BulkMoveWithWriteBarrier`, a sampling artifact that really belonged to the engine
loops calling it. The note **defers the generic fold rule to Trap #8** and keeps
only the touki-specific illustration plus the sharp "write-barrier over a ref-free
struct is impossible" tell, linking `dotnet-perf-discoveries.md` section 8. The
vendored filtrace core is untouched.

## Validation

- `tools/Validate-AgentFiles.ps1` + `tools/Test-AgentFileLinks.ps1` - pass (82
  files, all relative links resolve).
- Docs/skills-only; no C# touched. The overlay is in the `agent-files.yml` CI
  scope (markdownlint + lychee `--offline`); the fuzz plan is a plain docs file.
