### PR TITLE
docs: default --benchmark scoping; re-vendor filtrace skill to v0.3.0

### DIFF
--- a/.agents/skills/filtrace/SKILL.md
+++ b/.agents/skills/filtrace/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: filtrace
-description: Analyze .NET CPU, allocation, exception, GC, JIT, and wall-clock (thread-time) traces - .nettrace, .etl, and speedscope captures - with the filtrace CLI or MCP server. Use when a user asks where time or memory goes in a trace or benchmark, which method or source line is hot, why a run regressed against a baseline, what a captured .nettrace / .etl contains, or to rank / drill / diff / export a profile - including profiling .NET Framework (net481) via ETW, where an EventPipe ranking would mislead.
+description: Analyze .NET CPU, allocation, exception, GC, JIT, and wall-clock (thread-time) traces - .nettrace, .etl, and speedscope captures - with the filtrace CLI or MCP server. Use when a user asks where time or memory goes in a trace or benchmark, which method or source line is hot, why a run regressed against a baseline, what a captured .nettrace / .etl contains, or to rank / drill / diff / export a profile - including profiling .NET Framework (net481) via ETW, where an EventPipe ranking would mislead. Also covers capturing the trace first - choosing EventPipe vs ETW, elevation, and the recording tool (dotnet-trace, BenchmarkDotNet, PerfView, wpr).
 compatibility: Pairs with the filtrace MCP server (the KlutzyNinja.Filtrace.Mcp package, run via `dnx`) for in-agent tool calls; otherwise shells out to the filtrace CLI (the KlutzyNinja.Filtrace global tool). Either head provides the same analysis, so the skill degrades gracefully to whichever is installed.
 license: MIT
 metadata:
   github-path: .agents/skills/filtrace
-  github-pinned: 04fd8573ef801b98aeb77442642aca9180f0a49e
-  github-ref: refs/heads/main
+  github-pinned: v0.3.0
+  github-ref: refs/tags/v0.3.0
   github-repo: https://github.com/JeremyKuhne/filtrace
-  github-tree-sha: f75c6b3147d52a5782e715c2b9578e439cbd9455
+  github-tree-sha: fe6ead566151f22e27be3c6371b838cecbc78b07
   portability: repo-specific
 ---
 
@@ -23,6 +23,32 @@ an MCP server - there is no GUI. Output is dense text by default, or compact JSO
 This skill is the *how*; the full reference is single-sourced in
 [docs/workflow.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/workflow.md)
 and [docs/traps.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/traps.md).
+
+## Getting a trace to analyze
+
+filtrace records ETW captures itself - the `collect` verb launches an executable and
+records an `.etl` (Windows, Administrator) - and otherwise analyzes traces other tools
+record; for an EventPipe `.nettrace`, that recorder is `dotnet-trace` (cross-platform).
+Record or produce one, then point a verb - or `trace_info` - at the file. Pick the
+capture by the question:
+
+- **EventPipe** (`.nettrace` / `.speedscope.json`) - cross-platform, no elevation,
+  single process. From `dotnet-trace collect` or BenchmarkDotNet `-p EP`. Carries
+  CPU, allocations, exceptions, GC, and JIT.
+- **ETW** (`.etl`) - **Windows only, needs Administrator** (kernel sampling),
+  machine-wide. From `filtrace collect`, BenchmarkDotNet `-p ETW`, PerfView, or `wpr`.
+  It is the *only* source for wall-clock (`threadtime`), the native GC / JIT / `memcpy` split
+  (`--native-symbols` + `classify`), and multi-process scoping (`processes` +
+  `--process`).
+
+So "where's the time / what allocates" on one process -> EventPipe; "CPU-bound or
+blocked?", "GC versus my code?", or a machine-wide capture -> ETW. Two bundled
+scripts wrap the capture-then-analyze loop and print the scoped filtrace commands:
+[scripts/Capture-BenchmarkTrace.ps1](scripts/Capture-BenchmarkTrace.ps1) profiles a
+BenchmarkDotNet micro-benchmark (add `--keepFiles`, analyze with `--benchmark`), and
+[scripts/Capture-ProjectTrace.ps1](scripts/Capture-ProjectTrace.ps1) builds an
+executable project and traces its running output directly - never `dotnet run`,
+whose build/run host is a different process (see the trap catalog).
 
 ## The workflow: orient -> rank -> drill -> compare
 
@@ -93,6 +119,12 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 | `jitstats` | JIT method count, compile time, sizes |
 | `events --name <n>` | raw events by name, paged |
 
+**Capture** - record a Windows ETW `.etl` yourself (for an EventPipe `.nettrace`, use `dotnet-trace`):
+
+| Verb | Does |
+|---|---|
+| `collect` | launch an executable and record a CPU / thread-time `.etl` (Windows, Administrator) |
+
 **File ops** - manage the ETLX conversion cache TraceEvent keeps beside a trace:
 
 | Verb | Does |
@@ -147,10 +179,16 @@ The recurring ways a .NET trace investigation goes wrong:
    that default is usually right - but run `processes` first to see what is in the
    capture, then pass `--process <name>` if the auto-pick is wrong.
 
-4. **BenchmarkDotNet captures include the harness.** A raw ranking of a BDN trace
-   is dominated by the orchestrator and warmup iterations, not your `[Benchmark]`.
+4. **BenchmarkDotNet captures include the harness - scope with `--benchmark` by
+   default, not as an afterthought.** A raw ranking (or export) of a BDN trace is
+   dominated by the orchestrator and warmup iterations, not your `[Benchmark]`.
    Pass `--benchmark` to preset the root to the measured-workload wrapper so only
-   the measured code is ranked.
+   the measured code is analyzed. This applies to **every** verb that takes
+   `--root`, including `export` - a flame graph with the harness left in is not
+   just noisy, its proportions are wrong (the workload's own share of time reads
+   too small). `export` is the easiest verb to forget this on: it writes a file
+   and prints no "scoped to X" summary, so there is no output to notice the
+   omission in - check the command before running it, not the graph after.
 
 5. **Native runtime frames need `--native-symbols`.** Without it, the unmanaged
    ~10% of a trace - GC, JIT, `memset` / `memcpy`, write barriers - shows as an
@@ -173,6 +211,14 @@ The recurring ways a .NET trace investigation goes wrong:
    `memmove`, write-barriers, and GC-poll helpers into their managed caller -
    right for "which method is hot", wrong for "what kind of work dominates". Use
    `--no-fold` (or `classify`) to let the native leaves rank on their own.
+
+9. **Trace the built app, not `dotnet run`.** `dotnet run` builds and then forks
+   your program into a separate child process, so a single-process EventPipe
+   session launched with `dotnet-trace collect -- dotnet run ...` records the
+   build/run host, not your code, and the hot frames never appear. Build first,
+   then launch the built output directly (`dotnet-trace collect -- <app>.dll`, or
+   the apphost `<app>.exe`); the bundled `Capture-ProjectTrace.ps1` resolves that
+   run target for you.
 <!-- filtrace:end traps -->
 
 ## CLI or MCP

--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -24,6 +24,14 @@ and `docs/traps.md` as absolute `https://github.com/JeremyKuhne/filtrace` URLs:
 the load-bearing verb and trap catalogs are embedded in the skill body, so those
 links are supplementary and resolve from anywhere.
 
+The skill body also links two bundled scripts by *relative* path
+(`scripts/Capture-BenchmarkTrace.ps1`, `scripts/Capture-ProjectTrace.ps1`), so
+[scripts/](scripts/) is vendored here verbatim alongside `SKILL.md` - these are
+filtrace's own generic capture-then-analyze wrappers (any BenchmarkDotNet project
+or executable project), distinct from touki's own
+[tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) (a touki-specific
+net481 ETW wrapper, kept separately below).
+
 ## Cross-references (touki side)
 
 - [`performance-testing`](../performance-testing/SKILL.md) - the touki skill that
@@ -54,8 +62,14 @@ section 8.
 
 ## Updating
 
-Re-vendor from filtrace when its skill changes: copy
-`.agents/skills/filtrace/SKILL.md` from the filtrace repo, re-add this provenance
-block (bump `github-pinned` / `github-tree-sha` to the new commit), and keep
-touki-specific notes here, not in the core. When filtrace cuts a release whose
-package carries the updated skill, prefer pinning to that tag.
+Re-vendor from filtrace when its skill changes: copy both
+`.agents/skills/filtrace/SKILL.md` **and** its `scripts/` subfolder from the
+filtrace repo (the relative links in the body only resolve if `scripts/` is
+present here too), re-add this provenance block (bump `github-pinned` /
+`github-tree-sha` to the new commit or tag), and keep touki-specific notes here,
+not in the core. When filtrace cuts a release whose package carries the updated
+skill, pin to that tag (`github-ref: refs/tags/vX.Y.Z`, `github-pinned: vX.Y.Z` -
+a tag pin uses the tag name, not a commit SHA) rather than a branch/commit. After
+re-vendoring, run `tools/Validate-AgentFiles.ps1` and
+`tools/Test-AgentFileLinks.ps1` - the latter catches a missed `scripts/` copy
+immediately (dangling relative links).

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -16,8 +16,8 @@
         preferred when both exist - it is the only one of the two that carries
         allocation events and per-frame source locations, which the printed
         `alloc` / `lines` commands need; a .speedscope.json is CPU-self-time
-        only, and its `filtrace lines` output is always empty (per the filtrace
-        skill, speedscope inputs carry no line data). Falls back to
+        only and carries no per-frame source locations at all, so `filtrace
+        lines` against one always reports nothing. Falls back to
         .speedscope.json - printing only the commands that work against it
         (`cpu`, `export`) - when no .nettrace was produced.
       - ETW (-Profiler ETW): Windows only, self-elevates (one UAC prompt), machine
@@ -110,7 +110,11 @@ if ($Profiler -eq 'ETW' -and -not (Test-Elevated)) {
     # survives Start-Process joining the array into a single command line.
     $argList = @('-NoProfile', '-File', "`"$PSCommandPath`"", '-Project', "`"$($projFile.FullName)`"",
         '-Filter', "`"$Filter`"", '-Profiler', 'ETW', '-Tfm', $Tfm, '-Process', "`"$Process`"", '-Top', $Top)
-    $proc = Start-Process pwsh -Verb RunAs -PassThru -Wait -WorkingDirectory $repoRoot -ArgumentList $argList
+    # Relaunch with the host that is ALREADY running this script, not a hardcoded 'pwsh' -
+    # a caller on Windows PowerShell 5.1 without PowerShell 7 installed would otherwise
+    # fail here with pwsh unresolved.
+    $hostExe = (Get-Process -Id $PID).Path
+    $proc = Start-Process -FilePath $hostExe -Verb RunAs -PassThru -Wait -WorkingDirectory $repoRoot -ArgumentList $argList
     if ($proc.ExitCode -ne 0) { Write-Error "Elevated capture failed (exit $($proc.ExitCode)). See $log." -ErrorAction Continue ; exit $proc.ExitCode }
     if (Test-Path $log) { Write-Host "`n--- capture log tail (full log: $log) ---" -ForegroundColor Cyan ; Get-Content $log -Tail 20 }
     exit 0
@@ -140,19 +144,41 @@ if ($LASTEXITCODE -ne 0) { Write-Error "Benchmark run failed (exit $LASTEXITCODE
 # results/ subfolder, so recurse). For EventPipe, prefer the raw .nettrace over any
 # derived .speedscope.json from the same capture - the .nettrace also carries
 # allocation events and per-frame source locations that the alloc/lines commands
-# below need and a speedscope conversion does not; fall back to .speedscope.json
-# only when no .nettrace was produced.
+# below need and a speedscope conversion does not. But only prefer it when it is
+# actually the PAIRED raw file for this capture (same stem, i.e. produced together) -
+# otherwise a stale .nettrace left over from an earlier run would win over a fresh,
+# speedscope-only capture just because it happens to be a .nettrace. When the two
+# are not paired, whichever file is genuinely newest wins.
 if ($Profiler -eq 'ETW') {
     $trace = Get-ChildItem -Path $artifacts -Filter '*.etl' -Recurse -ErrorAction SilentlyContinue |
         Sort-Object LastWriteTime | Select-Object -Last 1
     if ($null -eq $trace) { Write-Error "No *.etl found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
 }
 else {
-    $trace = Get-ChildItem -Path $artifacts -Filter '*.nettrace' -Recurse -ErrorAction SilentlyContinue |
+    $netTrace = Get-ChildItem -Path $artifacts -Filter '*.nettrace' -Recurse -ErrorAction SilentlyContinue |
         Sort-Object LastWriteTime | Select-Object -Last 1
-    if ($null -eq $trace) {
-        $trace = Get-ChildItem -Path $artifacts -Filter '*.speedscope.json' -Recurse -ErrorAction SilentlyContinue |
-            Sort-Object LastWriteTime | Select-Object -Last 1
+    $speedscope = Get-ChildItem -Path $artifacts -Filter '*.speedscope.json' -Recurse -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime | Select-Object -Last 1
+
+    if ($null -eq $netTrace) {
+        $trace = $speedscope
+    }
+    elseif ($null -eq $speedscope) {
+        $trace = $netTrace
+    }
+    else {
+        # BenchmarkDotNet names both files from the same stem, e.g.
+        # foo-<timestamp>.nettrace / foo-<timestamp>.speedscope.json - strip each
+        # file's own suffix to compare the stems, not just Extension (which for
+        # *.speedscope.json is only ".json").
+        $netStem = $netTrace.BaseName
+        $scopeStem = $speedscope.Name -replace '\.speedscope\.json$', ''
+        if ($netStem -eq $scopeStem -or $netTrace.LastWriteTime -ge $speedscope.LastWriteTime) {
+            $trace = $netTrace
+        }
+        else {
+            $trace = $speedscope
+        }
     }
     if ($null -eq $trace) { Write-Error "No *.nettrace or *.speedscope.json found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
 }

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+    Capture a .NET CPU trace (EventPipe or ETW) of a BenchmarkDotNet benchmark, then
+    print the filtrace commands to analyze it. This helper drives the capture step via
+    BenchmarkDotNet's EventPipe or ETW profiler.
+
+.DESCRIPTION
+    Wraps the "record a trace, then analyze it" loop for a BenchmarkDotNet perf
+    project. Run it from the repository root (where BenchmarkDotNet.Artifacts should
+    land):
+
+      - EventPipe (-Profiler EP, the default): cross-platform, no elevation, single
+        process. Runs `dotnet run -c Release -f <Tfm> --project <Project> --
+        --filter <Filter> -p EP`, which exports a .speedscope.json.
+      - ETW (-Profiler ETW): Windows only, self-elevates (one UAC prompt), machine
+        wide. Runs the same with `-p ETW --keepFiles`, which writes a .etl. Only an
+        .etl carries wall-clock (threadtime), the native GC / JIT / memcpy split
+        (classify --native-symbols), and multi-process scoping.
+
+    Output is teed, never redirected away, so the elevated window shows live
+    progress instead of looking hung. The printed filtrace commands are pre-scoped:
+    an EventPipe trace with --benchmark (past the harness); an .etl additionally with
+    --process, because an .etl is machine-wide.
+
+    filtrace: https://github.com/JeremyKuhne/filtrace - install once with
+    `dotnet tool install -g KlutzyNinja.Filtrace`, or drive the MCP trace_* tools.
+
+.PARAMETER Project
+    Path to the perf project - a .csproj or the directory holding one. Required.
+
+.PARAMETER Filter
+    BenchmarkDotNet --filter glob selecting the benchmark(s), e.g. '*GlobMatchBench*'.
+    Profile one at a time for a clean trace. Required.
+
+.PARAMETER Profiler
+    'EP' (EventPipe, default) or 'ETW' (Windows, self-elevating).
+
+.PARAMETER Tfm
+    Target-framework moniker to run. Default net10.0.
+
+.PARAMETER Process
+    Process-name substring the printed ETW commands scope to with --process.
+    Defaults to the project file's base name (the benchmark host).
+
+.PARAMETER Top
+    Rows per ranking in the printed commands. Default 25.
+
+.EXAMPLE
+    ./Capture-BenchmarkTrace.ps1 -Project src/App.Perf -Filter '*GlobMatchBench*'
+
+.EXAMPLE
+    ./Capture-BenchmarkTrace.ps1 -Project src/App.Perf -Filter '*GlobMatchBench*' -Profiler ETW
+#>
+param(
+    [Parameter(Mandatory)][string]$Project,
+    [Parameter(Mandatory)][string]$Filter,
+    [ValidateSet('EP', 'ETW')][string]$Profiler = 'EP',
+    [string]$Tfm = 'net10.0',
+    [string]$Process,
+    [int]$Top = 25
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve the project file (accept either a .csproj or a directory holding one).
+$projItem = Get-Item -LiteralPath $Project
+if ($projItem.PSIsContainer) {
+    $projFile = Get-ChildItem -LiteralPath $Project -Filter *.csproj | Select-Object -First 1
+    if ($null -eq $projFile) { Write-Error "No .csproj found under $Project." -ErrorAction Continue ; exit 1 }
+}
+else {
+    $projFile = $projItem
+}
+if (-not $Process) { $Process = [System.IO.Path]::GetFileNameWithoutExtension($projFile.Name) }
+
+$repoRoot = (Get-Location).Path
+$artifacts = Join-Path $repoRoot 'BenchmarkDotNet.Artifacts'
+$log = Join-Path $artifacts 'capture.log'
+
+function Test-Elevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# Recording an .etl is Windows-only, and Test-Elevated below calls a Windows-only API, so
+# fail fast with a clear message rather than a PlatformNotSupportedException. Compare
+# against $false so Windows PowerShell 5.1 (undefined $IsWindows) is not mistaken for a
+# non-Windows OS.
+if ($Profiler -eq 'ETW' -and $IsWindows -eq $false) {
+    Write-Error 'ETW capture is Windows-only. Use -Profiler EP on this OS.' -ErrorAction Continue
+    exit 1
+}
+
+# ETW kernel sessions require Administrator. When not elevated, relaunch this script
+# in an elevated window that shows the capture's live progress, then wait for it.
+# -WorkingDirectory anchors the child at the repo root so BenchmarkDotNet.Artifacts (and
+# the capture log the parent tails) resolve there, not in the elevated shell's system32.
+if ($Profiler -eq 'ETW' -and -not (Test-Elevated)) {
+    Write-Host 'ETW capture needs Administrator; relaunching elevated (a UAC prompt will appear).' -ForegroundColor Yellow
+    # Quote path/value args so a project path, filter, or process name containing spaces
+    # survives Start-Process joining the array into a single command line.
+    $argList = @('-NoProfile', '-File', "`"$PSCommandPath`"", '-Project', "`"$($projFile.FullName)`"",
+        '-Filter', "`"$Filter`"", '-Profiler', 'ETW', '-Tfm', $Tfm, '-Process', "`"$Process`"", '-Top', $Top)
+    $proc = Start-Process pwsh -Verb RunAs -PassThru -Wait -WorkingDirectory $repoRoot -ArgumentList $argList
+    if ($proc.ExitCode -ne 0) { Write-Error "Elevated capture failed (exit $($proc.ExitCode)). See $log." -ErrorAction Continue ; exit $proc.ExitCode }
+    if (Test-Path $log) { Write-Host "`n--- capture log tail (full log: $log) ---" -ForegroundColor Cyan ; Get-Content $log -Tail 20 }
+    exit 0
+}
+
+New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
+
+# Without BenchmarkDotNet.Diagnostics.Windows the `-p ETW` profiler silently resolves
+# to UnresolvedDiagnoser and no .etl is written - fail fast with guidance.
+if ($Profiler -eq 'ETW' -and -not (Select-String -Path $projFile.FullName -Pattern 'BenchmarkDotNet.Diagnostics.Windows' -Quiet)) {
+    Write-Error "$($projFile.Name) does not reference BenchmarkDotNet.Diagnostics.Windows; -p ETW will no-op. Add the package first." -ErrorAction Continue
+    exit 1
+}
+
+# Both branches are multi-element arrays, so they stay arrays (a single-element
+# if-expression would unwrap to a scalar under Set-StrictMode).
+$profArg = if ($Profiler -eq 'ETW') { @('-p', 'ETW', '--keepFiles') } else { @('-p', 'EP') }
+
+Write-Host "Capturing $Profiler trace: $Filter ($Tfm)..." -ForegroundColor Cyan
+# Tee, do not redirect: an elevated window shows BenchmarkDotNet's live progress
+# while the run is also logged for the parent window to surface.
+dotnet run -c Release -f $Tfm --project $projFile.FullName -- --filter $Filter @profArg 2>&1 |
+    Tee-Object -FilePath $log
+if ($LASTEXITCODE -ne 0) { Write-Error "Benchmark run failed (exit $LASTEXITCODE). See $log." -ErrorAction Continue ; exit $LASTEXITCODE }
+
+# Locate the newest trace of the right kind (BenchmarkDotNet may nest it under a
+# results/ subfolder, so recurse).
+$pattern = if ($Profiler -eq 'ETW') { '*.etl' } else { '*.speedscope.json' }
+$trace = Get-ChildItem -Path $artifacts -Filter $pattern -Recurse -ErrorAction SilentlyContinue |
+    Sort-Object LastWriteTime | Select-Object -Last 1
+if ($null -eq $trace) { Write-Error "No $pattern found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
+
+# The build output BenchmarkDotNet kept (EventPipe) or --keepFiles preserved (ETW);
+# its embedded PDBs resolve managed frames to source lines for lines/heatmap.
+$symbols = Join-Path (Split-Path -Parent $projFile.FullName) "bin/Release/$Tfm"
+
+Write-Host "`nCaptured: $($trace.FullName)" -ForegroundColor Green
+Write-Host "`nNext-step filtrace commands:" -ForegroundColor Green
+if ($Profiler -eq 'ETW') {
+    # An .etl is machine-wide: scope every query to the benchmark process AND to
+    # the measured workload with --benchmark - both, every time, not just when a
+    # ranking looks noisy. --process narrows the OS process; --benchmark is what
+    # excludes the harness/warmup subtree so a ranking or export's proportions
+    # actually reflect the measured [Benchmark] code.
+    Write-Host "  filtrace processes `"$($trace.FullName)`""
+    Write-Host "  filtrace cpu `"$($trace.FullName)`" --process $Process --benchmark --top $Top"
+    Write-Host "  filtrace threadtime `"$($trace.FullName)`" --process $Process --benchmark --top $Top"
+    Write-Host "  filtrace lines `"$($trace.FullName)`" --process $Process --benchmark --symbols `"$symbols`""
+    Write-Host "  filtrace classify `"$($trace.FullName)`" --process $Process --benchmark --native-symbols"
+    Write-Host "  filtrace export `"$($trace.FullName)`" --process $Process --benchmark --native-symbols --symbols `"$symbols`" -o flame.speedscope.json"
+}
+else {
+    # A single-process EventPipe trace: scope past the BenchmarkDotNet harness with
+    # --benchmark - every verb here, export included, not just the ones that print
+    # a ranking.
+    Write-Host "  filtrace cpu `"$($trace.FullName)`" --benchmark --top $Top"
+    Write-Host "  filtrace alloc `"$($trace.FullName)`" --benchmark --top $Top"
+    Write-Host "  filtrace lines `"$($trace.FullName)`" --benchmark --symbols `"$symbols`""
+    Write-Host "  filtrace export `"$($trace.FullName)`" --benchmark --symbols `"$symbols`" -o flame.speedscope.json"
+}

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -11,7 +11,15 @@
 
       - EventPipe (-Profiler EP, the default): cross-platform, no elevation, single
         process. Runs `dotnet run -c Release -f <Tfm> --project <Project> --
-        --filter <Filter> -p EP`, which exports a .speedscope.json.
+        --filter <Filter> -p EP`, which writes a raw .nettrace and (today) also
+        a derived .speedscope.json from the same capture. The raw .nettrace is
+        preferred when both exist - it is the only one of the two that carries
+        allocation events and per-frame source locations, which the printed
+        `alloc` / `lines` commands need; a .speedscope.json is CPU-self-time
+        only, and its `filtrace lines` output is always empty (per the filtrace
+        skill, speedscope inputs carry no line data). Falls back to
+        .speedscope.json - printing only the commands that work against it
+        (`cpu`, `export`) - when no .nettrace was produced.
       - ETW (-Profiler ETW): Windows only, self-elevates (one UAC prompt), machine
         wide. Runs the same with `-p ETW --keepFiles`, which writes a .etl. Only an
         .etl carries wall-clock (threadtime), the native GC / JIT / memcpy split
@@ -129,11 +137,25 @@ dotnet run -c Release -f $Tfm --project $projFile.FullName -- --filter $Filter @
 if ($LASTEXITCODE -ne 0) { Write-Error "Benchmark run failed (exit $LASTEXITCODE). See $log." -ErrorAction Continue ; exit $LASTEXITCODE }
 
 # Locate the newest trace of the right kind (BenchmarkDotNet may nest it under a
-# results/ subfolder, so recurse).
-$pattern = if ($Profiler -eq 'ETW') { '*.etl' } else { '*.speedscope.json' }
-$trace = Get-ChildItem -Path $artifacts -Filter $pattern -Recurse -ErrorAction SilentlyContinue |
-    Sort-Object LastWriteTime | Select-Object -Last 1
-if ($null -eq $trace) { Write-Error "No $pattern found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
+# results/ subfolder, so recurse). For EventPipe, prefer the raw .nettrace over any
+# derived .speedscope.json from the same capture - the .nettrace also carries
+# allocation events and per-frame source locations that the alloc/lines commands
+# below need and a speedscope conversion does not; fall back to .speedscope.json
+# only when no .nettrace was produced.
+if ($Profiler -eq 'ETW') {
+    $trace = Get-ChildItem -Path $artifacts -Filter '*.etl' -Recurse -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime | Select-Object -Last 1
+    if ($null -eq $trace) { Write-Error "No *.etl found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
+}
+else {
+    $trace = Get-ChildItem -Path $artifacts -Filter '*.nettrace' -Recurse -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime | Select-Object -Last 1
+    if ($null -eq $trace) {
+        $trace = Get-ChildItem -Path $artifacts -Filter '*.speedscope.json' -Recurse -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime | Select-Object -Last 1
+    }
+    if ($null -eq $trace) { Write-Error "No *.nettrace or *.speedscope.json found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
+}
 
 # The build output BenchmarkDotNet kept (EventPipe) or --keepFiles preserved (ETW);
 # its embedded PDBs resolve managed frames to source lines for lines/heatmap.
@@ -154,12 +176,20 @@ if ($Profiler -eq 'ETW') {
     Write-Host "  filtrace classify `"$($trace.FullName)`" --process $Process --benchmark --native-symbols"
     Write-Host "  filtrace export `"$($trace.FullName)`" --process $Process --benchmark --native-symbols --symbols `"$symbols`" -o flame.speedscope.json"
 }
-else {
-    # A single-process EventPipe trace: scope past the BenchmarkDotNet harness with
-    # --benchmark - every verb here, export included, not just the ones that print
-    # a ranking.
+elseif ($trace.Name -like '*.nettrace') {
+    # A raw .nettrace carries CPU, allocations, and per-frame source locations -
+    # every verb below works against it. Scope past the BenchmarkDotNet harness
+    # with --benchmark - every verb here, export included, not just the ones that
+    # print a ranking.
     Write-Host "  filtrace cpu `"$($trace.FullName)`" --benchmark --top $Top"
     Write-Host "  filtrace alloc `"$($trace.FullName)`" --benchmark --top $Top"
     Write-Host "  filtrace lines `"$($trace.FullName)`" --benchmark --symbols `"$symbols`""
     Write-Host "  filtrace export `"$($trace.FullName)`" --benchmark --symbols `"$symbols`" -o flame.speedscope.json"
+}
+else {
+    # A derived .speedscope.json carries CPU self-time only: no allocation events
+    # (alloc needs a .nettrace) and no per-frame source locations (speedscope inputs
+    # never carry line data), so only print the commands that actually work against it.
+    Write-Host "  filtrace cpu `"$($trace.FullName)`" --benchmark --top $Top"
+    Write-Host "  filtrace export `"$($trace.FullName)`" --benchmark -o flame.speedscope.json"
 }

--- a/.agents/skills/filtrace/scripts/Capture-ProjectTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-ProjectTrace.ps1
@@ -127,7 +127,11 @@ if ($Profiler -eq 'ETW' -and -not (Test-Elevated)) {
         '-Profiler', 'ETW', '-Metric', $Metric, '-Tfm', $Tfm, '-Configuration', "`"$Configuration`"", '-Top', $Top)
     if ($Output) { $argList += @('-Output', "`"$Output`"") }
     if ($AppArgs.Count -gt 0) { $argList += @('-AppArgs') + ($AppArgs | ForEach-Object { "`"$_`"" }) }
-    $proc = Start-Process pwsh -Verb RunAs -PassThru -Wait -WorkingDirectory (Get-Location).Path -ArgumentList $argList
+    # Relaunch with the host that is ALREADY running this script, not a hardcoded 'pwsh' -
+    # a caller on Windows PowerShell 5.1 without PowerShell 7 installed would otherwise
+    # fail here with pwsh unresolved.
+    $hostExe = (Get-Process -Id $PID).Path
+    $proc = Start-Process -FilePath $hostExe -Verb RunAs -PassThru -Wait -WorkingDirectory (Get-Location).Path -ArgumentList $argList
     if ($proc.ExitCode -ne 0) { Write-Error "Elevated capture failed (exit $($proc.ExitCode))." -ErrorAction Continue ; exit $proc.ExitCode }
     exit 0
 }

--- a/.agents/skills/filtrace/scripts/Capture-ProjectTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-ProjectTrace.ps1
@@ -1,0 +1,255 @@
+<#
+.SYNOPSIS
+    Capture a .NET perf trace (EventPipe or ETW) of an executable project running,
+    then print the filtrace commands to analyze it. This helper drives the capture step:
+    EventPipe via dotnet-trace, ETW via the filtrace collect verb.
+
+.DESCRIPTION
+    Wraps the "build the project, run its output under a profiler, then analyze the
+    trace" loop for an ordinary executable project - a console app, worker, or web
+    host. It is the whole-application counterpart to Capture-BenchmarkTrace.ps1,
+    which profiles a BenchmarkDotNet micro-benchmark.
+
+    It builds the project, resolves the actual run target from the build output, and
+    launches THAT under the profiler - never `dotnet run`. `dotnet run` builds and
+    then forks your app into a separate child process, so a single-process EventPipe
+    session would trace the build/run host instead of your code. Launching the built
+    apphost (or `dotnet <app>.dll`) directly keeps the trace on the app itself.
+
+      - EventPipe (-Profiler EP, the default): cross-platform, no elevation, single
+        process. Runs `dotnet-trace collect -- <app>` and writes a .nettrace. Pass
+        -Metric alloc for a gc-verbose (allocation) capture instead of CPU sampling.
+      - ETW (-Profiler ETW): Windows only, self-elevates (one UAC prompt),
+        machine-wide, via `filtrace collect` (TraceEvent, no external recorder). Only an
+        .etl carries wall-clock (threadtime), the native GC / JIT / memcpy split
+        (classify --native-symbols), and multi-process scoping.
+
+    The app runs to completion (launch-only); the profiler stops when it exits. The
+    printed filtrace commands are pre-scoped: an EventPipe trace ranks the whole
+    process; an .etl additionally uses --process, because an .etl is machine-wide.
+
+    filtrace: https://github.com/JeremyKuhne/filtrace - install once with
+    `dotnet tool install -g KlutzyNinja.Filtrace`, or drive the MCP trace_* tools.
+
+.PARAMETER Project
+    Path to the executable project - a .csproj or the directory holding one. Required.
+
+.PARAMETER Profiler
+    'EP' (EventPipe, default) or 'ETW' (Windows, self-elevating).
+
+.PARAMETER Metric
+    'cpu' (default) or 'alloc'. EventPipe only: 'alloc' captures the gc-verbose
+    allocation profile instead of CPU sampling. An ETW capture always records CPU
+    and wall-clock (threadtime) together.
+
+.PARAMETER Tfm
+    Target-framework moniker to build and run. Default net10.0.
+
+.PARAMETER Configuration
+    Build configuration. Default Release - a perf trace should profile optimized output.
+
+.PARAMETER AppArgs
+    Arguments passed to the application after the profiler launches it.
+
+.PARAMETER Top
+    Rows per ranking in the printed commands. Default 25.
+
+.PARAMETER Output
+    Trace output path. Defaults to ./perf-traces/<AssemblyName>.<nettrace|etl>.
+
+.EXAMPLE
+    ./Capture-ProjectTrace.ps1 -Project src/MyApp
+
+.EXAMPLE
+    ./Capture-ProjectTrace.ps1 -Project src/MyApp -Metric alloc -AppArgs '--input','big.json'
+
+.EXAMPLE
+    ./Capture-ProjectTrace.ps1 -Project src/MyApp -Profiler ETW
+#>
+param(
+    [Parameter(Mandatory)][string]$Project,
+    [ValidateSet('EP', 'ETW')][string]$Profiler = 'EP',
+    [ValidateSet('cpu', 'alloc')][string]$Metric = 'cpu',
+    [string]$Tfm = 'net10.0',
+    [string]$Configuration = 'Release',
+    [string[]]$AppArgs = @(),
+    [int]$Top = 25,
+    [string]$Output
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve the project file (accept either a .csproj or a directory holding one).
+$projItem = Get-Item -LiteralPath $Project
+if ($projItem.PSIsContainer) {
+    $projFile = Get-ChildItem -LiteralPath $Project -Filter *.csproj | Select-Object -First 1
+    if ($null -eq $projFile) { Write-Error "No .csproj found under $Project." -ErrorAction Continue ; exit 1 }
+}
+else {
+    $projFile = $projItem
+}
+
+# Reading an .etl (and recording one via a kernel ETW session) is Windows-only.
+# Compare against $false so Windows PowerShell 5.1 (where $IsWindows is undefined) is
+# not mistaken for a non-Windows OS.
+if ($Profiler -eq 'ETW' -and $IsWindows -eq $false) {
+    Write-Error 'ETW capture is Windows-only. Use -Profiler EP on this OS.' -ErrorAction Continue
+    exit 1
+}
+
+function Test-Elevated {
+    $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object System.Security.Principal.WindowsPrincipal($id)
+    return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# filtrace records the ETW session itself (no external recorder); it installs as a global
+# tool under ~/.dotnet/tools, which a freshly elevated shell may not have on PATH yet.
+# Check it in the normal console (before any elevation) so the install hint is not buried
+# in a UAC window that then closes.
+$toolsDir = Join-Path $HOME '.dotnet/tools'
+if ((Test-Path $toolsDir) -and ($env:PATH -notlike "*$toolsDir*")) {
+    $env:PATH = "$toolsDir$([System.IO.Path]::PathSeparator)$env:PATH"
+}
+if ($Profiler -eq 'ETW' -and -not (Get-Command filtrace -ErrorAction SilentlyContinue)) {
+    Write-Error 'filtrace not found. Install it (dotnet tool install -g KlutzyNinja.Filtrace), then re-run.' -ErrorAction Continue
+    exit 1
+}
+
+# ETW kernel sessions require Administrator. When not elevated, relaunch this script
+# in an elevated window; -WorkingDirectory keeps the default output path (and any
+# relative -Output) resolving against the caller's directory, not system32.
+if ($Profiler -eq 'ETW' -and -not (Test-Elevated)) {
+    Write-Host 'ETW capture needs Administrator; relaunching elevated (a UAC prompt will appear).' -ForegroundColor Yellow
+    # Quote path/value args so a project path, output path, or app argument containing
+    # spaces survives Start-Process joining the array into a single command line.
+    $argList = @('-NoProfile', '-File', "`"$PSCommandPath`"", '-Project', "`"$($projFile.FullName)`"",
+        '-Profiler', 'ETW', '-Metric', $Metric, '-Tfm', $Tfm, '-Configuration', "`"$Configuration`"", '-Top', $Top)
+    if ($Output) { $argList += @('-Output', "`"$Output`"") }
+    if ($AppArgs.Count -gt 0) { $argList += @('-AppArgs') + ($AppArgs | ForEach-Object { "`"$_`"" }) }
+    $proc = Start-Process pwsh -Verb RunAs -PassThru -Wait -WorkingDirectory (Get-Location).Path -ArgumentList $argList
+    if ($proc.ExitCode -ne 0) { Write-Error "Elevated capture failed (exit $($proc.ExitCode))." -ErrorAction Continue ; exit $proc.ExitCode }
+    exit 0
+}
+
+Write-Host "Building $($projFile.Name) ($Configuration, $Tfm)..." -ForegroundColor Cyan
+dotnet build $projFile.FullName -c $Configuration -f $Tfm | Out-Host
+if ($LASTEXITCODE -ne 0) { Write-Error "Build failed (exit $LASTEXITCODE)." -ErrorAction Continue ; exit $LASTEXITCODE }
+
+# Resolve the built assembly, its name, and the output kind in one evaluation. With
+# more than one -getProperty the SDK returns JSON, so parse the Properties object.
+$propsJson = dotnet msbuild $projFile.FullName -getProperty:TargetPath -getProperty:AssemblyName `
+    -getProperty:OutputType "-p:Configuration=$Configuration" "-p:TargetFramework=$Tfm" 2>$null | Out-String
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($propsJson)) {
+    Write-Error "Could not read build properties from $($projFile.Name) (dotnet msbuild -getProperty failed). Ensure the project restores and builds for $Configuration/$Tfm." -ErrorAction Continue
+    exit 1
+}
+$props = ($propsJson | ConvertFrom-Json).Properties
+$targetPath = $props.TargetPath
+$assemblyName = $props.AssemblyName
+$outputType = $props.OutputType
+
+if ([string]::IsNullOrWhiteSpace($targetPath)) {
+    Write-Error "Could not resolve the build output (TargetPath) for $($projFile.Name)." -ErrorAction Continue
+    exit 1
+}
+if ($outputType -notin @('Exe', 'WinExe')) {
+    Write-Error "$($projFile.Name) is a '$outputType' project, not an executable. Point at an app project (OutputType Exe)." -ErrorAction Continue
+    exit 1
+}
+
+# Prefer the apphost so the process carries the app's own name (an .etl is
+# machine-wide, and `--process $assemblyName` is far easier to scope than `dotnet`).
+# Fall back to `dotnet <app>.dll` when no apphost was produced (UseAppHost=false).
+$outputDir = Split-Path -Parent $targetPath
+# Treat an undefined $IsWindows (Windows PowerShell 5.1) as Windows, matching the ETW
+# guard above, so the .exe apphost is still found there.
+$exeSuffix = ''
+if ($IsWindows -ne $false) { $exeSuffix = '.exe' }
+$appHost = Join-Path $outputDir ($assemblyName + $exeSuffix)
+if (Test-Path -LiteralPath $appHost) {
+    $runExe = $appHost
+    $runPrefixArgs = @()
+    $processName = $assemblyName
+}
+else {
+    $runExe = 'dotnet'
+    $runPrefixArgs = @($targetPath)
+    $processName = 'dotnet'
+}
+
+# The build output directory holds the portable PDBs that resolve source lines.
+$symbols = $outputDir
+
+# Default the trace path under ./perf-traces (created on demand).
+if (-not $Output) {
+    $captureDir = Join-Path (Get-Location).Path 'perf-traces'
+    New-Item -ItemType Directory -Force -Path $captureDir | Out-Null
+    $ext = 'nettrace'
+    if ($Profiler -eq 'ETW') { $ext = 'etl' }
+    $Output = Join-Path $captureDir "$assemblyName.$ext"
+}
+
+if ($Profiler -eq 'EP') {
+    # dotnet-trace is a separate global tool; make sure it is installed and on PATH.
+    $toolsDir = Join-Path $HOME '.dotnet/tools'
+    if ((Test-Path $toolsDir) -and ($env:PATH -notlike "*$toolsDir*")) {
+        $env:PATH = "$toolsDir$([System.IO.Path]::PathSeparator)$env:PATH"
+    }
+    if (-not (Get-Command dotnet-trace -ErrorAction SilentlyContinue)) {
+        Write-Host 'dotnet-trace not found; installing the global tool...' -ForegroundColor Yellow
+        dotnet tool install --global dotnet-trace | Out-Host
+        if ($LASTEXITCODE -ne 0) { Write-Error 'Failed to install dotnet-trace. Install it manually: dotnet tool install -g dotnet-trace.' -ErrorAction Continue ; exit 1 }
+        if ($env:PATH -notlike "*$toolsDir*") { $env:PATH = "$toolsDir$([System.IO.Path]::PathSeparator)$env:PATH" }
+    }
+
+    $traceProfile = 'cpu-sampling'
+    if ($Metric -eq 'alloc') { $traceProfile = 'gc-verbose' }
+
+    Write-Host "Capturing EventPipe ($Metric) trace of $processName..." -ForegroundColor Cyan
+    # Launch the built app directly (never `dotnet run`) so this single-process
+    # EventPipe session records the app, not a separate build/run host process.
+    $collectArgs = @('collect', '--output', $Output, '--profile', $traceProfile, '--', $runExe)
+    $collectArgs += $runPrefixArgs
+    $collectArgs += $AppArgs
+    dotnet-trace @collectArgs | Out-Host
+    if ($LASTEXITCODE -ne 0) { Write-Error "dotnet-trace failed (exit $LASTEXITCODE)." -ErrorAction Continue ; exit $LASTEXITCODE }
+}
+else {
+    Write-Host "Capturing ETW (CPU + threadtime) trace of $processName via filtrace collect..." -ForegroundColor Cyan
+    # filtrace records the ETW session itself with TraceEvent - no PerfView or wpr. It
+    # launches the built app, captures CPU + context-switch (threadtime) stacks with managed
+    # method names, and writes the machine-wide .etl the analysis verbs read.
+    # filtrace collect takes a single command-line string; quote any element that has
+    # whitespace (escaping embedded quotes) so argument boundaries survive the join, the
+    # way the EventPipe path preserves them by passing an array.
+    $launchArgs = (@($runPrefixArgs) + $AppArgs | ForEach-Object {
+            if ($_ -match '[\s"]') { '"' + ($_ -replace '"', '\"') + '"' } else { $_ }
+        }) -join ' '
+    $collectArgs = @('collect', '--launch', $runExe, '--output', $Output, '--metric', 'threadtime')
+    if ($launchArgs) { $collectArgs += @('--launch-args', $launchArgs) }
+    filtrace @collectArgs | Out-Host
+    if ($LASTEXITCODE -ne 0) { Write-Error "filtrace collect failed (exit $LASTEXITCODE)." -ErrorAction Continue ; exit $LASTEXITCODE }
+}
+
+Write-Host "`nCaptured: $Output" -ForegroundColor Green
+Write-Host "`nNext-step filtrace commands:" -ForegroundColor Green
+if ($Profiler -eq 'ETW') {
+    # An .etl is machine-wide: scope every query to the captured process.
+    Write-Host "  filtrace processes `"$Output`""
+    Write-Host "  filtrace cpu `"$Output`" --process $processName --top $Top"
+    Write-Host "  filtrace threadtime `"$Output`" --process $processName --top $Top"
+    Write-Host "  filtrace lines `"$Output`" --process $processName --symbols `"$symbols`""
+    Write-Host "  filtrace classify `"$Output`" --process $processName --native-symbols"
+}
+else {
+    # A single-process EventPipe trace ranks the whole app; there is no harness.
+    if ($Metric -eq 'alloc') {
+        Write-Host "  filtrace alloc `"$Output`" --top $Top"
+    }
+    else {
+        Write-Host "  filtrace cpu `"$Output`" --top $Top"
+    }
+    Write-Host "  filtrace lines `"$Output`" --symbols `"$symbols`""
+    Write-Host "  # scope past runtime startup with --root <Type>.<Method> once you see the ranking"
+}

--- a/.agents/skills/performance-testing/graphical-viewers.md
+++ b/.agents/skills/performance-testing/graphical-viewers.md
@@ -50,6 +50,14 @@ machine-wide `.etl` when you export** - pass `--process <name>` (CLI) or the
 do, or the export captures whichever process was busiest (a background app, not
 the benchmark).
 
+**For a BenchmarkDotNet capture, also pass `--benchmark` by default - every time,
+not just when the graph looks noisy.** `--process` only narrows the OS process;
+`--benchmark` is what excludes the harness/warmup subtree so the flame graph's
+proportions actually reflect the measured `[Benchmark]` code. Skipping it on
+`export` specifically is an easy miss: unlike a ranking verb, `export` writes a
+file and prints no "scoped to X" summary to notice is missing, so double-check
+the command line, not the output, before handing someone the graph.
+
 | | speedscope | Perfetto |
 |---|---|---|
 | Export format | `speedscope` (the default) | `chromium` (`--format chromium`) |

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -133,9 +133,23 @@ auto-scopes to the busiest process *by CPU sample count* (the quantity the
 rankings consume), which is normally the benchmark; but a noisy background app
 (antivirus, a VPN client) can own enough samples to win, so pass `--process <name>`
 to pin it. **Every CPU verb takes it** - `cpu`, `rank`, `threadtime`, `lines`,
-`callers`, `heatmap` (and the matching `trace_*` MCP tools). `filtrace processes
-<etl>` lists every process by weight so you can choose the right target. Quiesce
-other CPU consumers before capturing, or scope explicitly.
+`callers`, `heatmap`, `export` (and the matching `trace_*` MCP tools). `filtrace
+processes <etl>` lists every process by weight so you can choose the right
+target. Quiesce other CPU consumers before capturing, or scope explicitly.
+
+**Default every BenchmarkDotNet analysis to `--benchmark`, not just `--process`.**
+Process scoping only narrows *which OS process* the samples come from; a BDN
+process itself still interleaves the harness bootstrap, JIT/overhead warmup
+iterations, and the measured `[Benchmark]` workload in one call tree. `--benchmark`
+(preset root = the generated `WorkloadAction*` wrapper) is what isolates the
+measured code from that scaffolding, and it is **not optional for a BDN trace** -
+apply it by default to every verb that takes `--root`, including `export`. An
+unscoped export is not just noisy, its *proportions* are wrong: a flame graph or
+line ranking that still includes warmup materially understates the workload's own
+share of time. Forgetting it on `export` specifically is an easy miss because the
+verb writes a file instead of rendering a ranking, so there is no immediate
+"scoped to X" line to notice is missing - check the command before running it,
+not the output after.
 
 **`threadtime` vs `cpu`.** `threadtime` (ETL-only) is wall-clock per thread -
 running *and* blocked - while `cpu` is on-CPU time. When they agree closely the

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -132,7 +132,7 @@ process-scoped next-step filtrace commands:
 auto-scopes to the busiest process *by CPU sample count* (the quantity the
 rankings consume), which is normally the benchmark; but a noisy background app
 (antivirus, a VPN client) can own enough samples to win, so pass `--process <name>`
-to pin it. **Every CPU verb takes it** - `cpu`, `rank`, `threadtime`, `lines`,
+to pin it. **Every analysis verb takes it** - `cpu`, `rank`, `threadtime`, `lines`,
 `callers`, `heatmap`, `export` (and the matching `trace_*` MCP tools). `filtrace
 processes <etl>` lists every process by weight so you can choose the right
 target. Quiesce other CPU consumers before capturing, or scope explicitly.


### PR DESCRIPTION
## Summary

`filtrace`'s `export` verb lacked `--root`/`--benchmark` subtree scoping and `--native-symbols` native-frame resolution that every ranking verb already had (fixed upstream in [JeremyKuhne/filtrace#21](https://github.com/JeremyKuhne/filtrace/pull/21), now released as filtrace `v0.3.0`). This PR:

1. Reworks the `performance-testing` skill's guidance so scoping a BenchmarkDotNet analysis to `--benchmark` is a **default**, not optional advice - export included, since it's the easiest verb to forget it on (it prints no "scoped to X" summary to notice the omission in).
2. Re-vendors the `filtrace` skill to the new `v0.3.0` release now that it carries the fix.

## What changed

- `.agents/skills/performance-testing/profiling.md` and `graphical-viewers.md`: added a callout making `--benchmark` the default for every BenchmarkDotNet analysis, `export` included, with the reasoning (no output to notice the omission in - check the command, not the result).
- `.agents/skills/filtrace/SKILL.md`: re-vendored from filtrace `v0.3.0`. The previous copy was stale (pinned to a commit from *before* filtrace PR #18 - missing the "Getting a trace to analyze" section, trap #9, the updated trap #4 wording, and the `collect` verb row). Now **tag-pinned** (`github-ref: refs/tags/v0.3.0`, `github-pinned: v0.3.0`) instead of branch-pinned.
- `.agents/skills/filtrace/scripts/`: newly vendored (`Capture-BenchmarkTrace.ps1`, `Capture-ProjectTrace.ps1`, copied verbatim from filtrace). The skill body links these by relative path (added upstream in PR #18, after touki's stale pin); copying only `SKILL.md` left those links dangling, which `tools/Test-AgentFileLinks.ps1` caught.
- `.agents/skills/filtrace/overlay.md`: updated the "Updating" section to say to re-vendor `SKILL.md` **and** `scripts/` together, then run both `Validate-AgentFiles.ps1` and `Test-AgentFileLinks.ps1`.

## Testing

- Verified the published `filtrace` `0.3.0` global tool (installed from NuGet.org, not a private test package) against a real touki ETW trace: `filtrace export --benchmark --native-symbols` reproduces the manually-scoped result exactly (35,613 samples/ms weight; native GC/JIT frames like `clrjit!Compiler::compCompile` resolved).
- `tools/Validate-AgentFiles.ps1` and `tools/Test-AgentFileLinks.ps1` both pass (82 files scanned, all relative links resolve).
