### PR TITLE
Add ARM64 support alongside x64

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   # The Windows build runs Debug and Release on two parallel runners.
   # Coverage, pack, and Codecov are Release-only and gated by `matrix.configuration`.
-  # The `build` aggregator below depends on this matrix plus the macOS and
-  # Linux jobs and keeps the `.NET / build` status-check name stable for
-  # branch protection.
+  # The `build` aggregator below depends on this matrix plus the macOS, Linux,
+  # and ARM64 (Windows and Linux) jobs and keeps the `.NET / build`
+  # status-check name stable for branch protection.
   build-matrix:
     name: ".NET / build (Windows / ${{ matrix.configuration }})"
     runs-on: windows-latest
@@ -56,6 +56,17 @@ jobs:
     - name: Pack
       if: matrix.configuration == 'Release'
       run: dotnet pack --configuration Release --no-build -o ./artifacts/packages
+    - name: Verify packages are architecture neutral
+      if: matrix.configuration == 'Release'
+      # touki and touki.testsupport are pure-IL libraries with no native
+      # components and must load on any CPU architecture (x64, ARM64, ...).
+      # touki.slnx maps them to Platform=AnyCPU even though the rest of the
+      # solution defaults to x64 (see Directory.Build.props); this guards
+      # against that mapping regressing.
+      run: |
+        Get-ChildItem ./artifacts/packages -Filter *.nupkg | ForEach-Object {
+          pwsh tools/Test-PackageArchitectureNeutral.ps1 -PackagePath $_.FullName
+        }
     - name: Test
       run: |
         $configuration = '${{ matrix.configuration }}'
@@ -153,7 +164,7 @@ jobs:
   build:
     name: ".NET / build"
     runs-on: ubuntu-latest
-    needs: [build-matrix, macos-build, linux-build]
+    needs: [build-matrix, macos-build, linux-build, windows-arm64-build, linux-arm64-build]
     if: always()
     steps:
     - name: Verify upstream jobs
@@ -162,6 +173,8 @@ jobs:
           "build-matrix=${{ needs.build-matrix.result }}"
           "macos-build=${{ needs.macos-build.result }}"
           "linux-build=${{ needs.linux-build.result }}"
+          "windows-arm64-build=${{ needs.windows-arm64-build.result }}"
+          "linux-arm64-build=${{ needs.linux-arm64-build.result }}"
         )
         failed=0
         for r in "${results[@]}"; do
@@ -181,10 +194,16 @@ jobs:
     runs-on: macos-latest
 
     # The repo pins Platform=x64 in Directory.Build.props for the Windows-focused
-    # main build, which embeds AMD64 in the managed assembly's COFF header. The
-    # macOS GitHub-hosted runner is Apple Silicon (osx-arm64) and the .NET host
-    # refuses to load an AMD64-tagged managed assembly. Building this job as
-    # AnyCPU produces an architecture-neutral assembly that loads on any host.
+    # main dev/test build, which embeds AMD64 in the managed assembly's COFF
+    # header. touki.slnx maps the two NuGet-shipped projects (touki and
+    # touki.testsupport) to Platform=AnyCPU so the published packages stay
+    # architecture neutral, but touki.tests is still an x64-default
+    # executable (Microsoft.Testing.Platform host), and PlatformTarget follows
+    # $(Platform) for Exe outputs. The macOS GitHub-hosted runner is Apple
+    # Silicon (osx-arm64) and the .NET host refuses to load an AMD64-tagged
+    # executable. Building this job's test project as AnyCPU produces an
+    # architecture-neutral executable that loads on any host. The same
+    # pattern is reused by windows-arm64-build and linux-arm64-build below.
     env:
       _PlatformArgs: "-p:Platform=AnyCPU -p:Platforms=AnyCPU"
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
@@ -267,6 +286,105 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: mtp-logs-linux
+        path: |
+          artifacts/test-results/**/*.trx
+        if-no-files-found: warn
+        retention-days: 14
+
+  windows-arm64-build:
+    name: ".NET / build (Windows ARM64 / Release)"
+    runs-on: windows-11-arm
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+    steps:
+    - uses: actions/checkout@v5
+      with: { fetch-depth: 0 }
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.NUGET_PACKAGES }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+    # This is a native ARM64 Windows runner: touki.tests defaults to x64 (see
+    # macos-build's comment above for why), which won't load here either.
+    # Build it as AnyCPU instead.
+    - name: Restore
+      run: |
+        $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        dotnet restore touki.tests/touki.tests.csproj @platformArgs
+    - name: Build release
+      run: |
+        $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        dotnet build touki.tests/touki.tests.csproj -c Release -f net10.0 --no-restore @platformArgs
+    - name: Test release
+      run: |
+        $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        $resultsDir = Join-Path $PWD.Path "artifacts/test-results/windows-arm64-release"
+        New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+        dotnet test touki.tests/touki.tests.csproj -c Release -f net10.0 --no-build `
+          @platformArgs `
+          -p:TestingPlatformCaptureOutput=false `
+          --results-directory "$resultsDir" `
+          --report-trx `
+          --output Detailed
+    - name: Upload raw logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: mtp-logs-windows-arm64
+        path: |
+          artifacts/test-results/**/*.trx
+        if-no-files-found: warn
+        retention-days: 14
+
+  linux-arm64-build:
+    name: ".NET / build (Linux ARM64 / Release)"
+    runs-on: ubuntu-24.04-arm
+    env:
+      _PlatformArgs: "-p:Platform=AnyCPU -p:Platforms=AnyCPU"
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+    steps:
+    - uses: actions/checkout@v5
+      with: { fetch-depth: 0 }
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.NUGET_PACKAGES }}
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+    - name: Install xclip, Xvfb, and xauth
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends xclip xvfb xauth
+    - name: Restore
+      run: dotnet restore touki.tests/touki.tests.csproj $_PlatformArgs
+    - name: Build release
+      run: dotnet build touki.tests/touki.tests.csproj -c Release -f net10.0 --no-restore $_PlatformArgs
+    - name: Test release
+      run: |
+        resultsDir="$PWD/artifacts/test-results/linux-arm64-release"
+        mkdir -p "$resultsDir"
+
+        xvfb-run --auto-servernum dotnet test touki.tests/touki.tests.csproj -c Release -f net10.0 --no-build \
+          $_PlatformArgs \
+          -p:TestingPlatformCaptureOutput=false \
+          --results-directory "$resultsDir" \
+          --report-trx \
+          --output Detailed
+    - name: Upload raw logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: mtp-logs-linux-arm64
         path: |
           artifacts/test-results/**/*.trx
         if-no-files-found: warn

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,16 @@ jobs:
       run: dotnet build -c Release --no-restore
     - name: Pack
       run: dotnet pack -c Release --no-build -o ./artifacts
+    - name: Verify package is architecture neutral
+      # touki is a pure-IL library with no native components and must load on
+      # any CPU architecture (x64, ARM64, ...). touki.slnx maps it to
+      # Platform=AnyCPU even though the rest of the solution defaults to x64
+      # (see Directory.Build.props); this guards against that mapping
+      # regressing before anything is pushed to NuGet.
+      run: |
+        Get-ChildItem ./artifacts -Filter KlutzyNinja.Touki.*.nupkg |
+            Where-Object { $_.Name -notlike 'KlutzyNinja.Touki.TestSupport.*' } |
+            ForEach-Object { pwsh tools/Test-PackageArchitectureNeutral.ps1 -PackagePath $_.FullName }
     # Get a short-lived NuGet API key
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1

--- a/.github/workflows/publishtestsupport.yml
+++ b/.github/workflows/publishtestsupport.yml
@@ -57,6 +57,15 @@ jobs:
       run: dotnet build -c Release --no-restore
     - name: Pack
       run: dotnet pack -c Release --no-build -o ./artifacts
+    - name: Verify package is architecture neutral
+      # touki.testsupport is a pure-IL library with no native components and
+      # must load on any CPU architecture (x64, ARM64, ...). touki.slnx maps
+      # it to Platform=AnyCPU even though the rest of the solution defaults
+      # to x64 (see Directory.Build.props); this guards against that mapping
+      # regressing before anything is pushed to NuGet.
+      run: |
+        Get-ChildItem ./artifacts -Filter KlutzyNinja.Touki.TestSupport.*.nupkg |
+            ForEach-Object { pwsh tools/Test-PackageArchitectureNeutral.ps1 -PackagePath $_.FullName }
     # Get a short-lived NuGet API key
     - name: NuGet login (OIDC → temp API key)
       uses: NuGet/login@v1

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -62,6 +62,15 @@
 
   <!-- Set default Configuration and Platform -->
   <PropertyGroup>
+    <!--
+      x64 is the default dev/test/perf Platform so local Windows builds and
+      benchmarks match a well-known architecture. The two NuGet-shipped
+      projects (touki, touki.testsupport) - plus the analyzer assemblies
+      embedded in the touki package - are pure IL with no native components
+      and must run on any CPU architecture. touki.slnx maps them to
+      Platform=AnyCPU so the published packages stay architecture neutral
+      (see tools/Test-PackageArchitectureNeutral.ps1, which verifies this in CI).
+    -->
     <Platforms Condition="'$(Platforms)'==''">x64</Platforms>
     <Platform Condition="'$(Platform)'==''">x64</Platform>
     <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ PM> Install-Package KlutzyNinja.Touki
 
 - .NET 10.0 or later **OR** .NET Framework 4.7.2 or later
 - C# 14.0 or later for the best experience
+- Any CPU architecture supported by .NET - the package ships
+  architecture-neutral ("AnyCPU") assemblies with no native components, so
+  x64 and ARM64 are both fully supported on Windows, Linux, and macOS
 
 ## Contributing
 

--- a/tools/Test-PackageArchitectureNeutral.ps1
+++ b/tools/Test-PackageArchitectureNeutral.ps1
@@ -32,6 +32,9 @@ Set-StrictMode -Version 3.0
 $ErrorActionPreference = 'Stop'
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
+# Needed for the PEReader/CorFlags/Machine type literals below - not always
+# already loaded in the host's AppDomain (e.g. Windows PowerShell 5.1).
+Add-Type -AssemblyName System.Reflection.Metadata
 
 $PackagePath = (Resolve-Path $PackagePath).Path
 $extractDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())

--- a/tools/Test-PackageArchitectureNeutral.ps1
+++ b/tools/Test-PackageArchitectureNeutral.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Verify that the managed assemblies inside a .nupkg are architecture neutral.
+
+.DESCRIPTION
+    KlutzyNinja.Touki and KlutzyNinja.Touki.TestSupport are pure-IL libraries with
+    no native components, so every assembly they ship must be buildable as
+    "AnyCPU" (PE machine type I386 with the ILOnly CorFlag and without the
+    32BitRequired flag). A project that accidentally inherits the repo-wide
+    Platform=x64 dev default (see Directory.Build.props / touki.slnx) instead
+    gets tagged AMD64 (PE32Plus), which throws BadImageFormatException when
+    loaded into a non-x64 process - e.g. a native ARM64 .NET host on Windows,
+    Linux, or Apple Silicon macOS, or an ARM64 Visual Studio / dotnet CLI
+    analyzer host.
+
+    This script extracts every *.dll from the given .nupkg and fails if any of
+    them are not architecture neutral.
+
+.PARAMETER PackagePath
+    Path to the .nupkg file to inspect.
+
+.EXAMPLE
+    pwsh tools/Test-PackageArchitectureNeutral.ps1 -PackagePath ./artifacts/packages/KlutzyNinja.Touki.1.0.0.nupkg
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string]$PackagePath
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$PackagePath = (Resolve-Path $PackagePath).Path
+$extractDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $extractDir | Out-Null
+
+try {
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($PackagePath, $extractDir)
+
+    $dlls = @(Get-ChildItem -Path $extractDir -Recurse -Filter '*.dll')
+    if ($dlls.Count -eq 0) {
+        Write-Error "No assemblies found inside '$PackagePath'."
+    }
+
+    $failures = @()
+    foreach ($dll in $dlls) {
+        $bytes = [System.IO.File]::ReadAllBytes($dll.FullName)
+        $stream = [System.IO.MemoryStream]::new($bytes)
+        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+        try {
+            $headers = $peReader.PEHeaders
+            $machine = $headers.CoffHeader.Machine
+            $requires32Bit = $headers.CorHeader.Flags -band [System.Reflection.PortableExecutable.CorFlags]::Requires32Bit
+
+            $relativePath = $dll.FullName.Substring($extractDir.Length + 1)
+            if ($machine -ne [System.Reflection.PortableExecutable.Machine]::I386 -or $requires32Bit) {
+                $failures += "$relativePath -> Machine=$machine Requires32Bit=$([bool]$requires32Bit)"
+            }
+            else {
+                Write-Host "OK: $relativePath -> Machine=$machine"
+            }
+        }
+        finally {
+            $peReader.Dispose()
+        }
+    }
+
+    if ($failures.Count -gt 0) {
+        Write-Error "Found architecture-specific assemblies in '$PackagePath':`n$($failures -join "`n")"
+    }
+
+    Write-Host "All assemblies in '$PackagePath' are architecture neutral."
+}
+finally {
+    Remove-Item -Recurse -Force $extractDir -ErrorAction SilentlyContinue
+}

--- a/tools/Test-PackageArchitectureNeutral.ps1
+++ b/tools/Test-PackageArchitectureNeutral.ps1
@@ -47,24 +47,37 @@ try {
 
     $failures = @()
     foreach ($dll in $dlls) {
+        $relativePath = $dll.FullName.Substring($extractDir.Length + 1)
         $bytes = [System.IO.File]::ReadAllBytes($dll.FullName)
         $stream = [System.IO.MemoryStream]::new($bytes)
-        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
         try {
-            $headers = $peReader.PEHeaders
-            $machine = $headers.CoffHeader.Machine
-            $requires32Bit = $headers.CorHeader.Flags -band [System.Reflection.PortableExecutable.CorFlags]::Requires32Bit
+            $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+            try {
+                $headers = $peReader.PEHeaders
+                $machine = $headers.CoffHeader.Machine
+                $corHeader = $headers.CorHeader
 
-            $relativePath = $dll.FullName.Substring($extractDir.Length + 1)
-            if ($machine -ne [System.Reflection.PortableExecutable.Machine]::I386 -or $requires32Bit) {
-                $failures += "$relativePath -> Machine=$machine Requires32Bit=$([bool]$requires32Bit)"
+                if ($null -eq $corHeader) {
+                    $failures += "$relativePath -> not a managed (CLI) assembly"
+                    continue
+                }
+
+                $isILOnly = [bool]($corHeader.Flags -band [System.Reflection.PortableExecutable.CorFlags]::ILOnly)
+                $requires32Bit = [bool]($corHeader.Flags -band [System.Reflection.PortableExecutable.CorFlags]::Requires32Bit)
+
+                if ($machine -ne [System.Reflection.PortableExecutable.Machine]::I386 -or -not $isILOnly -or $requires32Bit) {
+                    $failures += "$relativePath -> Machine=$machine ILOnly=$isILOnly Requires32Bit=$requires32Bit"
+                }
+                else {
+                    Write-Host "OK: $relativePath -> Machine=$machine"
+                }
             }
-            else {
-                Write-Host "OK: $relativePath -> Machine=$machine"
+            finally {
+                $peReader.Dispose()
             }
         }
         finally {
-            $peReader.Dispose()
+            $stream.Dispose()
         }
     }
 

--- a/touki.slnx
+++ b/touki.slnx
@@ -29,13 +29,13 @@
     <Platform Project="x64" />
   </Project>
   <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj">
-    <Platform Project="x64" />
+    <Platform Project="AnyCPU" />
   </Project>
   <Project Path="touki.analyzers.tests/touki.analyzers.tests.csproj">
     <Platform Project="x64" />
   </Project>
   <Project Path="touki.analyzers/touki.analyzers.csproj">
-    <Platform Project="x64" />
+    <Platform Project="AnyCPU" />
   </Project>
   <Project Path="touki.fuzz/touki.fuzz.csproj">
     <Platform Project="x64" />
@@ -50,9 +50,9 @@
     <Platform Project="x64" />
   </Project>
   <Project Path="touki.testsupport/touki.testsupport.csproj">
-    <Platform Project="x64" />
+    <Platform Project="AnyCPU" />
   </Project>
   <Project Path="touki/touki.csproj">
-    <Platform Project="x64" />
+    <Platform Project="AnyCPU" />
   </Project>
 </Solution>

--- a/touki.testsupport/README.md
+++ b/touki.testsupport/README.md
@@ -13,6 +13,10 @@ extensions used by the touki test suite.
 - `net10.0`
 - `net472`
 
+Like `KlutzyNinja.Touki`, this package ships architecture-neutral
+("AnyCPU") assemblies with no native components, so x64 and ARM64 are both
+fully supported on Windows, Linux, and macOS.
+
 ## Notes
 
 This package is **not AOT-friendly** - it uses reflection to reach private


### PR DESCRIPTION
## Problem

Both published packages (`KlutzyNinja.Touki` and `KlutzyNinja.Touki.TestSupport`) were being built and packed as **AMD64-specific** assemblies (PE machine type `AMD64`/`PE32Plus`), because:

- `Directory.Build.props` pins the repo-wide dev/perf default to `Platform=x64`.
- `touki.slnx` mapped *every* project - including the two NuGet-shipped ones and the analyzer DLLs embedded in the `touki` package - to that platform.

An AMD64-tagged managed assembly throws `BadImageFormatException` when loaded into a native ARM64 .NET process (Windows ARM64, Linux ARM64, or Apple Silicon macOS), so the packages were effectively unusable there. The library code itself has no architecture-specific logic - this was purely a build/packaging defect.

## Fix

- **`touki.slnx`**: map `touki.csproj`, `touki.testsupport.csproj`, `touki.analyzers.csproj`, and `touki.analyzers.codefixes.csproj` to `Platform=AnyCPU` (a per-project platform override within the existing x64 solution axis), while the rest of the solution (tests, perf, fuzz, sample) keeps the x64 dev/perf default.
- **`tools/Test-PackageArchitectureNeutral.ps1`**: new script that extracts a `.nupkg` and fails if any assembly inside is architecture-specific.
- **`dotnet.yml`**: run the new verification script after `Pack`; add `windows-arm64-build` (`windows-11-arm`) and `linux-arm64-build` (`ubuntu-24.04-arm`) jobs mirroring the existing macOS (Apple Silicon) leg, wired into the `build` aggregator.
- **`publish.yml` / `publishtestsupport.yml`**: verify the packed nupkg is architecture neutral before pushing to NuGet.
- **`Directory.Build.props`, `README.md`, `touki.testsupport/README.md`**: document the AnyCPU/x64 split and both packages' ARM64 support.

## Validation

- Rebuilt from repo root exactly as CI/publish do (`dotnet build -c Release` + `dotnet pack -c Release --no-build`) and confirmed all 6 embedded assemblies (`touki` net10.0/net472, `touki.testsupport` net10.0/net472, both analyzer DLLs) are `Machine=I386`/`ILOnly` (architecture neutral) via `System.Reflection.PortableExecutable`.
- Confirmed the new verification script correctly passes on the fixed packages and fails on a known-bad x64-tagged assembly.
- Full test suite (6628 tests) passes on `net10.0`.
