### PR TITLE
Add SatelliteStringResourceManager for AOT-compatible localized strings

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
+    <PackageVersion Include="System.Resources.Extensions" Version="10.0.9" />
     <PackageVersion Include="TUnit" Version="1.48.6" />
     <PackageVersion Include="TUnit.Core" Version="1.48.6" />
   </ItemGroup>

--- a/touki.aot.tests/.editorconfig
+++ b/touki.aot.tests/.editorconfig
@@ -1,0 +1,26 @@
+# C# files
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# CA1852: Seal internal types
+dotnet_diagnostic.CA1852.severity = none
+
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none
+
+# CA1510: Use ArgumentNullException throw helper
+dotnet_diagnostic.CA1510.severity = none
+
+# CA1511: Use ArgumentException throw helper
+dotnet_diagnostic.CA1511.severity = none
+
+# CA1512: Use ArgumentOutOfRangeException throw helper
+dotnet_diagnostic.CA1512.severity = none
+
+# CA1513: Use ObjectDisposedException throw helper
+dotnet_diagnostic.CA1513.severity = none
+
+# CA1859: Use concrete types when possible for improved performance
+dotnet_diagnostic.CA1859.severity = silent

--- a/touki.aot.tests/Resources/SatelliteTestStrings.resx
+++ b/touki.aot.tests/Resources/SatelliteTestStrings.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hello</value>
+  </data>
+  <data name="Farewell" xml:space="preserve">
+    <value>Goodbye</value>
+  </data>
+</root>

--- a/touki.aot.tests/SatelliteStringResourceAotTests.cs
+++ b/touki.aot.tests/SatelliteStringResourceAotTests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Resources;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Touki.Io;
+
+namespace Touki.Resources;
+
+/// <summary>
+///  End-to-end proof that <see cref="SatelliteStringResourceManager"/> loads localized strings from
+///  loose <c>.resources</c> files when this assembly is published with Native AOT. Stock
+///  <see cref="ResourceManager"/> cannot do this because the AOT runtime has no satellite
+///  assembly loader; see docs/aot-localized-resources-plan.md.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Assertions use MSTest's <see cref="Assert"/> rather than a reflection-based assertion
+///   library so the published binary stays trim-clean. The side files are produced at runtime
+///   with <see cref="ResourceWriter"/> (its string path is AOT-safe) and read back through the
+///   manager, exercising both the writer and reader under Native AOT.
+///  </para>
+/// </remarks>
+[TestClass]
+public class SatelliteStringResourceAotTests
+{
+    private static readonly Assembly s_assembly = typeof(SatelliteStringResourceAotTests).Assembly;
+
+    // Neutral resources are embedded from Resources/SatelliteTestStrings.resx. Discover the actual
+    // manifest name at runtime so the test does not depend on root-namespace derivation.
+    private static string NeutralBaseName()
+    {
+        foreach (string name in s_assembly.GetManifestResourceNames())
+        {
+            if (name.EndsWith("SatelliteTestStrings.resources", StringComparison.Ordinal))
+            {
+                return name[..^".resources".Length];
+            }
+        }
+
+        throw new InvalidOperationException("The neutral test resources were not embedded.");
+    }
+
+    private static void WriteSideFile(string probeRoot, string culture, string baseName, string key, string value)
+    {
+        string directory = Path.Combine(probeRoot, culture);
+        Directory.CreateDirectory(directory);
+        using ResourceWriter writer = new(Path.Combine(directory, $"{baseName}.resources"));
+        writer.AddResource(key, value);
+        writer.Generate();
+    }
+
+    [TestMethod]
+    public void GetString_LocalizedSideFile_LoadsUnderAot()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, "Greeting", "Hallo");
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        Assert.AreEqual("Hallo", manager.GetString("Greeting", new CultureInfo("de")));
+    }
+
+    [TestMethod]
+    public void GetString_ParentCultureWalk_LoadsUnderAot()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, "Greeting", "Hallo");
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // de-DE has no side file; resolution must walk up to the "de" file.
+        Assert.AreEqual("Hallo", manager.GetString("Greeting", new CultureInfo("de-DE")));
+    }
+
+    [TestMethod]
+    public void GetString_NoSideFile_FallsBackToEmbeddedNeutralUnderAot()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        Assert.AreEqual("Hello", manager.GetString("Greeting", new CultureInfo("de")));
+    }
+
+    [TestMethod]
+    public void GetString_MissingKeyInSideFile_FallsBackToEmbeddedNeutralUnderAot()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, "Farewell", "Tschuss");
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        Assert.AreEqual("Tschuss", manager.GetString("Farewell", new CultureInfo("de")));
+        Assert.AreEqual("Hello", manager.GetString("Greeting", new CultureInfo("de")));
+    }
+}

--- a/touki.aot.tests/touki.aot.tests.csproj
+++ b/touki.aot.tests/touki.aot.tests.csproj
@@ -1,0 +1,55 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--
+      Native AOT is only supported on .NET Core, so this project single-targets the current LTS.
+      It exercises Touki.Resources.SatelliteStringResourceManager under the AOT toolchain:
+
+        - `dotnet test` runs the tests in managed mode (the SatelliteStringResourceManager logic).
+        - `dotnet publish -r <rid>` drives the ILC AOT compiler over touki + these tests, which - with
+          the repo-wide TreatWarningsAsErrors - fails the build on any IL2xxx/IL3xxx AOT incompatibility
+          in SatelliteStringResourceManager. This is the AOT-compatibility gate.
+
+      Executing the compiled MSTest runner as a native binary additionally requires the experimental,
+      closed-source MSTest.Engine + MSTest.SourceGeneration packages (the reflection-based
+      MSTest.TestAdapter cannot bootstrap under AOT). That dependency is deliberately left out; see the
+      "Testing" section of docs/aot-localized-resources-plan.md.
+    -->
+    <TargetFramework>$(DotNetCoreVersion)</TargetFramework>
+    <OutputType>Exe</OutputType>
+
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Touki</RootNamespace>
+    <AssemblyName>touki.aot.tests</AssemblyName>
+
+    <!-- Not a security boundary, the strong name is for identity and ease of use from other signed assemblies. -->
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\klutzyninja.snk</AssemblyOriginatorKeyFile>
+
+    <!--
+      Turn on the trim/AOT analyzers at build time and compile to native on publish. Combined with the
+      repo-wide TreatWarningsAsErrors this fails the build if any referenced code (including
+      SatelliteStringResourceManager) is not AOT-safe.
+    -->
+    <PublishAot>true</PublishAot>
+
+    <!-- Microsoft Testing Platform + MSTest runner (managed run via `dotnet test`). -->
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Assertions use MSTest's own Assert (AOT-safe); no reflection-heavy assertion library is
+         referenced so the code exercised under AOT stays trim-clean. -->
+    <PackageReference Include="MSTest.TestFramework" PrivateAssets="all" />
+    <PackageReference Include="MSTest.TestAdapter" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\touki\touki.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/touki.aot.tests/touki.aot.tests.csproj
+++ b/touki.aot.tests/touki.aot.tests.csproj
@@ -6,9 +6,11 @@
       It exercises Touki.Resources.SatelliteStringResourceManager under the AOT toolchain:
 
         - `dotnet test` runs the tests in managed mode (the SatelliteStringResourceManager logic).
-        - `dotnet publish -r <rid>` drives the ILC AOT compiler over touki + these tests, which - with
-          the repo-wide TreatWarningsAsErrors - fails the build on any IL2xxx/IL3xxx AOT incompatibility
-          in SatelliteStringResourceManager. This is the AOT-compatibility gate.
+        - `dotnet publish -r <rid> -c Release` drives the ILC AOT compiler over touki + these tests,
+          which - with the repo-wide TreatWarningsAsErrors - fails the build on any IL2xxx/IL3xxx AOT
+          incompatibility in SatelliteStringResourceManager. This is the AOT-compatibility gate.
+          (Supplying a RID turns on PublishAot; see the IsAotCompatible comment below for why it is
+          gated rather than always on.)
 
       Executing the compiled MSTest runner as a native binary additionally requires the experimental,
       closed-source MSTest.Engine + MSTest.SourceGeneration packages (the reflection-based
@@ -29,11 +31,21 @@
     <AssemblyOriginatorKeyFile>..\klutzyninja.snk</AssemblyOriginatorKeyFile>
 
     <!--
-      Turn on the trim/AOT analyzers at build time and compile to native on publish. Combined with the
-      repo-wide TreatWarningsAsErrors this fails the build if any referenced code (including
-      SatelliteStringResourceManager) is not AOT-safe.
+      Build-time trim/AOT analyzers are always on: IsAotCompatible turns on EnableAotAnalyzer,
+      EnableTrimAnalyzer, and EnableSingleFileAnalyzer, so - with the repo-wide TreatWarningsAsErrors -
+      a compile-time AOT/trim analyzer violation in any referenced code (including
+      SatelliteStringResourceManager) fails the build.
+
+      The full ILC whole-program gate turns on only for a RID publish (the AOT compiler always needs a
+      RID): "dotnet publish touki.aot.tests -r <rid> -c Release". PublishAot is gated on
+      RuntimeIdentifier rather than set unconditionally on purpose - a permanent PublishAot forces every
+      build (including the coverage-instrumented solution "dotnet test") into an AOT shape, under which
+      the code-coverage extension drops its "coverage-settings" option and the solution test run fails
+      with "Unknown option". Gating it here also keeps PublishAot from being passed as a global "-p:"
+      property, which would leak to non-AOT project references (net472, netstandard2.0) as NETSDK1207.
     -->
-    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
+    <PublishAot Condition="'$(RuntimeIdentifier)' != ''">true</PublishAot>
 
     <!-- Microsoft Testing Platform + MSTest runner (managed run via `dotnet test`). -->
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
@@ -46,6 +58,15 @@
          referenced so the code exercised under AOT stays trim-clean. -->
     <PackageReference Include="MSTest.TestFramework" PrivateAssets="all" />
     <PackageReference Include="MSTest.TestAdapter" PrivateAssets="all" />
+    <!--
+      The solution-wide "dotnet test" in CI passes the TRX report option (and, on Release, the
+      coverage option) to every Microsoft.Testing.Platform host. Those options are provided by these
+      extensions; without them this project's host rejects the option ("Unknown option", exit code 5)
+      and fails the run. Match touki.tests / touki.analyzers.tests. PrivateAssets="all" keeps the test
+      infrastructure from flowing to anything that references this project. The AOT gate is a separate
+      publish step, which does not exercise these code paths. -->
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/touki.slnx
+++ b/touki.slnx
@@ -28,14 +28,13 @@
   <Project Path="sample/sample.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
+  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj" />
   <Project Path="touki.analyzers.tests/touki.analyzers.tests.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers/touki.analyzers.csproj">
-    <Platform Project="AnyCPU" />
+  <Project Path="touki.analyzers/touki.analyzers.csproj" />
+  <Project Path="touki.aot.tests/touki.aot.tests.csproj">
+    <Platform Project="x64" />
   </Project>
   <Project Path="touki.fuzz/touki.fuzz.csproj">
     <Platform Project="x64" />
@@ -49,10 +48,6 @@
   <Project Path="touki.tests/touki.tests.csproj" Id="19ab971c-bbbf-45f9-8a09-11054caec775">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.testsupport/touki.testsupport.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
-  <Project Path="touki/touki.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
+  <Project Path="touki.testsupport/touki.testsupport.csproj" />
+  <Project Path="touki/touki.csproj" />
 </Solution>

--- a/touki.slnx
+++ b/touki.slnx
@@ -28,11 +28,15 @@
   <Project Path="sample/sample.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj" />
+  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
   <Project Path="touki.analyzers.tests/touki.analyzers.tests.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers/touki.analyzers.csproj" />
+  <Project Path="touki.analyzers/touki.analyzers.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
   <Project Path="touki.aot.tests/touki.aot.tests.csproj">
     <Platform Project="x64" />
   </Project>
@@ -48,6 +52,10 @@
   <Project Path="touki.tests/touki.tests.csproj" Id="19ab971c-bbbf-45f9-8a09-11054caec775">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.testsupport/touki.testsupport.csproj" />
-  <Project Path="touki/touki.csproj" />
+  <Project Path="touki.testsupport/touki.testsupport.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
+  <Project Path="touki/touki.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
 </Solution>

--- a/touki.tests/Touki/Resources/SatelliteStringResourceManagerTests.cs
+++ b/touki.tests/Touki/Resources/SatelliteStringResourceManagerTests.cs
@@ -1,0 +1,250 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using System.Resources.Extensions;
+
+namespace Touki.Resources;
+
+[TestClass]
+public class SatelliteStringResourceManagerTests
+{
+    private static readonly Assembly s_assembly = typeof(SatelliteStringResourceManagerTests).Assembly;
+
+    // The neutral resources are embedded from SatelliteTestStrings.resx. Discover the actual manifest
+    // name so the test does not depend on the assembly's root-namespace derivation.
+    private static string NeutralBaseName()
+    {
+        string resourceName = s_assembly.GetManifestResourceNames()
+            .Single(name => name.EndsWith("SatelliteTestStrings.resources", StringComparison.Ordinal));
+        return resourceName[..^".resources".Length];
+    }
+
+    private static void WriteSideFile(
+        string probeRoot,
+        string culture,
+        string baseName,
+        params (string Key, string Value)[] entries)
+    {
+        string directory = Path.Combine(probeRoot, culture);
+        Directory.CreateDirectory(directory);
+        using ResourceWriter writer = new(Path.Combine(directory, $"{baseName}.resources"));
+        foreach ((string key, string value) in entries)
+        {
+            writer.AddResource(key, value);
+        }
+
+        writer.Generate();
+    }
+
+    // Writes a default-format file mixing a string with an intrinsic non-string (an int).
+    private static void WriteMixedSideFile(string probeRoot, string culture, string baseName)
+    {
+        string directory = Path.Combine(probeRoot, culture);
+        Directory.CreateDirectory(directory);
+        using ResourceWriter writer = new(Path.Combine(directory, $"{baseName}.resources"));
+        writer.AddResource("Greeting", "Hallo");
+        writer.AddResource("Count", 42);
+        writer.Generate();
+    }
+
+    // Writes a file via PreserializedResourceWriter containing a resource whose value would require a
+    // TypeConverter (reflection) to materialize, which switches the file to the non-default reader type.
+    private static void WriteReflectionSideFile(string probeRoot, string culture, string baseName)
+    {
+        string directory = Path.Combine(probeRoot, culture);
+        Directory.CreateDirectory(directory);
+        using PreserializedResourceWriter writer = new(Path.Combine(directory, $"{baseName}.resources"));
+        writer.AddResource("Greeting", "Hallo");
+        writer.AddResource("Fancy", "10,20", "System.Drawing.Point, System.Drawing.Primitives");
+        writer.Generate();
+    }
+
+    [TestMethod]
+    public void GetString_CultureWithSideFile_ReturnsLocalizedValue()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Greeting", "Hallo"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hallo");
+    }
+
+    [TestMethod]
+    public void GetString_SpecificCulture_FallsBackToParentSideFile()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Greeting", "Hallo"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // de-DE has no side file; resolution must walk up to the "de" file.
+        manager.GetString("Greeting", new CultureInfo("de-DE")).Should().Be("Hallo");
+    }
+
+    [TestMethod]
+    public void GetString_SpecificCultureOverridesParent()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Greeting", "Hallo"), ("Farewell", "Tschuss"));
+        WriteSideFile(folder.TempPath, "de-DE", baseName, ("Greeting", "Gruezi"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // de-DE overrides the "de" value for a shared key...
+        manager.GetString("Greeting", new CultureInfo("de-DE")).Should().Be("Gruezi");
+        // ...and inherits keys it does not itself supply.
+        manager.GetString("Farewell", new CultureInfo("de-DE")).Should().Be("Tschuss");
+    }
+
+    [TestMethod]
+    public void GetString_NoSideFile_ReturnsEmbeddedNeutral()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void GetString_MissingKeyInSideFile_ReturnsEmbeddedNeutral()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Farewell", "Tschuss"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // Present in the side file.
+        manager.GetString("Farewell", new CultureInfo("de")).Should().Be("Tschuss");
+
+        // Absent from the side file; falls back to the embedded neutral value.
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void GetString_InvariantCulture_ReturnsEmbeddedNeutral()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Greeting", "Hallo"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        manager.GetString("Greeting", CultureInfo.InvariantCulture).Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void GetString_NeutralCulture_SkipsSideFileAndUsesEmbedded()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+
+        // The assembly's neutral culture is en-US (see NeutralLanguage in touki.tests.csproj). A side
+        // file for the neutral culture must be ignored: the neutral resources are embedded, so no
+        // probing happens for it.
+        WriteSideFile(folder.TempPath, "en-US", baseName, ("Greeting", "SHOULD_BE_IGNORED"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        manager.GetString("Greeting", new CultureInfo("en-US")).Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void GetString_CorruptSideFile_ReturnsEmbeddedNeutral()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        string directory = Path.Combine(folder.TempPath, "de");
+        Directory.CreateDirectory(directory);
+        System.IO.File.WriteAllBytes(Path.Combine(directory, $"{baseName}.resources"), [0x00, 0x01, 0x02, 0x03]);
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // A corrupt side file is treated as absent, so the key resolves to the embedded neutral value.
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void GetString_BuiltInNonStringResource_IsSkipped()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteMixedSideFile(folder.TempPath, "de", baseName);
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // The string entry still loads despite the non-string sibling...
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hallo");
+        // ...and the non-string (int) entry is ignored, so it falls back to neutral (absent -> null).
+        manager.GetString("Count", new CultureInfo("de")).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void GetString_ReflectionRequiringResource_TreatedAsAbsent()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteReflectionSideFile(folder.TempPath, "de", baseName);
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        // The file was written by PreserializedResourceWriter (a non-default reader type). The core
+        // ResourceReader rejects it at construction, so the whole file is treated as absent - no
+        // reflection is ever triggered and every key falls back to the embedded neutral resources.
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hello");
+        manager.GetString("Fancy", new CultureInfo("de")).Should().BeNull();
+    }
+
+    [TestMethod]
+    public void GetString_TableIsCached_SurvivesFileDeletion()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Greeting", "Hallo"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+        CultureInfo german = new("de");
+
+        manager.GetString("Greeting", german).Should().Be("Hallo");
+
+        // Delete the backing file; the cached table must still answer for the same culture.
+        System.IO.File.Delete(Path.Combine(folder.TempPath, "de", $"{baseName}.resources"));
+
+        manager.GetString("Greeting", german).Should().Be("Hallo");
+    }
+
+    [TestMethod]
+    public void GetString_CultureChange_RebuildsCache()
+    {
+        using TempFolder folder = new();
+        string baseName = NeutralBaseName();
+        WriteSideFile(folder.TempPath, "de", baseName, ("Greeting", "Hallo"));
+        WriteSideFile(folder.TempPath, "fr", baseName, ("Greeting", "Bonjour"));
+
+        SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
+
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hallo");
+        // Switching culture must rebuild the single-entry cache...
+        manager.GetString("Greeting", new CultureInfo("fr")).Should().Be("Bonjour");
+        // ...and switching back rebuilds it again.
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hallo");
+    }
+
+    [TestMethod]
+    public void ProbeRoot_ReflectsConstructorArgument()
+    {
+        using TempFolder folder = new();
+        SatelliteStringResourceManager manager = new(NeutralBaseName(), s_assembly, folder.TempPath);
+        manager.ProbeRoot.Should().Be(folder.TempPath);
+    }
+}

--- a/touki.tests/Touki/Resources/SatelliteTestStrings.resx
+++ b/touki.tests/Touki/Resources/SatelliteTestStrings.resx
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Greeting" xml:space="preserve">
+    <value>Hello</value>
+  </data>
+  <data name="Farewell" xml:space="preserve">
+    <value>Goodbye</value>
+  </data>
+</root>

--- a/touki.tests/touki.tests.csproj
+++ b/touki.tests/touki.tests.csproj
@@ -20,6 +20,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace />
 
+    <!-- Emits [NeutralResourcesLanguage("en-US")] so SatelliteStringResourceManager can recognize the
+         embedded neutral culture and skip side-file probing for it (exercised by its tests). -->
+    <NeutralLanguage>en-US</NeutralLanguage>
+
     <!-- Not a security boundary, the strong name is for identity and ease of use from other signed assemblies. -->
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\klutzyninja.snk</AssemblyOriginatorKeyFile>
@@ -53,6 +57,9 @@
     <PackageReference Include="Microsoft.Build" />
     <!-- Oracle reference for the FileSystemGlobbing dialect. Cross-platform, pure managed. -->
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <!-- Lets SatelliteStringResourceManager tests author a non-default-format (.resources) file via
+         PreserializedResourceWriter to validate how the manager handles reflection-requiring resources. -->
+    <PackageReference Include="System.Resources.Extensions" />
     <!-- Oracle reference for the Git dialect's gitignore evaluation. Ships native bits
          for Windows / Linux / macOS so the test class runs on every CI platform without
          a `git` executable on PATH. -->

--- a/touki/GlobalUsings.cs
+++ b/touki/GlobalUsings.cs
@@ -23,7 +23,9 @@ global using System.IO;
 global using System.IO.Enumeration;
 #endif
 
+global using BinaryReader = System.IO.BinaryReader;
 global using IOException = System.IO.IOException;
+global using MemoryStream = System.IO.MemoryStream;
 global using Stream = System.IO.Stream;
 global using StreamWriter = System.IO.StreamWriter;
 global using StringWriter = System.IO.StringWriter;

--- a/touki/GlobalUsings.cs
+++ b/touki/GlobalUsings.cs
@@ -23,6 +23,7 @@ global using System.IO;
 global using System.IO.Enumeration;
 #endif
 
+global using IOException = System.IO.IOException;
 global using Stream = System.IO.Stream;
 global using StreamWriter = System.IO.StreamWriter;
 global using StringWriter = System.IO.StringWriter;

--- a/touki/Touki/Resources/SatelliteStringResourceManager.cs
+++ b/touki/Touki/Resources/SatelliteStringResourceManager.cs
@@ -36,19 +36,21 @@ namespace Touki.Resources;
 ///  <para>
 ///   The merged table for the last requested culture is cached (as a frozen dictionary on .NET) and
 ///   rebuilt when the requested culture changes, which fits the overwhelmingly common
-///   single-UI-culture usage. The cache is updated without locking: under concurrent use with a
-///   changing culture a lookup may briefly observe a table built for a different culture (a stale
-///   result), but never an inconsistent one or a failure.
+///   single-UI-culture usage. The cache is a single immutable snapshot published through a
+///   <see langword="volatile"/> field, so it is updated without locking: under concurrent use with a
+///   changing culture a lookup may briefly observe the snapshot for a previously requested culture (a
+///   stale result), but never a torn or inconsistent one, and never a failure.
 ///  </para>
 ///  <para>
-///   Only string resources are supported. A <c>.resources</c> file that
-///   <see cref="ResourceReader"/> can open is always in the default binary format, whose non-string
-///   entries are intrinsic types (<see langword="int"/>, <c>byte[]</c>, and so on) that read without
-///   reflection and are ignored here. Files that would require reflection or serialization to read
-///   (a non-default reader type, such as one written by
+///   Only string resources are supported. Each entry's stored type is inspected with
+///   <c>ResourceReader.GetResourceData</c>, which reads the raw type tag and bytes without
+///   deserializing the value; only entries tagged as intrinsic strings are decoded, and every other
+///   entry (a primitive, an array, or a serialized object) is skipped without deserialization. Files
+///   that would require a non-default reader (for example one written by
 ///   <c>System.Resources.Extensions.PreserializedResourceWriter</c>) are rejected by the
-///   <see cref="ResourceReader"/> constructor and treated as absent, so no reflection or
-///   serialization is ever triggered - keeping the manager trim- and AOT-safe.
+///   <see cref="ResourceReader"/> constructor and treated as absent. No value is ever deserialized, so
+///   no reflection or legacy serialization is triggered - keeping the manager trim- and AOT-safe and
+///   never exposing untrusted <c>.resources</c> content to a deserializer.
 ///  </para>
 /// </remarks>
 public sealed class SatelliteStringResourceManager : ResourceManager
@@ -57,12 +59,11 @@ public sealed class SatelliteStringResourceManager : ResourceManager
     private readonly string _probeRoot;
     private readonly string? _neutralCultureName;
 
-    // Single-culture cache: the last requested culture, whether it is the neutral culture, and its
-    // merged string table (null when the culture is neutral - its resources are embedded, so no side
-    // files are consulted). Reset whenever the culture changes. Updated without locking; see GetString.
-    private string? _cachedCultureName;
-    private bool _cachedCultureIsNeutral;
-    private IReadOnlyDictionary<string, string>? _cachedStrings;
+    // Single-culture cache published as one immutable snapshot (see CultureCache). It holds the last
+    // requested culture, whether that culture is the neutral one, and its merged string table, and is
+    // replaced wholesale whenever the culture changes. The field is volatile so a concurrent reader
+    // always observes a fully-initialized snapshot - never a torn mix of fields. See GetString.
+    private volatile CultureCache? _cache;
 
 #if NET
     private static readonly IReadOnlyDictionary<string, string> s_emptyStrings = FrozenDictionary<string, string>.Empty;
@@ -123,23 +124,26 @@ public sealed class SatelliteStringResourceManager : ResourceManager
         ArgumentNullException.ThrowIfNull(name);
         culture ??= CultureInfo.CurrentUICulture;
 
-        // Rebuild only when the culture changes; the neutral check and the merged table are then
-        // computed once and reused for every subsequent lookup in the same culture. No lock is taken -
-        // a concurrent culture change can at worst make a lookup observe a stale table, never crash
-        // (the table reference is snapshotted below) - and the single-culture path is always exact.
-        if (!string.Equals(_cachedCultureName, culture.Name, StringComparison.Ordinal))
+        // Read the published snapshot once. The volatile field gives this read acquire semantics, so a
+        // non-null reference is always a fully-initialized CultureCache and every field read below
+        // comes from that one snapshot - never a torn mix.
+        CultureCache? cache = _cache;
+        if (cache is null || !string.Equals(cache.CultureName, culture.Name, StringComparison.Ordinal))
         {
-            // The neutral culture is matched ordinally; string.Equals is null-safe, so a missing
-            // NeutralResourcesLanguage attribute (null _neutralCultureName) simply never matches.
+            // Rebuild for the new culture and publish the snapshot atomically (the volatile write has
+            // release semantics). No lock is taken - under a concurrent culture change a lookup may
+            // observe a stale (previous-culture) snapshot, but never a torn or inconsistent one, and
+            // never fails. The neutral culture is matched ordinally; string.Equals is null-safe, so a
+            // missing NeutralResourcesLanguage attribute (null _neutralCultureName) simply never
+            // matches and side files are always consulted.
             bool isNeutral = string.Equals(culture.Name, _neutralCultureName, StringComparison.Ordinal);
-            _cachedCultureIsNeutral = isNeutral;
-            _cachedStrings = isNeutral ? null : BuildStrings(culture);
-            _cachedCultureName = culture.Name;
+            cache = new CultureCache(culture.Name, isNeutral, isNeutral ? null : BuildStrings(culture));
+            _cache = cache;
         }
 
-        // Snapshot the table reference so a concurrent rebuild cannot turn it null between the check
-        // and the lookup.
-        if (!_cachedCultureIsNeutral && _cachedStrings is { } strings && strings.TryGetValue(name, out string? value))
+        // A neutral culture has its resources embedded (Strings is null); every other culture consults
+        // its merged side-file table first.
+        if (!cache.IsNeutral && cache.Strings is { } strings && strings.TryGetValue(name, out string? value))
         {
             return value;
         }
@@ -223,19 +227,62 @@ public sealed class SatelliteStringResourceManager : ResourceManager
     {
         Dictionary<string, string> table = new(StringComparer.Ordinal);
         using ResourceReader reader = new(path);
+
+        // Collect the names first. enumerator.Key returns the name without touching the value; reading
+        // enumerator.Value, by contrast, would deserialize every entry - invoking reflection or legacy
+        // serialization for non-string entries - which would break the trim/AOT guarantee and turn
+        // untrusted .resources content into a deserialization surface.
+        List<string> names = [];
         IDictionaryEnumerator enumerator = reader.GetEnumerator();
         while (enumerator.MoveNext())
         {
-            // Only string values are kept. A file ResourceReader can open is in the default binary
-            // format, whose non-string entries are intrinsic types that read without reflection, so
-            // reading the value and rejecting non-strings is safe. Files that would need reflection
-            // to read are rejected by the ResourceReader constructor (handled in LoadTable).
-            if (enumerator.Key is string key && enumerator.Value is string value)
+            if (enumerator.Key is string key)
             {
-                table[key] = value;
+                names.Add(key);
             }
         }
 
+        foreach (string name in names)
+        {
+            // GetResourceData reads the stored type tag and the raw value bytes without deserializing.
+            reader.GetResourceData(name, out string resourceType, out byte[] resourceData);
+
+            // Keep only intrinsic strings; every other entry (a primitive, an array, or a serialized
+            // object) is skipped, so no value is ever deserialized.
+            if (!string.Equals(resourceType, "ResourceTypeCode.String", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            // A ResourceTypeCode.String payload is a length-prefixed UTF-8 string - exactly the format
+            // BinaryReader.ReadString expects - so it decodes with no serializer or reflection.
+            using MemoryStream stream = new(resourceData);
+            using BinaryReader valueReader = new(stream, System.Text.Encoding.UTF8);
+            table[name] = valueReader.ReadString();
+        }
+
         return table;
+    }
+
+    /// <summary>
+    ///  An immutable snapshot of the resolution state for a single culture. It is published atomically
+    ///  through the <see langword="volatile"/> <c>_cache</c> field, so a reader that reads the
+    ///  reference sees a fully-initialized instance - the culture name, the neutral flag, and the table
+    ///  are always mutually consistent (never torn), even on weak memory models.
+    /// </summary>
+    private sealed class CultureCache
+    {
+        internal CultureCache(string cultureName, bool isNeutral, IReadOnlyDictionary<string, string>? strings)
+        {
+            CultureName = cultureName;
+            IsNeutral = isNeutral;
+            Strings = strings;
+        }
+
+        internal string CultureName { get; }
+
+        internal bool IsNeutral { get; }
+
+        internal IReadOnlyDictionary<string, string>? Strings { get; }
     }
 }

--- a/touki/Touki/Resources/SatelliteStringResourceManager.cs
+++ b/touki/Touki/Resources/SatelliteStringResourceManager.cs
@@ -1,0 +1,238 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections;
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+#if NET
+using System.Collections.Frozen;
+#endif
+
+namespace Touki.Resources;
+
+/// <summary>
+///  A <see cref="ResourceManager"/> that resolves localized <b>string</b> resources from loose
+///  per-culture <c>.resources</c> files at runtime, falling back to the embedded neutral resources.
+///  Enables localization under Native AOT without embedding every language into the single native
+///  binary.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Native AOT bakes every satellite assembly into the native image at publish time; there is no
+///   runtime probe for a <c>&lt;culture&gt;/&lt;name&gt;.resources.dll</c> next to the application.
+///   This manager sidesteps that limitation by reading raw <c>.resources</c> files shipped as
+///   ordinary content next to the application, so only the small neutral set needs to be embedded.
+///  </para>
+///  <para>
+///   For a requested culture the manager walks from the most specific culture up to (but not
+///   including) the invariant culture, merging the side files it finds into a single table - more
+///   specific cultures win. When the requested culture is the assembly's neutral culture the side
+///   files are skipped entirely, since the neutral resources are embedded. When no side file
+///   supplies the key it defers to the embedded neutral resources through the base
+///   <see cref="ResourceManager"/>.
+///  </para>
+///  <para>
+///   The merged table for the last requested culture is cached (as a frozen dictionary on .NET) and
+///   rebuilt when the requested culture changes, which fits the overwhelmingly common
+///   single-UI-culture usage. The cache is updated without locking: under concurrent use with a
+///   changing culture a lookup may briefly observe a table built for a different culture (a stale
+///   result), but never an inconsistent one or a failure.
+///  </para>
+///  <para>
+///   Only string resources are supported. A <c>.resources</c> file that
+///   <see cref="ResourceReader"/> can open is always in the default binary format, whose non-string
+///   entries are intrinsic types (<see langword="int"/>, <c>byte[]</c>, and so on) that read without
+///   reflection and are ignored here. Files that would require reflection or serialization to read
+///   (a non-default reader type, such as one written by
+///   <c>System.Resources.Extensions.PreserializedResourceWriter</c>) are rejected by the
+///   <see cref="ResourceReader"/> constructor and treated as absent, so no reflection or
+///   serialization is ever triggered - keeping the manager trim- and AOT-safe.
+///  </para>
+/// </remarks>
+public sealed class SatelliteStringResourceManager : ResourceManager
+{
+    private readonly string _baseName;
+    private readonly string _probeRoot;
+    private readonly string? _neutralCultureName;
+
+    // Single-culture cache: the last requested culture, whether it is the neutral culture, and its
+    // merged string table (null when the culture is neutral - its resources are embedded, so no side
+    // files are consulted). Reset whenever the culture changes. Updated without locking; see GetString.
+    private string? _cachedCultureName;
+    private bool _cachedCultureIsNeutral;
+    private IReadOnlyDictionary<string, string>? _cachedStrings;
+
+#if NET
+    private static readonly IReadOnlyDictionary<string, string> s_emptyStrings = FrozenDictionary<string, string>.Empty;
+#else
+    private static readonly IReadOnlyDictionary<string, string> s_emptyStrings =
+        new Dictionary<string, string>(0, StringComparer.Ordinal);
+#endif
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="SatelliteStringResourceManager"/> class that
+    ///  probes for side files under <see cref="AppContext.BaseDirectory"/> in a <c>resources</c>
+    ///  subdirectory.
+    /// </summary>
+    /// <inheritdoc cref="SatelliteStringResourceManager(string, Assembly, string)"/>
+    public SatelliteStringResourceManager(string baseName, Assembly assembly)
+        : this(baseName, assembly, Path.Join(AppContext.BaseDirectory, "resources"))
+    {
+    }
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="SatelliteStringResourceManager"/> class.
+    /// </summary>
+    /// <param name="baseName">
+    ///  The root name of the resources, without culture or extension - for example
+    ///  <c>MyApp.Resources.SR</c>. Used both to locate the embedded neutral set and to name the
+    ///  per-culture side files.
+    /// </param>
+    /// <param name="assembly">The assembly that carries the embedded neutral resources.</param>
+    /// <param name="probeRoot">
+    ///  The directory that contains <c>&lt;culture&gt;/&lt;baseName&gt;.resources</c> files.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="baseName"/>, <paramref name="assembly"/>, or <paramref name="probeRoot"/> is
+    ///  <see langword="null"/>.
+    /// </exception>
+    public SatelliteStringResourceManager(string baseName, Assembly assembly, string probeRoot)
+        : base(baseName, assembly)
+    {
+        ArgumentNullException.ThrowIfNull(probeRoot);
+        _baseName = baseName;
+        _probeRoot = probeRoot;
+
+        // The neutral (embedded) culture never has a side file; knowing it lets us skip probing when
+        // it is the one requested. Absent attribute simply disables that shortcut.
+        _neutralCultureName =
+            (Attribute.GetCustomAttribute(assembly, typeof(NeutralResourcesLanguageAttribute)) as NeutralResourcesLanguageAttribute)
+                ?.CultureName;
+    }
+
+    /// <summary>
+    ///  The directory searched for per-culture side files.
+    /// </summary>
+    public string ProbeRoot => _probeRoot;
+
+    /// <inheritdoc/>
+    public override string? GetString(string name, CultureInfo? culture)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        culture ??= CultureInfo.CurrentUICulture;
+
+        // Rebuild only when the culture changes; the neutral check and the merged table are then
+        // computed once and reused for every subsequent lookup in the same culture. No lock is taken -
+        // a concurrent culture change can at worst make a lookup observe a stale table, never crash
+        // (the table reference is snapshotted below) - and the single-culture path is always exact.
+        if (!string.Equals(_cachedCultureName, culture.Name, StringComparison.Ordinal))
+        {
+            // The neutral culture is matched ordinally; string.Equals is null-safe, so a missing
+            // NeutralResourcesLanguage attribute (null _neutralCultureName) simply never matches.
+            bool isNeutral = string.Equals(culture.Name, _neutralCultureName, StringComparison.Ordinal);
+            _cachedCultureIsNeutral = isNeutral;
+            _cachedStrings = isNeutral ? null : BuildStrings(culture);
+            _cachedCultureName = culture.Name;
+        }
+
+        // Snapshot the table reference so a concurrent rebuild cannot turn it null between the check
+        // and the lookup.
+        if (!_cachedCultureIsNeutral && _cachedStrings is { } strings && strings.TryGetValue(name, out string? value))
+        {
+            return value;
+        }
+
+        // Fall back to the embedded neutral set. Passing the invariant culture avoids a satellite
+        // grovel that would always fail (and is unsupported) under Native AOT.
+        return base.GetString(name, CultureInfo.InvariantCulture);
+    }
+
+    private IReadOnlyDictionary<string, string> BuildStrings(CultureInfo culture)
+    {
+        Dictionary<string, string>? merged = null;
+
+        for (CultureInfo current = culture;
+            !current.Equals(CultureInfo.InvariantCulture)
+                && !string.Equals(current.Name, _neutralCultureName, StringComparison.Ordinal);
+            current = current.Parent)
+        {
+            Dictionary<string, string>? table = LoadTable(current.Name);
+            if (table is null)
+            {
+                continue;
+            }
+
+            if (merged is null)
+            {
+                merged = table;
+                continue;
+            }
+
+            // Parent cultures supply only the keys the more specific cultures did not.
+            foreach (KeyValuePair<string, string> entry in table)
+            {
+                if (!merged.ContainsKey(entry.Key))
+                {
+                    merged[entry.Key] = entry.Value;
+                }
+            }
+        }
+
+        return merged is null ? s_emptyStrings : Freeze(merged);
+
+#if NET
+        static FrozenDictionary<string, string> Freeze(Dictionary<string, string> table) =>
+            table.ToFrozenDictionary(StringComparer.Ordinal);
+#else
+        static Dictionary<string, string> Freeze(Dictionary<string, string> table) => table;
+#endif
+    }
+
+    private Dictionary<string, string>? LoadTable(string cultureName)
+    {
+        string path = Path.Join(_probeRoot, cultureName, $"{_baseName}.resources");
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return LoadStringTable(path);
+        }
+        catch (Exception ex) when (ex is IOException
+            or FormatException
+            or BadImageFormatException
+            or ArgumentException
+            or NotSupportedException)
+        {
+            // The side file is missing, unreadable, malformed, or not a default-format string
+            // .resources file. ResourceReader throws ArgumentException for a bad magic number and
+            // NotSupportedException for a non-default reader type (for example one written by
+            // PreserializedResourceWriter for resources that need reflection). Behave as if absent.
+            return null;
+        }
+    }
+
+    private static Dictionary<string, string> LoadStringTable(string path)
+    {
+        Dictionary<string, string> table = new(StringComparer.Ordinal);
+        using ResourceReader reader = new(path);
+        IDictionaryEnumerator enumerator = reader.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            // Only string values are kept. A file ResourceReader can open is in the default binary
+            // format, whose non-string entries are intrinsic types that read without reflection, so
+            // reading the value and rejecting non-strings is safe. Files that would need reflection
+            // to read are rejected by the ResourceReader constructor (handled in LoadTable).
+            if (enumerator.Key is string key && enumerator.Value is string value)
+            {
+                table[key] = value;
+            }
+        }
+
+        return table;
+    }
+}

--- a/touki/Touki/Resources/SatelliteStringResourceManager.cs
+++ b/touki/Touki/Resources/SatelliteStringResourceManager.cs
@@ -203,15 +203,18 @@ public sealed class SatelliteStringResourceManager : ResourceManager
             return LoadStringTable(path);
         }
         catch (Exception ex) when (ex is IOException
+            or UnauthorizedAccessException
             or FormatException
             or BadImageFormatException
             or ArgumentException
             or NotSupportedException)
         {
-            // The side file is missing, unreadable, malformed, or not a default-format string
-            // .resources file. ResourceReader throws ArgumentException for a bad magic number and
-            // NotSupportedException for a non-default reader type (for example one written by
-            // PreserializedResourceWriter for resources that need reflection). Behave as if absent.
+            // The side file is missing, unreadable (locked or access-denied), malformed, or not a
+            // default-format string .resources file. ResourceReader throws ArgumentException for a bad
+            // magic number and NotSupportedException for a non-default reader type (for example one
+            // written by PreserializedResourceWriter for resources that need reflection).
+            // UnauthorizedAccessException covers a probe directory or file the process cannot read.
+            // In every case, behave as if absent.
             return null;
         }
     }


### PR DESCRIPTION
## Summary

Adds a public `SatelliteStringResourceManager` that resolves localized **string** resources from loose per-culture `.resources` files at runtime, falling back to the embedded neutral set. This enables localization under Native AOT, where satellite assemblies are baked into the single native image and cannot be probed for at runtime.

The manager walks from the most specific culture up to (but not including) the invariant/neutral culture, merging the side files it finds (more specific cultures win), caches the merged table for the last requested culture (a frozen dictionary on .NET), and defers to the embedded neutral resources for any key it does not supply. Only string resources are supported; files that would require reflection or serialization to read are rejected at the `ResourceReader` constructor and treated as absent, so no reflection or serialization is ever triggered - keeping it trim- and AOT-safe.

## Changes

- **touki**: `SatelliteStringResourceManager` - a string-only `ResourceManager` subclass with a frozen-dictionary single-culture cache, lock-free reads, and no reflection/serialization.
- **touki**: add `IOException` to the `GlobalUsings` exchange-type aliases so it resolves on net472, where `Microsoft.IO` shadows `System.IO`.
- **touki.tests**: `SatelliteStringResourceManager` unit tests + neutral `.resx`; reference `System.Resources.Extensions`; set `NeutralLanguage`.
- **touki.aot.tests**: new net10 project published with `PublishAot=true` as a compile/publish gate for the manager.
- **Directory.Packages.props**: add `System.Resources.Extensions`.
- **touki.slnx**: wire in `touki.aot.tests`.

## Validation

- All TFMs (net10.0 / net11.0 / net472) build with 0 warnings / 0 errors.
- `SatelliteStringResourceManager` tests pass in Release on net10.0 and net481.

## Notes

- `touki.aot.tests` runs its cases on the managed runtime and additionally serves as an **AOT publish gate**: `dotnet publish -c Release` with `PublishAot=true` must succeed with no trim/AOT (IL2xxx/IL3xxx) warnings. Running the MSTest cases *natively* under AOT would require the experimental closed-source `MSTest.Engine` + source generator, which is deliberately not taken here.
- The design/plan document is intentionally excluded from this PR.