### PR TITLE
Add RawResourceReader and adopt it in SatelliteStringResourceManager

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,7 @@
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.3" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.9" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 </Project>

--- a/touki.perf/RawResourceReaderPerf.cs
+++ b/touki.perf/RawResourceReaderPerf.cs
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Buffers;
+using System.Resources;
+using System.Runtime.InteropServices;
+using Touki.Resources;
+
+namespace touki.perf;
+
+/// <summary>
+///  Measures <see cref="RawResourceReader"/> against the runtime's
+///  <see cref="System.Resources.ResourceReader"/> (the oracle) on both .NET Framework 4.8.1 RyuJIT
+///  and modern .NET RyuJIT.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Each logical operation - open a reader and look up one value, and a repeated lookup on a cached
+///   reader - is measured for the oracle and for <see cref="RawResourceReader"/> over two backings: a
+///   regular seekable stream (the oracle's array-allocating path) and an
+///   <see cref="System.IO.UnmanagedMemoryStream"/> / native memory (its pointer fast path). The
+///   <c>[MemoryDiagnoser]</c> column is the point of the comparison: <see cref="RawResourceReader"/>
+///   allocates nothing for open, lookup, or read, where the oracle allocates its index arrays and a
+///   <c>byte[]</c> per value.
+///  </para>
+/// </remarks>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net481, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+[SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 3, launchCount: 1)]
+public class RawResourceReaderPerf
+{
+    private const int ResourceCount = 200;
+
+    private byte[] _bytes = null!;
+    private string _path = null!;
+    private string _lookupKey = null!;
+    private readonly byte[] _scratch = new byte[256];
+
+    private ResourceReader _cachedOracle = null!;
+    private RawResourceReader _cachedRaw = null!;
+
+    private unsafe byte* _nativePointer;
+    private int _nativeLength;
+    private NativeMemoryManager _nativeManager = null!;
+    private ReadOnlyMemory<byte> _nativeMemory;
+
+    [GlobalSetup]
+    public unsafe void Setup()
+    {
+        System.IO.MemoryStream stream = new();
+        using (ResourceWriter writer = new(stream))
+        {
+            for (int i = 0; i < ResourceCount; i++)
+            {
+                writer.AddResource($"resource_{i}", $"value_{i}");
+            }
+
+            writer.Generate();
+        }
+
+        _bytes = stream.ToArray();
+        _lookupKey = $"resource_{ResourceCount / 2}";
+
+        _path = System.IO.Path.GetTempFileName();
+        System.IO.File.WriteAllBytes(_path, _bytes);
+
+        _cachedOracle = new ResourceReader(new System.IO.MemoryStream(_bytes));
+        _cachedRaw = new RawResourceReader(_bytes);
+
+        _nativeLength = _bytes.Length;
+        _nativePointer = (byte*)Marshal.AllocHGlobal(_nativeLength);
+        _bytes.AsSpan().CopyTo(new Span<byte>(_nativePointer, _nativeLength));
+        _nativeManager = new NativeMemoryManager(_nativePointer, _nativeLength);
+        _nativeMemory = _nativeManager.Memory;
+    }
+
+    [GlobalCleanup]
+    public unsafe void Cleanup()
+    {
+        _cachedOracle?.Dispose();
+
+        if (_nativePointer is not null)
+        {
+            Marshal.FreeHGlobal((nint)_nativePointer);
+            _nativePointer = null;
+        }
+
+        if (_path is not null && System.IO.File.Exists(_path))
+        {
+            System.IO.File.Delete(_path);
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Oracle_DiskStream_OpenLookup()
+    {
+        using ResourceReader reader = new(new System.IO.FileStream(
+            _path, System.IO.FileMode.Open, System.IO.FileAccess.Read, System.IO.FileShare.Read));
+        reader.GetResourceData(_lookupKey, out _, out byte[] data);
+        return data.Length;
+    }
+
+    [Benchmark]
+    public int Raw_MappedFile_OpenLookup()
+    {
+        using RawResourceReader reader = RawResourceReader.CreateFromFile(_path);
+        reader.TryFindResource(_lookupKey, out ResourceLocation location);
+        reader.TryGetResourceData(location.Index, _scratch, out int written);
+        return written;
+    }
+
+    [Benchmark]
+    public unsafe int Oracle_UnmanagedStream_OpenLookup()
+    {
+        using ResourceReader reader = new(new System.IO.UnmanagedMemoryStream(_nativePointer, _nativeLength));
+        reader.GetResourceData(_lookupKey, out _, out byte[] data);
+        return data.Length;
+    }
+
+    [Benchmark]
+    public int Raw_NativeMemory_OpenLookup()
+    {
+        RawResourceReader reader = new(_nativeMemory);
+        reader.TryFindResource(_lookupKey, out ResourceLocation location);
+        reader.TryGetResourceData(location.Index, _scratch, out int written);
+        return written;
+    }
+
+    [Benchmark]
+    public int Oracle_CachedReader_Lookup()
+    {
+        _cachedOracle.GetResourceData(_lookupKey, out _, out byte[] data);
+        return data.Length;
+    }
+
+    [Benchmark]
+    public int Raw_CachedReader_Lookup()
+    {
+        _cachedRaw.TryFindResource(_lookupKey, out ResourceLocation location);
+        _cachedRaw.TryGetResourceData(location.Index, _scratch, out int written);
+        return written;
+    }
+
+    private sealed unsafe class NativeMemoryManager : MemoryManager<byte>
+    {
+        private readonly byte* _pointer;
+        private readonly int _length;
+
+        public NativeMemoryManager(byte* pointer, int length)
+        {
+            _pointer = pointer;
+            _length = length;
+        }
+
+        public override Span<byte> GetSpan() => new(_pointer, _length);
+
+        public override MemoryHandle Pin(int elementIndex = 0) => new(_pointer + elementIndex);
+
+        public override void Unpin()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+        }
+    }
+}

--- a/touki.perf/RawResourceReaderPerf.cs
+++ b/touki.perf/RawResourceReaderPerf.cs
@@ -79,6 +79,7 @@ public class RawResourceReaderPerf
     public unsafe void Cleanup()
     {
         _cachedOracle?.Dispose();
+        _cachedRaw?.Dispose();
 
         if (_nativePointer is not null)
         {

--- a/touki.tests/System/EncodingExtensionsTests.cs
+++ b/touki.tests/System/EncodingExtensionsTests.cs
@@ -84,4 +84,32 @@ public class EncodingExtensionsTests
         Span<char> dst = stackalloc char[4];
         Encoding.UTF8.GetChars([], dst).Should().Be(0);
     }
+
+    [TestMethod]
+    public void TryGetChars_FitsDestination_WritesAndReturnsTrue()
+    {
+        string original = "abc\u4e2d";
+        byte[] bytes = Encoding.UTF8.GetBytes(original);
+        Span<char> dst = stackalloc char[original.Length];
+        Encoding.UTF8.TryGetChars(bytes, dst, out int written).Should().BeTrue();
+        written.Should().Be(original.Length);
+        dst.ToString().Should().Be(original);
+    }
+
+    [TestMethod]
+    public void TryGetChars_DestinationTooSmall_ReturnsFalse()
+    {
+        byte[] bytes = Encoding.UTF8.GetBytes("abcd");
+        Span<char> dst = stackalloc char[2];
+        Encoding.UTF8.TryGetChars(bytes, dst, out int written).Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryGetChars_EmptySource_ReturnsTrueZero()
+    {
+        Span<char> dst = stackalloc char[4];
+        Encoding.UTF8.TryGetChars([], dst, out int written).Should().BeTrue();
+        written.Should().Be(0);
+    }
 }

--- a/touki.tests/Touki/Io/MappedMemoryManagerTests.cs
+++ b/touki.tests/Touki/Io/MappedMemoryManagerTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+[TestClass]
+public class MappedMemoryManagerTests
+{
+    [TestMethod]
+    public void CreateFromFile_MapsFileContents()
+    {
+        byte[] bytes = [10, 20, 30, 40, 50];
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, bytes);
+
+        using MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+
+        manager.Memory.Length.Should().Be(bytes.Length);
+        manager.Memory.Span.SequenceEqual(bytes).Should().BeTrue();
+        manager.GetSpan().SequenceEqual(bytes).Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void CreateFromFile_NullPath_ThrowsArgumentNullException()
+    {
+        Action act = () => _ = MappedMemoryManager.CreateFromFile(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void CreateFromFile_EmptyFile_ThrowsIOException()
+    {
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "empty.bin");
+        System.IO.File.WriteAllBytes(path, []);
+
+        Action act = () => _ = MappedMemoryManager.CreateFromFile(path);
+        act.Should().Throw<System.IO.IOException>();
+    }
+
+    [TestMethod]
+    public void Dispose_IsIdempotent()
+    {
+        byte[] bytes = [1, 2, 3];
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, bytes);
+
+        MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+        ((IDisposable)manager).Dispose();
+        ((IDisposable)manager).Dispose();
+    }
+}

--- a/touki.tests/Touki/Io/MappedMemoryManagerTests.cs
+++ b/touki.tests/Touki/Io/MappedMemoryManagerTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Buffers;
+
 namespace Touki.Io;
 
 [TestClass]
@@ -51,5 +53,78 @@ public class MappedMemoryManagerTests
         MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
         ((IDisposable)manager).Dispose();
         ((IDisposable)manager).Dispose();
+    }
+
+    [TestMethod]
+    public void GetSpan_AfterDispose_ThrowsObjectDisposedException()
+    {
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, [1, 2, 3]);
+
+        MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+        ((IDisposable)manager).Dispose();
+
+        Action act = () => { _ = manager.GetSpan().Length; };
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [TestMethod]
+    public void Pin_AfterDispose_ThrowsObjectDisposedException()
+    {
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, [1, 2, 3]);
+
+        MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+        ((IDisposable)manager).Dispose();
+
+        Action act = () => manager.Pin();
+        act.Should().Throw<ObjectDisposedException>();
+    }
+
+    [TestMethod]
+    public void Pin_NegativeIndex_ThrowsArgumentOutOfRangeException()
+    {
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, [1, 2, 3]);
+
+        using MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+
+        Action act = () => manager.Pin(-1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void Pin_IndexBeyondLength_ThrowsArgumentOutOfRangeException()
+    {
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, [1, 2, 3]);
+
+        using MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+
+        Action act = () => manager.Pin(4);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public unsafe void Pin_ValidIndex_PinsAtOffset()
+    {
+        byte[] bytes = [10, 20, 30];
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "data.bin");
+        System.IO.File.WriteAllBytes(path, bytes);
+
+        using MappedMemoryManager manager = MappedMemoryManager.CreateFromFile(path);
+
+        using (MemoryHandle handle = manager.Pin(1))
+        {
+            ((byte*)handle.Pointer)[0].Should().Be((byte)20);
+        }
+
+        // Pinning at the end (elementIndex == length) is allowed and yields an end pointer.
+        using MemoryHandle endHandle = manager.Pin(bytes.Length);
     }
 }

--- a/touki.tests/Touki/Io/SpanReaderExtensionsTests.cs
+++ b/touki.tests/Touki/Io/SpanReaderExtensionsTests.cs
@@ -186,4 +186,93 @@ public class SpanReaderExtensionsTests
         reader.TryPeek(out char next).Should().BeTrue();
         next.Should().Be(' ');
     }
+
+    [TestMethod]
+    public void TryReadInt32LittleEndian_ReadsValueAndAdvances()
+    {
+        byte[] data = [0x78, 0x56, 0x34, 0x12];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryReadInt32LittleEndian(out int value).Should().BeTrue();
+        value.Should().Be(0x12345678);
+        reader.Position.Should().Be(4);
+        reader.End.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TryReadInt32LittleEndian_Sequential_ReadsBoth()
+    {
+        byte[] data = [1, 0, 0, 0, 2, 0, 0, 0];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryReadInt32LittleEndian(out int first).Should().BeTrue();
+        reader.TryReadInt32LittleEndian(out int second).Should().BeTrue();
+        first.Should().Be(1);
+        second.Should().Be(2);
+        reader.End.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void TryReadInt32LittleEndian_Truncated_ReturnsFalse()
+    {
+        byte[] data = [1, 2, 3];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryReadInt32LittleEndian(out int value).Should().BeFalse();
+        value.Should().Be(0);
+        reader.Position.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryRead7BitEncodedInt32_SingleByte_ReadsValue()
+    {
+        byte[] data = [5];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryRead7BitEncodedInt32(out int value).Should().BeTrue();
+        value.Should().Be(5);
+        reader.Position.Should().Be(1);
+    }
+
+    [TestMethod]
+    public void TryRead7BitEncodedInt32_MultiByte_ReadsValue()
+    {
+        byte[] data = [0xAC, 0x02];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryRead7BitEncodedInt32(out int value).Should().BeTrue();
+        value.Should().Be(300);
+        reader.Position.Should().Be(2);
+    }
+
+    [TestMethod]
+    public void TryRead7BitEncodedInt32_MaxValue_ReadsValue()
+    {
+        byte[] data = [0xFF, 0xFF, 0xFF, 0xFF, 0x07];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryRead7BitEncodedInt32(out int value).Should().BeTrue();
+        value.Should().Be(int.MaxValue);
+        reader.Position.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void TryRead7BitEncodedInt32_Truncated_ReturnsFalse()
+    {
+        byte[] data = [0x80];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryRead7BitEncodedInt32(out int value).Should().BeFalse();
+        value.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryRead7BitEncodedInt32_Overflow_ReturnsFalse()
+    {
+        byte[] data = [0x80, 0x80, 0x80, 0x80, 0x10];
+        SpanReader<byte> reader = new(data);
+
+        reader.TryRead7BitEncodedInt32(out int value).Should().BeFalse();
+        value.Should().Be(0);
+    }
 }

--- a/touki.tests/Touki/Io/SpanReaderExtensionsTests.cs
+++ b/touki.tests/Touki/Io/SpanReaderExtensionsTests.cs
@@ -264,6 +264,7 @@ public class SpanReaderExtensionsTests
 
         reader.TryRead7BitEncodedInt32(out int value).Should().BeFalse();
         value.Should().Be(0);
+        reader.Position.Should().Be(0);
     }
 
     [TestMethod]
@@ -274,5 +275,20 @@ public class SpanReaderExtensionsTests
 
         reader.TryRead7BitEncodedInt32(out int value).Should().BeFalse();
         value.Should().Be(0);
+        reader.Position.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryRead7BitEncodedInt32_TruncatedMidStream_RestoresPosition()
+    {
+        // Consume one byte, then attempt a truncated 7-bit read; the failed read must leave the reader
+        // where it began (position 1), not partially advanced.
+        byte[] data = [0x2A, 0x80];
+        SpanReader<byte> reader = new(data);
+        reader.TryRead(out byte _).Should().BeTrue();
+
+        reader.TryRead7BitEncodedInt32(out int value).Should().BeFalse();
+        value.Should().Be(0);
+        reader.Position.Should().Be(1);
     }
 }

--- a/touki.tests/Touki/Io/SpanReaderTests.cs
+++ b/touki.tests/Touki/Io/SpanReaderTests.cs
@@ -520,6 +520,59 @@ public class SpanReaderTests
     }
 
     [TestMethod]
+    public void SpanReader_TryAdvance_Success()
+    {
+        ReadOnlySpan<byte> span = [1, 2, 3, 4, 5];
+        SpanReader<byte> reader = new(span);
+
+        reader.TryAdvance(2).Should().BeTrue();
+        reader.Position.Should().Be(2);
+
+        reader.TryAdvance(3).Should().BeTrue();
+        reader.Position.Should().Be(5);
+    }
+
+    [TestMethod]
+    public void SpanReader_TryAdvance_ExactRemaining()
+    {
+        ReadOnlySpan<byte> span = [1, 2, 3];
+        SpanReader<byte> reader = new(span);
+
+        reader.TryAdvance(3).Should().BeTrue();
+        reader.Position.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void SpanReader_TryAdvance_Zero()
+    {
+        ReadOnlySpan<byte> span = [1, 2, 3];
+        SpanReader<byte> reader = new(span);
+
+        reader.TryAdvance(0).Should().BeTrue();
+        reader.Position.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void SpanReader_TryAdvance_CountTooLarge()
+    {
+        ReadOnlySpan<byte> span = [1, 2, 3];
+        SpanReader<byte> reader = new(span);
+
+        reader.TryAdvance(4).Should().BeFalse();
+        reader.Position.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void SpanReader_TryAdvance_NegativeCount()
+    {
+        ReadOnlySpan<byte> span = [1, 2, 3];
+        SpanReader<byte> reader = new(span);
+
+        reader.TryAdvance(-1).Should().BeFalse();
+        reader.Position.Should().Be(0);
+    }
+
+    [TestMethod]
     public void SpanReader_Length_Property()
     {
         ReadOnlySpan<byte> span = [1, 2, 3, 4, 5];

--- a/touki.tests/Touki/Resources/RawResourceReaderTests.cs
+++ b/touki.tests/Touki/Resources/RawResourceReaderTests.cs
@@ -1,0 +1,536 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections;
+using System.Resources;
+using System.Resources.Extensions;
+using System.Text;
+
+namespace Touki.Resources;
+
+[TestClass]
+public class RawResourceReaderTests
+{
+    // Writes a default-format .resources into memory and returns the bytes.
+    private static byte[] Write(Action<ResourceWriter> add)
+    {
+        MemoryStream stream = new();
+        using (ResourceWriter writer = new(stream))
+        {
+            add(writer);
+            writer.Generate();
+        }
+
+        return stream.ToArray();
+    }
+
+    // Bytes a BinaryWriter (the encoding ResourceWriter uses for primitive values) would produce.
+    private static byte[] PrimitiveBytes(Action<System.IO.BinaryWriter> write)
+    {
+        using MemoryStream stream = new();
+        using System.IO.BinaryWriter writer = new(stream);
+        write(writer);
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    [TestMethod]
+    public void Constructor_BadMagic_ThrowsArgumentException()
+    {
+        byte[] bytes = new byte[64];
+        Action act = () => _ = new RawResourceReader(bytes);
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [TestMethod]
+    public void Constructor_TruncatedHeader_ThrowsBadImageFormatException()
+    {
+        byte[] valid = Write(w => w.AddResource("a", "b"));
+        byte[] truncated = valid.AsSpan(0, 10).ToArray();
+        Action act = () => _ = new RawResourceReader(truncated);
+        act.Should().Throw<BadImageFormatException>();
+    }
+
+    [TestMethod]
+    public void Constructor_Version1_ThrowsNotSupportedException()
+    {
+        byte[] bytes = Write(w => w.AddResource("a", "b"));
+
+        // The format version int follows the ResourceManager header: magic(4) + rmHeaderVersion(4) +
+        // numBytesToSkip(4) + numBytesToSkip bytes.
+        int numBytesToSkip = BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(8, 4));
+        int versionOffset = 12 + numBytesToSkip;
+        BinaryPrimitives.WriteInt32LittleEndian(bytes.AsSpan(versionOffset, 4), 1);
+
+        Action act = () => _ = new RawResourceReader(bytes);
+        act.Should().Throw<NotSupportedException>();
+    }
+
+    [TestMethod]
+    public void ResourceCount_EmptyFile_ReturnsZero()
+    {
+        RawResourceReader reader = new(Write(static _ => { }));
+        reader.ResourceCount.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void ResourceCount_MatchesWrittenCount()
+    {
+        RawResourceReader reader = new(Write(static w =>
+        {
+            w.AddResource("one", "1");
+            w.AddResource("two", "2");
+            w.AddResource("three", "3");
+        }));
+
+        reader.ResourceCount.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void TryFindResource_ExistingName_ReturnsTrue()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("Greeting", "Hello")));
+
+        reader.TryFindResource("Greeting", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.String);
+        location.IsUserType.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public void TryFindResource_MissingName_ReturnsFalse()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("Greeting", "Hello")));
+
+        reader.TryFindResource("Absent", out ResourceLocation location).Should().BeFalse();
+        location.Should().Be(default(ResourceLocation));
+    }
+
+    [TestMethod]
+    public void TryFindResource_Span_ReturnsTrue()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("Greeting", "Hello")));
+
+        ReadOnlySpan<char> name = "Greeting".AsSpan();
+        reader.TryFindResource(name, out ResourceLocation location).Should().BeTrue();
+        location.Index.Should().BeInRange(0, 0);
+    }
+
+    [TestMethod]
+    public void TryFindResource_ManyResources_AllFoundWithCorrectContent()
+    {
+        const int count = 500;
+        RawResourceReader reader = new(Write(w =>
+        {
+            for (int i = 0; i < count; i++)
+            {
+                w.AddResource($"key_{i}", $"value_{i}");
+            }
+        }));
+
+        reader.ResourceCount.Should().Be(count);
+        for (int i = 0; i < count; i++)
+        {
+            reader.TryFindResource($"key_{i}", out ResourceLocation location).Should().BeTrue();
+            Span<byte> buffer = new byte[location.ByteLength];
+            reader.TryGetResourceData(location.Index, buffer, out int written).Should().BeTrue();
+            Encoding.UTF8.GetString(buffer[..written]).Should().Be($"value_{i}");
+        }
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_String_ReturnsUtf8Content()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("s", "caf\u00e9 \ud83d\ude00")));
+
+        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.String);
+
+        byte[] expected = Encoding.UTF8.GetBytes("caf\u00e9 \ud83d\ude00");
+        location.ByteLength.Should().Be(expected.Length);
+
+        Span<byte> buffer = new byte[location.ByteLength];
+        reader.TryGetResourceData(location.Index, buffer, out int written).Should().BeTrue();
+        buffer[..written].ToArray().Should().Equal(expected);
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_EmptyString_ReturnsZeroLength()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("s", "")));
+
+        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.String);
+        location.ByteLength.Should().Be(0);
+        reader.TryGetResourceData(location.Index, [], out int written).Should().BeTrue();
+        written.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_Primitives_MatchBinaryWriterEncoding()
+    {
+        (string Name, object Value, ResourceTypeCode Type, byte[] Expected)[] cases =
+        [
+            ("bool", true, ResourceTypeCode.Boolean, PrimitiveBytes(w => w.Write(true))),
+            ("char", 'Z', ResourceTypeCode.Char, PrimitiveBytes(w => w.Write((ushort)'Z'))),
+            ("byte", (byte)200, ResourceTypeCode.Byte, PrimitiveBytes(w => w.Write((byte)200))),
+            ("sbyte", (sbyte)-5, ResourceTypeCode.SByte, PrimitiveBytes(w => w.Write((sbyte)-5))),
+            ("short", (short)-1234, ResourceTypeCode.Int16, PrimitiveBytes(w => w.Write((short)-1234))),
+            ("ushort", (ushort)54321, ResourceTypeCode.UInt16, PrimitiveBytes(w => w.Write((ushort)54321))),
+            ("int", 1_000_000, ResourceTypeCode.Int32, PrimitiveBytes(w => w.Write(1_000_000))),
+            ("uint", 4_000_000_000u, ResourceTypeCode.UInt32, PrimitiveBytes(w => w.Write(4_000_000_000u))),
+            ("long", -9_000_000_000L, ResourceTypeCode.Int64, PrimitiveBytes(w => w.Write(-9_000_000_000L))),
+            ("ulong", 18_000_000_000_000_000_000UL, ResourceTypeCode.UInt64, PrimitiveBytes(w => w.Write(18_000_000_000_000_000_000UL))),
+            ("float", 3.14159f, ResourceTypeCode.Single, PrimitiveBytes(w => w.Write(3.14159f))),
+            ("double", 2.718281828, ResourceTypeCode.Double, PrimitiveBytes(w => w.Write(2.718281828))),
+            ("decimal", 12345.6789m, ResourceTypeCode.Decimal, PrimitiveBytes(w => w.Write(12345.6789m))),
+            ("datetime", new DateTime(2026, 7, 7, 1, 2, 3, DateTimeKind.Utc), ResourceTypeCode.DateTime, PrimitiveBytes(w => w.Write(new DateTime(2026, 7, 7, 1, 2, 3, DateTimeKind.Utc).ToBinary()))),
+            ("timespan", TimeSpan.FromMinutes(90), ResourceTypeCode.TimeSpan, PrimitiveBytes(w => w.Write(TimeSpan.FromMinutes(90).Ticks))),
+        ];
+
+        RawResourceReader reader = new(Write(w =>
+        {
+            foreach ((string name, object value, _, _) in cases)
+            {
+                w.AddResource(name, value);
+            }
+        }));
+
+        foreach ((string name, _, ResourceTypeCode type, byte[] expected) in cases)
+        {
+            reader.TryFindResource(name, out ResourceLocation location).Should().BeTrue($"'{name}' should exist");
+            location.TypeCode.Should().Be(type, $"'{name}' type");
+            location.ByteLength.Should().Be(expected.Length, $"'{name}' length");
+
+            Span<byte> buffer = new byte[location.ByteLength];
+            reader.TryGetResourceData(location.Index, buffer, out int written).Should().BeTrue();
+            buffer[..written].ToArray().Should().Equal(expected, $"'{name}' content");
+        }
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_ByteArray_ReturnsRawBytes()
+    {
+        byte[] payload = [0, 1, 2, 250, 251, 252, 253, 254, 255];
+        RawResourceReader reader = new(Write(w => w.AddResource("blob", payload)));
+
+        reader.TryFindResource("blob", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.ByteArray);
+        location.ByteLength.Should().Be(payload.Length);
+
+        Span<byte> buffer = new byte[location.ByteLength];
+        reader.TryGetResourceData(location.Index, buffer, out int written).Should().BeTrue();
+        buffer[..written].ToArray().Should().Equal(payload);
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_Stream_ReturnsRawBytes()
+    {
+        byte[] payload = [.. Enumerable.Range(0, 1000).Select(i => (byte)i)];
+        RawResourceReader reader = new(Write(w => w.AddResource("stream", new MemoryStream(payload))));
+
+        reader.TryFindResource("stream", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.Stream);
+        location.ByteLength.Should().Be(payload.Length);
+
+        Span<byte> buffer = new byte[location.ByteLength];
+        reader.TryGetResourceData(location.Index, buffer, out int written).Should().BeTrue();
+        buffer[..written].ToArray().Should().Equal(payload);
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_Null_ReturnsZeroLength()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("nothing", (object?)null)));
+
+        reader.TryFindResource("nothing", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.Null);
+        location.ByteLength.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryGetResourceData_UndersizedDestination_ReturnsFalse()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("s", "Hello")));
+
+        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
+        Span<byte> tooSmall = new byte[location.ByteLength - 1];
+        reader.TryGetResourceData(location.Index, tooSmall, out int written).Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void TryCopyResourceData_String_WritesUtf8ToStream()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("s", "Hello, streams")));
+
+        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
+        using MemoryStream destination = new();
+        reader.TryCopyResourceData(location.Index, destination).Should().BeTrue();
+        destination.ToArray().Should().Equal(Encoding.UTF8.GetBytes("Hello, streams"));
+    }
+
+    [TestMethod]
+    public void TryGetResourceName_ReturnsName()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("Greeting", "Hello")));
+
+        reader.TryFindResource("Greeting", out ResourceLocation location).Should().BeTrue();
+        Span<char> buffer = new char[64];
+        reader.TryGetResourceName(location.Index, buffer, out int written).Should().BeTrue();
+        buffer[..written].ToString().Should().Be("Greeting");
+    }
+
+    [TestMethod]
+    public void TryGetResourceName_UndersizedDestination_ReturnsFalse()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("Greeting", "Hello")));
+
+        reader.TryFindResource("Greeting", out ResourceLocation location).Should().BeTrue();
+        Span<char> tooSmall = new char[3];
+        reader.TryGetResourceName(location.Index, tooSmall, out int written).Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void GetLocation_InvalidIndex_ThrowsArgumentOutOfRange()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("a", "b")));
+
+        Action low = () => reader.GetLocation(-1);
+        Action high = () => reader.GetLocation(1);
+        low.Should().Throw<ArgumentOutOfRangeException>();
+        high.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [TestMethod]
+    public void UserType_ReportsTypeNameAndExposesNoData()
+    {
+        // A TypeConverter-backed resource switches the file to the DeserializingResourceReader format
+        // and stores a serialized user type. We should still read its type code and type name, and any
+        // sibling string, while refusing to hand back the serialized value bytes.
+        byte[] bytes = WritePreserialized(w =>
+        {
+            w.AddResource("plain", "readable");
+            w.AddResource("point", "10,20", "System.Drawing.Point, System.Drawing.Primitives");
+        });
+
+        RawResourceReader reader = new(bytes);
+
+        reader.TryFindResource("plain", out ResourceLocation plain).Should().BeTrue();
+        plain.TypeCode.Should().Be(ResourceTypeCode.String);
+        Span<byte> plainBuffer = new byte[plain.ByteLength];
+        reader.TryGetResourceData(plain.Index, plainBuffer, out int plainWritten).Should().BeTrue();
+        Encoding.UTF8.GetString(plainBuffer[..plainWritten]).Should().Be("readable");
+
+        reader.TryFindResource("point", out ResourceLocation point).Should().BeTrue();
+        point.IsUserType.Should().BeTrue();
+        reader.TryGetResourceData(point.Index, new byte[256], out _).Should().BeFalse();
+
+        Span<char> typeName = new char[256];
+        reader.TryGetUserTypeName(point.Index, typeName, out int typeWritten).Should().BeTrue();
+        typeName[..typeWritten].ToString().Should().Contain("System.Drawing.Point");
+    }
+
+    [TestMethod]
+    public void TryGetUserTypeName_NonUserType_ReturnsFalse()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("s", "Hello")));
+
+        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
+        reader.TryGetUserTypeName(location.Index, new char[64], out int written).Should().BeFalse();
+        written.Should().Be(0);
+    }
+
+    [TestMethod]
+    public void Reader_MatchesResourceReaderOracle()
+    {
+        byte[] bytes = Write(static w =>
+        {
+            w.AddResource("greeting", "Hello");
+            w.AddResource("count", 42);
+            w.AddResource("pi", 3.14159);
+            w.AddResource("flag", true);
+            w.AddResource("empty", "");
+            w.AddResource("unicode", "\u00e9\u00e8\u00ea");
+        });
+
+        // Oracle names via the runtime reader's enumerator keys (no value deserialization).
+        List<string> oracleNames = [];
+        using (ResourceReader oracle = new(new MemoryStream(bytes)))
+        {
+            IDictionaryEnumerator enumerator = oracle.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                oracleNames.Add((string)enumerator.Key);
+            }
+        }
+
+        RawResourceReader reader = new(bytes);
+        reader.ResourceCount.Should().Be(oracleNames.Count);
+
+        // Every oracle name is found, and the raw content decodes back to the oracle's typed value.
+        using ResourceReader values = new(new MemoryStream(bytes));
+        IDictionaryEnumerator valuesEnumerator = values.GetEnumerator();
+        while (valuesEnumerator.MoveNext())
+        {
+            string name = (string)valuesEnumerator.Key;
+            object? value = valuesEnumerator.Value;
+
+            reader.TryFindResource(name, out ResourceLocation location).Should().BeTrue($"'{name}' should exist");
+
+            Span<byte> content = new byte[location.ByteLength];
+            reader.TryGetResourceData(location.Index, content, out int written).Should().BeTrue();
+            ReadOnlySpan<byte> data = content[..written];
+
+            switch (value)
+            {
+                case string s:
+                    location.TypeCode.Should().Be(ResourceTypeCode.String);
+                    Encoding.UTF8.GetString(data).Should().Be(s);
+                    break;
+                case int i:
+                    location.TypeCode.Should().Be(ResourceTypeCode.Int32);
+                    BinaryPrimitives.ReadInt32LittleEndian(data).Should().Be(i);
+                    break;
+                case double d:
+                    location.TypeCode.Should().Be(ResourceTypeCode.Double);
+                    BitConverter.ToDouble(data.ToArray(), 0).Should().Be(d);
+                    break;
+                case bool b:
+                    location.TypeCode.Should().Be(ResourceTypeCode.Boolean);
+                    (data[0] != 0).Should().Be(b);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unexpected oracle value type for '{name}'.");
+            }
+        }
+
+        // And the reader enumerates the same set of names.
+        List<string> readerNames = [];
+        for (int i = 0; i < reader.ResourceCount; i++)
+        {
+            Span<char> nameBuffer = new char[256];
+            reader.TryGetResourceName(i, nameBuffer, out int nameWritten).Should().BeTrue();
+            readerNames.Add(nameBuffer[..nameWritten].ToString());
+        }
+
+        readerNames.Should().BeEquivalentTo(oracleNames);
+    }
+
+    [TestMethod]
+    public void Reader_OverNativeMemory_MatchesArrayBacking()
+    {
+        byte[] bytes = Write(static w =>
+        {
+            w.AddResource("greeting", "Hello");
+            w.AddResource("number", 12345);
+        });
+
+        using NativeMemoryManager native = new(bytes);
+        RawResourceReader arrayReader = new(bytes);
+        RawResourceReader nativeReader = new(native.Memory);
+
+        nativeReader.ResourceCount.Should().Be(arrayReader.ResourceCount);
+
+        nativeReader.TryFindResource("greeting", out ResourceLocation location).Should().BeTrue();
+        Span<byte> fromNative = new byte[location.ByteLength];
+        nativeReader.TryGetResourceData(location.Index, fromNative, out int nativeWritten).Should().BeTrue();
+
+        arrayReader.TryFindResource("greeting", out ResourceLocation arrayLocation).Should().BeTrue();
+        Span<byte> fromArray = new byte[arrayLocation.ByteLength];
+        arrayReader.TryGetResourceData(arrayLocation.Index, fromArray, out int arrayWritten).Should().BeTrue();
+
+        fromNative[..nativeWritten].ToArray().Should().Equal(fromArray[..arrayWritten].ToArray());
+
+        // TryCopyResourceData must also work when the memory is not array-backed.
+        using MemoryStream copy = new();
+        nativeReader.TryCopyResourceData(location.Index, copy).Should().BeTrue();
+        copy.ToArray().Should().Equal(Encoding.UTF8.GetBytes("Hello"));
+    }
+
+    [TestMethod]
+    public void CreateFromFile_MapsFileAndReadsWithoutCopying()
+    {
+        byte[] bytes = Write(static w =>
+        {
+            w.AddResource("greeting", "Hello");
+            w.AddResource("number", 12345);
+        });
+
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "test.resources");
+        System.IO.File.WriteAllBytes(path, bytes);
+
+        using RawResourceReader reader = RawResourceReader.CreateFromFile(path);
+
+        reader.ResourceCount.Should().Be(2);
+        reader.TryFindResource("greeting", out ResourceLocation location).Should().BeTrue();
+        Span<byte> buffer = new byte[location.ByteLength];
+        reader.TryGetResourceData(location.Index, buffer, out int written).Should().BeTrue();
+        Encoding.UTF8.GetString(buffer[..written]).Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void CreateFromFile_NullPath_ThrowsArgumentNullException()
+    {
+        Action act = () => _ = RawResourceReader.CreateFromFile(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void Dispose_MemoryBackedReader_IsIdempotentNoOp()
+    {
+        RawResourceReader reader = new(Write(static w => w.AddResource("s", "Hello")));
+        reader.Dispose();
+        reader.Dispose();
+
+        // The caller still owns the memory, so the reader remains usable after a no-op dispose.
+        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
+        location.TypeCode.Should().Be(ResourceTypeCode.String);
+    }
+
+    private static byte[] WritePreserialized(Action<PreserializedResourceWriter> add)
+    {
+        MemoryStream stream = new();
+        using (PreserializedResourceWriter writer = new(stream))
+        {
+            add(writer);
+            writer.Generate();
+        }
+
+        return stream.ToArray();
+    }
+
+    private sealed unsafe class NativeMemoryManager : MemoryManager<byte>
+    {
+        private byte* _pointer;
+        private readonly int _length;
+
+        public NativeMemoryManager(ReadOnlySpan<byte> data)
+        {
+            _length = data.Length;
+            _pointer = (byte*)Marshal.AllocHGlobal(_length);
+            data.CopyTo(new Span<byte>(_pointer, _length));
+        }
+
+        public override Span<byte> GetSpan() => new(_pointer, _length);
+
+        public override MemoryHandle Pin(int elementIndex = 0) => new(_pointer + elementIndex);
+
+        public override void Unpin()
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (_pointer is not null)
+            {
+                Marshal.FreeHGlobal((nint)_pointer);
+                _pointer = null;
+            }
+        }
+    }
+}

--- a/touki.tests/Touki/Resources/RawResourceReaderTests.cs
+++ b/touki.tests/Touki/Resources/RawResourceReaderTests.cs
@@ -314,6 +314,30 @@ public class RawResourceReaderTests
     }
 
     [TestMethod]
+    public void Members_AfterDispose_ThrowObjectDisposedException()
+    {
+        byte[] bytes = Write(static w => w.AddResource("Greeting", "Hello"));
+        using TempFolder folder = new();
+        string path = System.IO.Path.Combine(folder.TempPath, "afterdispose.resources");
+        System.IO.File.WriteAllBytes(path, bytes);
+
+        RawResourceReader reader = RawResourceReader.CreateFromFile(path);
+        reader.Dispose();
+
+        Action resourceCount = () => _ = reader.ResourceCount;
+        Action find = () => reader.TryFindResource("Greeting", out _);
+        Action getLocation = () => reader.GetLocation(0);
+        Action getData = () => reader.TryGetResourceData(0, new byte[16], out _);
+        Action getName = () => reader.TryGetResourceName(0, new char[16], out _);
+
+        resourceCount.Should().Throw<ObjectDisposedException>();
+        find.Should().Throw<ObjectDisposedException>();
+        getLocation.Should().Throw<ObjectDisposedException>();
+        getData.Should().Throw<ObjectDisposedException>();
+        getName.Should().Throw<ObjectDisposedException>();
+    }
+
+    [TestMethod]
     public void GetLocation_InvalidIndex_ThrowsArgumentOutOfRange()
     {
         RawResourceReader reader = new(Write(static w => w.AddResource("a", "b")));
@@ -500,15 +524,16 @@ public class RawResourceReaderTests
     }
 
     [TestMethod]
-    public void Dispose_MemoryBackedReader_IsIdempotentNoOp()
+    public void Dispose_MemoryBackedReader_IsIdempotent()
     {
         RawResourceReader reader = new(Write(static w => w.AddResource("s", "Hello")));
         reader.Dispose();
         reader.Dispose();
 
-        // The caller still owns the memory, so the reader remains usable after a no-op dispose.
-        reader.TryFindResource("s", out ResourceLocation location).Should().BeTrue();
-        location.TypeCode.Should().Be(ResourceTypeCode.String);
+        // Disposal is idempotent (the second call is safe), and the reader is marked disposed even
+        // though it owns no mapping, so subsequent member access throws.
+        Action act = () => reader.TryFindResource("s", out _);
+        act.Should().Throw<ObjectDisposedException>();
     }
 
     private static byte[] WritePreserialized(Action<PreserializedResourceWriter> add)

--- a/touki.tests/Touki/Resources/RawResourceReaderTests.cs
+++ b/touki.tests/Touki/Resources/RawResourceReaderTests.cs
@@ -295,6 +295,25 @@ public class RawResourceReaderTests
     }
 
     [TestMethod]
+    public void TryGetResourceName_NameLengthExceedsFile_ThrowsBadImageFormatException()
+    {
+        byte[] bytes = Write(static w => w.AddResource("resourcename", "v"));
+
+        // Corrupt the 7-bit name-length prefix (the byte just before the UTF-16LE name) to claim more
+        // bytes than the file holds. The reader must reject this as corruption rather than returning
+        // false, which would drive a caller to grow its buffer toward the claimed (unbounded) length.
+        byte[] nameUtf16 = Encoding.Unicode.GetBytes("resourcename");
+        int nameStart = bytes.AsSpan().IndexOf(nameUtf16);
+        nameStart.Should().BeGreaterThan(0);
+        bytes[nameStart - 1] = 126;
+
+        using RawResourceReader reader = new(bytes);
+        char[] destination = new char[8];
+        Action act = () => reader.TryGetResourceName(0, destination, out _);
+        act.Should().Throw<BadImageFormatException>();
+    }
+
+    [TestMethod]
     public void GetLocation_InvalidIndex_ThrowsArgumentOutOfRange()
     {
         RawResourceReader reader = new(Write(static w => w.AddResource("a", "b")));

--- a/touki.tests/Touki/Resources/SatelliteStringResourceManagerTests.cs
+++ b/touki.tests/Touki/Resources/SatelliteStringResourceManagerTests.cs
@@ -190,7 +190,7 @@ public class SatelliteStringResourceManagerTests
     }
 
     [TestMethod]
-    public void GetString_ReflectionRequiringResource_TreatedAsAbsent()
+    public void GetString_ExtensionsFormatSideFile_ReadsStringsSkipsUserTypes()
     {
         using TempFolder folder = new();
         string baseName = NeutralBaseName();
@@ -198,10 +198,11 @@ public class SatelliteStringResourceManagerTests
 
         SatelliteStringResourceManager manager = new(baseName, s_assembly, folder.TempPath);
 
-        // The file was written by PreserializedResourceWriter (a non-default reader type). The core
-        // ResourceReader rejects it at construction, so the whole file is treated as absent - no
-        // reflection is ever triggered and every key falls back to the embedded neutral resources.
-        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hello");
+        // The file was written by PreserializedResourceWriter (Extensions format). RawResourceReader
+        // parses it structurally: the intrinsic string entry is read...
+        manager.GetString("Greeting", new CultureInfo("de")).Should().Be("Hallo");
+        // ...while the serialized user-type entry is skipped by its type code alone - never
+        // deserialized - so it falls back to the embedded neutral resources (absent -> null).
         manager.GetString("Fancy", new CultureInfo("de")).Should().BeNull();
     }
 

--- a/touki.tests/Touki/StreamExtensionsTests.cs
+++ b/touki.tests/Touki/StreamExtensionsTests.cs
@@ -192,4 +192,93 @@ public class StreamExtensionsTests
         string result = writer.ToString();
         result.Should().Be(Environment.NewLine);
     }
+
+    [TestMethod]
+    public void Write_ByteSpan_AppendsToEmptyStream()
+    {
+        using MemoryStream memory = new();
+        ReadOnlySpan<byte> data = [1, 2, 3, 4, 5];
+
+        memory.Write(data);
+
+        memory.Position.Should().Be(5);
+        memory.Length.Should().Be(5);
+        byte[] expected = [1, 2, 3, 4, 5];
+        memory.ToArray().Should().Equal(expected);
+    }
+
+    [TestMethod]
+    public void Write_ByteSpan_OverwritesWithinLength()
+    {
+        using MemoryStream memory = new();
+        memory.Write([1, 2, 3, 4, 5], 0, 5);
+        memory.Position = 1;
+
+        ReadOnlySpan<byte> data = [9, 9];
+        memory.Write(data);
+
+        memory.Position.Should().Be(3);
+        memory.Length.Should().Be(5);
+        byte[] expected = [1, 9, 9, 4, 5];
+        memory.ToArray().Should().Equal(expected);
+    }
+
+    [TestMethod]
+    public void Write_ByteSpan_OverwritesAndExtends()
+    {
+        using MemoryStream memory = new();
+        memory.Write([1, 2, 3], 0, 3);
+        memory.Position = 2;
+
+        ReadOnlySpan<byte> data = [7, 8, 9];
+        memory.Write(data);
+
+        memory.Position.Should().Be(5);
+        memory.Length.Should().Be(5);
+        byte[] expected = [1, 2, 7, 8, 9];
+        memory.ToArray().Should().Equal(expected);
+    }
+
+    [TestMethod]
+    public void Write_ByteSpan_GrowsBeyondCapacity()
+    {
+        using MemoryStream memory = new(2);
+        ReadOnlySpan<byte> data = [1, 2, 3, 4, 5, 6, 7, 8];
+
+        memory.Write(data);
+
+        memory.Length.Should().Be(8);
+        byte[] expected = [1, 2, 3, 4, 5, 6, 7, 8];
+        memory.ToArray().Should().Equal(expected);
+    }
+
+    [TestMethod]
+    public void Write_ByteSpan_Empty_DoesNothing()
+    {
+        using MemoryStream memory = new();
+        memory.Write([1, 2, 3], 0, 3);
+        memory.Position = 3;
+
+        ReadOnlySpan<byte> empty = [];
+        memory.Write(empty);
+
+        memory.Position.Should().Be(3);
+        memory.Length.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void Write_ByteSpan_NonExpandableBackedStream_UsesFallback()
+    {
+        // A MemoryStream over a caller-owned array is not publicly visible, so TryGetBuffer fails and
+        // the rent/copy fallback path handles the write.
+        byte[] backing = new byte[5];
+        using MemoryStream memory = new(backing);
+        ReadOnlySpan<byte> data = [1, 2, 3, 4, 5];
+
+        memory.Write(data);
+
+        memory.Position.Should().Be(5);
+        byte[] expected = [1, 2, 3, 4, 5];
+        backing.Should().Equal(expected);
+    }
 }

--- a/touki/Framework/Polyfills/System.Text/EncodingExtensions.cs
+++ b/touki/Framework/Polyfills/System.Text/EncodingExtensions.cs
@@ -121,5 +121,41 @@ public static class EncodingExtensions
                 return encoding.GetString(bytePtr, bytes.Length);
             }
         }
+
+        /// <summary>
+        ///  Tries to decode a span of bytes into a span of characters.
+        /// </summary>
+        /// <returns>
+        ///  <see langword="true"/> if <paramref name="chars"/> was large enough to hold the decoded
+        ///  characters; otherwise <see langword="false"/>.
+        /// </returns>
+        public unsafe bool TryGetChars(ReadOnlySpan<byte> bytes, Span<char> chars, out int charsWritten)
+        {
+            ArgumentNullException.ThrowIfNull(encoding);
+
+            if (bytes.IsEmpty)
+            {
+                charsWritten = 0;
+                return true;
+            }
+
+            // A single pin shared between GetCharCount and GetChars via the pointer overloads; going
+            // through the sibling span extensions instead measures ~34% slower on net481 RyuJIT.
+            fixed (byte* bytePtr = &MemoryMarshal.GetReference(bytes))
+            {
+                if (chars.Length < encoding.GetCharCount(bytePtr, bytes.Length))
+                {
+                    charsWritten = 0;
+                    return false;
+                }
+
+                fixed (char* charPtr = &MemoryMarshal.GetReference(chars))
+                {
+                    charsWritten = encoding.GetChars(bytePtr, bytes.Length, charPtr, chars.Length);
+                }
+            }
+
+            return true;
+        }
     }
 }

--- a/touki/Framework/Touki/Io/StreamExtensions.cs
+++ b/touki/Framework/Touki/Io/StreamExtensions.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io;
+
+/// <summary>
+///  Extension methods for <see cref="Stream"/>.
+/// </summary>
+public static partial class StreamExtensions
+{
+    /// <param name="stream">The target stream.</param>
+    extension(Stream stream)
+    {
+        /// <summary>
+        ///  Writes a sequence of bytes to the current stream and advances the current position within this stream by
+        ///  the number of bytes written.
+        /// </summary>
+        public void Write(ReadOnlySpan<byte> buffer)
+        {
+            if (buffer.IsEmpty)
+            {
+                return;
+            }
+
+            // Fast path for publicly visible MemoryStreams: write straight into the backing array
+            // instead of renting a temporary and copying twice. SetLength grows the length (and the
+            // capacity, with amortized doubling) so the written region becomes part of the stream; it
+            // throws for a non-expandable stream exactly as Write would.
+            if (stream is MemoryStream memoryStream && memoryStream.TryGetBuffer(out ArraySegment<byte> segment))
+            {
+                int position = (int)memoryStream.Position;
+                int end = checked(position + buffer.Length);
+                if (end > memoryStream.Length)
+                {
+                    // Growth may reallocate the backing array, so re-acquire the segment afterward.
+                    memoryStream.SetLength(end);
+                    memoryStream.TryGetBuffer(out segment);
+                }
+
+                buffer.CopyTo(segment.AsSpan(position));
+                memoryStream.Position = end;
+                return;
+            }
+
+            byte[] temp = ArrayPool<byte>.Shared.Rent(buffer.Length);
+            try
+            {
+                buffer.CopyTo(temp);
+                stream.Write(temp, 0, buffer.Length);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(temp);
+            }
+        }
+    }
+}

--- a/touki/GlobalUsings.cs
+++ b/touki/GlobalUsings.cs
@@ -24,6 +24,11 @@ global using System.IO.Enumeration;
 #endif
 
 global using BinaryReader = System.IO.BinaryReader;
+global using FileAccess = System.IO.FileAccess;
+global using FileMode = System.IO.FileMode;
+global using FileShare = System.IO.FileShare;
+global using FileStream = System.IO.FileStream;
+global using HandleInheritability = System.IO.HandleInheritability;
 global using IOException = System.IO.IOException;
 global using MemoryStream = System.IO.MemoryStream;
 global using Stream = System.IO.Stream;

--- a/touki/Touki/Io/MappedMemoryManager.cs
+++ b/touki/Touki/Io/MappedMemoryManager.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.IO.MemoryMappedFiles;
+
+namespace Touki.Io;
+
+/// <summary>
+///  A <see cref="MemoryManager{T}"/> that exposes a read-only memory-mapped view of a file as
+///  <see cref="System.Memory{T}"/> / <see cref="ReadOnlyMemory{T}"/> without copying its contents.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The mapped view has a fixed address for its lifetime, so <see cref="Pin"/> and <see cref="Unpin"/>
+///   are trivial; <see cref="MemoryManager{T}"/> is only used to turn the native view pointer into a
+///   <see cref="ReadOnlyMemory{T}"/>. The view keeps the mapping alive, so the file and mapping handles
+///   are released as soon as the view exists; only the view is held for the life of this manager.
+///  </para>
+///  <para>
+///   Dispose the manager - directly, or through the owner returned by
+///   <see cref="MemoryManager{T}.Memory"/> - to unmap the view. Do not use the memory after disposing.
+///  </para>
+/// </remarks>
+public sealed unsafe class MappedMemoryManager : MemoryManager<byte>
+{
+    private readonly MemoryMappedViewAccessor _accessor;
+    private readonly byte* _pointer;
+    private readonly int _length;
+    private bool _disposed;
+
+    private MappedMemoryManager(MemoryMappedViewAccessor accessor, int length)
+    {
+        _accessor = accessor;
+        _length = length;
+
+        byte* pointer = null;
+        accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref pointer);
+        _pointer = pointer + accessor.PointerOffset;
+    }
+
+    /// <summary>
+    ///  Creates a <see cref="MappedMemoryManager"/> over a read-only memory mapping of the file at
+    ///  <paramref name="path"/>.
+    /// </summary>
+    /// <param name="path">The path of the file to map.</param>
+    /// <returns>A manager that owns the mapping until it is disposed.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
+    /// <exception cref="IOException">
+    ///  The file is empty or larger than <see cref="int.MaxValue"/> bytes.
+    /// </exception>
+    public static MappedMemoryManager CreateFromFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        using FileStream stream = new(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+        long length = stream.Length;
+        if (length is <= 0 or > int.MaxValue)
+        {
+            throw new IOException($"'{path}' is empty or too large to memory-map.");
+        }
+
+        using MemoryMappedFile file = MemoryMappedFile.CreateFromFile(
+            stream,
+            mapName: null,
+            capacity: 0,
+            MemoryMappedFileAccess.Read,
+            HandleInheritability.None,
+            leaveOpen: true);
+        MemoryMappedViewAccessor accessor = file.CreateViewAccessor(0, length, MemoryMappedFileAccess.Read);
+        try
+        {
+            return new MappedMemoryManager(accessor, (int)length);
+        }
+        catch
+        {
+            accessor.Dispose();
+            throw;
+        }
+    }
+
+    /// <inheritdoc/>
+    public override Span<byte> GetSpan() => new(_pointer, _length);
+
+    /// <inheritdoc/>
+    public override MemoryHandle Pin(int elementIndex = 0) => new(_pointer + elementIndex);
+
+    /// <inheritdoc/>
+    public override void Unpin()
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+        _accessor.Dispose();
+    }
+}

--- a/touki/Touki/Io/MappedMemoryManager.cs
+++ b/touki/Touki/Io/MappedMemoryManager.cs
@@ -81,10 +81,20 @@ public sealed unsafe class MappedMemoryManager : MemoryManager<byte>
     }
 
     /// <inheritdoc/>
-    public override Span<byte> GetSpan() => new(_pointer, _length);
+    public override Span<byte> GetSpan()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return new(_pointer, _length);
+    }
 
     /// <inheritdoc/>
-    public override MemoryHandle Pin(int elementIndex = 0) => new(_pointer + elementIndex);
+    public override MemoryHandle Pin(int elementIndex = 0)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentOutOfRangeException.ThrowIfNegative(elementIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(elementIndex, _length);
+        return new(_pointer + elementIndex);
+    }
 
     /// <inheritdoc/>
     public override void Unpin()

--- a/touki/Touki/Io/MappedMemoryManager.cs
+++ b/touki/Touki/Io/MappedMemoryManager.cs
@@ -18,6 +18,13 @@ namespace Touki.Io;
 ///   are released as soon as the view exists; only the view is held for the life of this manager.
 ///  </para>
 ///  <para>
+///   The backing view is mapped read-only. <see cref="MemoryManager{T}"/> requires the buffer to be
+///   exposed as a writable <see cref="Span{T}"/> / <see cref="System.Memory{T}"/>, but the contents
+///   must be treated as read-only: writing through the returned span or memory faults with an
+///   <see cref="AccessViolationException"/> because the underlying pages are read-only. Prefer
+///   consuming it as <see cref="ReadOnlyMemory{T}"/> / <see cref="ReadOnlySpan{T}"/>.
+///  </para>
+///  <para>
 ///   Dispose the manager - directly, or through the owner returned by
 ///   <see cref="MemoryManager{T}.Memory"/> - to unmap the view. Do not use the memory after disposing.
 ///  </para>

--- a/touki/Touki/Io/SpanReader.cs
+++ b/touki/Touki/Io/SpanReader.cs
@@ -430,6 +430,23 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     public void Advance(int count) => _unread = _unread[count..];
 
     /// <summary>
+    ///  Try to advance the reader by the given <paramref name="count"/>.
+    /// </summary>
+    /// <param name="count">The number of positions to advance.</param>
+    /// <returns><see langword="true"/> if the reader was successfully advanced; otherwise, <see langword="false"/>.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryAdvance(int count)
+    {
+        if (count < 0 || count > _unread.Length)
+        {
+            return false;
+        }
+
+        UnsafeAdvance(count);
+        return true;
+    }
+
+    /// <summary>
     ///  Rewind the reader by the given <paramref name="count"/>.
     /// </summary>
     /// <param name="count">The number of positions to rewind.</param>

--- a/touki/Touki/Io/SpanReaderExtensions.cs
+++ b/touki/Touki/Io/SpanReaderExtensions.cs
@@ -66,7 +66,7 @@ public static class SpanReaderExtensions
         ///  <para>
         ///   Matches <see cref="System.IO.BinaryWriter.Write7BitEncodedInt(int)"/>. Returns
         ///   <see langword="false"/> for a truncated or overlong (overflowing) encoding rather than
-        ///   throwing, so it is safe on untrusted input.
+        ///   throwing, leaving the reader's position unchanged, so it is safe on untrusted input.
         ///  </para>
         /// </remarks>
         /// <param name="value">On success, the value read.</param>
@@ -74,6 +74,7 @@ public static class SpanReaderExtensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryRead7BitEncodedInt32(out int value)
         {
+            int start = reader.Position;
             uint result = 0;
             const int MaxBytesWithoutOverflow = 4;
 
@@ -82,6 +83,7 @@ public static class SpanReaderExtensions
                 if (!reader.TryRead(out byte b))
                 {
                     value = 0;
+                    reader.Position = start;
                     return false;
                 }
 
@@ -97,6 +99,7 @@ public static class SpanReaderExtensions
             if (!reader.TryRead(out byte last) || last > 0b1111)
             {
                 value = 0;
+                reader.Position = start;
                 return false;
             }
 

--- a/touki/Touki/Io/SpanReaderExtensions.cs
+++ b/touki/Touki/Io/SpanReaderExtensions.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Buffers.Binary;
+
 namespace Touki.Io;
 
 /// <summary>
@@ -31,6 +33,76 @@ public static class SpanReaderExtensions
             }
 
             return foundDigit;
+        }
+    }
+
+    /// <param name="reader">The <see cref="SpanReader{T}"/> to read from.</param>
+    extension(ref SpanReader<byte> reader)
+    {
+        /// <summary>
+        ///  Reads a little-endian <see cref="int"/> and advances past it.
+        /// </summary>
+        /// <param name="value">On success, the value read.</param>
+        /// <returns>
+        ///  <see langword="true"/> if four bytes were available and read; otherwise <see langword="false"/>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryReadInt32LittleEndian(out int value)
+        {
+            if (reader.TryRead(sizeof(int), out ReadOnlySpan<byte> bytes))
+            {
+                value = BinaryPrimitives.ReadInt32LittleEndian(bytes);
+                return true;
+            }
+
+            value = 0;
+            return false;
+        }
+
+        /// <summary>
+        ///  Reads a 7-bit encoded (LEB128) <see cref="int"/> and advances past it.
+        /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   Matches <see cref="System.IO.BinaryWriter.Write7BitEncodedInt(int)"/>. Returns
+        ///   <see langword="false"/> for a truncated or overlong (overflowing) encoding rather than
+        ///   throwing, so it is safe on untrusted input.
+        ///  </para>
+        /// </remarks>
+        /// <param name="value">On success, the value read.</param>
+        /// <returns><see langword="true"/> if a well-formed value was read; otherwise <see langword="false"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool TryRead7BitEncodedInt32(out int value)
+        {
+            uint result = 0;
+            const int MaxBytesWithoutOverflow = 4;
+
+            for (int shift = 0; shift < MaxBytesWithoutOverflow * 7; shift += 7)
+            {
+                if (!reader.TryRead(out byte b))
+                {
+                    value = 0;
+                    return false;
+                }
+
+                result |= (uint)(b & 0x7F) << shift;
+                if (b <= 0x7F)
+                {
+                    value = (int)result;
+                    return true;
+                }
+            }
+
+            // The fifth byte can only contribute the top four bits; more would overflow an int.
+            if (!reader.TryRead(out byte last) || last > 0b1111)
+            {
+                value = 0;
+                return false;
+            }
+
+            result |= (uint)last << (MaxBytesWithoutOverflow * 7);
+            value = (int)result;
+            return true;
         }
     }
 }

--- a/touki/Touki/Io/StreamExtensions.cs
+++ b/touki/Touki/Io/StreamExtensions.cs
@@ -10,7 +10,7 @@ namespace Touki.Io;
 /// <summary>
 ///  Extension methods for <see cref="Stream"/>.
 /// </summary>
-public static partial class TextWriterExtensions
+public static partial class StreamExtensions
 {
     /// <param name="stream">The target stream.</param>
     extension(Stream stream)

--- a/touki/Touki/Resources/RawResourceReader.cs
+++ b/touki/Touki/Resources/RawResourceReader.cs
@@ -1,0 +1,624 @@
+﻿// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text;
+
+namespace Touki.Resources;
+
+/// <summary>
+///  Reads the default binary <c>.resources</c> format (version 2) directly over a caller-owned
+///  <see cref="ReadOnlyMemory{T}"/> or a memory-mapped file, without allocating strings or byte
+///  arrays.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Unlike <see cref="System.Resources.ResourceReader"/>, this type never materializes managed
+///   values: name lookups return an index, type, and byte length; value bytes are copied into a
+///   caller-supplied <see cref="Span{T}"/> or <see cref="Stream"/>. The name-hash and name-position
+///   index tables are read in place from the memory, so construction, lookup, and reads allocate
+///   nothing. This mirrors the runtime's <see cref="System.IO.UnmanagedMemoryStream"/> fast path but
+///   works over any <see cref="ReadOnlyMemory{T}"/> - a managed array or a memory-mapped view.
+///  </para>
+///  <para>
+///   The reader is immutable over its memory, so lookups are pure and require no locking. Only string
+///   resources, the primitive types, <c>byte[]</c>, and <see cref="Stream"/> values are exposed as
+///   raw bytes; serialized user types are reported by type code and type name only. No value is ever
+///   decoded or deserialized, so the reader triggers no reflection and is trim- and AOT-safe.
+///  </para>
+///  <para>
+///   Values are presented as content only - the on-disk length prefixes of strings, byte arrays, and
+///   streams are stripped, so <see cref="ResourceLocation.ByteLength"/> and
+///   <see cref="TryGetResourceData(int, Span{byte}, out int)"/> yield exactly the value bytes.
+///  </para>
+/// </remarks>
+public sealed class RawResourceReader : IDisposable
+{
+    // On-disk layout of a default-format (version 2) .resources file. All integers are little-endian
+    // and "7-bit int" is a LEB128-style length prefix. The reader validates and indexes this in place
+    // over _resources; it never copies or decodes the data.
+    //
+    //   ResourceManager header
+    //     int32   magic (0xBEEFCACE)
+    //     int32   ResourceManager header version
+    //     int32   byteCountToSkip
+    //     byte[]  reader / resource-set type names   (skipped: byteCountToSkip bytes)
+    //   ------------------------------------------------------------------------------------
+    //   RuntimeResourceSet header
+    //     int32   version (== 2)
+    //     int32   numResources
+    //     int32   numTypes
+    //     entry[] type-name table: numTypes x [7-bit len][UTF-8]     (_typeNamesOffset)
+    //   ------------------------------------------------------------------------------------
+    //     pad     to the next 8-byte boundary ('P','A','D' filler)
+    //   ------------------------------------------------------------------------------------
+    //   Index
+    //     int32[] nameHashes[numResources]     (sorted ascending)    (_nameHashesOffset)
+    //     int32[] namePositions[numResources]  (parallel to hashes)  (_namePositionsOffset)
+    //     int32   dataSectionOffset
+    //   ------------------------------------------------------------------------------------
+    //   Name section                                                 (_nameSectionOffset)
+    //     per resource, at _nameSectionOffset + namePositions[i]:
+    //       [7-bit byteLen][UTF-16LE name][int32 dataPosition]
+    //   ------------------------------------------------------------------------------------
+    //   Data section                                                 (_dataSectionOffset)
+    //     per resource, at _dataSectionOffset + dataPosition:
+    //       [7-bit ResourceTypeCode][value], where value is:
+    //         String              : [7-bit byteLen][UTF-8 bytes]
+    //         ByteArray / Stream  : [int32 byteLen][bytes]
+    //         primitives          : fixed-size little-endian
+    //         user types (>= 0x40): serialized payload (exposed by type name only)
+    //
+    // .resources magic number and the only supported RuntimeResourceSet format version.
+    private const int MagicNumber = unchecked((int)0xBEEFCACE);
+    private const int SupportedVersion = 2;
+
+    private readonly ReadOnlyMemory<byte> _resources;
+    private readonly IDisposable? _owned;
+    private readonly int _numResources;
+    private readonly int _numTypes;
+
+    // Absolute offsets into _resources, all computed once at construction.
+    private readonly int _typeNamesOffset;      // start of the type-name string table
+    private readonly int _nameHashesOffset;     // int32[_numResources], sorted ascending
+    private readonly int _namePositionsOffset;  // int32[_numResources], parallel to the hashes
+    private readonly int _nameSectionOffset;    // start of the name section
+    private readonly int _dataSectionOffset;    // start of the data section
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="RawResourceReader"/> class over the given
+    ///  <c>.resources</c> content.
+    /// </summary>
+    /// <param name="resources">
+    ///  The complete bytes of a default-format version 2 <c>.resources</c> file. The memory is not
+    ///  copied; the caller owns its lifetime and must keep it valid for the life of the reader.
+    /// </param>
+    /// <exception cref="ArgumentException">The data is not a <c>.resources</c> file (bad magic number).</exception>
+    /// <exception cref="NotSupportedException">
+    ///  The file is not format version 2 (for example a legacy version 1 file), or the current
+    ///  architecture is big-endian.
+    /// </exception>
+    /// <exception cref="BadImageFormatException">The file header is malformed or truncated.</exception>
+    public RawResourceReader(ReadOnlyMemory<byte> resources)
+        : this(resources, owned: null)
+    {
+    }
+
+    private RawResourceReader(ReadOnlyMemory<byte> resources, IDisposable? owned)
+    {
+        if (!BitConverter.IsLittleEndian)
+        {
+            throw new NotSupportedException("RawResourceReader is only supported on little-endian architectures.");
+        }
+
+        _owned = owned;
+        _resources = resources;
+        SpanReader<byte> reader = new(resources.Span);
+
+        if (!reader.TryReadInt32LittleEndian(out int magic) || magic != MagicNumber)
+        {
+            throw new ArgumentException(
+                "The data is not a valid .resources file (bad magic number).",
+                nameof(resources));
+        }
+
+        if (!reader.TryReadInt32LittleEndian(out int resourceManagerHeaderVersion)
+            || resourceManagerHeaderVersion < 0
+            || !reader.TryReadInt32LittleEndian(out int byteCountToSkip)
+
+            // Skip the rest of the ResourceManager header (reader and set type names). We parse the
+            // format structurally and do not validate the declared reader type, so files written for the
+            // System.Resources.Extensions reader are read up to their common primitive/string content.
+            || !reader.TryAdvance(byteCountToSkip))
+        {
+            ThrowBadImageFormatException("The file is not a valid .resources file (bad header).");
+        }
+
+        if (!reader.TryReadInt32LittleEndian(out int version) || version != SupportedVersion)
+        {
+            throw new NotSupportedException(
+                $"Unsupported .resources format version {version}; only version {SupportedVersion} is supported.");
+        }
+
+        if (!reader.TryReadInt32LittleEndian(out _numResources)
+            || _numResources < 0
+            || !reader.TryReadInt32LittleEndian(out _numTypes)
+            || _numTypes < 0)
+        {
+            ThrowBadImageFormatException("The file is not a valid .resources file (bad resource or type count).");
+        }
+
+        // Type-name table: _numTypes length-prefixed UTF-8 strings. Remember the start so user type
+        // names can be read on demand; skip past it here without allocating.
+        _typeNamesOffset = reader.Position;
+        for (int i = 0; i < _numTypes; i++)
+        {
+            if (!reader.TryRead7BitEncodedInt32(out int typeNameLength)
+                || typeNameLength < 0
+                || !reader.TryAdvance(typeNameLength))
+            {
+                ThrowBadImageFormatException("The file is not a valid .resources file (bad type name).");
+            }
+        }
+
+        // The name-hash array is aligned to 8 bytes (the writer pads with 'P','A','D').
+        if (!reader.TryAdvance((8 - (reader.Position & 7)) & 7))
+        {
+            ThrowBadImageFormatException("The file is not a valid .resources file (bad alignment).");
+        }
+
+        _nameHashesOffset = reader.Position;
+
+        // The two int32 index arrays and the data-section offset are fixed size; validate they fit.
+        long indexBytes = ((long)_numResources * 8) + 4;
+        if (indexBytes > reader.Unread.Length)
+        {
+            ThrowBadImageFormatException("The file is not a valid .resources file (truncated index).");
+        }
+
+        _namePositionsOffset = _nameHashesOffset + (_numResources * 4);
+        reader.Position = _namePositionsOffset + (_numResources * 4);
+
+        if (!reader.TryReadInt32LittleEndian(out _dataSectionOffset))
+        {
+            ThrowBadImageFormatException("The file is not a valid .resources file (bad data section).");
+        }
+
+        _nameSectionOffset = reader.Position;
+
+        if (_dataSectionOffset < _nameSectionOffset || _dataSectionOffset > reader.Length)
+        {
+            ThrowBadImageFormatException("The file is not a valid .resources file (bad data section).");
+        }
+    }
+
+    /// <summary>
+    ///  Creates a <see cref="RawResourceReader"/> that memory-maps the file at <paramref name="path"/>.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The file is mapped, not copied, so no array is allocated for its contents. The returned
+    ///   reader owns the mapping and releases it when <see cref="Dispose"/> is called; do not use the
+    ///   reader after disposing it.
+    ///  </para>
+    /// </remarks>
+    /// <param name="path">The path of a <c>.resources</c> file.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
+    public static RawResourceReader CreateFromFile(string path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        MappedMemoryManager resource = MappedMemoryManager.CreateFromFile(path);
+        try
+        {
+            return new RawResourceReader(resource.Memory, resource);
+        }
+        catch
+        {
+            ((IDisposable)resource).Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///  Releases the memory mapping owned by this reader. A reader constructed directly over a
+    ///  <see cref="ReadOnlyMemory{T}"/> owns nothing, so disposing it is a no-op.
+    /// </summary>
+    public void Dispose() => _owned?.Dispose();
+
+    /// <summary>
+    ///  The number of resources in the file.
+    /// </summary>
+    public int ResourceCount => _numResources;
+
+    /// <summary>
+    ///  Finds a resource by name.
+    /// </summary>
+    /// <param name="name">The resource name to look up (ordinal, case-sensitive).</param>
+    /// <param name="location">On success, the located resource.</param>
+    /// <returns><see langword="true"/> if a resource with the given name exists.</returns>
+    /// <exception cref="BadImageFormatException">The file is malformed.</exception>
+    public bool TryFindResource(ReadOnlySpan<char> name, out ResourceLocation location)
+    {
+        location = default;
+        if (_numResources == 0)
+        {
+            return false;
+        }
+
+        // The .resources name hash is djb2 over the UTF-16 code units; it is part of the file format
+        // and must never change.
+        uint nameHash = 5381;
+        for (int i = 0; i < name.Length; i++)
+        {
+            nameHash = ((nameHash << 5) + nameHash) ^ name[i];
+        }
+
+        int hash = (int)nameHash;
+
+        // The header is validated as little-endian at construction, so the sorted int32 hash array can
+        // be reinterpreted in place and searched directly - no per-probe reads.
+        ReadOnlySpan<byte> resources = _resources.Span;
+        ReadOnlySpan<int> hashes = MemoryMarshal.Cast<byte, int>(resources.Slice(_nameHashesOffset, _numResources * 4));
+
+        // Binary search the sorted hash array.
+        int lo = 0;
+        int hi = _numResources - 1;
+        int index = -1;
+        while (lo <= hi)
+        {
+            int mid = (int)(((uint)lo + (uint)hi) >> 1);
+            int currentHash = hashes[mid];
+            if (currentHash == hash)
+            {
+                index = mid;
+                break;
+            }
+
+            if (currentHash < hash)
+            {
+                lo = mid + 1;
+            }
+            else
+            {
+                hi = mid - 1;
+            }
+        }
+
+        if (index < 0)
+        {
+            return false;
+        }
+
+        // Hashes can collide; expand to the full run of equal hashes and compare names.
+        int runStart = index;
+        while (runStart > 0 && hashes[runStart - 1] == hash)
+        {
+            runStart--;
+        }
+
+        int runEnd = index;
+        while (runEnd < _numResources - 1 && hashes[runEnd + 1] == hash)
+        {
+            runEnd++;
+        }
+
+        SpanReader<byte> reader = new(resources);
+        for (int i = runStart; i <= runEnd; i++)
+        {
+            reader.Position = _nameSectionOffset + GetNamePosition(i);
+            if (!reader.TryRead7BitEncodedInt32(out int nameByteLength)
+                || nameByteLength < 0
+                || (nameByteLength & 1) != 0)
+            {
+                ThrowBadImageFormatException("A resource name is corrupted.");
+            }
+
+            if ((long)nameByteLength != (long)name.Length * 2)
+            {
+                continue;
+            }
+
+            if (!reader.TryRead(nameByteLength, out ReadOnlySpan<byte> nameBytes))
+            {
+                ThrowBadImageFormatException("A resource name is corrupted.");
+            }
+
+            // Names are stored UTF-16LE and the reader requires a little-endian architecture, so the
+            // bytes can be reinterpreted as chars and compared directly.
+            if (MemoryMarshal.Cast<byte, char>(nameBytes).SequenceEqual(name))
+            {
+                if (!reader.TryReadInt32LittleEndian(out int dataPosition))
+                {
+                    ThrowBadImageFormatException("A resource name is corrupted.");
+                }
+
+                location = BuildLocation(i, dataPosition);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc cref="TryFindResource(ReadOnlySpan{char}, out ResourceLocation)"/>
+    /// <exception cref="ArgumentNullException"><paramref name="name"/> is <see langword="null"/>.</exception>
+    public bool TryFindResource(string name, out ResourceLocation location)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        return TryFindResource(name.AsSpan(), out location);
+    }
+
+    /// <summary>
+    ///  Gets the location (type and byte length) of the resource at <paramref name="index"/>.
+    /// </summary>
+    /// <param name="index">A resource index in the range <c>[0, <see cref="ResourceCount"/>)</c>.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is out of range.</exception>
+    /// <exception cref="BadImageFormatException">The file is malformed.</exception>
+    public ResourceLocation GetLocation(int index)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _numResources);
+        return BuildLocation(index, ReadDataPosition(index));
+    }
+
+    /// <summary>
+    ///  Copies the raw value content of the resource at <paramref name="index"/> into
+    ///  <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="index">A resource index in the range <c>[0, <see cref="ResourceCount"/>)</c>.</param>
+    /// <param name="destination">The span to copy the value bytes into.</param>
+    /// <param name="bytesWritten">On success, the number of bytes written.</param>
+    /// <returns>
+    ///  <see langword="false"/> if the resource is a user type (no bytes are exposed) or if
+    ///  <paramref name="destination"/> is too small; otherwise <see langword="true"/>.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is out of range.</exception>
+    public bool TryGetResourceData(int index, Span<byte> destination, out int bytesWritten)
+    {
+        ResourceLocation location = GetLocation(index);
+        if (location.IsUserType || destination.Length < location.ByteLength)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        _resources.Span.Slice(location.ContentOffset, location.ByteLength).CopyTo(destination);
+        bytesWritten = location.ByteLength;
+        return true;
+    }
+
+    /// <summary>
+    ///  Copies the raw value content of the resource at <paramref name="index"/> into
+    ///  <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="index">A resource index in the range <c>[0, <see cref="ResourceCount"/>)</c>.</param>
+    /// <param name="destination">The stream to write the value bytes to.</param>
+    /// <returns><see langword="false"/> if the resource is a user type; otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="destination"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is out of range.</exception>
+    public bool TryCopyResourceData(int index, Stream destination)
+    {
+        ArgumentNullException.ThrowIfNull(destination);
+
+        ResourceLocation location = GetLocation(index);
+        if (location.IsUserType)
+        {
+            return false;
+        }
+
+        ReadOnlyMemory<byte> content = _resources.Slice(location.ContentOffset, location.ByteLength);
+        destination.Write(content.Span);
+        return true;
+    }
+
+    /// <summary>
+    ///  Copies the name of the resource at <paramref name="index"/> into <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="index">A resource index in the range <c>[0, <see cref="ResourceCount"/>)</c>.</param>
+    /// <param name="destination">The span to copy the name characters into.</param>
+    /// <param name="charsWritten">On success, the number of characters written.</param>
+    /// <returns><see langword="false"/> if <paramref name="destination"/> is too small; otherwise <see langword="true"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is out of range.</exception>
+    /// <exception cref="BadImageFormatException">The file is malformed.</exception>
+    public bool TryGetResourceName(int index, Span<char> destination, out int charsWritten)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _numResources);
+
+        SpanReader<byte> reader = new(_resources.Span) { Position = _nameSectionOffset + GetNamePosition(index) };
+        if (!reader.TryRead7BitEncodedInt32(out int nameByteLength)
+            || nameByteLength < 0
+            || (nameByteLength & 1) != 0)
+        {
+            ThrowBadImageFormatException("A resource name is corrupted.");
+        }
+
+        int charCount = nameByteLength / 2;
+        if (destination.Length < charCount)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        if (!reader.TryRead(nameByteLength, out ReadOnlySpan<byte> nameBytes))
+        {
+            ThrowBadImageFormatException("A resource name is corrupted.");
+        }
+
+        // Names are stored UTF-16LE and the reader requires a little-endian architecture, so the bytes
+        // can be reinterpreted as chars and copied directly.
+        MemoryMarshal.Cast<byte, char>(nameBytes).CopyTo(destination);
+        charsWritten = charCount;
+        return true;
+    }
+
+    /// <summary>
+    ///  Copies the declared type name of the user type at <paramref name="index"/> into
+    ///  <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="index">A resource index in the range <c>[0, <see cref="ResourceCount"/>)</c>.</param>
+    /// <param name="destination">The span to copy the type name characters into.</param>
+    /// <param name="charsWritten">On success, the number of characters written.</param>
+    /// <returns>
+    ///  <see langword="false"/> if the resource is not a user type or if <paramref name="destination"/>
+    ///  is too small; otherwise <see langword="true"/>.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is out of range.</exception>
+    /// <exception cref="BadImageFormatException">The file is malformed.</exception>
+    public bool TryGetUserTypeName(int index, Span<char> destination, out int charsWritten)
+    {
+        ResourceLocation location = GetLocation(index);
+        if (!location.IsUserType)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        int typeIndex = (int)location.TypeCode - (int)ResourceTypeCode.StartOfUserTypes;
+        if (typeIndex < 0 || typeIndex >= _numTypes)
+        {
+            throw new BadImageFormatException("A user type index is out of range.");
+        }
+
+        SpanReader<byte> reader = new(_resources.Span) { Position = _typeNamesOffset };
+        for (int i = 0; i < typeIndex; i++)
+        {
+            if (!reader.TryRead7BitEncodedInt32(out int skipLength)
+                || skipLength < 0
+                || !reader.TryAdvance(skipLength))
+            {
+                ThrowBadImageFormatException("A user type name is corrupted.");
+            }
+        }
+
+        if (!reader.TryRead7BitEncodedInt32(out int typeNameLength) || typeNameLength < 0)
+        {
+            ThrowBadImageFormatException("A user type name is corrupted.");
+        }
+
+        if (!reader.TryRead(typeNameLength, out ReadOnlySpan<byte> typeNameBytes))
+        {
+            ThrowBadImageFormatException("A user type name is corrupted.");
+        }
+
+        return Encoding.UTF8.TryGetChars(typeNameBytes, destination, out charsWritten);
+    }
+
+    // Reads the data-section virtual offset stored after the name for a resource index.
+    private int ReadDataPosition(int index)
+    {
+        SpanReader<byte> reader = new(_resources.Span) { Position = _nameSectionOffset + GetNamePosition(index) };
+        if (!reader.TryRead7BitEncodedInt32(out int nameByteLength)
+            || nameByteLength < 0
+            || !reader.TryAdvance(nameByteLength))
+        {
+            ThrowBadImageFormatException("A resource name is corrupted.");
+        }
+
+        if (!reader.TryReadInt32LittleEndian(out int dataPosition))
+        {
+            ThrowBadImageFormatException("A resource name is corrupted.");
+        }
+
+        return dataPosition;
+    }
+
+    // Reads a resource's type code and computes its content offset and length.
+    private ResourceLocation BuildLocation(int index, int dataPosition)
+    {
+        if (dataPosition < 0 || dataPosition >= _resources.Length - _dataSectionOffset)
+        {
+            throw new BadImageFormatException("A resource data offset is out of range.");
+        }
+
+        SpanReader<byte> reader = new(_resources.Span) { Position = _dataSectionOffset + dataPosition };
+        if (!reader.TryRead7BitEncodedInt32(out int typeCodeValue))
+        {
+            ThrowBadImageFormatException("A resource type code is corrupted.");
+        }
+
+        ResourceTypeCode typeCode = (ResourceTypeCode)typeCodeValue;
+
+        if (typeCodeValue >= (int)ResourceTypeCode.StartOfUserTypes)
+        {
+            // Serialized user type: report the code and type name only, no value bytes.
+            return new ResourceLocation(index, typeCode, byteLength: 0, contentOffset: reader.Position);
+        }
+
+        int contentLength;
+        switch (typeCode)
+        {
+            case ResourceTypeCode.Null:
+                contentLength = 0;
+                break;
+            case ResourceTypeCode.Boolean:
+            case ResourceTypeCode.Byte:
+            case ResourceTypeCode.SByte:
+                contentLength = 1;
+                break;
+            case ResourceTypeCode.Char:
+            case ResourceTypeCode.Int16:
+            case ResourceTypeCode.UInt16:
+                contentLength = 2;
+                break;
+            case ResourceTypeCode.Int32:
+            case ResourceTypeCode.UInt32:
+            case ResourceTypeCode.Single:
+                contentLength = 4;
+                break;
+            case ResourceTypeCode.Int64:
+            case ResourceTypeCode.UInt64:
+            case ResourceTypeCode.Double:
+            case ResourceTypeCode.DateTime:
+            case ResourceTypeCode.TimeSpan:
+                contentLength = 8;
+                break;
+            case ResourceTypeCode.Decimal:
+                contentLength = 16;
+                break;
+            case ResourceTypeCode.String:
+                if (!reader.TryRead7BitEncodedInt32(out contentLength))
+                {
+                    ThrowBadImageFormatException("A resource value length is out of range.");
+                }
+
+                break;
+            case ResourceTypeCode.ByteArray:
+            case ResourceTypeCode.Stream:
+                if (!reader.TryReadInt32LittleEndian(out contentLength))
+                {
+                    ThrowBadImageFormatException("A resource value length is out of range.");
+                }
+
+                break;
+            default:
+                throw new BadImageFormatException($"Unsupported resource type code 0x{typeCodeValue:X}.");
+        }
+
+        int contentOffset = reader.Position;
+        if (contentLength < 0 || contentOffset > _resources.Length - contentLength)
+        {
+            ThrowBadImageFormatException("A resource value length is out of range.");
+        }
+
+        return new ResourceLocation(index, typeCode, contentLength, contentOffset);
+    }
+
+    private int GetNamePosition(int index)
+    {
+        SpanReader<byte> reader = new(_resources.Span) { Position = _namePositionsOffset + (index * 4) };
+        if (!reader.TryReadInt32LittleEndian(out int position)
+            || position < 0
+            || position > _dataSectionOffset - _nameSectionOffset)
+        {
+            ThrowBadImageFormatException("A resource name offset is out of range.");
+        }
+
+        return position;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [DoesNotReturn]
+    private static void ThrowBadImageFormatException(string message) => throw new BadImageFormatException(message);
+}

--- a/touki/Touki/Resources/RawResourceReader.cs
+++ b/touki/Touki/Resources/RawResourceReader.cs
@@ -511,6 +511,7 @@ public sealed class RawResourceReader : IDisposable
         SpanReader<byte> reader = new(_resources.Span) { Position = _nameSectionOffset + GetNamePosition(index) };
         if (!reader.TryRead7BitEncodedInt32(out int nameByteLength)
             || nameByteLength < 0
+            || (nameByteLength & 1) != 0
             || !reader.TryAdvance(nameByteLength))
         {
             ThrowBadImageFormatException("A resource name is corrupted.");

--- a/touki/Touki/Resources/RawResourceReader.cs
+++ b/touki/Touki/Resources/RawResourceReader.cs
@@ -434,16 +434,19 @@ public sealed class RawResourceReader : IDisposable
             ThrowBadImageFormatException("A resource name is corrupted.");
         }
 
+        // Read the name bytes before checking the destination size so a length that runs past the end
+        // of the file is rejected as corruption here, rather than returning false and driving the caller
+        // to grow its buffer toward the claimed (potentially unbounded) length.
+        if (!reader.TryRead(nameByteLength, out ReadOnlySpan<byte> nameBytes))
+        {
+            ThrowBadImageFormatException("A resource name is corrupted.");
+        }
+
         int charCount = nameByteLength / 2;
         if (destination.Length < charCount)
         {
             charsWritten = 0;
             return false;
-        }
-
-        if (!reader.TryRead(nameByteLength, out ReadOnlySpan<byte> nameBytes))
-        {
-            ThrowBadImageFormatException("A resource name is corrupted.");
         }
 
         // Names are stored UTF-16LE and the reader requires a little-endian architecture, so the bytes

--- a/touki/Touki/Resources/RawResourceReader.cs
+++ b/touki/Touki/Resources/RawResourceReader.cs
@@ -32,7 +32,7 @@ namespace Touki.Resources;
 ///   <see cref="TryGetResourceData(int, Span{byte}, out int)"/> yield exactly the value bytes.
 ///  </para>
 /// </remarks>
-public sealed class RawResourceReader : IDisposable
+public sealed class RawResourceReader : DisposableBase
 {
     // On-disk layout of a default-format (version 2) .resources file. All integers are little-endian
     // and "7-bit int" is a LEB128-style length prefix. The reader validates and indexes this in place
@@ -221,15 +221,32 @@ public sealed class RawResourceReader : IDisposable
     }
 
     /// <summary>
-    ///  Releases the memory mapping owned by this reader. A reader constructed directly over a
-    ///  <see cref="ReadOnlyMemory{T}"/> owns nothing, so disposing it is a no-op.
+    ///  Releases the memory mapping owned by this reader, if any. Disposal is thread-safe and
+    ///  idempotent; after it, member access throws <see cref="ObjectDisposedException"/>. A reader
+    ///  constructed directly over a <see cref="ReadOnlyMemory{T}"/> owns no mapping to release.
     /// </summary>
-    public void Dispose() => _owned?.Dispose();
+    /// <param name="disposing">
+    ///  <see langword="true"/> when called from <see cref="DisposableBase.Dispose()"/>.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _owned?.Dispose();
+        }
+    }
 
     /// <summary>
     ///  The number of resources in the file.
     /// </summary>
-    public int ResourceCount => _numResources;
+    public int ResourceCount
+    {
+        get
+        {
+            ObjectDisposedException.ThrowIf(Disposed, this);
+            return _numResources;
+        }
+    }
 
     /// <summary>
     ///  Finds a resource by name.
@@ -240,6 +257,8 @@ public sealed class RawResourceReader : IDisposable
     /// <exception cref="BadImageFormatException">The file is malformed.</exception>
     public bool TryFindResource(ReadOnlySpan<char> name, out ResourceLocation location)
     {
+        ObjectDisposedException.ThrowIf(Disposed, this);
+
         location = default;
         if (_numResources == 0)
         {
@@ -357,6 +376,7 @@ public sealed class RawResourceReader : IDisposable
     /// <exception cref="BadImageFormatException">The file is malformed.</exception>
     public ResourceLocation GetLocation(int index)
     {
+        ObjectDisposedException.ThrowIf(Disposed, this);
         ArgumentOutOfRangeException.ThrowIfNegative(index);
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _numResources);
         return BuildLocation(index, ReadDataPosition(index));
@@ -423,6 +443,7 @@ public sealed class RawResourceReader : IDisposable
     /// <exception cref="BadImageFormatException">The file is malformed.</exception>
     public bool TryGetResourceName(int index, Span<char> destination, out int charsWritten)
     {
+        ObjectDisposedException.ThrowIf(Disposed, this);
         ArgumentOutOfRangeException.ThrowIfNegative(index);
         ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, _numResources);
 

--- a/touki/Touki/Resources/ResourceLocation.cs
+++ b/touki/Touki/Resources/ResourceLocation.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Resources;
+
+/// <summary>
+///  Describes a single resource located by <see cref="RawResourceReader"/>: its index, stored type,
+///  and the length in bytes of its raw value content.
+/// </summary>
+public readonly struct ResourceLocation
+{
+    internal ResourceLocation(int index, ResourceTypeCode typeCode, int byteLength, int contentOffset)
+    {
+        Index = index;
+        TypeCode = typeCode;
+        ByteLength = byteLength;
+        ContentOffset = contentOffset;
+    }
+
+    /// <summary>
+    ///  The zero-based index of the resource within the reader.
+    /// </summary>
+    public int Index { get; }
+
+    /// <summary>
+    ///  The stored type of the resource value.
+    /// </summary>
+    public ResourceTypeCode TypeCode { get; }
+
+    /// <summary>
+    ///  The length, in bytes, of the raw value content (with any length prefix already removed). It is
+    ///  <c>0</c> for <see cref="ResourceTypeCode.Null"/> and for user types (see
+    ///  <see cref="IsUserType"/>).
+    /// </summary>
+    public int ByteLength { get; }
+
+    /// <summary>
+    ///  <see langword="true"/> when the resource is a serialized user type
+    ///  (<see cref="TypeCode"/> is at or above <see cref="ResourceTypeCode.StartOfUserTypes"/>), whose
+    ///  value bytes are not exposed.
+    /// </summary>
+    public bool IsUserType => TypeCode >= ResourceTypeCode.StartOfUserTypes;
+
+    /// <summary>
+    ///  Absolute offset of the value content within the reader's memory.
+    /// </summary>
+    internal int ContentOffset { get; }
+}

--- a/touki/Touki/Resources/ResourceTypeCode.cs
+++ b/touki/Touki/Resources/ResourceTypeCode.cs
@@ -1,0 +1,132 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Resources;
+
+/// <summary>
+///  Identifies the type of a value stored in a default-format <c>.resources</c> file.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The values are the on-disk contract of the binary <c>.resources</c> format (version 2) and
+///   must never change. They mirror the runtime's internal
+///   <c>System.Resources.ResourceTypeCode</c>. <see cref="RawResourceReader"/> exposes them so a
+///   caller can inspect a resource's stored type without decoding or deserializing the value.
+///  </para>
+///  <para>
+///   Values <c>0x00</c> through <c>0x1F</c> are primitives and reserved values; <c>0x20</c> through
+///   <c>0x3F</c> are specially recognized types (<c>byte[]</c> and <see cref="System.IO.Stream"/>);
+///   values at or above <see cref="StartOfUserTypes"/> identify serialized user types, whose index
+///   into the file's type table is <c>typeCode - StartOfUserTypes</c>.
+///  </para>
+/// </remarks>
+public enum ResourceTypeCode
+{
+    /// <summary>
+    ///  A <see langword="null"/> value.
+    /// </summary>
+    Null = 0,
+
+    /// <summary>
+    ///  A <see cref="string"/>, stored as length-prefixed UTF-8.
+    /// </summary>
+    String = 1,
+
+    /// <summary>
+    ///  A <see cref="bool"/>.
+    /// </summary>
+    Boolean = 2,
+
+    /// <summary>
+    ///  A <see cref="char"/>, stored as a <see cref="ushort"/>.
+    /// </summary>
+    Char = 3,
+
+    /// <summary>
+    ///  A <see cref="byte"/>.
+    /// </summary>
+    Byte = 4,
+
+    /// <summary>
+    ///  An <see cref="sbyte"/>.
+    /// </summary>
+    SByte = 5,
+
+    /// <summary>
+    ///  An <see cref="short"/>.
+    /// </summary>
+    Int16 = 6,
+
+    /// <summary>
+    ///  A <see cref="ushort"/>.
+    /// </summary>
+    UInt16 = 7,
+
+    /// <summary>
+    ///  An <see cref="int"/>.
+    /// </summary>
+    Int32 = 8,
+
+    /// <summary>
+    ///  A <see cref="uint"/>.
+    /// </summary>
+    UInt32 = 9,
+
+    /// <summary>
+    ///  A <see cref="long"/>.
+    /// </summary>
+    Int64 = 0xA,
+
+    /// <summary>
+    ///  A <see cref="ulong"/>.
+    /// </summary>
+    UInt64 = 0xB,
+
+    /// <summary>
+    ///  A <see cref="float"/>.
+    /// </summary>
+    Single = 0xC,
+
+    /// <summary>
+    ///  A <see cref="double"/>.
+    /// </summary>
+    Double = 0xD,
+
+    /// <summary>
+    ///  A <see cref="decimal"/>, stored as four <see cref="int"/> values (16 bytes).
+    /// </summary>
+    Decimal = 0xE,
+
+    /// <summary>
+    ///  A <see cref="System.DateTime"/>, stored as an <see cref="long"/> from
+    ///  <see cref="System.DateTime.ToBinary"/>.
+    /// </summary>
+    DateTime = 0xF,
+
+    /// <summary>
+    ///  A <see cref="System.TimeSpan"/>, stored as its <see cref="System.TimeSpan.Ticks"/>.
+    /// </summary>
+    TimeSpan = 0x10,
+
+    /// <summary>
+    ///  The highest primitive type code. Change this if new primitives are added.
+    /// </summary>
+    LastPrimitive = TimeSpan,
+
+    /// <summary>
+    ///  A <c>byte[]</c>, stored as an <see cref="int"/> length followed by the bytes.
+    /// </summary>
+    ByteArray = 0x20,
+
+    /// <summary>
+    ///  A <see cref="System.IO.Stream"/>, stored as an <see cref="int"/> length followed by the bytes.
+    /// </summary>
+    Stream = 0x21,
+
+    /// <summary>
+    ///  The first type code assigned to a serialized user type. The type's name is found in the
+    ///  file's type table at index <c>typeCode - StartOfUserTypes</c>.
+    /// </summary>
+    StartOfUserTypes = 0x40
+}

--- a/touki/Touki/Resources/SatelliteStringResourceManager.cs
+++ b/touki/Touki/Resources/SatelliteStringResourceManager.cs
@@ -220,7 +220,7 @@ public sealed class SatelliteStringResourceManager : ResourceManager
     [SkipLocalsInit]
     private static Dictionary<string, string> LoadStringTable(string path)
     {
-        Dictionary<string, string> table = new(StringComparer.Ordinal);
+        Dictionary<string, string> table = [with(StringComparer.Ordinal)];
         using RawResourceReader reader = RawResourceReader.CreateFromFile(path);
 
         // Walk the entries by index. RawResourceReader parses the .resources structure in place and
@@ -244,16 +244,29 @@ public sealed class SatelliteStringResourceManager : ResourceManager
                 continue;
             }
 
-            // The name is UTF-16; grow the scratch buffer on the rare chance a name does not fit.
+            // The name is UTF-16; grow the scratch buffer on the rare chance a name does not fit. The
+            // reader rejects a name length that exceeds the file, so growth is bounded; guard the
+            // doubling against int overflow as defense in depth and treat it as corruption.
             int nameLength;
             while (!reader.TryGetResourceName(i, nameBuffer.AsSpan(), out nameLength))
             {
-                nameBuffer.EnsureCapacity(nameBuffer.Length * 2);
+                int newLength = nameBuffer.Length * 2;
+                if (newLength < 0)
+                {
+                    throw new BadImageFormatException("A resource name length is corrupted.");
+                }
+
+                nameBuffer.EnsureCapacity(newLength);
             }
 
             // The value is the string's UTF-8 content bytes with the length prefix already stripped.
+            // The entry was validated as an intrinsic string and the buffer sized to its length, so a
+            // failed read means the file is inconsistent; treat it as corruption.
             valueBuffer.EnsureCapacity(location.ByteLength);
-            reader.TryGetResourceData(i, valueBuffer.AsSpan(), out int valueLength);
+            if (!reader.TryGetResourceData(i, valueBuffer.AsSpan(), out int valueLength))
+            {
+                throw new BadImageFormatException("A resource value is corrupted.");
+            }
 
             table[nameBuffer[..nameLength].ToString()] = Encoding.UTF8.GetString(valueBuffer[..valueLength]);
         }

--- a/touki/Touki/Resources/SatelliteStringResourceManager.cs
+++ b/touki/Touki/Resources/SatelliteStringResourceManager.cs
@@ -2,13 +2,11 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-using System.Collections;
+using System.Collections.Frozen;
 using System.Globalization;
 using System.Reflection;
 using System.Resources;
-#if NET
-using System.Collections.Frozen;
-#endif
+using System.Text;
 
 namespace Touki.Resources;
 
@@ -34,7 +32,7 @@ namespace Touki.Resources;
 ///   <see cref="ResourceManager"/>.
 ///  </para>
 ///  <para>
-///   The merged table for the last requested culture is cached (as a frozen dictionary on .NET) and
+///   The merged table for the last requested culture is cached (as a frozen dictionary) and
 ///   rebuilt when the requested culture changes, which fits the overwhelmingly common
 ///   single-UI-culture usage. The cache is a single immutable snapshot published through a
 ///   <see langword="volatile"/> field, so it is updated without locking: under concurrent use with a
@@ -42,15 +40,16 @@ namespace Touki.Resources;
 ///   stale result), but never a torn or inconsistent one, and never a failure.
 ///  </para>
 ///  <para>
-///   Only string resources are supported. Each entry's stored type is inspected with
-///   <c>ResourceReader.GetResourceData</c>, which reads the raw type tag and bytes without
-///   deserializing the value; only entries tagged as intrinsic strings are decoded, and every other
-///   entry (a primitive, an array, or a serialized object) is skipped without deserialization. Files
-///   that would require a non-default reader (for example one written by
-///   <c>System.Resources.Extensions.PreserializedResourceWriter</c>) are rejected by the
-///   <see cref="ResourceReader"/> constructor and treated as absent. No value is ever deserialized, so
-///   no reflection or legacy serialization is triggered - keeping the manager trim- and AOT-safe and
-///   never exposing untrusted <c>.resources</c> content to a deserializer.
+///   Only string resources are supported. Each side file is read with <see cref="RawResourceReader"/>,
+///   which parses the binary <c>.resources</c> structure directly and never materializes managed
+///   values. Only entries whose stored type is the intrinsic string type are decoded; every other
+///   entry - a primitive, an array, a <see cref="Stream"/>, or a serialized user type - is skipped by
+///   its type code alone, so no value is ever deserialized. This holds even for files written by
+///   <c>System.Resources.Extensions.PreserializedResourceWriter</c>: their plain-string entries are
+///   read and their serialized user-type entries are skipped, with no reflection or legacy
+///   serialization ever triggered - keeping the manager trim- and AOT-safe and never exposing
+///   untrusted <c>.resources</c> content to a deserializer. Only default-format version 2
+///   <c>.resources</c> files are read; any other file is treated as absent.
 ///  </para>
 /// </remarks>
 public sealed class SatelliteStringResourceManager : ResourceManager
@@ -65,12 +64,11 @@ public sealed class SatelliteStringResourceManager : ResourceManager
     // always observes a fully-initialized snapshot - never a torn mix of fields. See GetString.
     private volatile CultureCache? _cache;
 
-#if NET
-    private static readonly IReadOnlyDictionary<string, string> s_emptyStrings = FrozenDictionary<string, string>.Empty;
-#else
-    private static readonly IReadOnlyDictionary<string, string> s_emptyStrings =
-        new Dictionary<string, string>(0, StringComparer.Ordinal);
-#endif
+    // IDE0301 suggests a '[]' collection expression here, but FrozenDictionary is abstract and cannot
+    // be constructed that way (CS0144); the cached empty singleton is correct and allocation-free.
+#pragma warning disable IDE0301
+    private static readonly FrozenDictionary<string, string> s_emptyStrings = FrozenDictionary<string, string>.Empty;
+#pragma warning restore IDE0301
 
     /// <summary>
     ///  Initializes a new instance of the <see cref="SatelliteStringResourceManager"/> class that
@@ -153,7 +151,7 @@ public sealed class SatelliteStringResourceManager : ResourceManager
         return base.GetString(name, CultureInfo.InvariantCulture);
     }
 
-    private IReadOnlyDictionary<string, string> BuildStrings(CultureInfo culture)
+    private FrozenDictionary<string, string> BuildStrings(CultureInfo culture)
     {
         Dictionary<string, string>? merged = null;
 
@@ -186,12 +184,8 @@ public sealed class SatelliteStringResourceManager : ResourceManager
 
         return merged is null ? s_emptyStrings : Freeze(merged);
 
-#if NET
         static FrozenDictionary<string, string> Freeze(Dictionary<string, string> table) =>
             table.ToFrozenDictionary(StringComparer.Ordinal);
-#else
-        static Dictionary<string, string> Freeze(Dictionary<string, string> table) => table;
-#endif
     }
 
     private Dictionary<string, string>? LoadTable(string cultureName)
@@ -214,51 +208,54 @@ public sealed class SatelliteStringResourceManager : ResourceManager
             or NotSupportedException)
         {
             // The side file is missing, unreadable (locked or access-denied), malformed, or not a
-            // default-format string .resources file. ResourceReader throws ArgumentException for a bad
-            // magic number and NotSupportedException for a non-default reader type (for example one
-            // written by PreserializedResourceWriter for resources that need reflection).
-            // UnauthorizedAccessException covers a probe directory or file the process cannot read.
-            // In every case, behave as if absent.
+            // default-format version 2 .resources file. RawResourceReader throws ArgumentException for a
+            // bad magic number, NotSupportedException for an unsupported format version, and
+            // BadImageFormatException for a truncated or malformed file; IOException and
+            // UnauthorizedAccessException cover a probe directory or file the process cannot open. In
+            // every case, behave as if absent.
             return null;
         }
     }
 
+    [SkipLocalsInit]
     private static Dictionary<string, string> LoadStringTable(string path)
     {
         Dictionary<string, string> table = new(StringComparer.Ordinal);
-        using ResourceReader reader = new(path);
+        using RawResourceReader reader = RawResourceReader.CreateFromFile(path);
 
-        // Collect the names first. enumerator.Key returns the name without touching the value; reading
-        // enumerator.Value, by contrast, would deserialize every entry - invoking reflection or legacy
-        // serialization for non-string entries - which would break the trim/AOT guarantee and turn
-        // untrusted .resources content into a deserialization surface.
-        List<string> names = [];
-        IDictionaryEnumerator enumerator = reader.GetEnumerator();
-        while (enumerator.MoveNext())
+        // Walk the entries by index. RawResourceReader parses the .resources structure in place and
+        // never materializes a value, so inspecting each entry's type code and reading a string's raw
+        // content bytes triggers no reflection or legacy serialization.
+        int count = reader.ResourceCount;
+
+        // Decode names and values through scratch buffers that start on the stack and spill to the
+        // shared ArrayPool only when an unusually long entry overflows them.
+        using BufferScope<char> nameBuffer = new(stackalloc char[256]);
+        using BufferScope<byte> valueBuffer = new(stackalloc byte[512]);
+
+        for (int i = 0; i < count; i++)
         {
-            if (enumerator.Key is string key)
-            {
-                names.Add(key);
-            }
-        }
+            ResourceLocation location = reader.GetLocation(i);
 
-        foreach (string name in names)
-        {
-            // GetResourceData reads the stored type tag and the raw value bytes without deserializing.
-            reader.GetResourceData(name, out string resourceType, out byte[] resourceData);
-
-            // Keep only intrinsic strings; every other entry (a primitive, an array, or a serialized
-            // object) is skipped, so no value is ever deserialized.
-            if (!string.Equals(resourceType, "ResourceTypeCode.String", StringComparison.Ordinal))
+            // Keep only intrinsic strings; every other entry - a primitive, an array, a stream, or
+            // a serialized user type - is skipped by its type code alone, so no value is decoded.
+            if (location.TypeCode != ResourceTypeCode.String)
             {
                 continue;
             }
 
-            // A ResourceTypeCode.String payload is a length-prefixed UTF-8 string - exactly the format
-            // BinaryReader.ReadString expects - so it decodes with no serializer or reflection.
-            using MemoryStream stream = new(resourceData);
-            using BinaryReader valueReader = new(stream, System.Text.Encoding.UTF8);
-            table[name] = valueReader.ReadString();
+            // The name is UTF-16; grow the scratch buffer on the rare chance a name does not fit.
+            int nameLength;
+            while (!reader.TryGetResourceName(i, nameBuffer.AsSpan(), out nameLength))
+            {
+                nameBuffer.EnsureCapacity(nameBuffer.Length * 2);
+            }
+
+            // The value is the string's UTF-8 content bytes with the length prefix already stripped.
+            valueBuffer.EnsureCapacity(location.ByteLength);
+            reader.TryGetResourceData(i, valueBuffer.AsSpan(), out int valueLength);
+
+            table[nameBuffer[..nameLength].ToString()] = Encoding.UTF8.GetString(valueBuffer[..valueLength]);
         }
 
         return table;
@@ -272,7 +269,7 @@ public sealed class SatelliteStringResourceManager : ResourceManager
     /// </summary>
     private sealed class CultureCache
     {
-        internal CultureCache(string cultureName, bool isNeutral, IReadOnlyDictionary<string, string>? strings)
+        internal CultureCache(string cultureName, bool isNeutral, FrozenDictionary<string, string>? strings)
         {
             CultureName = cultureName;
             IsNeutral = isNeutral;
@@ -283,6 +280,6 @@ public sealed class SatelliteStringResourceManager : ResourceManager
 
         internal bool IsNeutral { get; }
 
-        internal IReadOnlyDictionary<string, string>? Strings { get; }
+        internal FrozenDictionary<string, string>? Strings { get; }
     }
 }

--- a/touki/touki.csproj
+++ b/touki/touki.csproj
@@ -61,6 +61,8 @@
     <!-- This provides Range and Index support downlevel. -->
     <PackageReference Include="Microsoft.Bcl.Memory" />
     <PackageReference Include="Microsoft.Bcl.HashCode" />
+    <!-- This provides FrozenDictionary downlevel; the Frozen types ship in the Immutable assembly. -->
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Adds a public, allocation-free reader for version 2 `.resources` files (`RawResourceReader`) and uses it to load the per-culture string tables in `SatelliteStringResourceManager`, replacing the inbox `ResourceReader` path. Localized string loading is now faster and allocation-light, and involves no reflection or legacy serialization - keeping the manager trim- and AOT-safe.

## Changes

- **`RawResourceReader`** (new public): little-endian, V2-only reader over `ReadOnlyMemory<byte>` with a memory-mapped file factory. Content-only data access, lookup by index or name (`ReadOnlySpan<char>`/`string`), and zero managed allocation on the read path. Adds public `ResourceLocation` and `ResourceTypeCode`.
- **`MappedMemoryManager`** (new public): a `MemoryManager<byte>` over a read-only memory-mapped file view, backing `RawResourceReader.CreateFromFile`.
- **`SpanReader<byte>`**: adds `TryReadInt32LittleEndian`, `TryRead7BitEncodedInt32`, and `TryAdvance`.
- **Polyfills**: `EncodingExtensions` gains span `GetString`/`TryGetChars`; adds a net472 `Stream.Write(ReadOnlySpan<byte>)`.
- **`SatelliteStringResourceManager`**: loads string tables via `RawResourceReader` (no reflection/deserialization; intrinsic strings read, user-type/serialized entries skipped by type code). Now uses `FrozenDictionary` on every TFM via a `System.Collections.Immutable` reference on net472 (the Frozen types ship in that assembly), removing the prior per-TFM `#if` split. Scratch buffers use `BufferScope` (stack + pool fallback).

## Notes

- The net472 flavor of the `KlutzyNinja.Touki` package gains a `System.Collections.Immutable` dependency; net10/net11 are unaffected (`FrozenDictionary` is inbox there).
- Behavior change for Extensions-format side files: their plain-string entries are now read (previously the whole file was rejected as absent); serialized user types are still skipped without deserialization.

## Validation

- Builds clean on net10.0, net11.0, and net472 (0 warnings / 0 errors).
- Full test suite green in both Release (21,740) and Debug (21,721); new tests cover `RawResourceReader`, `MappedMemoryManager`, the `SpanReader`/`Encoding`/`Stream` additions, and the manager conversion.
- Load A/B (`RawResourceReader` vs the old `ResourceReader` path): ~11x faster on modern .NET RyuJIT (net10) and ~7x on .NET Framework 4.8.1 RyuJIT, with a large allocation reduction.