### PR TITLE
Fix Codecov coverage collection

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -115,8 +115,7 @@ jobs:
 
         $reports = @(
           Get-ChildItem -Path $resultsDir -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
-            Group-Object Name |
-            ForEach-Object { $_.Group[0].FullName }
+            ForEach-Object { $_.FullName }
         )
         if ($reports.Count -eq 0) {
           throw 'No Cobertura reports found; coverage collection failed.'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,25 +73,52 @@ jobs:
         $resultsDir = Join-Path $PWD.Path "artifacts/test-results/$($configuration.ToLower())"
         New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 
-        # MTP args appended only on Release: coverage instrumentation slows tests
-        # and Codecov only consumes the Release run.
-        $extraArgs = @()
-        if ($configuration -eq 'Release') {
-          $extraArgs = @(
-            '--coverage',
-            '--coverage-output-format', 'cobertura',
-            '--coverage-settings', "$PWD/.config/coverage.settings.xml"
-          )
-        }
-
         dotnet test -c $configuration --no-build `
           -p:TestingPlatformCaptureOutput=false `
           --results-directory "$resultsDir" `
           --report-trx `
-          --output Detailed `
-          @extraArgs
+          --output Detailed
+    - name: Collect coverage
+      if: matrix.configuration == 'Release'
+      run: |
+        # Coverage collected through the solution-level MTP invocation has produced empty Cobertura
+        # files on GitHub-hosted Windows runners since the repository switched to MTP.
+        # Run each production-code test target separately and sequentially instead. This also avoids
+        # merging the duplicate report copies MTP places under the TRX results directory.
+        $coverageRuns = @(
+          @{ Name = 'touki-net10'; Project = 'touki.tests/touki.tests.csproj'; Framework = 'net10.0' },
+          @{ Name = 'touki-net11'; Project = 'touki.tests/touki.tests.csproj'; Framework = 'net11.0' },
+          @{ Name = 'touki-net481'; Project = 'touki.tests/touki.tests.csproj'; Framework = 'net481' },
+          @{ Name = 'aot-net10'; Project = 'touki.aot.tests/touki.aot.tests.csproj'; Framework = 'net10.0' }
+        )
+
+        foreach ($run in $coverageRuns) {
+          $resultsDir = Join-Path $PWD.Path "artifacts/coverage-results/$($run.Name)"
+          New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+          dotnet test $run.Project -c Release -f $run.Framework --no-build `
+            -p:TestingPlatformCaptureOutput=false `
+            --results-directory "$resultsDir" `
+            --output Normal `
+            --coverage `
+            --coverage-output-format cobertura `
+            --coverage-settings "$PWD/.config/coverage.settings.xml"
+
+          $reports = @(Get-ChildItem -Path $resultsDir -Filter '*.cobertura.xml')
+          if ($reports.Count -ne 1) {
+            throw "Expected exactly one Cobertura report for $($run.Name), found $($reports.Count)."
+          }
+
+          [xml] $coverage = Get-Content -Raw $reports[0].FullName
+          $linesValid = [int] $coverage.coverage.'lines-valid'
+          if ($linesValid -le 0) {
+            throw "Coverage report for $($run.Name) is empty."
+          }
+
+          Write-Host "$($run.Name): $linesValid coverable lines"
+        }
     - name: Generate coverage report
-      if: always() && matrix.configuration == 'Release'
+      if: matrix.configuration == 'Release'
       run: |
         $reportGeneratorVersion = '5.5.9'
         if (dotnet tool list -g | Select-String -SimpleMatch 'dotnet-reportgenerator-globaltool') {
@@ -106,12 +133,11 @@ jobs:
           exit 0
         }
         $reports = @(
-          Get-ChildItem -Path artifacts -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
+          Get-ChildItem -Path artifacts/coverage-results -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
             ForEach-Object { $_.FullName }
         )
         if ($reports.Count -eq 0) {
-          Write-Warning 'No cobertura reports found; skipping report generation.'
-          exit 0
+          throw 'No Cobertura reports found; coverage collection failed.'
         }
         $reportsArg = ($reports -join ';')
         New-Item -ItemType Directory -Force -Path artifacts/coverage | Out-Null
@@ -126,7 +152,7 @@ jobs:
             Add-Content -Path $env:GITHUB_STEP_SUMMARY
         }
     - name: Upload coverage report
-      if: always() && matrix.configuration == 'Release'
+      if: matrix.configuration == 'Release'
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
@@ -134,7 +160,7 @@ jobs:
         if-no-files-found: warn
         retention-days: 14
     - name: Upload coverage to Codecov
-      if: always() && matrix.configuration == 'Release'
+      if: matrix.configuration == 'Release'
       uses: codecov/codecov-action@v5
       with:
         files: artifacts/coverage/Cobertura.xml

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -73,49 +73,25 @@ jobs:
         $resultsDir = Join-Path $PWD.Path "artifacts/test-results/$($configuration.ToLower())"
         New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
 
+        # Coverage is Release-only: instrumentation slows tests and Codecov consumes one merged run.
+        $extraArgs = @()
+        if ($configuration -eq 'Release') {
+          $extraArgs = @(
+            '--coverage',
+            '--coverage-output-format', 'cobertura',
+            '--coverage-settings', "$PWD/.config/coverage.settings.xml"
+          )
+        }
+
         dotnet test -c $configuration --no-build `
           -p:TestingPlatformCaptureOutput=false `
           --results-directory "$resultsDir" `
           --report-trx `
-          --output Detailed
-    - name: Collect coverage
-      if: matrix.configuration == 'Release'
-      run: |
-        # Coverage collected through the solution-level MTP invocation has produced empty Cobertura
-        # files on GitHub-hosted Windows runners since the repository switched to MTP.
-        # Run each production-code test target separately and sequentially instead. This also avoids
-        # merging the duplicate report copies MTP places under the TRX results directory.
-        $coverageRuns = @(
-          @{ Name = 'touki-net10'; Project = 'touki.tests/touki.tests.csproj'; Framework = 'net10.0' },
-          @{ Name = 'touki-net11'; Project = 'touki.tests/touki.tests.csproj'; Framework = 'net11.0' },
-          @{ Name = 'touki-net481'; Project = 'touki.tests/touki.tests.csproj'; Framework = 'net481' },
-          @{ Name = 'aot-net10'; Project = 'touki.aot.tests/touki.aot.tests.csproj'; Framework = 'net10.0' }
-        )
+          --output Detailed `
+          @extraArgs
 
-        foreach ($run in $coverageRuns) {
-          $resultsDir = Join-Path $PWD.Path "artifacts/coverage-results/$($run.Name)"
-          New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
-
-          dotnet test $run.Project -c Release -f $run.Framework --no-build `
-            -p:TestingPlatformCaptureOutput=false `
-            --results-directory "$resultsDir" `
-            --output Normal `
-            --coverage `
-            --coverage-output-format cobertura `
-            --coverage-settings "$PWD/.config/coverage.settings.xml"
-
-          $reports = @(Get-ChildItem -Path $resultsDir -Filter '*.cobertura.xml')
-          if ($reports.Count -ne 1) {
-            throw "Expected exactly one Cobertura report for $($run.Name), found $($reports.Count)."
-          }
-
-          [xml] $coverage = Get-Content -Raw $reports[0].FullName
-          $linesValid = [int] $coverage.coverage.'lines-valid'
-          if ($linesValid -le 0) {
-            throw "Coverage report for $($run.Name) is empty."
-          }
-
-          Write-Host "$($run.Name): $linesValid coverable lines"
+        if ($LASTEXITCODE -ne 0) {
+          throw "Tests failed with exit code $LASTEXITCODE."
         }
     - name: Generate coverage report
       if: matrix.configuration == 'Release'
@@ -128,12 +104,17 @@ jobs:
           dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
         }
 
-        if (-not (Test-Path artifacts)) {
-          Write-Warning 'No artifacts directory found; skipping report generation.'
-          exit 0
+        if ($LASTEXITCODE -ne 0) {
+          throw "ReportGenerator setup failed with exit code $LASTEXITCODE."
         }
+
+        $resultsDir = 'artifacts/test-results/release'
+        if (-not (Test-Path $resultsDir)) {
+          throw "Coverage results directory '$resultsDir' was not created."
+        }
+
         $reports = @(
-          Get-ChildItem -Path artifacts/coverage-results -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
+          Get-ChildItem -Path $resultsDir -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
             ForEach-Object { $_.FullName }
         )
         if ($reports.Count -eq 0) {
@@ -147,8 +128,27 @@ jobs:
           -reporttypes:'Cobertura;HtmlInline;MarkdownSummaryGithub' `
           -classfilters:'-Touki.Resources.SR;-Touki.Framework.Resources.SRF' `
           -title:'touki'
-        if (Test-Path artifacts/coverage/SummaryGithub.md) {
-          Get-Content artifacts/coverage/SummaryGithub.md |
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "ReportGenerator failed with exit code $LASTEXITCODE."
+        }
+
+        $coveragePath = 'artifacts/coverage/Cobertura.xml'
+        if (-not (Test-Path $coveragePath)) {
+          throw "ReportGenerator did not create '$coveragePath'."
+        }
+
+        [xml] $coverage = Get-Content -Raw $coveragePath
+        $linesValid = [int] $coverage.coverage.'lines-valid'
+        if ($linesValid -le 0) {
+          throw 'The merged Cobertura report contains no coverable lines.'
+        }
+
+        Write-Host "Merged coverage report: $linesValid coverable lines"
+
+        $summaryPath = 'artifacts/coverage/SummaryGithub.md'
+        if (Test-Path $summaryPath) {
+          Get-Content $summaryPath |
             Add-Content -Path $env:GITHUB_STEP_SUMMARY
         }
     - name: Upload coverage report

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -114,8 +114,9 @@ jobs:
         }
 
         $reports = @(
-          Get-ChildItem -Path $resultsDir -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
-            ForEach-Object { $_.FullName }
+          Get-ChildItem -Path $resultsDir -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
+            Group-Object Name |
+            ForEach-Object { $_.Group[0].FullName }
         )
         if ($reports.Count -eq 0) {
           throw 'No Cobertura reports found; coverage collection failed.'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.203" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.2.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.2.3" />


### PR DESCRIPTION
## Summary

Restore Codecov reporting by upgrading `Microsoft.Testing.Extensions.CodeCoverage` to 18.9.0 and hardening the existing solution-level coverage workflow against silent failures and empty uploads.

Codecov's last successfully processed report was commit `46c8d4a` (June 1, 90.23%). The first unusable report was `2789e30`, which switched CI's solution-level `dotnet test` invocation to Microsoft Testing Platform. The Harness announcement was coincidental.

The actual trigger is `ContinuousIntegrationBuild=true`, which `touki.csproj` enables under `GITHUB_ACTIONS`. It rewrites PDB source paths to deterministic `/_/...` paths. `Microsoft.Testing.Extensions.CodeCoverage` 18.7.0 has a confirmed bug handling those paths and emits empty Cobertura reports. Microsoft fixed it in 18.9.0: https://github.com/microsoft/codecoverage/issues/221

## Changes

- Upgrade `Microsoft.Testing.Extensions.CodeCoverage` from 18.7.0 to 18.9.0.
- Keep the existing solution-level Debug/Release test flow and Release-only coverage collection.
- Check the native `dotnet test` exit code before running later PowerShell commands.
- Fail when the coverage results directory or raw reports are missing.
- Check ReportGenerator setup and execution exit codes.
- Require the merged `Cobertura.xml` to exist and contain at least one coverable line before artifact/Codecov upload.

## Validation

Reproduced the defect locally under the GitHub Actions build condition:

- 18.7.0 + `GITHUB_ACTIONS=true`: 181-byte Cobertura report, 0 valid lines.
- 18.9.0 + `GITHUB_ACTIONS=true`: 1.62 MB report, 6,372 valid / 6,058 covered lines.

Full solution-level Release validation with `GITHUB_ACTIONS=true`:

- Restore: passed.
- Build: 0 warnings, 0 errors.
- Tests: passed.
- Four substantive raw reports plus one expected empty analyzer-only report.
- Merged report: 15,736 valid / 14,692 covered lines; 9,048 valid / 8,057 covered branches; 216 classes; 2.66 MB.
- Debug tests: 21,745 total, 0 failed.
- Workflow/MSBuild diagnostics: no errors.
- `git diff --check`: clean.