### PR TITLE
Reduce CI costs and harden approval boundaries

### DIFF
--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -26,6 +26,23 @@ Repo-specific companion to the vendored [address-pr-feedback](SKILL.md) skill. T
   has been violated on this repo specifically during PR-feedback rounds. Re-read it
   at the start of every invocation.
 
+## Approval-boundary override
+
+Touki requires separate approval for committing and pushing review fixes. Where
+the vendored core treats one publishing verb as approval for both actions, this
+overlay narrows it:
+
+- `git commit` requires an explicit commit instruction in the user's most recent
+  message.
+- `push`, `ship it`, or `send it` authorizes only pushing existing commits.
+- `update the PR` or resolving review threads authorizes only the named remote PR
+  actions; it does not authorize a prerequisite commit or push.
+- Commit, push, and PR-operation approval do not imply one another. Every action
+  performed must be explicit in the same most recent message.
+
+The latest [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes)
+always wins over examples in the vendored core.
+
 ## Updating
 
 Pull upstream changes to the core with `gh skill update address-pr-feedback`

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -28,6 +28,23 @@ Repo-specific companion to the vendored [create-pr](SKILL.md) skill. The
 - touki is the canonical repo (no `upstream` remote in the usual clone), so PRs
   target `origin/main`.
 
+## Approval-boundary override
+
+Touki requires separate approval for committing, pushing, and creating a PR.
+Where the vendored core groups these actions under one "publishing verb", this
+overlay narrows it:
+
+- `git commit` requires an explicit commit instruction in the user's most recent
+  message.
+- `push`, `ship it`, or `send it` authorizes only pushing existing commits.
+- A PR request authorizes only the named PR action; it does not authorize a
+  prerequisite commit or push.
+- Commit, push, and PR-operation approval do not imply one another. Every action
+  performed must be explicit in the same most recent message.
+
+The latest [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes)
+always wins over examples in the vendored core.
+
 ## Updating
 
 Pull upstream changes to the core with `gh skill update create-pr` (review the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -126,21 +126,44 @@ JIT-naming rule, regression thresholds) live in
 
 ## Working with the user on changes
 
-Two hard requirements, both violated on this repo before:
+Three hard requirements, all violated on this repo before:
 
-1. **Never push without explicit user approval.**
-2. **Never create a pull request without explicit user approval.**
+1. **Never create or rewrite a commit without explicit user approval.**
+2. **Never push without explicit user approval.**
+3. **Never create a pull request without explicit user approval.**
 
-Local commits are reversible and don't need approval. Anything that
-publishes to the remote or to GitHub does.
+Editing, committing, pushing, and pull-request operations are separate approval
+boundaries. A request to implement or fix something authorizes edits only. Leave
+completed changes pending and unstaged for review unless the user explicitly asks
+to stage them.
 
-### Pre-flight before any publishing tool
+### Pre-flight before any commit, push, or PR tool
 
-Re-read the **most recent user message verbatim**. The only acceptable
-approvals are an explicit publishing verb in that message: `push`,
-`commit and push`, `ship it`, `send it`, `open the PR`, `create the PR`,
-`make the PR`, or an equivalent. If the message does not contain one of
-those verbs, **stop and ask one short yes/no question.**
+Re-read the **most recent user message verbatim** before crossing each boundary.
+
+- Creating or rewriting a commit requires an explicit commit instruction in that
+  message: `commit`, `commit these changes`, `make the commit`, `commit and push`,
+  or an unambiguous equivalent that names creating a commit.
+- Pushing requires an explicit push instruction in that message: `push`,
+  `commit and push`, `ship it`, `send it`, or an equivalent.
+- Creating, editing, merging, or closing a PR requires an explicit instruction
+  for that PR action: `open the PR`, `create the PR`, `make the PR`, `edit the
+  PR`, `merge the PR`, `close the PR`, or an equivalent.
+- Approval for one boundary does not imply approval for another. In particular,
+  commit approval does not authorize a push; push approval does not authorize a
+  commit or PR action; and a PR request does not authorize a prerequisite commit
+  or push.
+
+If the message does not authorize the exact boundary, **stop and ask one short
+yes/no question.**
+
+Tools and commands that count as **commit or history rewrite** (require commit
+approval):
+
+- Terminal: `git commit` (including `--amend`), `git merge`, `git cherry-pick`,
+  `git revert`, and `git rebase`.
+- Any tool that creates or rewrites a local commit, even if it does not invoke
+  `git commit` by name.
 
 Tools that count as **push** (require approval):
 
@@ -160,10 +183,9 @@ approval):
   `mcp_io_github_git_merge_pull_request`,
   `github-pull-request_create_pull_request`.
 
-### Phrasings that are NOT approval
+### Phrasings with limited or no approval
 
-None of these authorize a push or a PR. They have all been
-mistaken for it on this repo:
+These have all been interpreted too broadly on this repo:
 
 - "address the review comments" / "fix the comments" / "look at the
   comments" - edit-only.
@@ -172,6 +194,10 @@ mistaken for it on this repo:
 - "fix the CI failure" / "the PR is failing" - diagnosis or local
   fix, not a push.
 - "pull main and work on X" - authorizes the work only.
+- "looks good" / "that works" - feedback, not permission to commit.
+- "push it" / "ship it" / "open the PR" when changes are still pending -
+  approval only for the named action, not permission to create a prerequisite
+  commit or perform another boundary action.
 
 When in doubt, ask one short yes/no question.
 
@@ -185,16 +211,24 @@ When in doubt, ask one short yes/no question.
    before the first push, unless the user says otherwise.
 2. Edit.
 3. Validate (`dotnet build`, `dotnet test -c Release`).
-4. Stage by path and commit locally whenever the change is coherent;
-   local commits are reversible and don't need approval.
-5. **Stop.** Describe the change and show or summarize the diff.
-   **On explicit publish verb**, push or PR. If unsure, ask.
+4. Leave the changes pending and unstaged. Describe the change and show or
+  summarize the diff, then **stop** for review.
+5. **On explicit commit approval**, stage by path and create only the approved
+  commit. Commit approval does not authorize a push.
+6. **On explicit push approval**, push only the approved commits. Push approval
+  does not authorize a PR operation.
+7. **On explicit PR-operation approval**, perform only the named PR action. If
+  the branch needs an unapproved commit or push first, stop and ask.
 
 ### After a violation
 
-Acknowledge directly without minimizing. **Do not push a follow-up
-"fix" commit without explicit approval** - that compounds the
-failure. The user decides whether to revert, force-push, or leave it.
+Acknowledge directly without minimizing. If an unauthorized local commit is the
+current unpushed `HEAD`, verify that fact, then ask for explicit approval before
+uncommitting that revision while preserving its changes in the working tree.
+Never erase the changes. If the commit was pushed or is not the current `HEAD`,
+stop and let the user decide whether to revert, rewrite, or leave it. **Do not
+create or push a follow-up "fix" commit without explicit approval** - that
+compounds the failure.
 
 ### Other rules
 
@@ -212,18 +246,20 @@ failure. The user decides whether to revert, force-push, or leave it.
 Autopilot, or with `chat.tools.global.autoApprove` enabled. The agent
 cannot tell from inside a session which mode is active. **Assume the
 mechanical backstops below may be disabled** and self-enforce the rule
-above on every publishing tool. The agent's pre-flight check is the
+above on every commit and publishing tool. The agent's pre-flight check is the
 only guard that works in every configuration.
 
 - **Terminal (VS Code Copilot agent mode).** [.vscode/settings.json](../.vscode/settings.json)
   contains a denylist (`chat.tools.terminal.autoApprove` with `false`
-  entries) for `git push`, `git reset --hard`, `git rebase`, `git merge`,
-  `git cherry-pick`, `git tag`, destructive `git branch -d/-D`, and
-  `gh pr create|merge|close|edit`. In Default Approvals mode each
-  denied command requires an in-chat **Allow** click; that click is
-  the approval. **In Bypass Approvals or Autopilot, this denylist is
+  entries) for `git commit`, `git push`, `git reset`, `git rebase`,
+  `git merge`, `git cherry-pick`, `git revert`, `git tag`, destructive
+  `git branch -d/-D`, and `gh pr create|merge|close|edit`. In Default
+  Approvals mode each denied command requires an in-chat **Allow** click.
+  That click is defense-in-depth only; it does not replace the explicit
+  commit or publishing instruction required in the latest user message.
+  **In Bypass Approvals or Autopilot, this denylist is
   ignored at runtime** - the entries remain as documentation of
-  which commands cross the publish boundary, and as a defense-in-depth
+  which commands cross a commit or publish boundary, and as a defense-in-depth
   tripwire for contributors and agents who *are* in Default Approvals
   mode. Do not rely on the denylist to stop you.
 - **MCP and in-process tools are NOT covered by
@@ -247,11 +283,11 @@ only guard that works in every configuration.
   direct writes to `main` itself.
 
 The agent's pre-flight check (re-read the user's most recent message
-verbatim and confirm it contains an explicit publishing verb) is
-load-bearing. If the message does not contain such a verb, stop and ask
-one short yes/no question. Do not assume the user "obviously" wants the
-change published, and do not assume an approval prompt will appear to
-catch a mistake.
+verbatim and confirm it authorizes the exact commit or publishing boundary)
+is load-bearing. If the message does not contain that authorization, stop and
+ask one short yes/no question. Do not assume the user "obviously" wants the
+change committed or published, and do not assume an approval prompt will
+appear to catch a mistake.
 
 ## General guidance
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -160,8 +160,8 @@ yes/no question.**
 Tools and commands that count as **commit or history rewrite** (require commit
 approval):
 
-- Terminal: `git commit` (including `--amend`), `git merge`, `git cherry-pick`,
-  `git revert`, and `git rebase`.
+- Terminal: `git commit` (including `--amend`), `git reset`, `git merge`,
+  `git cherry-pick`, `git revert`, and `git rebase`.
 - Any tool that creates or rewrites a local commit, even if it does not invoke
   `git commit` by name.
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,3 @@
-# This workflow will build a .NET project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
-
 name: .NET
 
 on:
@@ -9,203 +6,78 @@ on:
   push:
     branches: [ "main" ]
 
-# Cancel in-flight runs when a force-push to a PR supersedes them. Pushes
-# to `main` are NOT queued: `github.head_ref` is empty for non-PR events,
-# so the group expression falls through to `github.run_id`, which is
-# unique per run. That keeps back-to-back merges into `main` running in
-# parallel instead of serializing behind each other.
+# Cancel superseded PR runs. Pushes to main use the unique run id and continue independently.
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # The Windows build runs Debug and Release on two parallel runners.
-  # Coverage, pack, and Codecov are Release-only and gated by `matrix.configuration`.
-  # The `build` aggregator below depends on this matrix plus the macOS, Linux,
-  # and ARM64 (Windows and Linux) jobs and keeps the `.NET / build`
-  # status-check name stable for branch protection.
-  build-matrix:
-    name: ".NET / build (Windows / ${{ matrix.configuration }})"
-    runs-on: windows-latest
+  # Linux ARM64 is cheaper than standard Linux and Windows, so it owns the full
+  # Debug/Release x net10.0/net11.0 matrix. Release/net10.0 also performs the
+  # full-solution build, package checks, auxiliary tests, and coverage upload.
+  linux-arm64:
     strategy:
       fail-fast: false
       matrix:
         configuration: [Debug, Release]
-    env:
-      # Co-locate the NuGet cache inside the workspace so actions/cache can
-      # restore/save it reliably on every OS, avoiding ~/.nuget path quirks
-      # under non-bash shells.
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+        tfm: [net10.0, net11.0]
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: ubuntu-24.04-arm
+      platform-name: Linux ARM64
+      artifact-name: linux-arm64-${{ matrix.configuration }}-${{ matrix.tfm }}
+      configuration: ${{ matrix.configuration }}
+      tfm: ${{ matrix.tfm }}
+      anycpu: true
+      linux-desktop: true
+      full-validation: ${{ matrix.configuration == 'Release' && matrix.tfm == 'net10.0' }}
+      collect-coverage: ${{ matrix.configuration == 'Release' && matrix.tfm == 'net10.0' }}
+      pack: ${{ matrix.configuration == 'Release' && matrix.tfm == 'net10.0' }}
+    secrets: inherit
 
-    steps:
-    - uses: actions/checkout@v5
-      with: { fetch-depth: 0 }
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-    - name: Restore dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration ${{ matrix.configuration }} --no-restore
-    - name: Pack
-      if: matrix.configuration == 'Release'
-      run: dotnet pack --configuration Release --no-build -o ./artifacts/packages
-    - name: Verify packages are architecture neutral
-      if: matrix.configuration == 'Release'
-      # touki and touki.testsupport are pure-IL libraries with no native
-      # components and must load on any CPU architecture (x64, ARM64, ...).
-      # touki.slnx maps them to Platform=AnyCPU even though the rest of the
-      # solution defaults to x64 (see Directory.Build.props); this guards
-      # against that mapping regressing.
-      run: |
-        Get-ChildItem ./artifacts/packages -Filter *.nupkg | ForEach-Object {
-          pwsh tools/Test-PackageArchitectureNeutral.ps1 -PackagePath $_.FullName
-        }
-    - name: Test
-      run: |
-        $configuration = '${{ matrix.configuration }}'
-        $resultsDir = Join-Path $PWD.Path "artifacts/test-results/$($configuration.ToLower())"
-        New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+  # Keep one Windows x64 smoke leg for platform-specific behavior. The complete
+  # Windows matrix is available through the manually dispatched workflow.
+  windows:
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: windows-latest
+      platform-name: Windows x64
+      artifact-name: windows-release-net10.0
+      configuration: Release
+      tfm: net10.0
+      additional-tfm: net481
 
-        # Coverage is Release-only: instrumentation slows tests and Codecov consumes one merged run.
-        $extraArgs = @()
-        if ($configuration -eq 'Release') {
-          $extraArgs = @(
-            '--coverage',
-            '--coverage-output-format', 'cobertura',
-            '--coverage-settings', "$PWD/.config/coverage.settings.xml"
-          )
-        }
+  # Keep one native Windows ARM64 smoke leg, also limited to the supported net10.0 baseline.
+  windows-arm64:
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: windows-11-arm
+      platform-name: Windows ARM64
+      artifact-name: windows-arm64-release-net10.0
+      configuration: Release
+      tfm: net10.0
+      anycpu: true
 
-        dotnet test -c $configuration --no-build `
-          -p:TestingPlatformCaptureOutput=false `
-          --results-directory "$resultsDir" `
-          --report-trx `
-          --output Detailed `
-          @extraArgs
-
-        if ($LASTEXITCODE -ne 0) {
-          throw "Tests failed with exit code $LASTEXITCODE."
-        }
-    - name: Generate coverage report
-      if: matrix.configuration == 'Release'
-      run: |
-        $reportGeneratorVersion = '5.5.9'
-        if (dotnet tool list -g | Select-String -SimpleMatch 'dotnet-reportgenerator-globaltool') {
-          dotnet tool update -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
-        }
-        else {
-          dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
-        }
-
-        if ($LASTEXITCODE -ne 0) {
-          throw "ReportGenerator setup failed with exit code $LASTEXITCODE."
-        }
-
-        $resultsDir = 'artifacts/test-results/release'
-        if (-not (Test-Path $resultsDir)) {
-          throw "Coverage results directory '$resultsDir' was not created."
-        }
-
-        $reports = @(
-          Get-ChildItem -Path $resultsDir -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
-            ForEach-Object { $_.FullName }
-        )
-        if ($reports.Count -eq 0) {
-          throw 'No Cobertura reports found; coverage collection failed.'
-        }
-        $reportsArg = ($reports -join ';')
-        New-Item -ItemType Directory -Force -Path artifacts/coverage | Out-Null
-        reportgenerator `
-          "-reports:$reportsArg" `
-          -targetdir:artifacts/coverage `
-          -reporttypes:'Cobertura;HtmlInline;MarkdownSummaryGithub' `
-          -classfilters:'-Touki.Resources.SR;-Touki.Framework.Resources.SRF' `
-          -title:'touki'
-
-        if ($LASTEXITCODE -ne 0) {
-          throw "ReportGenerator failed with exit code $LASTEXITCODE."
-        }
-
-        $coveragePath = 'artifacts/coverage/Cobertura.xml'
-        if (-not (Test-Path $coveragePath)) {
-          throw "ReportGenerator did not create '$coveragePath'."
-        }
-
-        [xml] $coverage = Get-Content -Raw $coveragePath
-        $linesValid = [int] $coverage.coverage.'lines-valid'
-        if ($linesValid -le 0) {
-          throw 'The merged Cobertura report contains no coverable lines.'
-        }
-
-        Write-Host "Merged coverage report: $linesValid coverable lines"
-
-        $summaryPath = 'artifacts/coverage/SummaryGithub.md'
-        if (Test-Path $summaryPath) {
-          Get-Content $summaryPath |
-            Add-Content -Path $env:GITHUB_STEP_SUMMARY
-        }
-    - name: Upload coverage report
-      if: matrix.configuration == 'Release'
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report
-        path: artifacts/coverage
-        if-no-files-found: warn
-        retention-days: 14
-    - name: Upload coverage to Codecov
-      if: matrix.configuration == 'Release'
-      uses: codecov/codecov-action@v5
-      with:
-        files: artifacts/coverage/Cobertura.xml
-        # Coverage upload is informational and must not gate the build. The
-        # Codecov uploader has an intermittent sha256/GPG signature race on the
-        # CDN that hard-fails otherwise unrelated PRs (Codecov-side bug, "no
-        # security issue" per the maintainers):
-        # https://github.com/codecov/codecov-action/issues/1940
-        fail_ci_if_error: false
-        disable_search: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-    - name: Upload raw logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: mtp-logs-${{ matrix.configuration }}
-        path: |
-          artifacts/test-results/**/*.trx
-        if-no-files-found: warn
-        retention-days: 14
-
-  # Aggregator: preserves the `.NET / build` status-check name so branch
-  # protection on `main` doesn't have to be updated. `needs.<job>.result` is
-  # `success` only when every upstream job (and every matrix leg of
-  # `build-matrix`) succeeded; any other state fails the aggregator and
-  # (transitively) the required check.
+  # Preserve the stable required-check name while using the cheapest runner for
+  # this lightweight aggregation job.
   build:
     name: ".NET / build"
-    runs-on: ubuntu-latest
-    needs: [build-matrix, macos-build, linux-build, windows-arm64-build, linux-arm64-build]
+    runs-on: ubuntu-slim
+    needs: [linux-arm64, windows, windows-arm64]
     if: always()
     steps:
     - name: Verify upstream jobs
+      shell: bash
       run: |
         results=(
-          "build-matrix=${{ needs.build-matrix.result }}"
-          "macos-build=${{ needs.macos-build.result }}"
-          "linux-build=${{ needs.linux-build.result }}"
-          "windows-arm64-build=${{ needs.windows-arm64-build.result }}"
-          "linux-arm64-build=${{ needs.linux-arm64-build.result }}"
+          "linux-arm64=${{ needs.linux-arm64.result }}"
+          "windows=${{ needs.windows.result }}"
+          "windows-arm64=${{ needs.windows-arm64.result }}"
         )
         failed=0
-        for r in "${results[@]}"; do
-          echo "$r"
-          case "$r" in
+        for result in "${results[@]}"; do
+          echo "$result"
+          case "$result" in
             *=success) ;;
             *) failed=1 ;;
           esac
@@ -214,220 +86,3 @@ jobs:
           echo "::error::One or more upstream jobs did not succeed."
           exit 1
         fi
-
-  macos-build:
-    name: ".NET / build (macOS / Release / ${{ matrix.tfm }})"
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        tfm: [net10.0, net11.0]
-
-    # The repo pins Platform=x64 in Directory.Build.props for the Windows-focused
-    # main dev/test build, which embeds AMD64 in the managed assembly's COFF
-    # header. touki.slnx maps the two NuGet-shipped projects (touki and
-    # touki.testsupport) to Platform=AnyCPU so the published packages stay
-    # architecture neutral, but touki.tests is still an x64-default
-    # executable (Microsoft.Testing.Platform host), and PlatformTarget follows
-    # $(Platform) for Exe outputs. The macOS GitHub-hosted runner is Apple
-    # Silicon (osx-arm64) and the .NET host refuses to load an AMD64-tagged
-    # executable. Building this job's test project as AnyCPU produces an
-    # architecture-neutral executable that loads on any host. The same
-    # pattern is reused by windows-arm64-build and linux-arm64-build below.
-    env:
-      _PlatformArgs: "-p:Platform=AnyCPU -p:Platforms=AnyCPU"
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
-    steps:
-    - uses: actions/checkout@v5
-      with: { fetch-depth: 0 }
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-    - name: Restore
-      run: dotnet restore touki.tests/touki.tests.csproj $_PlatformArgs
-    - name: Build release
-      run: dotnet build touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-restore $_PlatformArgs
-    - name: Test release
-      run: |
-        resultsDir="$PWD/artifacts/test-results/macos-release-${{ matrix.tfm }}"
-        mkdir -p "$resultsDir"
-
-        dotnet test touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-build \
-          $_PlatformArgs \
-          -p:TestingPlatformCaptureOutput=false \
-          --results-directory "$resultsDir" \
-          --report-trx \
-          --output Detailed
-    - name: Upload raw logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: mtp-logs-macos-${{ matrix.tfm }}
-        path: |
-          artifacts/test-results/**/*.trx
-        if-no-files-found: warn
-        retention-days: 14
-
-  linux-build:
-    name: ".NET / build (Linux / Release / ${{ matrix.tfm }})"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        tfm: [net10.0, net11.0]
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
-    steps:
-    - uses: actions/checkout@v5
-      with: { fetch-depth: 0 }
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-    - name: Install xclip, Xvfb, and xauth
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends xclip xvfb xauth
-    - name: Restore
-      run: dotnet restore touki.tests/touki.tests.csproj
-    - name: Build release
-      run: dotnet build touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-restore
-    - name: Test release
-      run: |
-        resultsDir="$PWD/artifacts/test-results/linux-release-${{ matrix.tfm }}"
-        mkdir -p "$resultsDir"
-
-        xvfb-run --auto-servernum dotnet test touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-build \
-          -p:TestingPlatformCaptureOutput=false \
-          --results-directory "$resultsDir" \
-          --report-trx \
-          --output Detailed
-    - name: Upload raw logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: mtp-logs-linux-${{ matrix.tfm }}
-        path: |
-          artifacts/test-results/**/*.trx
-        if-no-files-found: warn
-        retention-days: 14
-
-  windows-arm64-build:
-    name: ".NET / build (Windows ARM64 / Release / ${{ matrix.tfm }})"
-    runs-on: windows-11-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        tfm: [net10.0, net11.0]
-    env:
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
-    steps:
-    - uses: actions/checkout@v5
-      with: { fetch-depth: 0 }
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-    # This is a native ARM64 Windows runner: touki.tests defaults to x64 (see
-    # macos-build's comment above for why), which won't load here either.
-    # Build it as AnyCPU instead.
-    - name: Restore
-      run: |
-        $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
-        dotnet restore touki.tests/touki.tests.csproj @platformArgs
-    - name: Build release
-      run: |
-        $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
-        dotnet build touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-restore @platformArgs
-    - name: Test release
-      run: |
-        $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
-        $resultsDir = Join-Path $PWD.Path "artifacts/test-results/windows-arm64-release-${{ matrix.tfm }}"
-        New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
-
-        dotnet test touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-build `
-          @platformArgs `
-          -p:TestingPlatformCaptureOutput=false `
-          --results-directory "$resultsDir" `
-          --report-trx `
-          --output Detailed
-    - name: Upload raw logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: mtp-logs-windows-arm64-${{ matrix.tfm }}
-        path: |
-          artifacts/test-results/**/*.trx
-        if-no-files-found: warn
-        retention-days: 14
-
-  linux-arm64-build:
-    name: ".NET / build (Linux ARM64 / Release / ${{ matrix.tfm }})"
-    runs-on: ubuntu-24.04-arm
-    strategy:
-      fail-fast: false
-      matrix:
-        tfm: [net10.0, net11.0]
-    env:
-      _PlatformArgs: "-p:Platform=AnyCPU -p:Platforms=AnyCPU"
-      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
-
-    steps:
-    - uses: actions/checkout@v5
-      with: { fetch-depth: 0 }
-    - name: Cache NuGet packages
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.NUGET_PACKAGES }}
-        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v5
-    - name: Install xclip, Xvfb, and xauth
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends xclip xvfb xauth
-    - name: Restore
-      run: dotnet restore touki.tests/touki.tests.csproj $_PlatformArgs
-    - name: Build release
-      run: dotnet build touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-restore $_PlatformArgs
-    - name: Test release
-      run: |
-        resultsDir="$PWD/artifacts/test-results/linux-arm64-release-${{ matrix.tfm }}"
-        mkdir -p "$resultsDir"
-
-        xvfb-run --auto-servernum dotnet test touki.tests/touki.tests.csproj -c Release -f ${{ matrix.tfm }} --no-build \
-          $_PlatformArgs \
-          -p:TestingPlatformCaptureOutput=false \
-          --results-directory "$resultsDir" \
-          --report-trx \
-          --output Detailed
-    - name: Upload raw logs
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: mtp-logs-linux-arm64-${{ matrix.tfm }}
-        path: |
-          artifacts/test-results/**/*.trx
-        if-no-files-found: warn
-        retention-days: 14

--- a/.github/workflows/manual-linux.yml
+++ b/.github/workflows/manual-linux.yml
@@ -1,0 +1,41 @@
+name: .NET - Full Linux Matrix
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Release]
+        tfm: [net10.0, net11.0]
+        runner:
+          - label: ubuntu-slim
+            platform: Linux Slim x64
+            artifact: linux-slim
+            anycpu: false
+            desktop: false
+          - label: ubuntu-latest
+            platform: Linux x64
+            artifact: linux-x64
+            anycpu: false
+            desktop: true
+          - label: ubuntu-24.04-arm
+            platform: Linux ARM64
+            artifact: linux-arm64
+            anycpu: true
+            desktop: true
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: ${{ matrix.runner.label }}
+      platform-name: ${{ matrix.runner.platform }}
+      artifact-name: ${{ matrix.runner.artifact }}-${{ matrix.configuration }}-${{ matrix.tfm }}
+      configuration: ${{ matrix.configuration }}
+      tfm: ${{ matrix.tfm }}
+      anycpu: ${{ matrix.runner.anycpu }}
+      linux-desktop: ${{ matrix.runner.desktop }}

--- a/.github/workflows/manual-macos.yml
+++ b/.github/workflows/manual-macos.yml
@@ -1,0 +1,31 @@
+name: .NET - Full macOS Matrix
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Release]
+        tfm: [net10.0, net11.0]
+        runner:
+          - label: macos-latest
+            platform: macOS ARM64
+            artifact: macos-arm64
+          - label: macos-15-intel
+            platform: macOS Intel
+            artifact: macos-intel
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: ${{ matrix.runner.label }}
+      platform-name: ${{ matrix.runner.platform }}
+      artifact-name: ${{ matrix.runner.artifact }}-${{ matrix.configuration }}-${{ matrix.tfm }}
+      configuration: ${{ matrix.configuration }}
+      tfm: ${{ matrix.tfm }}
+      anycpu: true

--- a/.github/workflows/manual-windows.yml
+++ b/.github/workflows/manual-windows.yml
@@ -1,0 +1,46 @@
+name: .NET - Full Windows Matrix
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  modern-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Release]
+        tfm: [net10.0, net11.0]
+        runner:
+          - label: windows-latest
+            platform: Windows x64
+            artifact: windows-x64
+            anycpu: false
+          - label: windows-11-arm
+            platform: Windows ARM64
+            artifact: windows-arm64
+            anycpu: true
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: ${{ matrix.runner.label }}
+      platform-name: ${{ matrix.runner.platform }}
+      artifact-name: ${{ matrix.runner.artifact }}-${{ matrix.configuration }}-${{ matrix.tfm }}
+      configuration: ${{ matrix.configuration }}
+      tfm: ${{ matrix.tfm }}
+      anycpu: ${{ matrix.runner.anycpu }}
+
+  net-framework:
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Debug, Release]
+    uses: ./.github/workflows/platform-tests.yml
+    with:
+      runner: windows-latest
+      platform-name: Windows x64
+      artifact-name: windows-x64-${{ matrix.configuration }}-net481
+      configuration: ${{ matrix.configuration }}
+      tfm: net481

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -333,7 +333,13 @@ jobs:
       shell: pwsh
       run: |
         $reportGeneratorVersion = '5.5.9'
-        dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        if (dotnet tool list -g | Select-String -SimpleMatch 'dotnet-reportgenerator-globaltool') {
+          dotnet tool update -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        }
+        else {
+          dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        }
+
         if ($LASTEXITCODE -ne 0) {
           throw "ReportGenerator setup failed with exit code $LASTEXITCODE."
         }

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -1,0 +1,394 @@
+name: Platform Tests
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      platform-name:
+        required: true
+        type: string
+      artifact-name:
+        required: true
+        type: string
+      tfm:
+        required: true
+        type: string
+      additional-tfm:
+        default: ''
+        type: string
+      configuration:
+        required: true
+        type: string
+      anycpu:
+        default: false
+        type: boolean
+      linux-desktop:
+        default: false
+        type: boolean
+      full-validation:
+        default: false
+        type: boolean
+      collect-coverage:
+        default: false
+        type: boolean
+      pack:
+        default: false
+        type: boolean
+    secrets:
+      CODECOV_TOKEN:
+        required: false
+
+jobs:
+  test:
+    name: "${{ inputs.platform-name }} / ${{ inputs.configuration }} / ${{ inputs.tfm }}"
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 30
+    env:
+      NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
+
+    steps:
+    - uses: actions/checkout@v5
+      with: { fetch-depth: 0 }
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.NUGET_PACKAGES }}
+        key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('**/*.csproj', 'Directory.Packages.props', 'Directory.Build.props', 'Directory.Build.targets', 'global.json') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-nuget-
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v5
+    - name: Install Linux desktop dependencies
+      if: inputs.linux-desktop
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends xclip xvfb xauth
+    - name: Restore
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        if ('${{ inputs.full-validation }}' -eq 'true') {
+          dotnet restore
+          if ($LASTEXITCODE -ne 0) {
+            throw "Solution restore failed with exit code $LASTEXITCODE."
+          }
+        }
+        else {
+          dotnet restore touki.tests/touki.tests.csproj @platformArgs
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "Restore failed with exit code $LASTEXITCODE."
+        }
+    - name: Build
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        if ('${{ inputs.full-validation }}' -eq 'true') {
+          # Compile the complete solution on its declared x64 platform. ARM jobs
+          # rebuild only the executable test hosts as AnyCPU below.
+          dotnet build --configuration '${{ inputs.configuration }}' --no-restore
+          if ($LASTEXITCODE -ne 0) {
+            throw "Solution build failed with exit code $LASTEXITCODE."
+          }
+
+          if ($platformArgs.Count -gt 0) {
+            foreach ($project in @(
+              'touki.tests/touki.tests.csproj',
+              'touki.analyzers.tests/touki.analyzers.tests.csproj',
+              'touki.aot.tests/touki.aot.tests.csproj'
+            )) {
+              dotnet restore $project @platformArgs
+              if ($LASTEXITCODE -ne 0) {
+                throw "Restore for '$project' failed with exit code $LASTEXITCODE."
+              }
+            }
+
+            dotnet build touki.tests/touki.tests.csproj `
+              --configuration '${{ inputs.configuration }}' `
+              --framework '${{ inputs.tfm }}' `
+              --no-restore `
+              @platformArgs
+            if ($LASTEXITCODE -ne 0) {
+              throw "touki.tests build failed with exit code $LASTEXITCODE."
+            }
+
+            dotnet build touki.analyzers.tests/touki.analyzers.tests.csproj `
+              --configuration '${{ inputs.configuration }}' `
+              --framework net10.0 `
+              --no-restore `
+              @platformArgs
+            if ($LASTEXITCODE -ne 0) {
+              throw "touki.analyzers.tests build failed with exit code $LASTEXITCODE."
+            }
+
+            dotnet build touki.aot.tests/touki.aot.tests.csproj `
+              --configuration '${{ inputs.configuration }}' `
+              --framework net10.0 `
+              --no-restore `
+              @platformArgs
+            if ($LASTEXITCODE -ne 0) {
+              throw "touki.aot.tests build failed with exit code $LASTEXITCODE."
+            }
+          }
+        }
+        else {
+          dotnet build touki.tests/touki.tests.csproj `
+            --configuration '${{ inputs.configuration }}' `
+            --framework '${{ inputs.tfm }}' `
+            --no-restore `
+            @platformArgs
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "Build failed with exit code $LASTEXITCODE."
+        }
+    - name: Test
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        $resultsDir = Join-Path $PWD.Path 'artifacts/test-results/${{ inputs.artifact-name }}'
+        New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+        $testArgs = @(
+          'test', 'touki.tests/touki.tests.csproj',
+          '--configuration', '${{ inputs.configuration }}',
+          '--framework', '${{ inputs.tfm }}',
+          '--no-build'
+        )
+        $testArgs += $platformArgs
+        $testArgs += @(
+          '-p:TestingPlatformCaptureOutput=false',
+          '--results-directory', $resultsDir,
+          '--report-trx',
+          '--output', 'Detailed'
+        )
+
+        if ('${{ inputs.collect-coverage }}' -eq 'true') {
+          $testArgs += @(
+            '--coverage',
+            '--coverage-output-format', 'cobertura',
+            '--coverage-settings', "$PWD/.config/coverage.settings.xml"
+          )
+        }
+
+        if ('${{ inputs.linux-desktop }}' -eq 'true') {
+          & xvfb-run --auto-servernum dotnet @testArgs
+        }
+        else {
+          & dotnet @testArgs
+        }
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "Tests failed with exit code $LASTEXITCODE."
+        }
+    - name: Build additional target framework
+      if: inputs.additional-tfm != ''
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        dotnet build touki.tests/touki.tests.csproj `
+          --configuration '${{ inputs.configuration }}' `
+          --framework '${{ inputs.additional-tfm }}' `
+          --no-restore `
+          @platformArgs
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "Build for '${{ inputs.additional-tfm }}' failed with exit code $LASTEXITCODE."
+        }
+    - name: Test additional target framework
+      if: inputs.additional-tfm != ''
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        $resultsDir = Join-Path $PWD.Path `
+          'artifacts/test-results/${{ inputs.artifact-name }}/${{ inputs.additional-tfm }}'
+        New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+
+        dotnet test touki.tests/touki.tests.csproj `
+          --configuration '${{ inputs.configuration }}' `
+          --framework '${{ inputs.additional-tfm }}' `
+          --no-build `
+          @platformArgs `
+          -p:TestingPlatformCaptureOutput=false `
+          --results-directory $resultsDir `
+          --report-trx `
+          --output Detailed
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "Tests for '${{ inputs.additional-tfm }}' failed with exit code $LASTEXITCODE."
+        }
+    - name: Test auxiliary projects
+      if: inputs.full-validation
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        $projects = @(
+          'touki.analyzers.tests/touki.analyzers.tests.csproj',
+          'touki.aot.tests/touki.aot.tests.csproj'
+        )
+
+        foreach ($project in $projects) {
+          $extraArgs = @()
+          if ('${{ inputs.collect-coverage }}' -eq 'true' -and $project -like 'touki.aot.tests/*') {
+            $extraArgs = @(
+              '--coverage',
+              '--coverage-output-format', 'cobertura',
+              '--coverage-settings', "$PWD/.config/coverage.settings.xml"
+            )
+          }
+
+          dotnet test $project `
+            --configuration '${{ inputs.configuration }}' `
+            --framework net10.0 `
+            --no-build `
+            @platformArgs `
+            -p:TestingPlatformCaptureOutput=false `
+            --results-directory 'artifacts/test-results/${{ inputs.artifact-name }}' `
+            --report-trx `
+            --output Detailed `
+            @extraArgs
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Tests for '$project' failed with exit code $LASTEXITCODE."
+          }
+        }
+    - name: Pack
+      if: inputs.pack
+      shell: pwsh
+      run: |
+        $platformArgs = @()
+        if ('${{ inputs.anycpu }}' -eq 'true') {
+          $platformArgs = @('-p:Platform=AnyCPU', '-p:Platforms=AnyCPU')
+        }
+
+        $projects = @(
+          'touki/touki.csproj',
+          'touki.testsupport/touki.testsupport.csproj'
+        )
+        foreach ($project in $projects) {
+          dotnet pack $project `
+            --configuration '${{ inputs.configuration }}' `
+            --output ./artifacts/packages `
+            @platformArgs
+
+          if ($LASTEXITCODE -ne 0) {
+            throw "Pack for '$project' failed with exit code $LASTEXITCODE."
+          }
+        }
+    - name: Verify packages are architecture neutral
+      if: inputs.pack
+      shell: pwsh
+      run: |
+        $packages = @(Get-ChildItem ./artifacts/packages -Filter *.nupkg)
+        $expectedPackages = @{
+          'KlutzyNinja.Touki' = '^KlutzyNinja\.Touki\.\d.*\.nupkg$'
+          'KlutzyNinja.Touki.TestSupport' = '^KlutzyNinja\.Touki\.TestSupport\.\d.*\.nupkg$'
+        }
+
+        if ($packages.Count -ne $expectedPackages.Count) {
+          throw "Expected $($expectedPackages.Count) packages, found $($packages.Count)."
+        }
+
+        foreach ($expected in $expectedPackages.GetEnumerator()) {
+          $matches = @($packages | Where-Object Name -Match $expected.Value)
+          if ($matches.Count -ne 1) {
+            throw "Expected exactly one '$($expected.Key)' package, found $($matches.Count)."
+          }
+
+          pwsh tools/Test-PackageArchitectureNeutral.ps1 -PackagePath $matches[0].FullName
+          if ($LASTEXITCODE -ne 0) {
+            throw "Architecture validation failed for '$($matches[0].Name)'."
+          }
+        }
+    - name: Generate coverage report
+      if: inputs.collect-coverage
+      shell: pwsh
+      run: |
+        $reportGeneratorVersion = '5.5.9'
+        dotnet tool install -g dotnet-reportgenerator-globaltool --version $reportGeneratorVersion
+        if ($LASTEXITCODE -ne 0) {
+          throw "ReportGenerator setup failed with exit code $LASTEXITCODE."
+        }
+
+        $resultsDir = 'artifacts/test-results/${{ inputs.artifact-name }}'
+        $reports = @(
+          Get-ChildItem -Path $resultsDir -Recurse -Filter '*.cobertura.xml' -ErrorAction SilentlyContinue |
+            ForEach-Object { $_.FullName }
+        )
+        if ($reports.Count -eq 0) {
+          throw 'No Cobertura reports found; coverage collection failed.'
+        }
+
+        New-Item -ItemType Directory -Force -Path artifacts/coverage | Out-Null
+        reportgenerator `
+          "-reports:$($reports -join ';')" `
+          -targetdir:artifacts/coverage `
+          -reporttypes:'Cobertura;HtmlInline;MarkdownSummaryGithub' `
+          -classfilters:'-Touki.Resources.SR;-Touki.Framework.Resources.SRF' `
+          -title:'touki'
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "ReportGenerator failed with exit code $LASTEXITCODE."
+        }
+
+        [xml] $coverage = Get-Content -Raw artifacts/coverage/Cobertura.xml
+        if ([int] $coverage.coverage.'lines-valid' -le 0) {
+          throw 'The merged Cobertura report contains no coverable lines.'
+        }
+
+        if (Test-Path artifacts/coverage/SummaryGithub.md) {
+          Get-Content artifacts/coverage/SummaryGithub.md |
+            Add-Content -Path $env:GITHUB_STEP_SUMMARY
+        }
+    - name: Upload coverage report
+      if: inputs.collect-coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: artifacts/coverage
+        if-no-files-found: warn
+        retention-days: 14
+    - name: Upload coverage to Codecov
+      if: inputs.collect-coverage
+      uses: codecov/codecov-action@v5
+      with:
+        files: artifacts/coverage/Cobertura.xml
+        fail_ci_if_error: false
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}
+    - name: Upload raw logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: mtp-logs-${{ inputs.artifact-name }}
+        path: artifacts/test-results/**/*.trx
+        if-no-files-found: warn
+        retention-days: 14

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,17 +13,19 @@
       "slnx",
       "Touki"
     ],
-    // Publish-boundary enforcement for Copilot agent-mode terminal calls.
+    // Commit- and publish-boundary enforcement for Copilot agent-mode terminal calls.
     // See AGENTS.md "Working with the user on changes". Deny entries force an
     // explicit in-chat Allow click before the command runs; allow entries keep
     // routine read-only git verbs frictionless.
     "chat.tools.terminal.autoApprove": {
         "/^git\\s+(status|diff|log|show|branch|stash\\s+list|rev-parse|ls-files|config\\s+--get)\\b/": true,
+        "/^git\\s+commit\\b/": false,
         "/^git\\s+push\\b/": false,
-        "/^git\\s+reset\\s+--hard\\b/": false,
+        "/^git\\s+reset\\b/": false,
         "/^git\\s+rebase\\b/": false,
         "/^git\\s+merge\\b/": false,
         "/^git\\s+cherry-pick\\b/": false,
+        "/^git\\s+revert\\b/": false,
         "/^git\\s+tag\\b/": false,
         "/^git\\s+branch\\s+-[dD]\\b/": false,
         "/^gh\\s+pr\\s+(create|merge|close|edit)\\b/": false,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,21 +125,44 @@ JIT-naming rule, regression thresholds) live in
 
 ## Working with the user on changes
 
-Two hard requirements, both violated on this repo before:
+Three hard requirements, all violated on this repo before:
 
-1. **Never push without explicit user approval.**
-2. **Never create a pull request without explicit user approval.**
+1. **Never create or rewrite a commit without explicit user approval.**
+2. **Never push without explicit user approval.**
+3. **Never create a pull request without explicit user approval.**
 
-Local commits are reversible and don't need approval. Anything that
-publishes to the remote or to GitHub does.
+Editing, committing, pushing, and pull-request operations are separate approval
+boundaries. A request to implement or fix something authorizes edits only. Leave
+completed changes pending and unstaged for review unless the user explicitly asks
+to stage them.
 
-### Pre-flight before any publishing tool
+### Pre-flight before any commit, push, or PR tool
 
-Re-read the **most recent user message verbatim**. The only acceptable
-approvals are an explicit publishing verb in that message: `push`,
-`commit and push`, `ship it`, `send it`, `open the PR`, `create the PR`,
-`make the PR`, or an equivalent. If the message does not contain one of
-those verbs, **stop and ask one short yes/no question.**
+Re-read the **most recent user message verbatim** before crossing each boundary.
+
+- Creating or rewriting a commit requires an explicit commit instruction in that
+  message: `commit`, `commit these changes`, `make the commit`, `commit and push`,
+  or an unambiguous equivalent that names creating a commit.
+- Pushing requires an explicit push instruction in that message: `push`,
+  `commit and push`, `ship it`, `send it`, or an equivalent.
+- Creating, editing, merging, or closing a PR requires an explicit instruction
+  for that PR action: `open the PR`, `create the PR`, `make the PR`, `edit the
+  PR`, `merge the PR`, `close the PR`, or an equivalent.
+- Approval for one boundary does not imply approval for another. In particular,
+  commit approval does not authorize a push; push approval does not authorize a
+  commit or PR action; and a PR request does not authorize a prerequisite commit
+  or push.
+
+If the message does not authorize the exact boundary, **stop and ask one short
+yes/no question.**
+
+Tools and commands that count as **commit or history rewrite** (require commit
+approval):
+
+- Terminal: `git commit` (including `--amend`), `git merge`, `git cherry-pick`,
+  `git revert`, and `git rebase`.
+- Any tool that creates or rewrites a local commit, even if it does not invoke
+  `git commit` by name.
 
 Tools that count as **push** (require approval):
 
@@ -159,10 +182,9 @@ approval):
   `mcp_io_github_git_merge_pull_request`,
   `github-pull-request_create_pull_request`.
 
-### Phrasings that are NOT approval
+### Phrasings with limited or no approval
 
-None of these authorize a push or a PR. They have all been
-mistaken for it on this repo:
+These have all been interpreted too broadly on this repo:
 
 - "address the review comments" / "fix the comments" / "look at the
   comments" - edit-only.
@@ -171,6 +193,10 @@ mistaken for it on this repo:
 - "fix the CI failure" / "the PR is failing" - diagnosis or local
   fix, not a push.
 - "pull main and work on X" - authorizes the work only.
+- "looks good" / "that works" - feedback, not permission to commit.
+- "push it" / "ship it" / "open the PR" when changes are still pending -
+  approval only for the named action, not permission to create a prerequisite
+  commit or perform another boundary action.
 
 When in doubt, ask one short yes/no question.
 
@@ -184,16 +210,24 @@ When in doubt, ask one short yes/no question.
    before the first push, unless the user says otherwise.
 2. Edit.
 3. Validate (`dotnet build`, `dotnet test -c Release`).
-4. Stage by path and commit locally whenever the change is coherent;
-   local commits are reversible and don't need approval.
-5. **Stop.** Describe the change and show or summarize the diff.
-   **On explicit publish verb**, push or PR. If unsure, ask.
+4. Leave the changes pending and unstaged. Describe the change and show or
+  summarize the diff, then **stop** for review.
+5. **On explicit commit approval**, stage by path and create only the approved
+  commit. Commit approval does not authorize a push.
+6. **On explicit push approval**, push only the approved commits. Push approval
+  does not authorize a PR operation.
+7. **On explicit PR-operation approval**, perform only the named PR action. If
+  the branch needs an unapproved commit or push first, stop and ask.
 
 ### After a violation
 
-Acknowledge directly without minimizing. **Do not push a follow-up
-"fix" commit without explicit approval** - that compounds the
-failure. The user decides whether to revert, force-push, or leave it.
+Acknowledge directly without minimizing. If an unauthorized local commit is the
+current unpushed `HEAD`, verify that fact, then ask for explicit approval before
+uncommitting that revision while preserving its changes in the working tree.
+Never erase the changes. If the commit was pushed or is not the current `HEAD`,
+stop and let the user decide whether to revert, rewrite, or leave it. **Do not
+create or push a follow-up "fix" commit without explicit approval** - that
+compounds the failure.
 
 ### Other rules
 
@@ -211,18 +245,20 @@ failure. The user decides whether to revert, force-push, or leave it.
 Autopilot, or with `chat.tools.global.autoApprove` enabled. The agent
 cannot tell from inside a session which mode is active. **Assume the
 mechanical backstops below may be disabled** and self-enforce the rule
-above on every publishing tool. The agent's pre-flight check is the
+above on every commit and publishing tool. The agent's pre-flight check is the
 only guard that works in every configuration.
 
 - **Terminal (VS Code Copilot agent mode).** [.vscode/settings.json](.vscode/settings.json)
   contains a denylist (`chat.tools.terminal.autoApprove` with `false`
-  entries) for `git push`, `git reset --hard`, `git rebase`, `git merge`,
-  `git cherry-pick`, `git tag`, destructive `git branch -d/-D`, and
-  `gh pr create|merge|close|edit`. In Default Approvals mode each
-  denied command requires an in-chat **Allow** click; that click is
-  the approval. **In Bypass Approvals or Autopilot, this denylist is
+  entries) for `git commit`, `git push`, `git reset`, `git rebase`,
+  `git merge`, `git cherry-pick`, `git revert`, `git tag`, destructive
+  `git branch -d/-D`, and `gh pr create|merge|close|edit`. In Default
+  Approvals mode each denied command requires an in-chat **Allow** click.
+  That click is defense-in-depth only; it does not replace the explicit
+  commit or publishing instruction required in the latest user message.
+  **In Bypass Approvals or Autopilot, this denylist is
   ignored at runtime** - the entries remain as documentation of
-  which commands cross the publish boundary, and as a defense-in-depth
+  which commands cross a commit or publish boundary, and as a defense-in-depth
   tripwire for contributors and agents who *are* in Default Approvals
   mode. Do not rely on the denylist to stop you.
 - **MCP and in-process tools are NOT covered by
@@ -246,11 +282,11 @@ only guard that works in every configuration.
   direct writes to `main` itself.
 
 The agent's pre-flight check (re-read the user's most recent message
-verbatim and confirm it contains an explicit publishing verb) is
-load-bearing. If the message does not contain such a verb, stop and ask
-one short yes/no question. Do not assume the user "obviously" wants the
-change published, and do not assume an approval prompt will appear to
-catch a mistake.
+verbatim and confirm it authorizes the exact commit or publishing boundary)
+is load-bearing. If the message does not contain that authorization, stop and
+ask one short yes/no question. Do not assume the user "obviously" wants the
+change committed or published, and do not assume an approval prompt will
+appear to catch a mistake.
 
 ## General guidance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,8 +159,8 @@ yes/no question.**
 Tools and commands that count as **commit or history rewrite** (require commit
 approval):
 
-- Terminal: `git commit` (including `--amend`), `git merge`, `git cherry-pick`,
-  `git revert`, and `git rebase`.
+- Terminal: `git commit` (including `--amend`), `git reset`, `git merge`,
+  `git cherry-pick`, `git revert`, and `git rebase`.
 - Any tool that creates or rewrites a local commit, even if it does not invoke
   `git commit` by name.
 

--- a/touki.slnx
+++ b/touki.slnx
@@ -27,11 +27,15 @@
   <Project Path="sample/sample.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj" />
+  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
   <Project Path="touki.analyzers.tests/touki.analyzers.tests.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers/touki.analyzers.csproj" />
+  <Project Path="touki.analyzers/touki.analyzers.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
   <Project Path="touki.aot.tests/touki.aot.tests.csproj">
     <Platform Project="x64" />
   </Project>
@@ -47,6 +51,10 @@
   <Project Path="touki.tests/touki.tests.csproj" Id="19ab971c-bbbf-45f9-8a09-11054caec775">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.testsupport/touki.testsupport.csproj" />
-  <Project Path="touki/touki.csproj" />
+  <Project Path="touki.testsupport/touki.testsupport.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
+  <Project Path="touki/touki.csproj">
+    <Platform Project="AnyCPU" />
+  </Project>
 </Solution>

--- a/touki.slnx
+++ b/touki.slnx
@@ -21,22 +21,17 @@
   </Folder>
   <Folder Name="/Solution Items/GitHub/">
     <File Path=".github/copilot-instructions.md" />
-    <File Path=".github/workflows/dotnet.yml" />
     <File Path=".github/workflows/publish.yml" />
     <File Path=".github/workflows/publishtestsupport.yml" />
   </Folder>
   <Project Path="sample/sample.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
+  <Project Path="touki.analyzers.codefixes/touki.analyzers.codefixes.csproj" />
   <Project Path="touki.analyzers.tests/touki.analyzers.tests.csproj">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.analyzers/touki.analyzers.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
+  <Project Path="touki.analyzers/touki.analyzers.csproj" />
   <Project Path="touki.aot.tests/touki.aot.tests.csproj">
     <Platform Project="x64" />
   </Project>
@@ -52,10 +47,6 @@
   <Project Path="touki.tests/touki.tests.csproj" Id="19ab971c-bbbf-45f9-8a09-11054caec775">
     <Platform Project="x64" />
   </Project>
-  <Project Path="touki.testsupport/touki.testsupport.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
-  <Project Path="touki/touki.csproj">
-    <Platform Project="AnyCPU" />
-  </Project>
+  <Project Path="touki.testsupport/touki.testsupport.csproj" />
+  <Project Path="touki/touki.csproj" />
 </Solution>

--- a/touki.tests/Touki/Io/MatchAnyTests.cs
+++ b/touki.tests/Touki/Io/MatchAnyTests.cs
@@ -264,9 +264,9 @@ public class MatchAnyTests
     [TestMethod]
     public void MatchAnyDirectoryAfter_MatchesFile_AlwaysReturnsFalse()
     {
-        IEnumerationMatcher matcher = new MatchAnyDirectory(
-            "/root",
+        using IEnumerationMatcher matcher = new MatchAnyDirectory(
             "subdir",
+            "/root",
             MatchType.Simple,
             MatchCasing.CaseSensitive);
 


### PR DESCRIPTION
## Summary

- move the automatic Debug/Release x net10.0/net11.0 matrix to Linux ARM64
- keep automatic Windows x64 coverage for Release net10.0 and net481, plus Windows ARM64 Release net10.0
- add reusable platform-test logic and manually dispatched full Linux, macOS, and Windows matrices
- move the required-check aggregator to Linux Slim and keep package, coverage, and auxiliary-test validation on the Linux ARM quality leg
- require action-specific approval for commits, pushes, and PR operations, backed by the VS Code terminal denylist and repo-local skill overlays
- simplify solution metadata while retaining architecture-neutral package validation

## Cost impact

Using current GitHub-hosted runner rates and assuming equal job duration, the automatic runner-rate footprint drops from roughly $0.192 to $0.042 per concurrent matrix minute, about 78% lower. Actual savings depend on job duration and per-job minute rounding.

Codecov now comes from the Release/net10.0 Linux ARM quality leg plus the AOT test host. Release net11.0 and Windows net481 still run automatically but are intentionally not duplicated for coverage collection.

## Validation

- `actionlint` across all workflows
- `pwsh tools/Validate-AgentFiles.ps1`
- `pwsh tools/Validate-AgentSkills.ps1`
- `pwsh tools/Test-AgentFileLinks.ps1`
- full Debug and Release solution builds
- automatic Windows-equivalent net10.0 and net481 test runs; net481: 8,082 total, 8,064 passed, 18 expected skips
- analyzer and AOT auxiliary tests with coverage generation
- exact publish restore/build/pack path and architecture-neutral checks for both NuGet packages
- reusable ARM command path: full solution build, AnyCPU test hosts, main/auxiliary tests, pack, and package checks