### PR TITLE
Add trim-safe BinaryFormattedObject deserialization

### DIFF
--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -63,8 +63,8 @@ The catalog contains three categories:
 - **Commons core** - `metadata.portability: portable`, complete portfolio
   metadata, and `metadata.github-*` provenance pinned to an immutable release.
 - **Tool-shipped core** - copied from the tool's own repository (currently
-  `filtrace`); its source owns the core metadata and Touki records local bindings
-  in an overlay.
+  `filtrace`); its source owns the core metadata. When the core is overlay-capable,
+  Touki records package wiring, local paths, and update provenance in `overlay.md`.
 - **Touki-owned skill** - `metadata.portability: repo-specific` and complete
   local portfolio metadata, with no `metadata.github-*` provenance.
 
@@ -84,7 +84,12 @@ core-pin: v0.10.0
 ---
 ```
 
-`core` matches the directory; `core-pin` matches the core's `github-pinned` value.
+`core` matches the directory. For a commons core, `core-pin` matches the core's
+`github-pinned` value. For a tool-shipped core, use the installed package version
+or an exact source revision as `core-pin`; review the bindings whenever that pin
+changes. A tool-shipped source-revision overlay also records `core-repo` and
+`core-tree-sha` so the local payload can be verified, and may record a separate
+`runtime-pin` when the published executable version differs from the skill source.
 
 ## Thin core plus sibling files
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -39,11 +39,11 @@ a skill would need to change to be reused in another repo: `portable` (generic),
 [agent-skills commons](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in its `SKILL.md`) paired with a local `overlay.md`
 that carries the touki-specific cross-references and example links.
-`vendored (tool repo) + overlay` is the same pattern pinned to a tool's own repo
-instead of the commons: `filtrace` is a copy of the skill shipped by the
-standalone [JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)
-analyzer, re-vendored from there rather than the commons. Do not
-hand-edit a vendored core; `gh skill update` tracks it against upstream.
+`vendored (tool repo) + overlay` is an exact skill payload from the tool's own
+repository plus a consumer-owned `overlay.md`. Filtrace is temporarily pinned to
+the exact source revision that enabled overlays while its executable packages
+remain at release 0.6.0. Do not hand-edit a vendored core; update it from an exact
+tool release or source revision.
 
 ## Disambiguation
 
@@ -134,11 +134,11 @@ Both describe "where's the time / which method is hot", but they sit on opposite
 sides of a hand-off:
 
 - **Author or run a benchmark, capture a touki trace, and interpret the result**
-  (the `-p EP --keepFiles` recipe, the EventPipe-vs-ETW divergence, reading the
-  line ranking) -> `performance-testing`.
+  (isolated all-case manifest capture, the EventPipe-vs-ETW divergence, reading
+  the method/line evidence) -> `performance-testing`.
 - **Drive the filtrace analyzer over an existing trace** - the `cpu` / `rank` /
-  `callers` / `lines` / `diff` / `export` verbs and `trace_*` tools, the symbol
-  gate, the trap catalog -> `filtrace`.
+  `callers` / `lines` / `diff` / `batch` / `export` verbs and `trace_*` tools,
+  the provider/source quality gates, the trap catalog -> `filtrace`.
 
 The usual flow is `performance-testing` to produce the trace, then `filtrace` to
 rank and drill it.

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -36,6 +36,10 @@ Repo-specific companion to the vendored [agent-files-review](SKILL.md) skill. Th
   [Validate-AgentFiles.ps1](../../../tools/Validate-AgentFiles.ps1). The vendored
   [frontmatter reference](frontmatter.md) describes a broader portable rule; use
   Touki's stricter rule for files authored in this repository.
+- A tool-shipped overlay pinned to an unreleased source revision records
+  `core-repo` and `core-tree-sha`; verify the upstream-owned payload tree
+  separately from the consumer-owned overlay. Use a separate `runtime-pin` when
+  published executable packages intentionally trail the skill source.
 
 ## Cross-references
 

--- a/.agents/skills/filtrace/README.md
+++ b/.agents/skills/filtrace/README.md
@@ -13,3 +13,28 @@ Copilot (VS Code, CLI, cloud agent) and Claude Code, and it ships inside the
 `KlutzyNinja.Filtrace.Mcp` NuGet package (under `skills/`). See
 [docs/implementation-plan.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/implementation-plan.md)
 (M4) for the knowledge-layer milestone.
+
+## Consumer overlays
+
+The skill is complete without local configuration. A consuming repository may add
+an `overlay.md` beside `SKILL.md` to bind the workflow to project-specific paths,
+capture defaults, symbol directories, process/root conventions, or safety policy.
+The overlay is consumer-owned and is not part of the packaged filtrace skill.
+
+Use the installed package version or source revision as `core-pin`:
+
+```markdown
+---
+core: filtrace
+core-pin: vX.Y.Z
+---
+
+# Filtrace overlay
+
+## Bindings
+
+- Build outputs and symbols are under `artifacts/bin`.
+- Prefer BenchmarkDotNet workload scope for captures under `BenchmarkDotNet.Artifacts`.
+```
+
+Review the bindings whenever the filtrace skill is updated, then update `core-pin`.

--- a/.agents/skills/filtrace/SKILL.md
+++ b/.agents/skills/filtrace/SKILL.md
@@ -1,24 +1,29 @@
 ---
 name: filtrace
-description: Analyze .NET CPU, allocation, exception, GC, JIT, and wall-clock (thread-time) traces - .nettrace, .etl, and speedscope captures - with the filtrace CLI or MCP server. Use when a user asks where time or memory goes in a trace or benchmark, which method or source line is hot, why a run regressed against a baseline, what a captured .nettrace / .etl contains, or to rank / drill / diff / export a profile - including profiling .NET Framework (net481) via ETW, where an EventPipe ranking would mislead. Also covers capturing the trace first - choosing EventPipe vs ETW, elevation, and the recording tool (dotnet-trace, BenchmarkDotNet, PerfView, wpr).
-compatibility: Pairs with the filtrace MCP server (the KlutzyNinja.Filtrace.Mcp package, run via `dnx`) for in-agent tool calls; otherwise shells out to the filtrace CLI (the KlutzyNinja.Filtrace global tool). Either head provides the same analysis, so the skill degrades gracefully to whichever is installed.
+description: Analyze .NET CPU, allocation, exception, GC, JIT, and wall-clock (thread-time) data in .nettrace, .etl, and speedscope files with the filtrace CLI or MCP server. Use when a user asks where time or allocation volume goes in a trace or benchmark, which method or source line is hot, why a run regressed against a baseline, what a captured .nettrace / .etl contains, or to rank / drill / diff / export a profile - including profiling .NET Framework (net481) via ETW, where an EventPipe ranking would mislead. Also covers capturing the trace first - choosing EventPipe vs ETW, elevation, and the recording tool (dotnet-trace, BenchmarkDotNet, PerfView, wpr).
 license: MIT
+compatibility: Pairs with the filtrace MCP server (the KlutzyNinja.Filtrace.Mcp package, run via `dnx`) for in-agent tool calls; otherwise shells out to the filtrace CLI (the KlutzyNinja.Filtrace global tool). Both heads share the analysis core; capture, cache operations, and all-process ETW widening are CLI-only.
 metadata:
-  github-path: .agents/skills/filtrace
-  github-pinned: v0.4.0
-  github-ref: refs/tags/v0.4.0
-  github-repo: https://github.com/JeremyKuhne/filtrace
-  github-tree-sha: 934293350c746d43eabcf540e29929880d88a13f
-  portability: repo-specific
+   portability: repo-specific
+   applicability: tool-shipped
+   binding: optional-overlay
+   risk: local-write
+   maturity: stable
+   requires: none
+   related: performance-testing
 ---
 
 # Analyzing .NET traces with filtrace
 
-filtrace ranks, drills into, diffs, and exports CPU / allocation / exception /
-GC / JIT / thread-time profiles from `.nettrace`, `.etl`, and speedscope
-captures, from both modern .NET and .NET Framework. It is a command-line tool and
+If `overlay.md` exists beside this file, read it before acting; it contains
+consumer-specific bindings. This core remains usable without it.
+
+filtrace ranks CPU / allocation / exception / contention / wait / activity /
+thread-time data, reports GC / JIT / thread-pool / disk activity, and drills into,
+diffs, or exports CPU profiles from `.nettrace`, `.etl`, and speedscope captures.
+It reads both modern .NET and .NET Framework traces. It is a command-line tool and
 an MCP server - there is no GUI. Output is dense text by default, or compact JSON
-(`--format json`). It runs on .NET 10 but reads traces from any runtime.
+(`--format json`); the analyzer itself runs on .NET 10.
 
 This skill is the *how*; the full reference is single-sourced in
 [docs/workflow.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/workflow.md)
@@ -32,9 +37,14 @@ record; for an EventPipe `.nettrace`, that recorder is `dotnet-trace` (cross-pla
 Record or produce one, then point a verb - or `trace_info` - at the file. Pick the
 capture by the question:
 
-- **EventPipe** (`.nettrace` / `.speedscope.json`) - cross-platform, no elevation,
-  single process. From `dotnet-trace collect` or BenchmarkDotNet `-p EP`. Carries
-  CPU, allocations, exceptions, GC, and JIT.
+- **EventPipe** (`.nettrace`) - cross-platform, no elevation, single process. From
+   `dotnet-trace collect` or BenchmarkDotNet `-p EP`. It can carry CPU,
+   allocations, exceptions, contention, thread-pool, GC, and JIT data when the
+   corresponding providers/keywords are enabled; activities require their application
+   provider enabled. .NET 9+ wait-handle analysis needs a non-default capture keyword
+   (recipes below).
+   BenchmarkDotNet may also derive a CPU-only `.speedscope.json`; prefer the raw
+   `.nettrace` when both exist.
 - **ETW** (`.etl`) - **Windows only, needs Administrator** (kernel sampling),
   machine-wide. From `filtrace collect`, BenchmarkDotNet `-p ETW`, PerfView, or `wpr`.
   It is the *only* source for wall-clock (`threadtime`), the native GC / JIT / `memcpy` split
@@ -45,7 +55,26 @@ So "where's the time / what allocates" on one process -> EventPipe; "CPU-bound o
 blocked?", "GC versus my code?", or a machine-wide capture -> ETW. Two bundled
 scripts wrap the capture-then-analyze loop and print the scoped filtrace commands:
 [scripts/Capture-BenchmarkTrace.ps1](scripts/Capture-BenchmarkTrace.ps1) profiles a
-BenchmarkDotNet micro-benchmark (add `--keepFiles`, analyze with `--benchmark`), and
+BenchmarkDotNet micro-benchmark in an isolated run directory, emits an all-case
+manifest, verifies exact generated-child PDBs, and prints commands only for
+known-enabled analyses. Each command uses the benchmark, process, method, or other
+scope supported by its verb; structured reports and orientation commands keep their
+own syntax. Disabled/unknown states become warnings;
+full BenchmarkDotNet output stays in the run log. Use `-Format Json` for a compact
+handoff or `-Quiet` for warnings only. On a non-fatal elevated wait timeout, text
+modes emit a warning; `-Format Json` returns `status: "timeout"`, `runId`, `log`, and
+`message` instead of empty stdout. JSON stdout stays under 20 KiB; when full case
+detail would exceed that budget, a minimal completed result points to `manifest.json`;
+every compact fallback includes `runDirectory`, using the canonical run-relative path
+if an absolute path cannot fit.
+Manifest cases carry explicit benchmark/parameter identity. Pass both
+`-OperationCount` and `-OperationUnit` to add complete per-operation metadata, or
+omit both.
+Recorder-established command fallback is used only when filtrace is unavailable;
+if `filtrace info` is present but cannot read a case, every analysis is unknown and
+no command is emitted. Recorder fallback never fabricates an `eventCount`; only a
+successful `filtrace info` result supplies an observed count, including zero.
+Same-project/same-TFM overlap is rejected rather than sharing outputs. The
 [scripts/Capture-ProjectTrace.ps1](scripts/Capture-ProjectTrace.ps1) builds an
 executable project and traces its running output directly - never `dotnet run`,
 whose build/run host is a different process (see the trap catalog).
@@ -55,26 +84,72 @@ loaded, no manual upload:
 [scripts/Open-SpeedscopeTrace.ps1](scripts/Open-SpeedscopeTrace.ps1) serves a
 `--format speedscope` profile to speedscope.app (defaulting to the Left Heavy hotspot
 view), and [scripts/Open-PerfettoTrace.ps1](scripts/Open-PerfettoTrace.ps1) serves a
-`--format chromium` trace to the Perfetto UI. Each hosts the file on a one-shot loopback
-listener, so nothing is uploaded.
+`--format chromium` synthetic flame-graph trace to the Perfetto UI. Each hosts the
+file on a one-shot loopback listener, so nothing is uploaded.
+
+For `rank --metric wait`, capture a .NET 9+ process with the runtime's default
+keywords plus `WaitHandle` (`0x40000000000`); the combined mask for the runtime
+used here is `0x414C14FCCBD`:
+
+```pwsh
+dotnet-trace collect --profile cpu-sampling `
+   --providers Microsoft-Windows-DotNETRuntime:0x414C14FCCBD:5 -- <app> <args>
+```
+
+A plain `dotnet-trace collect` can capture CPU, runtime contention, and structured
+runtime reports depending on its selected profile, but `wait` needs the explicit
+keyword above.
+
+Activity ranking and `--activity` CPU scope need completed EventSource Start/Stop
+pairs **and that application provider enabled during capture**. Use matching
+`OperationStart` / `OperationStop` events (or explicit Start/Stop opcodes) and add
+the provider alongside CPU sampling, for example:
+
+```pwsh
+dotnet-trace collect --profile cpu-sampling `
+   --providers MyCompany-RequestSource:0xFFFFFFFFFFFFFFFF:5 -- <app> <args>
+```
+
+Replace the provider name; level `5` is Verbose and the mask enables all keywords.
 
 ## The workflow: orient -> rank -> drill -> compare
 
 Almost every investigation is the same four moves:
 
 1. **Orient.** Read the trace's format, sample count, and symbol-resolution rate
-   first - `filtrace info <trace>` or the `trace_info` tool. A
-   symbol-resolution rate **below 0.8** means managed frames are missing and the
-   rankings cannot be trusted; pass `--symbols <build-output-dir>` (the directory
-   holding your portable PDBs) before reading further.
+   first - `filtrace info <trace>` or the `trace_info` tool. A rate **below 0.8**
+   fires a quality warning: inspect the unresolved rows before trusting frame names.
+   Managed method names normally come from the capture's CLR rundown; `--symbols`
+   supplies matching PDBs for source lines, not a replacement for missing rundown.
+   Treat that rate as frame-name quality only. Before source-line analysis, inspect
+   `sourceResolution`: require exact matches for the relevant modules, report mapped
+   versus sampled managed frames, and use `highestUnmappedModules` plus
+   `searchedDirectories` to diagnose the missing PDBs. If
+   `pdbIdentityMismatchModules` names a module, the expected PDB filename exists but
+   its GUID or age differs from the trace. For BenchmarkDotNet, point symbols at the
+   generated child output retained with `--keepFiles`. Once the relevant module
+   matches, compare `sourceMappedManagedMethodCount` with
+   `sampledManagedMethodCount`; use `unmappedNamedManagedFrameCount` and
+   `highestUnmappedMethods` to quantify and identify named frames that remain
+   `<no source>`.
+   Unresolved native ETW frames can depress the aggregate while managed-method
+   rankings remain usable; use `--native-symbols` when the native runtime split matters.
+   Check `availableAnalyses` before selecting a metric, then read
+   `analyses.<name>`: `captureStatus` and `eventCount` distinguish enabled-zero,
+   disabled, observed, and unknown provider state.
 2. **Rank.** Find the hottest frames by the metric that matches the question -
    `cpu`, `alloc`, `exceptions`, or `threadtime` (or `rank --metric <m>`).
    Self-time finds the leaf that burns the resource; inclusive-time finds the
    subtree that drives it.
-3. **Drill.** Follow the hot frame into detail: `callers <frame>` (who calls it),
-   `lines` / `heatmap <file>` (which source lines), or `tree` (what it calls).
-4. **Compare.** `diff <before> <after>` to see what regressed or improved, or
-   `export --format speedscope` to hand a human a flame graph.
+3. **Drill CPU.** For an unwindowed CPU ranking, follow the hot frame with
+   `callers <frame>` (who calls it), `lines` / `heatmap <file>` (which source
+   lines), or `tree` (what it calls). These tools read CPU stacks only. For alloc,
+   exceptions, contention, wait, activity, or threadtime, compare self/inclusive
+   rankings or refine `root` / `time` instead of crossing into a CPU drill.
+4. **Compare.** `diff <before> <after>` accepts traces or capture manifests and
+   reports absolute plus normalized changes. `batch <manifest>` runs one compact
+   ranking query across every case; `export --format speedscope` hands a human a
+   flame graph.
 
 ```pwsh
 filtrace info app.nettrace                   # 1. orient: format, symbol rate, analyses
@@ -84,6 +159,21 @@ filtrace lines app.nettrace --symbols bin/Release/net10.0   # 3. hot source line
 filtrace diff before.nettrace after.nettrace # 4. what changed
 ```
 
+Choose the analysis from the symptom, confirm it appears in `availableAnalyses`,
+then require `captureStatus: enabled` before interpreting a zero as an empty
+workload:
+
+| Symptom / question | Start with | What it establishes |
+|---|---|---|
+| CPU saturated or a hot loop | `cpu` self, then inclusive / callers | executing leaf, then the subtree or caller driving it |
+| Slow with low CPU | `threadtime` (`.etl`), or `contention` / `wait` / `threadpool` (`.nettrace`) | broad on/off-CPU split, lock/handle waits, or pool starvation |
+| High allocation rate or GC pauses | `alloc`, then `gcstats` | sampled allocation volume by site, then collection/pause cost |
+| Startup or first-call delay | `jitstats` | JIT count and compile cost |
+| Repeated exceptions | `exceptions` self, then inclusive | thrown types, then the paths that throw them |
+| One captured request or job is slow | metric `activity`, then CPU scoped with `activity` | completed activity paths, then CPU inside the named operation |
+| A spike occurs at an unknown time | `timeline`, then `rank --time` | the busy window, then its stacks |
+| Physical disk pressure | `diskio` (`.etl` with disk keywords) | files ranked by physical disk service time |
+
 <!-- filtrace:begin verbs -->
 ### CLI verbs
 
@@ -91,7 +181,7 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 
 | Verb | Shows |
 |---|---|
-| `info` | format, sample count, symbol-resolution rate, per-thread counts, the analyses the trace can answer, and quality warnings - the CLI counterpart of `trace_info` |
+| `info` | format, samples, frame-name and source/PDB quality, per-thread counts, per-analysis format/capture/event state, and quality warnings - the CLI counterpart of `trace_info` |
 
 **Rank** - find the hottest frames by a metric:
 
@@ -103,14 +193,14 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 | `exceptions` | exception types, by count | `.nettrace` |
 | `threadtime` | wall-clock (running + blocked) | `.etl` (Windows) |
 
-**Drill** - follow a ranking into detail:
+**CPU drill** - follow a CPU ranking into detail:
 
 | Verb | Shows |
 |---|---|
-| `callers <frame>` | immediate callers of a frame |
-| `lines` | hottest source lines of the scoped methods |
-| `heatmap <file>` | per-line heat for one source file |
-| `tree` | top-down call tree from the root |
+| `callers <frame>` | immediate CPU callers of a frame, or a caller/callee view with `--callees` |
+| `lines` | hottest CPU source lines of the scoped methods |
+| `heatmap <file>` | per-line CPU heat for one source file |
+| `tree` | top-down CPU call tree from the root |
 
 **Inventory** - see what a (possibly machine-wide) capture holds:
 
@@ -119,11 +209,18 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 | `processes` | processes by CPU-sample weight, to pick a `--process` target |
 | `classify` | CPU time by runtime work category (zeroing / copying / GC / JIT) |
 
+**Temporal** - see what happened when, to find the window to drill:
+
+| Verb | Shows |
+|---|---|
+| `timeline` | per-bucket GC / CPU / exception / allocation / JIT activity across the trace |
+
 **Compare and export:**
 
 | Verb | Does |
 |---|---|
-| `diff <before> <after>` | what got slower/faster between two traces |
+| `diff <before> <after>` | absolute and normalized CPU changes; trace pairs or paired manifests |
+| `batch <manifest>` | one compact metric ranking across every parameterized manifest case |
 | `export --format <fmt>` | write a flame graph for a viewer - `speedscope` or `chromium` |
 
 **Structured reports:**
@@ -134,7 +231,7 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 | `jitstats` | JIT method count, compile time, sizes (`.nettrace`) |
 | `threadpool` | worker-thread adjustments and starvation - slow under load, CPU idle (`.nettrace`) |
 | `diskio` | physical disk I/O by file: bytes and disk service time (`.etl`, Windows) |
-| `events --name <n>` | raw events by name, paged (`.nettrace`, or `.etl` on Windows) |
+| `events --name <n>` | raw events, filtered by name / payload / pid / tid, paged (`.nettrace`, or `.etl` on Windows) |
 
 **Capture** - record a Windows ETW `.etl` yourself (for an EventPipe `.nettrace`, use `dotnet-trace`):
 
@@ -148,31 +245,91 @@ filtrace diff before.nettrace after.nettrace # 4. what changed
 |---|---|
 | `convert` | build the ETLX cache up front |
 | `clean` | remove the ETLX cache to force a rebuild |
+
+Same-trace conversions are coordinated by canonical path across threads and
+processes. filtrace converts to a unique sibling temporary file and atomically
+publishes the completed cache, so MCP calls against one trace may run in parallel;
+different traces remain independent. `trace_info.etlxCacheState` and the `convert`
+verb report `hit`, `waited`, `converted`, or `recovered` (`null` for speedscope).
+`clean` waits for an active conversion before removing its cache.
 <!-- filtrace:end verbs -->
 
 Run `filtrace <verb> --help` for the full option set of any verb.
 
 ## Scope and symbols
 
-- **Scope to one process.** The stack verbs that read a multi-process `.etl`
-  (`cpu`, `threadtime`, `rank`, `callers`, `lines`, `heatmap`, `tree`, `classify`)
-  auto-scope to the busiest process tree. Run `processes` first to see the
-  capture, then `--process <name>` to override, or `--all-processes` to widen.
+- **Scope to one process.** The verbs that read a multi-process `.etl`
+  (`cpu`, `threadtime`, `rank`, `callers`, `lines`, `heatmap`, `tree`, `classify`,
+  `timeline`) auto-scope to the busiest process tree. Run `processes` first to see the
+   capture, then `--process <name>` to override. The CLI also accepts `--all-processes`
+   to widen; MCP tools support automatic or named-process scope, not an all-process
+   aggregate.
   `alloc` / `exceptions` read a single-process `.nettrace` and have no process
   options.
-- **Scope to the benchmark.** For a BenchmarkDotNet capture, `--benchmark` presets
-  the root to the measured-workload wrapper so the harness and warmup do not
-  dominate the ranking.
+- **Scope to the benchmark.** For every root-aware stack analysis of a
+   BenchmarkDotNet capture, scope to its `WorkloadAction` wrapper. In the CLI, pass
+   `--benchmark` to every verb that offers it. In MCP, pass
+   `benchmark: true` to `trace_rank`, `trace_callers`, `trace_tree`,
+   `trace_classify`, and `trace_export`. The wrapper includes warmup and actual
+   iterations and excludes harness/overhead scaffolding. Do not guess a benchmark
+   method substring: root/frame warnings report the total match count, then list up to
+   25 full definitions and 10 depths per definition with omitted-count markers, plus
+   which outermost/deepest definition was selected. Narrow an ambiguous selector before
+   trusting percentages. `lines` / `heatmap` have no root scope; narrow them by
+   method/file and treat percentages as whole-trace.
 - **Scope to a time window.** `rank --time <start>,<end>` (milliseconds relative to
   the trace start, either bound optional: `1000,5000`, `1000,`, or `,5000`) keeps
   only the samples anchored in the window. It applies to every metric, so it zooms
   a `.nettrace` / `.etl` ranking to the slice around a spike or one slow request
-  (not `.speedscope.json`, whose timeline is not in milliseconds).
+   (`.speedscope.json` is aggregate-only here and warns that the window was ignored).
 - **Symbols.** Managed frames (including NGEN and ReadyToRun framework methods)
-  resolve for free from the trace's CLR rundown. `--symbols <dir>` resolves your
-  own managed frames and source lines; `--native-symbols` (CPU `.etl` only,
-  opt-in, network) names the unmanaged GC / JIT / `memcpy` frames that otherwise
-  show as a `?` leaf.
+   resolve to method names from the trace's CLR rundown. `--symbols <dir>` supplies
+   matching local PDBs for source-line attribution; do not assume it repairs missing
+   rundown names or that a same-named PDB matches. Confirm exact PDB modules and
+   sampled source mapping in `trace_info.sourceResolution`; for BenchmarkDotNet,
+   prefer the retained generated child output over the outer project output.
+   `--native-symbols` (CPU `.etl` only, opt-in, network) names the
+   unmanaged GC / JIT / `memcpy` frames that otherwise show as a `?` leaf.
+
+## Interpret and report the evidence
+
+- Read `warnings` before the payload and use `hints` as candidate next steps. An
+   empty or poorly resolved result is a reason to fix scope/symbols, not evidence
+   that the behavior does not exist.
+- State the trace format, selected process/root/time window, metric, and
+   self-versus-inclusive measure with the finding. Percentages are relative to that
+   scope; CPU milliseconds are sampled estimates, not exact elapsed duration.
+- Keep counts separate from weight. `trace_info.sampleCount` describes the loaded
+   whole trace after process/activity/time filters; it does not establish that a
+   narrower query is well sampled. Rankings/callers expose
+   `contributingRecordCount`; lines/heat maps expose attributed and unattributed
+   record counts. `scopeWeight` remains metric weight, never a generic record count.
+- Apply the default 200-record method and 1,000-record line guidance only to periodic
+   CPU sampling. Evented speedscope records are duration intervals: report their count
+   separately from weight, but do not apply periodic thresholds. A null count means
+   the source cannot establish meaningful record semantics.
+- `alloc` attributes `GCAllocationTick` volume to allocation sites. It does **not**
+   report retained bytes, object reachability, or GC-root paths, so it cannot prove a
+   memory leak; use a heap snapshot/dump tool for retention.
+- `threadtime` aggregates running and blocked intervals across threads. Do not call
+   its total a request's latency unless the scope isolates that request/thread.
+- `contention`, `wait`, and `activity` pair Start/Stop events. An operation still
+   open at trace end may be absent; an empty ranking does not rule out an active
+   hang. Use ETW threadtime or a dump/current-state tool when the unfinished state
+   itself is the question.
+- `diff` reports absolute weight, scope shares, percentage-point change, normalized
+   weight change, and appearing/disappearing frames. Scope direct traces consistently
+   with root/process/benchmark. Manifest cases pair only by exact benchmark plus
+   parameters; per-operation fields require complete count and matching unit on both
+   sides.
+- `batch` / `trace_batch` returns one compact top-frame row and case-specific warnings
+   for each of at most 24 manifest cases. Use the returned path with `rank` for detail.
+- Chromium export reconstructs one aggregate synthetic track whose widths preserve
+   sample weight. Its axis is not the capture's original timestamps, thread
+   concurrency, or idle gaps; use `timeline` / `--time` for temporal conclusions.
+- Report observations separately from hypotheses. A hot frame, high allocation
+   site, or positive diff identifies where recorded cost landed; it does not by itself
+   establish root cause or prove that a code change caused the difference.
 
 ## Traps
 
@@ -188,12 +345,25 @@ The recurring ways a .NET trace investigation goes wrong:
    trace can be 56% on the ETW (`.etl`) capture of the same workload. Capture
    net481 under ETW (`threadtime` / `cpu` over an `.etl`) and rank that.
 
-2. **Trust the symbol-resolution rate before the rankings.** A rate below **0.8**
-   (surfaced by `trace_info` / the load warning) means managed frames are missing
-   and the names are unreliable - pass `--symbols <build-output-dir>`. Caveat: the
-   aggregate rate conflates managed and native frames, so a net481 ETW capture can
-   read low while every *managed* leaf resolves correctly; the warning hedges this
-   ("managed-method rankings remain usable").
+2. **Treat low symbol resolution as a quality gate, not an automatic rejection.**
+   A rate below **0.8** (surfaced by `trace_info` / the load warning) means unresolved
+   frames need inspection. Managed method names normally come from CLR rundown;
+   `--symbols <build-output-dir>` supplies matching PDBs for source lines, not a
+   replacement for missing rundown. The aggregate rate conflates managed and native
+   frames, so a net481 ETW capture can read low while every *managed* leaf resolves
+   correctly; in that case managed-method rankings remain usable, and
+   `--native-symbols` is the relevant opt-in when the native runtime split matters.
+   Conversely, 100% method-name resolution does not prove that any source line is
+   available. Before `lines` or `heatmap`, inspect `trace_info.sourceResolution`:
+   require the relevant module in `matchingPdbModules`, then report mapped versus
+   sampled managed frames and `highestUnmappedModules`. When
+   `pdbIdentityMismatchModules` names the module, the expected PDB filename exists
+   but its GUID or age differs from the trace. For BenchmarkDotNet, use the generated
+   child output retained with `--keepFiles`, not the outer project output. Once the
+   relevant module appears in `matchingPdbModules`, compare
+   `sourceMappedManagedMethodCount` with `sampledManagedMethodCount`; then use
+   `unmappedNamedManagedFrameCount` and `highestUnmappedMethods` to quantify and
+   identify named frames that still map to `<no source>`.
 
 3. **On a machine-wide `.etl`, confirm the process before scoping.** filtrace
    auto-scopes to the busiest process tree ranked by **CPU-sample count** (a
@@ -203,46 +373,67 @@ The recurring ways a .NET trace investigation goes wrong:
 
 4. **BenchmarkDotNet captures include the harness - scope with `--benchmark` by
    default, not as an afterthought.** A raw ranking (or export) of a BDN trace is
-   dominated by the orchestrator and warmup iterations, not your `[Benchmark]`.
-   Pass `--benchmark` to preset the root to the measured-workload wrapper so only
-   the measured code is analyzed. This applies to **every** verb that takes
-   `--root`, including `export` - a flame graph with the harness left in is not
-   just noisy, its proportions are wrong (the workload's own share of time reads
-   too small). `export` is the easiest verb to forget this on: it writes a file
-   and prints no "scoped to X" summary, so there is no output to notice the
-   omission in - check the command before running it, not the graph after.
+   mixed with orchestrator and overhead scaffolding outside your `[Benchmark]`.
+   In the CLI, pass `--benchmark` to every verb that offers it; in MCP, pass
+   `benchmark: true` to `trace_rank`, `trace_callers`, `trace_tree`,
+   `trace_classify`, and `trace_export`. The wrapper includes warmup and actual
+   workload iterations; it excludes harness/overhead scaffolding, not warmup. This
+   applies especially to export - a flame graph with the harness left in is not just
+   noisy, its proportions are wrong. Do not substitute a benchmark method substring:
+   if root/frame warnings report multiple definitions or depths, narrow the selector
+   before trusting the result. `lines` / `heatmap` cannot preserve root scope; narrow
+   them with their method/file filter and treat percentages as whole-trace.
 
-5. **Native runtime frames need `--native-symbols`.** Without it, the unmanaged
-   ~10% of a trace - GC, JIT, `memset` / `memcpy`, write barriers - shows as an
-   unresolved `?` leaf. Opt in (CPU `.etl` only; fetches PDBs from the Microsoft
-   public symbol server, cached locally) to name it, then `classify` to get the
+5. **A healthy whole trace can still produce a statistically thin scoped result.**
+   `trace_info.sampleCount` describes the loaded trace, while a root, focus method,
+   method filter, or file filter may retain only a small subset. Read the query's
+   `contributingRecordCount` or line-level attributed/unattributed counts separately
+   from `scopeWeight`, which is metric weight rather than a record count. The default
+   200-record method and 1,000-record line warnings apply only to periodic CPU
+   sampling. Evented speedscope records are duration intervals: report their count,
+   but do not treat it as a periodic sample confidence gate.
+
+6. **A supported format does not prove the provider was enabled.**
+   `availableAnalyses` is the format inventory only. Read
+   `trace_info.analyses.<name>` before acting: observed events prove `enabled`;
+   recorder metadata can prove `enabled` with zero events or `disabled`; without
+   either, the status is `unknown`. Never relabel unknown as an empty workload.
+   The bundled capture helpers write `<trace>.filtrace.json`; preserve that sidecar
+   with the trace so enabled-zero stays distinguishable from disabled.
+
+7. **Native runtime frames need `--native-symbols`.** Without it, the unmanaged
+   share of a trace - GC, JIT, `memset` / `memcpy`, write barriers - shows as
+   unresolved `?` leaves. Opt in (CPU `.etl` only; fetches PDBs from the Microsoft
+   public symbol server, cached locally) to name them, then `classify` to get the
    zeroing-vs-copying-vs-GC-vs-JIT split. It is off by default so analysis stays
    offline and deterministic.
 
-6. **Self-time and inclusive-time answer different questions.** Self-time finds
+8. **Self-time and inclusive-time answer different questions.** Self-time finds
    the leaf that burns the resource; inclusive-time finds the subtree that drives
    it. Ranking by the wrong measure hides the frame you want - start with self for
    "what is hot", switch to inclusive for "what is responsible".
 
-7. **Reading an `.etl` is Windows-only.** The ETW -> ETLX conversion needs
-   Windows; once converted, the `.etlx` resolves managed frames and analyzes
-   identically on any OS ("convert on Windows, analyze anywhere"). The CLI/MCP
-   `.etl` paths are guarded and report a clean error off Windows.
+9. **Reading an `.etl` through filtrace is Windows-only.** The ETW -> ETLX
+   conversion needs Windows, and direct `.etlx` input is not part of the current
+   CLI or MCP surface. The `.etl` paths report a clean error off Windows. Do not
+   serialize same-trace MCP calls as a workaround: filtrace now coordinates ETLX
+   conversion across threads and processes, publishes atomically, and reports
+   `hit`, `waited`, `converted`, or `recovered` in `trace_info.etlxCacheState`.
 
-8. **The default fold list hides runtime leaves on purpose.** It folds
+10. **The default fold list hides runtime leaves on purpose.** It folds
    `memmove`, write-barriers, and GC-poll helpers into their managed caller -
    right for "which method is hot", wrong for "what kind of work dominates". Use
    `--no-fold` (or `classify`) to let the native leaves rank on their own.
 
-9. **Trace the built app, not `dotnet run`.** `dotnet run` builds and then forks
+11. **Trace the built app, not `dotnet run`.** `dotnet run` builds and then forks
    your program into a separate child process, so a single-process EventPipe
    session launched with `dotnet-trace collect -- dotnet run ...` records the
    build/run host, not your code, and the hot frames never appear. Build first,
-   then launch the built output directly (`dotnet-trace collect -- <app>.dll`, or
-   the apphost `<app>.exe`); the bundled `Capture-ProjectTrace.ps1` resolves that
-   run target for you.
+   then launch the built output directly (`dotnet-trace collect -- dotnet
+   <app>.dll`, or `dotnet-trace collect -- <apphost>`); the bundled
+   `Capture-ProjectTrace.ps1` resolves that run target for you.
 
-10. **A machine-wide `.etl` can be huge - capture lean, then scope at analysis.**
+12. **A machine-wide `.etl` can be huge - capture lean, then scope at analysis.**
    ETW kernel tracing is machine-wide, so the wrong keywords balloon the file: the
    File/Disk *name* rundowns enumerate every open file on the box (hundreds of
    thousands of events that dwarf the workload) no matter how short the window.
@@ -251,8 +442,9 @@ The recurring ways a .NET trace investigation goes wrong:
    File/Disk rundown - so prefer it and bound open-ended runs with `--duration` or
    `--max-size-mb` (a circular buffer that keeps the last N MB). Only a `diskio` capture
    needs the File/Disk keywords, and `filtrace collect` has no switch for them: that
-   capture comes from another recorder (PerfView, `wpr`, or BenchmarkDotNet ETW), so
-   expect the system-wide rundown there and trim it down afterward. To focus a big
+   capture comes from another recorder (PerfView, `wpr`, or a custom BenchmarkDotNet
+   `EtwProfilerConfig` enabling `DiskIO` / `DiskFileIO`; plain `-p ETW` is CPU-only),
+   so expect the system-wide rundown there and trim it down afterward. To focus a big
    capture on your code, scope at *analysis* time with `--process` (lossless - it keeps
    managed stacks); physically trimming the file by relogging is a transport-only
    optimization that currently drops JITted managed frames.
@@ -260,16 +452,19 @@ The recurring ways a .NET trace investigation goes wrong:
 
 ## CLI or MCP
 
-The two heads expose the same analysis:
+The two heads share one analysis core, with deliberately different operational
+surfaces:
 
 - **CLI** - `dotnet tool install -g KlutzyNinja.Filtrace`, then `filtrace <verb>`.
-- **MCP server** - `dnx KlutzyNinja.Filtrace.Mcp` over stdio, exposing fifteen
+- **MCP server** - `dnx KlutzyNinja.Filtrace.Mcp` over stdio, exposing seventeen
   `trace_*` tools (`trace_info`, `trace_rank`, `trace_callers`, `trace_lines`,
   `trace_heatmap`, `trace_tree`, `trace_processes`, `trace_classify`,
-  `trace_diff`, `trace_export`, `trace_gc`, `trace_jit`, `trace_threadpool`,
-  `trace_diskio`, `trace_query_events`).
+   `trace_diff`, `trace_batch`, `trace_export`, `trace_timeline`, `trace_gc`, `trace_jit`,
+  `trace_threadpool`, `trace_diskio`, `trace_query_events`).
   Each returns one envelope: a `schemaVersion`, a `warnings` list, next-step
-  `hints`, and the typed result.
+   `hints`, and the typed result. MCP can auto-scope or select a named ETW process;
+   use the CLI when the question requires `--all-processes`, capture, or ETLX cache
+   operations.
 
 See [docs/workflow.md](https://github.com/JeremyKuhne/filtrace/blob/main/docs/workflow.md)
 for the full verb/tool reference and the MCP config snippet, and

--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -1,89 +1,88 @@
 ---
 core: filtrace
-core-pin: v0.4.0
+core-pin: a04fdd8cae33af5dd8fb5a25329c8c75eb7dea73
+core-repo: https://github.com/JeremyKuhne/filtrace
+core-tree-sha: 43e5f226a606a25da9917b68d29c828a9e95aa4c
+runtime-pin: 0.6.0
 ---
 
 # Touki overlay - filtrace
 
-Repo-specific companion to the vendored [filtrace](SKILL.md) skill. The `SKILL.md`
-is a **pinned copy** of the agent skill shipped by the standalone
-[JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace) trace analyzer (see
-the `metadata.github-*` provenance in `SKILL.md`'s frontmatter). filtrace is a
-*tool-shipped skill*: its canonical home is the tool's own repo (single-sourced
-from filtrace `docs/`), not the
-[agent-skills commons](https://github.com/JeremyKuhne/agent-skills). Do not
-hand-edit the core - re-vendor it from filtrace instead. Everything
-touki-specific lives here.
+Repository-specific bindings for the tool-shipped [filtrace](SKILL.md) core.
+The upstream-owned [skill](SKILL.md), [README](README.md), and [scripts](scripts/)
+match standalone
+[JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace) source commit
+`a04fdd8cae33af5dd8fb5a25329c8c75eb7dea73` (skill tree
+`43e5f226a606a25da9917b68d29c828a9e95aa4c`). That unreleased revision enables
+consumer overlays; the executable packages remain pinned to release `0.6.0`.
 
-## How touki consumes filtrace
+## Bindings
 
-filtrace ships as published NuGet packages; touki uses both heads:
+- **MCP server** - registered in [.vscode/mcp.json](../../../.vscode/mcp.json)
+  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.0`, exposing the seventeen `trace_*`
+  tools an agent calls directly. No clone or build is required.
+- **CLI, fresh install** -
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.0`.
+- **CLI, existing install** -
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.0`.
+- Run `filtrace --version` and require `0.6.0` before passing that executable
+  to the capture helpers. Installing does not upgrade an older global tool.
+- Touki's [profiling](../performance-testing/profiling.md) and
+  [graphical-viewers](../performance-testing/graphical-viewers.md) pages drive
+  the vendored capture and viewer scripts.
+- [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) remains
+  Touki-specific because it wraps the local net481 benchmark workflow.
 
-- **MCP server** - registered in [.vscode/mcp.json](../../../.vscode/mcp.json) as
-  `dnx KlutzyNinja.Filtrace.Mcp@0.4.0`, exposing the fifteen `trace_*` tools an agent
-  calls directly. No clone or build required.
-- **CLI** - `dotnet tool install -g KlutzyNinja.Filtrace`, then `filtrace <verb>`.
+## Upstream follow-up
 
-The skill body's "full reference" links point at filtrace's `docs/workflow.md`
-and `docs/traps.md` as absolute `https://github.com/JeremyKuhne/filtrace` URLs:
-the load-bearing verb and trap catalogs are embedded in the skill body, so those
-links are supplementary and resolve from anywhere.
+Release 0.6.0 completes
+[filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42): first-class
+BenchmarkDotNet scoping and ambiguity diagnostics, query-specific contributing
+record counts, ETLX conversion coordination, provider enablement/event state,
+source/PDB quality, isolated all-case capture manifests, normalized
+manifest-aware diff, and batch analysis.
 
-The skill body also links four bundled scripts by *relative* path
-(`scripts/Capture-BenchmarkTrace.ps1`, `scripts/Capture-ProjectTrace.ps1`,
-`scripts/Open-SpeedscopeTrace.ps1`, `scripts/Open-PerfettoTrace.ps1`), so
-[scripts/](scripts/) is vendored here verbatim alongside `SKILL.md` (and
-`README.md`) - these are filtrace's own generic capture-then-analyze and
-viewer-opener wrappers (any BenchmarkDotNet project or executable project).
-[profiling.md](../performance-testing/profiling.md) and
-[graphical-viewers.md](../performance-testing/graphical-viewers.md) link to these
-vendored scripts directly rather than keeping a touki-local fork - touki
-previously carried its own `tools/Open-SpeedscopeTrace.ps1` /
-`tools/Open-PerfettoTrace.ps1`, removed once filtrace started shipping (and
-improving on) the same scripts here. `tools/Capture-EtwTrace.ps1` remains
-touki-specific (a net481 ETW wrapper around a touki.perf benchmark run, kept
-separately below) since filtrace's `Capture-ProjectTrace.ps1` has no
-BenchmarkDotNet-specific knowledge.
+The implementation supports process and BenchmarkDotNet scoping for
+manifest-aware `diff` and `batch`, but the current core's scope inventories do
+not list those tools. Its process-scope inventory also omits `export`. Correct
+those generic reference lists in filtrace and re-vendor a later source revision;
+do not patch the pinned core here.
 
-## Cross-references (touki side)
+The 0.6 capture helper also accepts any discovered `filtrace` executable without
+checking its version or response schema. Add a helper-side compatibility
+preflight upstream; Touki's profiling workflow performs the version check before
+invoking the pinned payload.
 
-- [`performance-testing`](../performance-testing/SKILL.md) - the touki skill that
-  *delegates* trace-driving to filtrace. It owns the touki-specific half: how to
-  capture a benchmark trace (`-p EP --keepFiles`, where the symbols build is),
-  the EventPipe-vs-ETW attribution divergence, and reading the line ranking. For
-  the filtrace verb/tool reference and trap catalog it points here.
-- [profiling.md](../performance-testing/profiling.md) and
-  [graphical-viewers.md](../performance-testing/graphical-viewers.md) - the touki
-  capture recipes and viewer launchers that drive filtrace.
-- [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) - the touki
-  net481 ETW capture wrapper that prints scoped `filtrace` next-step commands.
+Touki uses BenchmarkDotNet 0.16.0-preview.1. Its log escapes quotes inside
+`--benchmarkName`, writes parameter displays as `[Scenario=...]`, and emits
+`// Runtime=...` environment lines. The 0.6 helper's parser does not fully
+understand that shape, so verify every manifest case has nonempty `benchmark`
+and `parameters` before using manifest-aware `batch` or `diff`. Analyze direct
+trace paths when identity is incomplete; never guess case pairing.
 
-## Touki note - a concrete Trap #8 hit
+The 0.6 helper also caps the on-disk manifest at 20 KiB. Split broad filters
+before capture rather than relying on the compact-stdout fallback for a large
+case matrix. Treat `activity` as unavailable unless the application EventSource
+provider was explicitly enabled; the default BenchmarkDotNet EventPipe capture
+does not establish that provider merely because the helper sidecar says enabled.
 
-The core's **Trap #8** already covers this: filtrace folds JIT-helper thunks
-(`memmove`, write-barriers, GC-poll) into their managed caller **by default**, so
-its ranking does not surface the artifact below - only a *raw / unfolded*
-EventPipe view (or a third-party viewer) does. Recorded here as the touki data
-point behind that trap: a pre-filtrace `CpuSampling` trace of touki's extglob
-enumeration read `System.Buffer.BulkMoveWithWriteBarrier` at 93% inclusive - a
-sampling artifact that really belonged to the two engine loop bodies calling it.
-The sharp tell: a write-barrier variant over a **ref-free** struct is impossible
-(it needs `RuntimeHelpers.IsReferenceOrContainsReferences<T>()`), so it cannot be
-a real call; attribute it to the caller with `callers`. Full writeup:
-[docs/dotnet-perf-discoveries.md](../../../docs/dotnet-perf-discoveries.md)
-section 8.
+## Concrete fold-list hit
+
+filtrace folds JIT-helper thunks (`memmove`, write barriers, GC polls) into their
+managed caller by default. A pre-filtrace trace of Touki extglob enumeration put
+93% inclusive time on `System.Buffer.BulkMoveWithWriteBarrier`, even though the
+walked struct contained no GC references. The frame was an attribution artifact;
+`callers` identified the engine loops that owned the cost. The full writeup is in
+[dotnet-perf-discoveries.md](../../../docs/dotnet-perf-discoveries.md), section 8.
 
 ## Updating
 
-Re-vendor from filtrace when its skill changes: copy both
-`.agents/skills/filtrace/SKILL.md` **and** its `scripts/` subfolder from the
-filtrace repo (the relative links in the body only resolve if `scripts/` is
-present here too), re-add this provenance block (bump `github-pinned` /
-`github-tree-sha` to the new commit or tag), and keep touki-specific notes here,
-not in the core. When filtrace cuts a release whose package carries the updated
-skill, pin to that tag (`github-ref: refs/tags/vX.Y.Z`, `github-pinned: vX.Y.Z` -
-a tag pin uses the tag name, not a commit SHA) rather than a branch/commit. After
-re-vendoring, run `tools/Validate-AgentFiles.ps1` and
-`tools/Test-AgentFileLinks.ps1` - the latter catches a missed `scripts/` copy
-immediately (dangling relative links). Update the matching
-`KlutzyNinja.Filtrace.Mcp@<version>` pin in `.vscode/mcp.json` in the same change.
+Until overlay support is released, copy the complete upstream-owned payload from
+an exact filtrace source revision and record that revision in `core-pin`. When a
+published release contains the overlay contract, copy the payload from its exact
+tag, set `core-pin` to that version, and update the CLI/MCP package pins together.
+Never hand-edit the tool-shipped core; fix generic content upstream and re-vendor
+it.
+
+After updating, review these bindings and run `tools/Validate-AgentFiles.ps1`,
+`tools/Validate-AgentSkills.ps1`, and `tools/Test-AgentFileLinks.ps1`.

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -6,29 +6,32 @@
 
 .DESCRIPTION
     Wraps the "record a trace, then analyze it" loop for a BenchmarkDotNet perf
-    project. Run it from the repository root (where BenchmarkDotNet.Artifacts should
-    land):
+    project. Run it from the repository root. Each invocation passes a run-specific
+    `--artifacts` directory and `--keepFiles`, enumerates every profiler output in
+    that run, and emits a compact manifest with parameterized benchmark identity,
+    trace pairs, runtime/source identity, and exact symbols when verified:
 
       - EventPipe (-Profiler EP, the default): cross-platform, no elevation, single
-        process. Runs `dotnet run -c Release -f <Tfm> --project <Project> --
-        --filter <Filter> -p EP`, which writes a raw .nettrace and (today) also
-        a derived .speedscope.json from the same capture. The raw .nettrace is
-        preferred when both exist - it is the only one of the two that carries
-        allocation events and per-frame source locations, which the printed
-        `alloc` / `lines` commands need; a .speedscope.json is CPU-self-time
-        only and carries no per-frame source locations at all, so `filtrace
-        lines` against one always reports nothing. Falls back to
-        .speedscope.json - printing only the commands that work against it
-        (`cpu`, `export`) - when no .nettrace was produced.
+        process. BenchmarkDotNet normally writes a raw .nettrace and a paired derived
+        .speedscope.json. The manifest retains both; analysis commands use the raw
+        trace when present, or limit a speedscope-only case to CPU/export commands.
       - ETW (-Profiler ETW): Windows only, self-elevates (one UAC prompt), machine
-        wide. Runs the same with `-p ETW --keepFiles`, which writes a .etl. Only an
+        wide. Uses `-p ETW --keepFiles`, which writes a .etl. Only an
         .etl carries wall-clock (threadtime), the native GC / JIT / memcpy split
         (classify --native-symbols), and multi-process scoping.
 
-    Output is teed, never redirected away, so the elevated window shows live
-    progress instead of looking hung. The printed filtrace commands are pre-scoped:
-    an EventPipe trace with --benchmark (past the harness); an .etl additionally with
-    --process, because an .etl is machine-wide.
+    Full BenchmarkDotNet output is written only to capture.log. The final Text or Json
+    handoff contains the manifest path, warnings, and commands only for analyses whose
+    captureStatus is known-enabled. Enabled-zero remains actionable; disabled and
+    unknown analyses are explained instead of receiving commands. Quiet Text mode
+    emits warnings only.
+
+    Every invocation writes BenchmarkDotNet output and capture.log under a unique
+    BenchmarkDotNet.Artifacts/filtrace-runs/<RunId> directory, then emits manifest.json
+    with every parameterized capture case. A same-project/same-TFM handle lock rejects
+    overlap before any build starts. Logged child OutDir paths are verified with
+    filtrace info; source commands are printed only when an exact PDB maps sampled
+    frames. No globally newest artifact is selected.
 
     filtrace: https://github.com/JeremyKuhne/filtrace - install once with
     `dotnet tool install -g KlutzyNinja.Filtrace`, or drive the MCP trace_* tools.
@@ -53,6 +56,43 @@
 .PARAMETER Top
     Rows per ranking in the printed commands. Default 25.
 
+.PARAMETER OperationCount
+    Optional positive operation count represented by each captured case. Specify
+    together with OperationUnit to enable per-operation manifest comparison.
+
+.PARAMETER OperationUnit
+    Optional operation unit (for example items or requests). Specify together with
+    OperationCount. Both fields are omitted when neither parameter is supplied.
+
+.PARAMETER ElevatedTimeoutSeconds
+    How long the non-elevated parent waits for the self-elevated ETW capture to finish
+    before it stops blocking and reports the capture.log path. Default 1200 (20 minutes). Only
+    the ETW self-elevation path uses it - it is the backstop that keeps a never-signaled
+    elevated child from hanging the parent indefinitely.
+
+.PARAMETER RunId
+    Optional stable identifier for this capture run. Defaults to a UTC timestamp plus
+    a random suffix. The run's BenchmarkDotNet artifacts and capture log are written
+    under BenchmarkDotNet.Artifacts/filtrace-runs/<RunId>.
+
+.PARAMETER DotnetPath
+    Path or command name for the dotnet host. Defaults to dotnet from PATH.
+
+.PARAMETER FiltracePath
+    Path or command name for filtrace. Used after capture to verify which logged
+    BenchmarkDotNet child output has an exact PDB match for each trace.
+
+.PARAMETER Format
+    Final result format: Text (default) or Json. BenchmarkDotNet output always stays
+    in capture.log.
+
+.PARAMETER Quiet
+    Suppress informational progress in Text mode. Warnings and errors still surface.
+
+.PARAMETER ElevatedChild
+    Internal switch reserved for the self-elevated ETW child process. Do not pass it
+    directly; non-ETW or non-elevated use is rejected.
+
 .EXAMPLE
     ./Capture-BenchmarkTrace.ps1 -Project src/App.Perf -Filter '*GlobMatchBench*'
 
@@ -65,10 +105,532 @@ param(
     [ValidateSet('EP', 'ETW')][string]$Profiler = 'EP',
     [string]$Tfm = 'net10.0',
     [string]$Process,
-    [int]$Top = 25
+    [int]$Top = 25,
+    [ValidateScript({ $_ -gt 0 -and -not [double]::IsNaN($_) -and -not [double]::IsInfinity($_) })]
+    [double]$OperationCount,
+    [ValidateLength(1, 64)][string]$OperationUnit,
+    [ValidateRange(1, 2147483647)][int]$ElevatedTimeoutSeconds = 1200,
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$')][string]$RunId,
+    [string]$DotnetPath = 'dotnet',
+    [string]$FiltracePath = 'filtrace',
+    [ValidateSet('Text', 'Json')][string]$Format = 'Text',
+    [switch]$Quiet,
+    [switch]$ElevatedChild
 )
 
 $ErrorActionPreference = 'Stop'
+$showProgress = $Format -eq 'Text' -and -not $Quiet
+
+function Write-CaptureMetadata([string]$TracePath, [System.Collections.IDictionary]$Analyses) {
+    $metadata = [ordered]@{
+        schemaVersion = 1
+        analyses = $Analyses
+    } | ConvertTo-Json -Depth 3 -Compress
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    try {
+        [System.IO.File]::WriteAllText("$TracePath.filtrace.json", $metadata, $encoding)
+    }
+    catch {
+        Write-Warning "Capture succeeded, but metadata could not be written: $($_.Exception.Message). Provider enablement will be unknown during analysis."
+    }
+}
+
+function Write-RunManifest([string]$Path, [System.Collections.IDictionary]$Manifest) {
+    $maxManifestBytes = 20KB
+    $json = $Manifest | ConvertTo-Json -Depth 8 -Compress
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    $manifestBytes = $encoding.GetByteCount($json)
+    if ($manifestBytes -ge $maxManifestBytes) {
+        throw "Capture manifest is $manifestBytes UTF-8 bytes; it must stay under 20 KiB. Narrow the benchmark filter or split the capture into fewer cases."
+    }
+
+    [System.IO.File]::WriteAllText($Path, $json, $encoding)
+}
+
+function Get-CaptureCases([string]$ArtifactsDirectory, [string]$CaptureProfiler) {
+    $maxCases = 256
+    $casesByStem = @{}
+    foreach ($file in Get-ChildItem -LiteralPath $ArtifactsDirectory -Recurse -File -ErrorAction SilentlyContinue) {
+        $kind = $null
+        $stem = $null
+        if ($file.Name -like '*.speedscope.json') {
+            $kind = 'speedscope'
+            $stem = $file.Name -replace '\.speedscope\.json$', ''
+        }
+        elseif ($CaptureProfiler -eq 'ETW' -and $file.Extension -eq '.etl') {
+            $kind = 'trace'
+            $stem = $file.BaseName
+        }
+        elseif ($CaptureProfiler -eq 'EP' -and $file.Extension -eq '.nettrace') {
+            $kind = 'trace'
+            $stem = $file.BaseName
+        }
+        else {
+            continue
+        }
+
+        if (-not $casesByStem.ContainsKey($stem)) {
+            if ($casesByStem.Count -ge $maxCases) {
+                throw "Capture produced more than $maxCases cases; narrow the benchmark filter."
+            }
+
+            $casesByStem[$stem] = [ordered]@{
+                id = $stem
+                benchmarkId = $null
+                benchmark = $null
+                parameters = $null
+                benchmarkDisplay = $null
+                capturedUtc = $file.LastWriteTimeUtc.ToString('O')
+                trace = $null
+                speedscope = $null
+                symbolsDirectory = $null
+                operationCount = $null
+                operationUnit = $null
+                symbolCandidates = @()
+                analyses = [ordered]@{}
+                commands = @()
+                warnings = @()
+            }
+        }
+
+        $casesByStem[$stem][$kind] = $file.FullName
+        if ($kind -eq 'trace') {
+            $casesByStem[$stem].capturedUtc = $file.LastWriteTimeUtc.ToString('O')
+        }
+    }
+
+    return @($casesByStem.Values | Sort-Object { $_.capturedUtc }, { $_.id })
+}
+
+function Get-SymbolCandidates([string]$CaptureLog, [string]$OuterSymbolsDirectory) {
+    $maxCandidates = 32
+    $candidates = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::OrdinalIgnoreCase)
+    $outerCandidate = Get-LocalDirectoryCandidate $OuterSymbolsDirectory
+    if ($outerCandidate) {
+        [void]$candidates.Add($outerCandidate)
+    }
+
+    :captureLog foreach ($line in Get-Content -LiteralPath $CaptureLog) {
+        foreach ($match in [regex]::Matches($line, '/p:OutDir="([^"]+)"')) {
+            $directory = Get-LocalDirectoryCandidate $match.Groups[1].Value
+            if ($directory) {
+                [void]$candidates.Add($directory)
+                if ($candidates.Count -ge $maxCandidates) { break captureLog }
+            }
+        }
+    }
+
+    return @($candidates | Sort-Object)
+}
+
+function Get-LocalDirectoryCandidate([string]$Path) {
+    if ([string]::IsNullOrWhiteSpace($Path) -or
+        $Path.StartsWith('\\', [StringComparison]::Ordinal) -or
+        $Path.StartsWith('//', [StringComparison]::Ordinal)) {
+        return $null
+    }
+
+    try {
+        $fullPath = [System.IO.Path]::GetFullPath($Path)
+        if ($fullPath.StartsWith('\\', [StringComparison]::Ordinal) -or
+            $fullPath.StartsWith('//', [StringComparison]::Ordinal) -or
+            -not (Test-Path -LiteralPath $fullPath -PathType Container)) {
+            return $null
+        }
+
+        return $fullPath
+    }
+    catch {
+        return $null
+    }
+}
+
+function Set-BenchmarkIdentities([System.Collections.IDictionary[]]$CaptureCases, [string]$CaptureLog) {
+    $benchmarksById = @{}
+    $benchmarksInExecutionOrder = New-Object 'System.Collections.Generic.List[System.Collections.IDictionary]'
+    $currentDisplay = $null
+    foreach ($line in Get-Content -LiteralPath $CaptureLog) {
+        if ($line -match '^// Benchmark: (.+)$') {
+            $currentDisplay = $Matches[1]
+            continue
+        }
+
+        if ($null -ne $currentDisplay -and
+            $line -match '--benchmarkName\s+(?:"([^"]+)"|(\S+)).*--benchmarkId\s+(\d+)') {
+            $benchmarkId = [int]$Matches[3]
+            if (-not $benchmarksById.ContainsKey($benchmarkId)) {
+                $benchmarkName = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
+                $benchmarksById[$benchmarkId] = [ordered]@{
+                    benchmarkId = $benchmarkId
+                    benchmark = $benchmarkName
+                    parameters = Get-BenchmarkParameters $currentDisplay
+                    benchmarkDisplay = $currentDisplay
+                }
+                $benchmarksInExecutionOrder.Add($benchmarksById[$benchmarkId])
+            }
+        }
+    }
+
+    foreach ($benchmarkName in @($benchmarksInExecutionOrder.benchmark | Select-Object -Unique)) {
+        $benchmarks = @($benchmarksInExecutionOrder | Where-Object { $_.benchmark -eq $benchmarkName })
+        $prefix = "$benchmarkName-"
+        $cases = @(
+            $CaptureCases |
+                Where-Object { $_.id.StartsWith($prefix, [StringComparison]::Ordinal) } |
+                Sort-Object { $_.capturedUtc }, { $_.id }
+        )
+        if ($benchmarks.Count -ne $cases.Count) { continue }
+
+        # Parameter values are not encoded in profiler filenames. BenchmarkDotNet
+        # executes cases sequentially, so within one exact benchmark name use logged
+        # execution order only when each completed trace has a distinct timestamp.
+        # Otherwise leave identity null rather than silently mis-pair parameters.
+        if ($cases.Count -gt 1 -and @($cases.capturedUtc | Select-Object -Unique).Count -ne $cases.Count) {
+            continue
+        }
+
+        for ($index = 0; $index -lt $cases.Count; $index++) {
+            $cases[$index].benchmarkId = $benchmarks[$index].benchmarkId
+            $cases[$index].benchmark = $benchmarks[$index].benchmark
+            $cases[$index].parameters = $benchmarks[$index].parameters
+            $cases[$index].benchmarkDisplay = $benchmarks[$index].benchmarkDisplay
+        }
+    }
+}
+
+function Get-BenchmarkParameters([string]$BenchmarkDisplay) {
+    $close = $BenchmarkDisplay.LastIndexOf('): ', [StringComparison]::Ordinal)
+    if ($close -lt 0) { return '' }
+    $open = $BenchmarkDisplay.IndexOf('(')
+    if ($open -ge 0 -and $open -lt $close) {
+        return $BenchmarkDisplay.Substring($open + 1, $close - $open - 1)
+    }
+
+    return ''
+}
+
+function Get-SourceIdentity([string]$ProjectDirectory) {
+    if ($null -eq (Get-Command git -ErrorAction SilentlyContinue)) { return $null }
+    try {
+        $repository = & git -C $ProjectDirectory rev-parse --show-toplevel 2>$null | Select-Object -First 1
+        $commit = & git -C $ProjectDirectory rev-parse HEAD 2>$null | Select-Object -First 1
+        if ($LASTEXITCODE -ne 0 -or -not $repository -or -not $commit) { return $null }
+        return [ordered]@{
+            repository = [System.IO.Path]::GetFullPath($repository)
+            commit = $commit
+        }
+    }
+    catch {
+        return $null
+    }
+}
+
+function Get-DefaultCaptureStatuses([string]$CaptureProfiler, [bool]$HasRawTrace) {
+    if (-not $HasRawTrace) {
+        return [ordered]@{ cpu = 'enabled' }
+    }
+
+    if ($CaptureProfiler -eq 'ETW') {
+        return [ordered]@{
+            cpu = 'enabled'; threadtime = 'enabled'; classify = 'enabled';
+            processes = 'enabled'; diskio = 'disabled'; events = 'enabled'
+        }
+    }
+
+    return [ordered]@{
+        cpu = 'enabled'; alloc = 'disabled'; exceptions = 'enabled';
+        contention = 'enabled'; wait = 'disabled'; activity = 'enabled';
+        gcstats = 'enabled'; jitstats = 'enabled'; threadpool = 'enabled';
+        events = 'enabled'
+    }
+}
+
+function ConvertTo-CaptureStatus($Status) {
+    switch ([string]$Status) {
+        'enabled' { return 'enabled' }
+        'disabled' { return 'disabled' }
+        'unknown' { return 'unknown' }
+        default { return 'unknown' }
+    }
+}
+
+function Test-HasAnalysisInfo($TraceInfo) {
+    return $null -ne $TraceInfo -and
+        $null -ne $TraceInfo.analyses -and
+        @($TraceInfo.analyses.PSObject.Properties).Count -gt 0
+}
+
+function ConvertTo-AnalysisMap(
+    $TraceInfo,
+    [System.Collections.IDictionary]$CaptureStatuses,
+    [bool]$AllowRecorderFallback) {
+    $analyses = [ordered]@{}
+    if (Test-HasAnalysisInfo $TraceInfo) {
+        foreach ($property in $TraceInfo.analyses.PSObject.Properties) {
+            $analyses[$property.Name] = [ordered]@{
+                captureStatus = ConvertTo-CaptureStatus $property.Value.captureStatus
+                eventCount = $property.Value.eventCount
+            }
+        }
+        return $analyses
+    }
+
+    foreach ($name in $CaptureStatuses.Keys) {
+        $status = if ($AllowRecorderFallback) {
+            ConvertTo-CaptureStatus $CaptureStatuses[$name]
+        }
+        else {
+            'unknown'
+        }
+        $analyses[$name] = [ordered]@{
+            captureStatus = $status
+            eventCount = $null
+        }
+    }
+    return $analyses
+}
+
+function Get-TraceInfoResult(
+    [string]$TracePath,
+    [string]$SymbolsDirectory,
+    [string]$FiltraceCommand) {
+    try {
+        $arguments = @('info', $TracePath, '--format', 'json')
+        if ($SymbolsDirectory) { $arguments += @('--symbols', $SymbolsDirectory) }
+        $json = & $FiltraceCommand @arguments 2>$null | Out-String
+        if ($LASTEXITCODE -ne 0) { return $null }
+        return ($json | ConvertFrom-Json).result
+    }
+    catch {
+        return $null
+    }
+}
+
+function Find-ExactSymbolDirectory([string]$TracePath, [string[]]$Candidates, [string]$FiltraceCommand) {
+    $bestDirectory = $null
+    $bestMappedFrames = 0
+    foreach ($candidate in $Candidates) {
+        $traceInfo = Get-TraceInfoResult $TracePath $candidate $FiltraceCommand
+        $source = if ($null -ne $traceInfo) { $traceInfo.sourceResolution } else { $null }
+        if ($null -eq $source -or $source.matchingPdbModules.Count -eq 0) { continue }
+        $mappedFrames = [int]$source.mappedManagedFrameCount
+        if ($mappedFrames -gt $bestMappedFrames) {
+            $bestMappedFrames = $mappedFrames
+            $bestDirectory = $candidate
+        }
+    }
+
+    return $bestDirectory
+}
+
+function ConvertTo-PowerShellArgument([string]$Value) {
+    return "'$($Value.Replace("'", "''"))'"
+}
+
+function Test-AnalysisEnabled([System.Collections.IDictionary]$Analyses, [string]$Name) {
+    return $Analyses.Contains($Name) -and $Analyses[$Name].captureStatus -eq 'enabled'
+}
+
+function Get-CaseCommands(
+    [System.Collections.IDictionary]$CaptureCase,
+    [string]$CaptureProfiler,
+    [string]$ProcessName,
+    [string]$MethodFilter,
+    [int]$TopRows) {
+    $commands = New-Object 'System.Collections.Generic.List[string]'
+    $analysisPath = if ($CaptureCase.trace) { $CaptureCase.trace } else { $CaptureCase.speedscope }
+    $trace = ConvertTo-PowerShellArgument $analysisPath
+    $symbols = if ($CaptureCase.symbolsDirectory) { ConvertTo-PowerShellArgument $CaptureCase.symbolsDirectory } else { $null }
+
+    if ($CaptureProfiler -eq 'ETW') {
+        $process = ConvertTo-PowerShellArgument $ProcessName
+        if (Test-AnalysisEnabled $CaptureCase.analyses 'processes') {
+            $commands.Add("filtrace processes $trace")
+        }
+        if (Test-AnalysisEnabled $CaptureCase.analyses 'cpu') {
+            $commands.Add("filtrace cpu $trace --process $process --benchmark --top $TopRows")
+            if ($symbols) {
+                $method = ConvertTo-PowerShellArgument $MethodFilter
+                $commands.Add("filtrace lines $trace --process $process --method $method --symbols $symbols")
+            }
+            $exportSymbols = if ($symbols) { " --symbols $symbols" } else { '' }
+            $commands.Add("filtrace export $trace --process $process --benchmark --native-symbols$exportSymbols -o flame.speedscope.json")
+        }
+        if (Test-AnalysisEnabled $CaptureCase.analyses 'threadtime') {
+            $commands.Add("filtrace threadtime $trace --process $process --benchmark --top $TopRows")
+        }
+        if (Test-AnalysisEnabled $CaptureCase.analyses 'classify') {
+            $commands.Add("filtrace classify $trace --process $process --benchmark --native-symbols")
+        }
+        if (Test-AnalysisEnabled $CaptureCase.analyses 'diskio') {
+            $commands.Add("filtrace diskio $trace --top $TopRows")
+        }
+        return @($commands)
+    }
+
+    if (Test-AnalysisEnabled $CaptureCase.analyses 'cpu') {
+        $commands.Add("filtrace cpu $trace --benchmark --top $TopRows")
+        if ($symbols) {
+            $method = ConvertTo-PowerShellArgument $MethodFilter
+            $commands.Add("filtrace lines $trace --method $method --symbols $symbols")
+            $commands.Add("filtrace export $trace --benchmark --symbols $symbols -o flame.speedscope.json")
+        }
+        else {
+            $commands.Add("filtrace export $trace --benchmark -o flame.speedscope.json")
+        }
+    }
+    if (Test-AnalysisEnabled $CaptureCase.analyses 'alloc') {
+        $commands.Add("filtrace alloc $trace --benchmark --top $TopRows")
+    }
+    if (Test-AnalysisEnabled $CaptureCase.analyses 'exceptions') {
+        $commands.Add("filtrace exceptions $trace --benchmark --top $TopRows")
+    }
+    foreach ($metric in @('contention', 'wait', 'activity')) {
+        if (Test-AnalysisEnabled $CaptureCase.analyses $metric) {
+            $commands.Add("filtrace rank $trace --metric $metric --benchmark --top $TopRows")
+        }
+    }
+    foreach ($report in @('gcstats', 'jitstats', 'threadpool')) {
+        if (Test-AnalysisEnabled $CaptureCase.analyses $report) {
+            $commands.Add("filtrace $report $trace")
+        }
+    }
+    return @($commands)
+}
+
+function Get-CaseWarnings([System.Collections.IDictionary]$CaptureCase) {
+    $warnings = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($name in $CaptureCase.analyses.Keys) {
+        $status = $CaptureCase.analyses[$name].captureStatus
+        if ($status -eq 'disabled') {
+            $warnings.Add("$name capture disabled; recapture with a profile that enables it")
+        }
+        elseif ($status -eq 'unknown') {
+            $warnings.Add("$name capture status unknown; no command emitted")
+        }
+    }
+    if ($CaptureCase.trace -and -not $CaptureCase.symbolsDirectory) {
+        $warnings.Add('source lines unavailable; no logged child output had an exact matching PDB')
+    }
+    return @($warnings)
+}
+
+function Write-CaptureResult(
+    [object[]]$CaptureCases,
+    [string]$ManifestPath,
+    [string]$CaptureRunId,
+    [string]$OutputFormat,
+    [bool]$QuietOutput,
+    [ValidateSet('completed', 'timeout')]
+    [string]$Status = 'completed',
+    [string]$LogPath = $null,
+    [string]$Message = $null) {
+    if ($OutputFormat -eq 'Json') {
+        if ($Status -eq 'timeout') {
+            $result = [ordered]@{
+                schemaVersion = 1
+                status = 'timeout'
+                runId = $CaptureRunId
+                manifest = $null
+                log = $LogPath
+                message = $Message
+                warnings = @()
+                cases = @()
+            }
+        }
+        else {
+            $result = [ordered]@{
+                schemaVersion = 1
+                status = $Status
+                runId = $CaptureRunId
+                manifest = $ManifestPath
+                warnings = @(
+                    foreach ($captureCase in $CaptureCases) {
+                        foreach ($warning in $captureCase.warnings) {
+                            [ordered]@{ case = $captureCase.id; message = $warning }
+                        }
+                    }
+                )
+                cases = @(
+                    foreach ($captureCase in $CaptureCases) {
+                        [ordered]@{
+                            id = $captureCase.id
+                            trace = $captureCase.trace
+                            speedscope = $captureCase.speedscope
+                            commands = $captureCase.commands
+                        }
+                    }
+                )
+            }
+        }
+
+        $maxResultBytes = 20KB
+        $encoding = New-Object System.Text.UTF8Encoding($false)
+        $runDirectoryPath = if ($ManifestPath) {
+            Split-Path -Parent $ManifestPath
+        }
+        elseif ($LogPath) {
+            Split-Path -Parent $LogPath
+        }
+        else {
+            "BenchmarkDotNet.Artifacts/filtrace-runs/$CaptureRunId"
+        }
+        $json = $result | ConvertTo-Json -Depth 6 -Compress
+        if ($encoding.GetByteCount($json) -ge $maxResultBytes) {
+            # Completed runs have a manifest; a timed-out child may have produced only
+            # partial output, so the fallback guidance differs by status.
+            $fallbackMessage = if ($Status -eq 'timeout') {
+                'Timeout details exceeded 20 KiB; inspect the run directory for partial output.'
+            }
+            else {
+                'JSON handoff exceeded 20 KiB; read the manifest for full cases, commands, and warnings.'
+            }
+            $result = [ordered]@{
+                schemaVersion = 1
+                status = $Status
+                runId = $CaptureRunId
+                manifest = $ManifestPath
+                runDirectory = $runDirectoryPath
+                message = $fallbackMessage
+            }
+            $json = $result | ConvertTo-Json -Depth 3 -Compress
+            if ($encoding.GetByteCount($json) -ge $maxResultBytes) {
+                $result.manifest = $null
+                $result.runDirectory = "BenchmarkDotNet.Artifacts/filtrace-runs/$CaptureRunId"
+                $result.message = 'JSON handoff exceeded 20 KiB; inspect runDirectory relative to the invocation working directory.'
+                $json = $result | ConvertTo-Json -Depth 3 -Compress
+            }
+        }
+
+        $json
+        return
+    }
+
+    if ($Status -eq 'timeout') {
+        Write-Warning $Message
+        return
+    }
+
+    if (-not $QuietOutput) {
+        Write-Host "`nCaptured $($CaptureCases.Count) case(s)." -ForegroundColor Green
+        Write-Host "Manifest: $ManifestPath" -ForegroundColor Green
+        foreach ($captureCase in $CaptureCases) {
+            $analysisPath = if ($captureCase.trace) { $captureCase.trace } else { $captureCase.speedscope }
+            Write-Host "`nCase: $($captureCase.id)" -ForegroundColor Green
+            Write-Host "Captured: $analysisPath"
+            if ($captureCase.commands.Count -gt 0) {
+                Write-Host 'Next-step filtrace commands:'
+                foreach ($command in $captureCase.commands) { Write-Host "  $command" }
+            }
+            foreach ($warning in $captureCase.warnings) { Write-Warning "[$($captureCase.id)] $warning" }
+        }
+        return
+    }
+
+    foreach ($captureCase in $CaptureCases) {
+        foreach ($warning in $captureCase.warnings) { Write-Warning "[$($captureCase.id)] $warning" }
+    }
+}
 
 # Resolve the project file (accept either a .csproj or a directory holding one).
 $projItem = Get-Item -LiteralPath $Project
@@ -80,15 +642,56 @@ else {
     $projFile = $projItem
 }
 if (-not $Process) { $Process = [System.IO.Path]::GetFileNameWithoutExtension($projFile.Name) }
+$hasOperationCount = $PSBoundParameters.ContainsKey('OperationCount')
+$hasOperationUnit = $PSBoundParameters.ContainsKey('OperationUnit') -and
+    -not [string]::IsNullOrWhiteSpace($OperationUnit)
+if ($hasOperationCount -ne $hasOperationUnit) {
+    Write-Error 'Specify OperationCount and OperationUnit together, or omit both.' -ErrorAction Continue
+    exit 1
+}
 
 $repoRoot = (Get-Location).Path
-$artifacts = Join-Path $repoRoot 'BenchmarkDotNet.Artifacts'
-$log = Join-Path $artifacts 'capture.log'
+if (-not $RunId) {
+    $RunId = "$([DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss'))-$([Guid]::NewGuid().ToString('N').Substring(0, 8))"
+}
+$runDirectory = Join-Path $repoRoot "BenchmarkDotNet.Artifacts/filtrace-runs/$RunId"
+$artifacts = Join-Path $runDirectory 'artifacts'
+$log = Join-Path $runDirectory 'capture.log'
 
 function Test-Elevated {
     $id = [System.Security.Principal.WindowsIdentity]::GetCurrent()
     $principal = New-Object System.Security.Principal.WindowsPrincipal($id)
     return $principal.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Test-SafeElevationArgument([string]$Value) {
+    return $null -ne $Value -and
+        $Value.IndexOfAny([char[]]@('"', "`r", "`n")) -lt 0 -and
+        -not $Value.EndsWith('\', [StringComparison]::Ordinal)
+}
+
+if ($ElevatedChild -and $Profiler -ne 'ETW') {
+    Write-Error '-ElevatedChild is reserved for the internal elevated ETW handoff.' -ErrorAction Continue
+    exit 1
+}
+
+if ($Profiler -eq 'ETW') {
+    $elevationArguments = [ordered]@{
+        Script = $PSCommandPath
+        Project = $projFile.FullName
+        Filter = $Filter
+        Tfm = $Tfm
+        Process = $Process
+        DotnetPath = $DotnetPath
+        FiltracePath = $FiltracePath
+    }
+    if ($hasOperationUnit) { $elevationArguments.OperationUnit = $OperationUnit }
+    foreach ($argument in $elevationArguments.GetEnumerator()) {
+        if (-not (Test-SafeElevationArgument ([string]$argument.Value))) {
+            Write-Error "ETW elevation argument '$($argument.Key)' cannot contain quotes, newlines, or end in a backslash." -ErrorAction Continue
+            exit 1
+        }
+    }
 }
 
 # Recording an .etl is Windows-only, and Test-Elevated below calls a Windows-only API, so
@@ -100,27 +703,128 @@ if ($Profiler -eq 'ETW' -and $IsWindows -eq $false) {
     exit 1
 }
 
+if ($ElevatedChild -and -not (Test-Elevated)) {
+    Write-Error '-ElevatedChild requires an elevated Windows process.' -ErrorAction Continue
+    exit 1
+}
+
 # ETW kernel sessions require Administrator. When not elevated, relaunch this script
-# in an elevated window that shows the capture's live progress, then wait for it.
-# -WorkingDirectory anchors the child at the repo root so BenchmarkDotNet.Artifacts (and
-# the capture log the parent tails) resolve there, not in the elevated shell's system32.
+# in an elevated window, then wait for it.
+# -WorkingDirectory anchors the child at the repo root so BenchmarkDotNet.Artifacts
+# and capture.log are created there, not in the elevated shell's system32 directory.
 if ($Profiler -eq 'ETW' -and -not (Test-Elevated)) {
-    Write-Host 'ETW capture needs Administrator; relaunching elevated (a UAC prompt will appear).' -ForegroundColor Yellow
+    if ($showProgress) {
+        Write-Host 'ETW capture needs Administrator; relaunching elevated (a UAC prompt will appear).' -ForegroundColor Yellow
+    }
     # Quote path/value args so a project path, filter, or process name containing spaces
     # survives Start-Process joining the array into a single command line.
     $argList = @('-NoProfile', '-File', "`"$PSCommandPath`"", '-Project', "`"$($projFile.FullName)`"",
-        '-Filter', "`"$Filter`"", '-Profiler', 'ETW', '-Tfm', $Tfm, '-Process', "`"$Process`"", '-Top', $Top)
+        '-Filter', "`"$Filter`"", '-Profiler', 'ETW', '-Tfm', "`"$Tfm`"", '-Process', "`"$Process`"", '-Top', $Top,
+        '-RunId', $RunId, '-DotnetPath', "`"$DotnetPath`"", '-FiltracePath', "`"$FiltracePath`"", '-Format', $Format,
+        '-ElevatedChild')
+    if ($hasOperationCount) {
+        $argList += @(
+            '-OperationCount', $OperationCount.ToString('R', [Globalization.CultureInfo]::InvariantCulture),
+            '-OperationUnit', "`"$OperationUnit`"")
+    }
+    if ($Quiet) { $argList += '-Quiet' }
     # Relaunch with the host that is ALREADY running this script, not a hardcoded 'pwsh' -
     # a caller on Windows PowerShell 5.1 without PowerShell 7 installed would otherwise
     # fail here with pwsh unresolved.
     $hostExe = (Get-Process -Id $PID).Path
-    $proc = Start-Process -FilePath $hostExe -Verb RunAs -PassThru -Wait -WorkingDirectory $repoRoot -ArgumentList $argList
-    if ($proc.ExitCode -ne 0) { Write-Error "Elevated capture failed (exit $($proc.ExitCode)). See $log." -ErrorAction Continue ; exit $proc.ExitCode }
-    if (Test-Path $log) { Write-Host "`n--- capture log tail (full log: $log) ---" -ForegroundColor Cyan ; Get-Content $log -Tail 20 }
+    # Do NOT pass -Wait here. With -Verb RunAs, Start-Process -Wait can fail to release
+    # after the elevated child self-closes, hanging the parent forever even though the
+    # capture already finished and the .etl is on disk. Take the process object and wait on
+    # it directly with a bounded WaitForExit, so a lost or access-denied handle degrades to
+    # a timeout result that reports the log path instead of an indefinite hang.
+    $proc = Start-Process -FilePath $hostExe -Verb RunAs -PassThru -WorkingDirectory $repoRoot -ArgumentList $argList
+    if ($null -eq $proc) {
+        Write-Error 'Elevated relaunch returned no process handle; cannot wait for the capture. Check for a blocked UAC prompt.' -ErrorAction Continue
+        exit 1
+    }
+    # WaitForExit / HasExited / ExitCode can each throw (e.g. Access Denied reading the
+    # elevated, higher-integrity child's handle). Under $ErrorActionPreference='Stop' an
+    # uncaught throw would abort the script instead of producing the bounded timeout result,
+    # so guard every handle access and treat a throw as a timeout-like miss.
+    # Clamp to Int32.MaxValue so a large timeout cannot overflow the millisecond argument.
+    $waitMs = [int][Math]::Min([long]$ElevatedTimeoutSeconds * 1000, [int]::MaxValue)
+    $exited = $false
+    try { $exited = $proc.WaitForExit($waitMs) } catch { $exited = $false }
+    if (-not $exited) {
+        $timeoutMessage = "Elevated capture did not signal completion within $ElevatedTimeoutSeconds s; not blocking further. See $log for progress."
+        Write-CaptureResult -CaptureCases @() -ManifestPath $null -CaptureRunId $RunId `
+            -OutputFormat $Format -QuietOutput ([bool]$Quiet) -Status timeout `
+            -LogPath $log -Message $timeoutMessage
+        exit 0
+    }
+    # ExitCode is only defined once the child has exited, and reading it on a higher-integrity
+    # (elevated) process can throw Access Denied - treat either as 'not observed', non-fatal.
+    $childExit = 0
+    try { if ($proc.HasExited) { $childExit = $proc.ExitCode } } catch { $childExit = 0 }
+    if ($childExit -ne 0) { Write-Error "Elevated capture failed (exit $childExit). See $log." -ErrorAction Continue ; exit $childExit }
+    $manifestPath = Join-Path $runDirectory 'manifest.json'
+    if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+        Write-Error "Elevated capture did not produce $manifestPath. See $log for details." -ErrorAction Continue
+        exit 1
+    }
+    $childManifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+    Write-CaptureResult @($childManifest.cases) $manifestPath $RunId $Format ([bool]$Quiet)
     exit 0
 }
 
-New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
+$projectLockName = [regex]::Replace(
+    [System.IO.Path]::GetFileNameWithoutExtension($projFile.Name),
+    '[^A-Za-z0-9._-]',
+    '_')
+if ([string]::IsNullOrEmpty($projectLockName)) { $projectLockName = 'project' }
+$tfmLockName = [regex]::Replace($Tfm, '[^A-Za-z0-9._-]', '_')
+if ([string]::IsNullOrEmpty($tfmLockName)) { $tfmLockName = 'default' }
+$lockName = "$projectLockName-$tfmLockName"
+$lockDirectory = Join-Path $projFile.DirectoryName 'obj/filtrace-capture-locks'
+New-Item -ItemType Directory -Force -Path $lockDirectory | Out-Null
+$lockPath = Join-Path $lockDirectory "$lockName.lock"
+try {
+    $captureLock = [System.IO.File]::Open(
+        $lockPath,
+        [System.IO.FileMode]::OpenOrCreate,
+        [System.IO.FileAccess]::ReadWrite,
+        [System.IO.FileShare]::None)
+}
+catch [System.IO.IOException] {
+    Write-Error "A capture is already active for project '$($projFile.FullName)' and TFM '$Tfm'. Wait for it to finish before starting another." -ErrorAction Continue
+    exit 1
+}
+
+try {
+    $runsDirectory = Split-Path -Parent $runDirectory
+    New-Item -ItemType Directory -Force -Path $runsDirectory | Out-Null
+    if (Test-Path -LiteralPath $runDirectory) {
+        Write-Error "Capture run ID '$RunId' already exists at '$runDirectory'. Choose a new RunId; existing run artifacts are never reused." -ErrorAction Continue
+        exit 1
+    }
+
+    $runClaimPath = Join-Path $runsDirectory "$RunId.claim"
+    try {
+        $runClaim = [System.IO.File]::Open(
+            $runClaimPath,
+            [System.IO.FileMode]::CreateNew,
+            [System.IO.FileAccess]::Write,
+            [System.IO.FileShare]::None)
+        $runClaim.Dispose()
+    }
+    catch [System.IO.IOException] {
+        Write-Error "Capture run ID '$RunId' is already reserved. Choose a new RunId; existing run artifacts are never reused." -ErrorAction Continue
+        exit 1
+    }
+
+    # A pre-existing directory from an older helper may not have a claim file. Recheck
+    # after the atomic claim to close the check/create race before writing any output.
+    if (Test-Path -LiteralPath $runDirectory) {
+        Write-Error "Capture run ID '$RunId' already exists at '$runDirectory'. Choose a new RunId; existing run artifacts are never reused." -ErrorAction Continue
+        exit 1
+    }
+
+    New-Item -ItemType Directory -Force -Path $artifacts | Out-Null
 
 # Without BenchmarkDotNet.Diagnostics.Windows the `-p ETW` profiler silently resolves
 # to UnresolvedDiagnoser and no .etl is written - fail fast with guidance.
@@ -129,93 +833,108 @@ if ($Profiler -eq 'ETW' -and -not (Select-String -Path $projFile.FullName -Patte
     exit 1
 }
 
-# Both branches are multi-element arrays, so they stay arrays (a single-element
-# if-expression would unwrap to a scalar under Set-StrictMode).
-$profArg = if ($Profiler -eq 'ETW') { @('-p', 'ETW', '--keepFiles') } else { @('-p', 'EP') }
+# Preserve the BenchmarkDotNet build output for source-symbol resolution under both
+# profilers. Both branches are multi-element arrays, so they stay arrays (a
+# single-element if-expression would unwrap to a scalar under Set-StrictMode).
+$profArg = @('-p', $Profiler, '--keepFiles')
+$benchmarkArguments = @('run', '-c', 'Release', '-f', $Tfm, '--project', $projFile.FullName, '--', '--filter', $Filter) +
+    $profArg + @('--artifacts', $artifacts)
+$startedUtc = [DateTimeOffset]::UtcNow
 
-Write-Host "Capturing $Profiler trace: $Filter ($Tfm)..." -ForegroundColor Cyan
-# Tee, do not redirect: an elevated window shows BenchmarkDotNet's live progress
-# while the run is also logged for the parent window to surface.
-dotnet run -c Release -f $Tfm --project $projFile.FullName -- --filter $Filter @profArg 2>&1 |
-    Tee-Object -FilePath $log
+if ($showProgress) {
+    Write-Host "Capturing $Profiler trace: $Filter ($Tfm)..." -ForegroundColor Cyan
+}
+# Keep full BenchmarkDotNet output in the run log; stdout remains a compact filtrace
+# handoff rather than a duplicate benchmark transcript.
+& $DotnetPath @benchmarkArguments 2>&1 |
+    Tee-Object -FilePath $log | Out-Null
 if ($LASTEXITCODE -ne 0) { Write-Error "Benchmark run failed (exit $LASTEXITCODE). See $log." -ErrorAction Continue ; exit $LASTEXITCODE }
 
-# Locate the newest trace of the right kind (BenchmarkDotNet may nest it under a
-# results/ subfolder, so recurse). For EventPipe, prefer the raw .nettrace over any
-# derived .speedscope.json from the same capture - the .nettrace also carries
-# allocation events and per-frame source locations that the alloc/lines commands
-# below need and a speedscope conversion does not. But only prefer it when it is
-# actually the PAIRED raw file for this capture (same stem, i.e. produced together) -
-# otherwise a stale .nettrace left over from an earlier run would win over a fresh,
-# speedscope-only capture just because it happens to be a .nettrace. When the two
-# are not paired, whichever file is genuinely newest wins.
-if ($Profiler -eq 'ETW') {
-    $trace = Get-ChildItem -Path $artifacts -Filter '*.etl' -Recurse -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime | Select-Object -Last 1
-    if ($null -eq $trace) { Write-Error "No *.etl found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
+$captureCases = @(Get-CaptureCases $artifacts $Profiler)
+if ($captureCases.Count -eq 0) {
+    Write-Error "No capture files found in $artifacts. Did the capture run?" -ErrorAction Continue
+    exit 1
 }
-else {
-    $netTrace = Get-ChildItem -Path $artifacts -Filter '*.nettrace' -Recurse -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime | Select-Object -Last 1
-    $speedscope = Get-ChildItem -Path $artifacts -Filter '*.speedscope.json' -Recurse -ErrorAction SilentlyContinue |
-        Sort-Object LastWriteTime | Select-Object -Last 1
-
-    if ($null -eq $netTrace) {
-        $trace = $speedscope
+Set-BenchmarkIdentities $captureCases $log
+if ($hasOperationCount) {
+    foreach ($captureCase in $captureCases) {
+        $captureCase.operationCount = $OperationCount
+        $captureCase.operationUnit = $OperationUnit
     }
-    elseif ($null -eq $speedscope) {
-        $trace = $netTrace
+}
+
+# The project build output carries matching PDBs for source lines; --keepFiles also
+# preserves BenchmarkDotNet's generated build output for manual follow-up.
+$symbols = Join-Path (Split-Path -Parent $projFile.FullName) "bin/Release/$Tfm"
+$symbolCandidates = @(Get-SymbolCandidates $log $symbols)
+$filtraceAvailable = $null -ne (Get-Command $FiltracePath -ErrorAction SilentlyContinue)
+foreach ($captureCase in $captureCases) {
+    $captureCase.symbolCandidates = $symbolCandidates
+    if ($captureCase.trace -and $filtraceAvailable) {
+        $captureCase.symbolsDirectory = Find-ExactSymbolDirectory $captureCase.trace $symbolCandidates $FiltracePath
+    }
+}
+$methodFilter = $Filter.Trim('*')
+if ([string]::IsNullOrWhiteSpace($methodFilter)) { $methodFilter = 'BenchmarkMethod' }
+
+foreach ($captureCase in $captureCases) {
+    $captureStatuses = Get-DefaultCaptureStatuses $Profiler ([bool]$captureCase.trace)
+    if ($captureCase.trace) {
+        Write-CaptureMetadata $captureCase.trace $captureStatuses
+    }
+
+    $analysisPath = if ($captureCase.trace) { $captureCase.trace } else { $captureCase.speedscope }
+    $traceInfo = if ($filtraceAvailable) {
+        Get-TraceInfoResult $analysisPath $captureCase.symbolsDirectory $FiltracePath
     }
     else {
-        # BenchmarkDotNet names both files from the same stem, e.g.
-        # foo-<timestamp>.nettrace / foo-<timestamp>.speedscope.json - strip each
-        # file's own suffix to compare the stems, not just Extension (which for
-        # *.speedscope.json is only ".json").
-        $netStem = $netTrace.BaseName
-        $scopeStem = $speedscope.Name -replace '\.speedscope\.json$', ''
-        if ($netStem -eq $scopeStem -or $netTrace.LastWriteTime -ge $speedscope.LastWriteTime) {
-            $trace = $netTrace
-        }
-        else {
-            $trace = $speedscope
-        }
+        $null
     }
-    if ($null -eq $trace) { Write-Error "No *.nettrace or *.speedscope.json found in $artifacts. Did the capture run?" -ErrorAction Continue ; exit 1 }
+    $traceInfoFailed = $filtraceAvailable -and -not (Test-HasAnalysisInfo $traceInfo)
+    $captureCase.analyses = ConvertTo-AnalysisMap $traceInfo $captureStatuses (-not $filtraceAvailable)
+    $captureCase.commands = Get-CaseCommands $captureCase $Profiler $Process $methodFilter $Top
+    $captureCase.warnings = @(
+        if ($traceInfoFailed) {
+            'filtrace info could not verify analysis availability; no commands emitted'
+        }
+        Get-CaseWarnings $captureCase
+    )
 }
 
-# The build output BenchmarkDotNet kept (EventPipe) or --keepFiles preserved (ETW);
-# its embedded PDBs resolve managed frames to source lines for lines/heatmap.
-$symbols = Join-Path (Split-Path -Parent $projFile.FullName) "bin/Release/$Tfm"
+$manifestPath = Join-Path $runDirectory 'manifest.json'
+$manifest = [ordered]@{
+    schemaVersion = 1
+    runId = $RunId
+    startedUtc = $startedUtc.ToString('O')
+    completedUtc = [DateTimeOffset]::UtcNow.ToString('O')
+    command = [ordered]@{
+        executable = $DotnetPath
+        arguments = $benchmarkArguments
+    }
+    project = $projFile.FullName
+    tfm = $Tfm
+    filter = $Filter
+    profiler = $Profiler
+    process = $Process
+    source = Get-SourceIdentity $projFile.DirectoryName
+    runtimes = @(
+        Get-Content -LiteralPath $log |
+            Where-Object { $_ -match '^Runtime = ' } |
+            Sort-Object -Unique
+    )
+    paths = [ordered]@{
+        runDirectory = $runDirectory
+        artifactsDirectory = $artifacts
+        log = $log
+    }
+    cases = $captureCases
+}
+Write-RunManifest $manifestPath $manifest
 
-Write-Host "`nCaptured: $($trace.FullName)" -ForegroundColor Green
-Write-Host "`nNext-step filtrace commands:" -ForegroundColor Green
-if ($Profiler -eq 'ETW') {
-    # An .etl is machine-wide: scope every query to the benchmark process AND to
-    # the measured workload with --benchmark - both, every time, not just when a
-    # ranking looks noisy. --process narrows the OS process; --benchmark is what
-    # excludes the harness/warmup subtree so a ranking or export's proportions
-    # actually reflect the measured [Benchmark] code.
-    Write-Host "  filtrace processes `"$($trace.FullName)`""
-    Write-Host "  filtrace cpu `"$($trace.FullName)`" --process $Process --benchmark --top $Top"
-    Write-Host "  filtrace threadtime `"$($trace.FullName)`" --process $Process --benchmark --top $Top"
-    Write-Host "  filtrace lines `"$($trace.FullName)`" --process $Process --benchmark --symbols `"$symbols`""
-    Write-Host "  filtrace classify `"$($trace.FullName)`" --process $Process --benchmark --native-symbols"
-    Write-Host "  filtrace export `"$($trace.FullName)`" --process $Process --benchmark --native-symbols --symbols `"$symbols`" -o flame.speedscope.json"
+if (-not $ElevatedChild) {
+    Write-CaptureResult $captureCases $manifestPath $RunId $Format ([bool]$Quiet)
 }
-elseif ($trace.Name -like '*.nettrace') {
-    # A raw .nettrace carries CPU, allocations, and per-frame source locations -
-    # every verb below works against it. Scope past the BenchmarkDotNet harness
-    # with --benchmark - every verb here, export included, not just the ones that
-    # print a ranking.
-    Write-Host "  filtrace cpu `"$($trace.FullName)`" --benchmark --top $Top"
-    Write-Host "  filtrace alloc `"$($trace.FullName)`" --benchmark --top $Top"
-    Write-Host "  filtrace lines `"$($trace.FullName)`" --benchmark --symbols `"$symbols`""
-    Write-Host "  filtrace export `"$($trace.FullName)`" --benchmark --symbols `"$symbols`" -o flame.speedscope.json"
 }
-else {
-    # A derived .speedscope.json carries CPU self-time only: no allocation events
-    # (alloc needs a .nettrace) and no per-frame source locations (speedscope inputs
-    # never carry line data), so only print the commands that actually work against it.
-    Write-Host "  filtrace cpu `"$($trace.FullName)`" --benchmark --top $Top"
-    Write-Host "  filtrace export `"$($trace.FullName)`" --benchmark -o flame.speedscope.json"
+finally {
+    $captureLock.Dispose()
 }

--- a/.agents/skills/filtrace/scripts/Capture-ProjectTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-ProjectTrace.ps1
@@ -86,6 +86,20 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+function Write-CaptureMetadata([string]$TracePath, [System.Collections.IDictionary]$Analyses) {
+    $metadata = [ordered]@{
+        schemaVersion = 1
+        analyses = $Analyses
+    } | ConvertTo-Json -Depth 3 -Compress
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    try {
+        [System.IO.File]::WriteAllText("$TracePath.filtrace.json", $metadata, $encoding)
+    }
+    catch {
+        Write-Warning "Capture succeeded, but metadata could not be written: $($_.Exception.Message). Provider enablement will be unknown during analysis."
+    }
+}
+
 # Resolve the project file (accept either a .csproj or a directory holding one).
 $projItem = Get-Item -LiteralPath $Project
 if ($projItem.PSIsContainer) {
@@ -248,6 +262,19 @@ if ($Profiler -eq 'EP') {
     $collectArgs += $AppArgs
     dotnet-trace @collectArgs | Out-Host
     if ($LASTEXITCODE -ne 0) { Write-Error "dotnet-trace failed (exit $LASTEXITCODE)." -ErrorAction Continue ; exit $LASTEXITCODE }
+
+    if ($Metric -eq 'alloc') {
+        # gc-verbose establishes allocation and GC events, but dotnet-trace profile
+        # composition varies across tool versions; leave other families unknown.
+        Write-CaptureMetadata $Output ([ordered]@{
+            alloc = 'enabled'; gcstats = 'enabled'; events = 'enabled'
+        })
+    }
+    else {
+        # cpu-sampling establishes CPU, but dotnet-trace profile composition varies
+        # across tool versions; leave other runtime families unknown.
+        Write-CaptureMetadata $Output ([ordered]@{ cpu = 'enabled'; events = 'enabled' })
+    }
 }
 else {
     Write-Host "Capturing ETW (CPU + threadtime) trace of $processName via filtrace collect..." -ForegroundColor Cyan
@@ -264,6 +291,10 @@ else {
     if ($launchArgs) { $collectArgs += @('--launch-args', $launchArgs) }
     filtrace @collectArgs | Out-Host
     if ($LASTEXITCODE -ne 0) { Write-Error "filtrace collect failed (exit $LASTEXITCODE)." -ErrorAction Continue ; exit $LASTEXITCODE }
+    Write-CaptureMetadata $Output ([ordered]@{
+        cpu = 'enabled'; threadtime = 'enabled'; classify = 'enabled';
+        processes = 'enabled'; diskio = 'disabled'; events = 'enabled'
+    })
 }
 
 Write-Host "`nCaptured: $Output" -ForegroundColor Green
@@ -280,10 +311,11 @@ else {
     # A single-process EventPipe trace ranks the whole app; there is no harness.
     if ($Metric -eq 'alloc') {
         Write-Host "  filtrace alloc `"$Output`" --top $Top"
+        Write-Host "  filtrace gcstats `"$Output`""
     }
     else {
         Write-Host "  filtrace cpu `"$Output`" --top $Top"
+        Write-Host "  filtrace lines `"$Output`" --symbols `"$symbols`""
+        Write-Host "  # scope past runtime startup with --root <Type>.<Method> once you see the ranking"
     }
-    Write-Host "  filtrace lines `"$Output`" --symbols `"$symbols`""
-    Write-Host "  # scope past runtime startup with --root <Type>.<Method> once you see the ranking"
 }

--- a/.agents/skills/performance-testing/overlay.md
+++ b/.agents/skills/performance-testing/overlay.md
@@ -68,6 +68,37 @@ The full field manual is [docs/performance-investigation.md](../../../docs/perfo
 (profiling sections 3a methods, 3f lines); the no-filtrace PowerShell fallback is
 [docs/performance-investigation-without-mcp.md](../../../docs/performance-investigation-without-mcp.md).
 
+## Candidate upstream improvements
+
+The generic parts of [profiling.md](profiling.md) added after the July 2026 NRBF
+investigation are intentionally being validated in Touki before promotion to
+[`JeremyKuhne/agent-skills`](https://github.com/JeremyKuhne/agent-skills).
+
+Implemented locally and candidates for promotion:
+
+- separate harness guidance for one-shot phase measurement versus adaptive phase
+  profiling;
+- an experiment ledger that retains rejected variants and allocation outcomes.
+
+Periodic CPU sample-quality, provider-state, source-resolution, BenchmarkDotNet
+scope, and trace-manifest contracts are now owned by the filtrace 0.6 tool-shipped
+skill. They remain cross-referenced from Touki's profiling page but are not
+`agent-skills` promotion candidates.
+
+Further portable candidates are specified in
+[performance-investigation-agent-tooling-retrospective.md](../../../docs/performance-investigation-agent-tooling-retrospective.md)
+but are not yet implemented as local skill guidance: exact-source comparison and
+reconstructable run-artifact provenance. Keep that distinction until the workflow
+has been exercised locally or promoted directly upstream.
+
+Do not copy these changes into the pinned core locally. Once the guidance has
+settled, uplevel the portable wording to `agent-skills`, publish a new commons
+version, and re-vendor/re-pin the performance-testing core here. Filtrace release
+[0.6.0](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.0) completed the
+product, capture-script, and tool-shipped-skill work from
+[filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42); do not promote
+those tool-specific details to `agent-skills`.
+
 ## Tuple-swap on .NET Core hot paths (touki measurement)
 
 `IDE0180` ("use tuple to swap values") is disabled globally in

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -12,38 +12,103 @@ by method or by source `file:line`. filtrace is registered as an MCP server in
 [.vscode/mcp.json](../../../.vscode/mcp.json), so **an agent calls its tools
 directly** - `trace_info` first, then `trace_rank` / `trace_callers` /
 `trace_lines` / `trace_heatmap`. The equivalent CLI verbs (below) are the manual
-fallback. One capture serves every drill:
+fallback. Prefer the bundled isolated capture helper; one run emits every
+parameterized case, exact child symbols, provider-aware commands, and a manifest
+that `batch` and `diff` can consume:
 
 ```powershell
-# Capture once. --keepFiles preserves BDN's build so its PDB GUID survives for
-# the line ranking below.
-dotnet run -c Release -f net10.0 --project touki.perf -- `
-    --filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' -p EP --keepFiles
+$filtraceVersion = (& filtrace --version | Select-Object -First 1).Trim()
+if ($filtraceVersion -ne '0.6.0') {
+  throw "filtrace 0.6.0 is required; found '$filtraceVersion'."
+}
 
-$trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
-    -Filter '*GlobEnumeratorExtGlobSingleWithRoot*.nettrace' |
-    Sort-Object LastWriteTime | Select-Object -Last 1).FullName
-# The exact build BDN profiled - its PDB GUID matches the trace:
-$sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
+$handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
+  -Project touki.perf/touki.perf.csproj `
+  -Filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' `
+  -Tfm net10.0 -Format Json | ConvertFrom-Json
 
-# filtrace is the standalone analyzer (github.com/JeremyKuhne/filtrace), published
-# to NuGet. Install once with `dotnet tool install -g KlutzyNinja.Filtrace`, then
-# call `filtrace <verb>` directly. (The MCP tools above need no install.)
+$manifest = Get-Content $handoff.manifest -Raw | ConvertFrom-Json
+$manifest.cases | Select-Object benchmark, parameters, trace, symbolsDirectory, warnings
 
-# Method ranking, scoped to a workload frame (which method owns the self-time).
-filtrace cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
+if ($manifest.cases.Where({ -not $_.benchmark -or -not $_.parameters }).Count -ne 0) {
+  throw 'Manifest case identity is incomplete; analyze direct trace paths instead.'
+}
 
-# Line ranking inside the dominant method (which lines of its hot loop dominate).
-filtrace lines $trace --method RunEngine --symbols $sym --top 30
-
-# Who calls a folded JIT-helper artifact, to confirm what it's attributable to.
-filtrace callers $trace 'BulkMoveWithWriteBarrier'
+# Rank all parameterized cases compactly, then drill one case with rank/callers/lines.
+filtrace batch $handoff.manifest --metric cpu --benchmark
+$manifest.cases[0].commands
 ```
 
 The MCP tools map onto those verbs one-to-one: `trace_rank` (with
 `measure: self|inclusive`) for the method ranking, `trace_lines` for the line
 ranking, `trace_callers` for the caller breakdown, and `trace_info` for the
 load-and-summarize the other tools do implicitly.
+
+## Agent protocol for phase investigations
+
+**Use different harnesses for measurement and profiling.** A mutable or
+consumable intermediate representation needs fresh state for every measured
+operation: prepare a bounded batch in `IterationSetup`, consume every item once,
+normalize with `OperationsPerInvoke`, and release the batch in
+`IterationCleanup`. Sweep one item, an intermediate batch, and a larger batch:
+the first exposes timer overhead, while the last exposes retained-live-set
+distortion. Keep the smallest batch that amortizes the harness without changing
+the workload.
+
+That one-shot shape is often a poor CPU-profiling harness. For profiling, prefer
+an adaptive end-to-end benchmark and root-scope filtrace to the phase method.
+Work before that call remains outside the selected subtree, while BenchmarkDotNet
+can execute enough operations to produce a denser profile. Profile the one-shot
+benchmark only when a compatible periodic CPU capture has enough contributing
+samples in the selected query.
+
+Validate a phase split before trusting it: phase allocations should add to the
+independently measured end-to-end allocation at reported precision, and phase
+means should approximately add to the end-to-end mean. A large gap usually means
+setup leaked into one measurement, mutable state was reused, or the batch changed
+GC/live-set behavior.
+
+**Use the filtrace 0.6 evidence contracts:**
+
+- Read `trace_info.analyses.<name>` before interpreting a metric.
+  `captureStatus: enabled` plus `eventCount: 0` is a valid empty analysis;
+  `disabled` is unavailable; `unknown` remains unknown. Preserve the capture
+  helper's `<trace>.filtrace.json` sidecar with the trace.
+- For Touki's BenchmarkDotNet 0.16.0-preview.1 logs, require nonempty
+  `benchmark` and `parameters` on every case before using manifest-aware
+  `batch`/`diff`; the 0.6 helper can leave identity incomplete. Split broad
+  captures before the helper's 20 KiB on-disk manifest limit. Treat `activity`
+  as unavailable unless the application EventSource provider was explicitly
+  enabled, regardless of the default helper sidecar.
+- Read `sourceResolution` separately from managed frame-name resolution. Require
+  the relevant module in `matchingPdbModules`; use `pdbIdentityMismatchModules`,
+  `highestUnmappedModules`, and `highestUnmappedMethods` to diagnose `<no source>`.
+  The capture manifest's `symbolsDirectory` is the verified generated-child path.
+- Root-aware tools accept either the BenchmarkDotNet preset (`benchmark: true` /
+  `--benchmark`) or an explicit frame root (`root` / `--root`), never both. Use
+  the preset for the whole measured workload and replace it with the phase method
+  root for phase-specific analysis. Read ambiguity warnings and selected frame
+  definitions instead of guessing a benchmark-method substring. `lines`/`heatmap`
+  remain whole-trace views narrowed by method/file rather than a stack root.
+- Rankings/callers expose `contributingRecordCount`; lines/heat maps expose
+  attributed and unattributed record counts. Keep those counts separate from
+  `scopeWeight`. Apply the 200/1,000 quality guidance only to periodic CPU samples,
+  never evented speedscope records.
+- Same-trace MCP calls may run in parallel: ETLX conversion is coordinated across
+  threads/processes and `trace_info.etlxCacheState` reports `hit`, `waited`,
+  `converted`, or `recovered`.
+- Use `trace_batch`/`batch` for parameter matrices and manifest-aware
+  `trace_diff`/`diff` for before/after scope shares. Per-operation values require
+  matching operation count and unit metadata in both manifests.
+
+Keep a compact experiment ledger while iterating:
+
+| Hypothesis | Small edit | Check | Time | Allocation | Target frame | Decision |
+| --- | --- | --- | ---: | ---: | --- | --- |
+
+Record rejected variants as well as retained changes. Rejections prevent a later
+agent from repeating attractive experiments that already lost on another TFM or
+on allocation.
 
 Things that bite, kept short - full rationale in
 [docs/performance-investigation.md](../../../docs/performance-investigation.md)
@@ -62,13 +127,15 @@ sections 3a (methods) and 3f (lines):
   JIT-helper thunks (`BulkMoveWithWriteBarrier`, `Thread.PollGCWorker`,
   `Buffer.Memmove`) as the hotspot. The analyzer folds both by default; a
   `BulkMoveWithWriteBarrier` over a GC-ref-free struct is always an artifact.
-- **`--root` must be a frame inside the workload**, not the benchmark method
-  name (that also matches BDN's `Activity Benchmark(...)` wrapper and pulls in
-  idle threadpool threads).
-- **Line ranking needs `--symbols` pointing at BDN's `...-DefaultJob-N/bin/...`
-  build** - `touki.dll` ships its PDB embedded, and the symbols build's GUID
-  must match the trace (hence `--keepFiles`). A wrong dir resolves frames to
-  `<no source>` or is rejected with a GUID mismatch.
+- **Scope root-aware analysis with `--benchmark` / `benchmark: true`.** For a
+  phase inside the benchmark, use its explicit library root *instead of* the
+  benchmark preset after inspecting ambiguity diagnostics. Do not substitute the
+  benchmark method name: it can also match an activity/harness wrapper. `lines`
+  and `heatmap` do not preserve stack-root scope; narrow them by method/file.
+- **Line ranking needs the exact generated-child symbols.** Use the capture
+  manifest's verified `symbolsDirectory` and inspect `trace_info.sourceResolution`.
+  A wrong/same-named PDB can leave `<no source>` even when frame-name resolution
+  is 1.0; `pdbIdentityMismatchModules` identifies an exact identity mismatch.
 - **Inlining attribution differs by profiler, and it corrupts the *method*
   ranking - not just the line view.** EventPipe's managed walker credits a
   fully-inlined callee's self-time to its *physical host* method (and, in the
@@ -137,16 +204,22 @@ to pin it. **Every analysis verb takes it** - `cpu`, `rank`, `threadtime`, `line
 processes <etl>` lists every process by weight so you can choose the right
 target. Quiesce other CPU consumers before capturing, or scope explicitly.
 
-**Default every BenchmarkDotNet analysis to `--benchmark`, not just `--process`.**
+**Default every root-aware BenchmarkDotNet analysis to `--benchmark`, not just
+`--process`, unless you are explicitly scoping to a phase root.**
 Process scoping only narrows *which OS process* the samples come from; a BDN
 process itself still interleaves the harness bootstrap, JIT/overhead warmup
 iterations, and the measured `[Benchmark]` workload in one call tree. `--benchmark`
 (preset root = the generated `WorkloadAction*` wrapper) is what isolates the
 measured code from that scaffolding, and it is **not optional for a BDN trace** -
-apply it by default to every verb that takes `--root`, including `export`. An
+apply it by default to every verb that offers it, including `export`; pass
+`benchmark: true` to the corresponding MCP tools. For a phase-specific query,
+replace the preset with `--root <phase-frame>` / `root: <phase-frame>`; the two
+scope selectors are mutually exclusive. An
 unscoped export is not just noisy, its *proportions* are wrong: a flame graph or
 line ranking that still includes warmup materially understates the workload's own
-share of time. Forgetting it on `export` specifically is an easy miss because the
+share of time. `lines` and `heatmap` cannot preserve root scope, so filter those
+by method/file and report their percentages as whole-trace. Forgetting benchmark
+scope on `export` specifically is an easy miss because the
 verb writes a file instead of rendering a ranking, so there is no immediate
 "scoped to X" line to notice is missing - check the command before running it,
 not the output after.
@@ -165,12 +238,12 @@ to trust it or escalate. Three cases, two different fixes:
 - **Density - are there enough samples?** EventPipe samples each managed thread at
   a fixed **~100 Hz**, so coverage is a function of *total* capture time (BDN
   repeats the op across many iterations), not single-op latency. Rules of thumb
-  from this machine: a frame needs roughly **>=200-300 samples** for a trustworthy
-  self-%, and **>=1,000 samples** - about **~10 s of cumulative time in that
-  frame** at 100 Hz - before its *line* view spreads usefully. `trace_info`
-  reports the total count; multiply by the frame's self-% to see whether it clears
-  the bar. Under BDN's repetition you almost always clear the *method* bar; for a
-  short hot path you usually miss the *line* bar.
+  from this machine: a frame needs roughly **>=200-300 periodic CPU samples** for
+  a trustworthy self-%, and **>=1,000 samples** - about **~10 s of cumulative time
+  in that frame** at 100 Hz - before its *line* view spreads usefully. Read
+  `contributingRecordCount` from rank/callers and attributed/unattributed counts
+  from lines/heat maps; never reinterpret `scopeWeight` as a count. Filtrace emits
+  thin-scope warnings. These thresholds do not apply to evented speedscope records.
 - **Sparse but *correct* - the tree points at the right method, just thin.**
   Lengthen the measured work (a larger input or the long-running scenario) or
   capture ETW for ~10x density. **Lengthening the scenario is the right lever

--- a/.github/workflows/agent-files.yml
+++ b/.github/workflows/agent-files.yml
@@ -30,6 +30,11 @@ jobs:
               - .agents/**
               - .vscode/mcp.json
               - docs/agent-customization.md
+              - docs/binary-formatted-object-performance.md
+              - docs/filtrace-local-demo.md
+              - docs/performance-investigation.md
+              - docs/performance-investigation-without-mcp.md
+              - docs/performance-investigation-agent-tooling-retrospective.md
               - tools/Validate-AgentFiles.ps1
               - tools/Validate-AgentSkills.ps1
               - .markdownlint.jsonc
@@ -79,6 +84,11 @@ jobs:
             .github/agents/**/*.md
             .agents/**/*.md
             docs/agent-customization.md
+            docs/binary-formatted-object-performance.md
+            docs/filtrace-local-demo.md
+            docs/performance-investigation.md
+            docs/performance-investigation-without-mcp.md
+            docs/performance-investigation-agent-tooling-retrospective.md
           config: .markdownlint.jsonc
 
       - name: Link check
@@ -95,4 +105,9 @@ jobs:
             .github/agents/**/*.md
             .agents/**/*.md
             docs/agent-customization.md
+            docs/binary-formatted-object-performance.md
+            docs/filtrace-local-demo.md
+            docs/performance-investigation.md
+            docs/performance-investigation-without-mcp.md
+            docs/performance-investigation-agent-tooling-retrospective.md
           fail: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,6 +46,7 @@ jobs:
       configuration: Release
       tfm: net10.0
       additional-tfm: net481
+      native-aot-rid: win-x64
 
   # Keep one native Windows ARM64 smoke leg, also limited to the supported net10.0 baseline.
   windows-arm64:

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -36,6 +36,9 @@ on:
       pack:
         default: false
         type: boolean
+      native-aot-rid:
+        default: ''
+        type: string
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -279,6 +282,18 @@ jobs:
           if ($LASTEXITCODE -ne 0) {
             throw "Tests for '$project' failed with exit code $LASTEXITCODE."
           }
+        }
+    - name: Publish NativeAOT validation project
+      if: inputs.native-aot-rid != ''
+      shell: pwsh
+      run: |
+        dotnet publish touki.aot.tests/touki.aot.tests.csproj `
+          --configuration Release `
+          --runtime '${{ inputs.native-aot-rid }}' `
+          --output 'artifacts/native-aot/${{ inputs.native-aot-rid }}'
+
+        if ($LASTEXITCODE -ne 0) {
+          throw "NativeAOT publish for '${{ inputs.native-aot-rid }}' failed with exit code $LASTEXITCODE."
         }
     - name: Pack
       if: inputs.pack

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,15 +8,16 @@
         },
         // filtrace trace-analysis MCP server, consumed from the published
         // KlutzyNinja.Filtrace.Mcp package (github.com/JeremyKuhne/filtrace),
-        // pinned to the same release as the vendored filtrace skill.
+        // pinned to published release 0.6.0. The vendored skill may be pinned
+        // independently to an exact source revision.
         // `dnx` (the .NET 10 SDK tool runner) downloads and runs the package on
         // demand; `--yes` auto-confirms the one-time download. No local clone or
-        // build required. Update this pin with the vendored skill, then restart.
+        // build required. Restart this server after changing the package pin.
         "filtrace": {
             "type": "stdio",
             "command": "dnx",
             "args": [
-                "KlutzyNinja.Filtrace.Mcp@0.4.0",
+                "KlutzyNinja.Filtrace.Mcp@0.6.0",
                 "--yes"
             ]
         }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,9 @@
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="ModelContextProtocol" Version="1.3.0" />
     <PackageVersion Include="SharpFuzz" Version="2.2.0" />
+    <PackageVersion Include="System.Formats.Nrbf" Version="10.0.9" />
     <PackageVersion Include="System.Resources.Extensions" Version="10.0.9" />
+    <PackageVersion Include="System.Runtime.Serialization.Formatters" Version="10.0.9" />
     <PackageVersion Include="TUnit" Version="1.48.6" />
     <PackageVersion Include="TUnit.Core" Version="1.48.6" />
   </ItemGroup>

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -42,7 +42,12 @@ Currently wired up:
 | Server | Purpose |
 | ------ | ------- |
 | `microsoft-learn` (`https://learn.microsoft.com/api/mcp`) | Current official .NET BCL docs and reference content. Used by the [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) workflow when verifying modern API shapes before deciding whether to polyfill. |
-| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.4.0`) | Pinned local .NET trace analysis tools used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The package version matches the vendored skill release. |
+| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.0`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The package remains at 0.6.0 while the [overlay](../.agents/skills/filtrace/overlay.md) pins the unreleased overlay-capable skill source independently. |
+
+After changing a workspace MCP package pin, run **MCP: Restart Server** and choose
+the server (or reload the VS Code window) before relying on newly added tools or
+parameters. Editing `mcp.json` does not replace the schema already attached to an
+active chat session.
 
 ## Frontmatter requirements
 

--- a/docs/binary-formatted-object-performance.md
+++ b/docs/binary-formatted-object-performance.md
@@ -1,0 +1,422 @@
+# BinaryFormattedObject performance baseline
+
+This document records the July 11, 2026 baseline for trusted NRBF deserialization through
+`BinaryFormatter`, Touki's `BinaryFormattedObject`, and the exact source at
+[`JeremyKuhne/binaryformat`](https://github.com/JeremyKuhne/binaryformat) commit
+`aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743`.
+
+The benchmark uses only payloads generated during `GlobalSetup`. It is not evidence that
+`BinaryFormatter` or NRBF deserialization is safe for untrusted data.
+
+The agent-workflow and filtrace lessons from this investigation are captured in
+[performance-investigation-agent-tooling-retrospective.md](performance-investigation-agent-tooling-retrospective.md).
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Date | 2026-07-11 |
+| OS | Windows 11 25H2, build 10.0.26200.8655 |
+| CPU | Intel Core i9-14900K, 24 physical / 32 logical cores |
+| Memory | 127.72 GiB |
+| BenchmarkDotNet | 0.16.0-preview.1 |
+| SDK | 11.0.100-preview.5.26302.115 |
+| .NET 10 | 10.0.9, x64 RyuJIT x86-64-v3, concurrent workstation GC |
+| .NET 11 | 11.0.0-preview.5.26302.115, x64 RyuJIT x86-64-v3, concurrent workstation GC |
+| .NET Framework | 4.8.1 (4.8.9325.0), x64 RyuJIT, concurrent workstation GC |
+| BinaryFormatter package | System.Runtime.Serialization.Formatters 10.0.9 |
+| Upstream BinaryFormat | Clean Release build of `aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743` |
+
+The modern end-to-end rows use BenchmarkDotNet's adaptive `DefaultJob`. Paired parser
+and net10 materialization rows use fixed `MediumRun` jobs. All builds are Release builds.
+The upstream project targets net8.0 but runs in the selected net10.0 or net11.0 benchmark
+host. It cannot be loaded by the net481 host.
+
+## Scenarios
+
+Every implementation consumes identical serialized bytes from its own reusable stream.
+Setup validates the entire result graph and verifies that repeated end-to-end calls do not
+reuse mutable result state.
+
+| Scenario | Payload |
+| --- | --- |
+| `Int32Array_1K` | An `int[1024]` containing deterministic non-default values |
+| `StringList_128` | A `List<string>` containing 128 distinct strings |
+| `CustomObject` | A custom object with an integer, string, UTC `DateTime`, and `int[64]` |
+| `ObjectTree_127` | A depth-7 binary tree containing 127 custom nodes and strings |
+| `SharedCycle_128` | A 128-node graph with a ring, shared references, and a node array |
+| `SerializableCallback` | An `ISerializable` object with `int[256]`, a serialization constructor, and callback |
+
+## Reproduction
+
+Run from the repository root in PowerShell:
+
+```powershell
+# BinaryFormatter versus Touki on .NET Framework.
+dotnet run -c Release -f net481 --project touki.perf -- `
+  --filter '*BinaryFormattedObjectPerf*' --allCategories EndToEnd
+
+# Exact-source three-way end-to-end comparisons.
+./tools/Run-BinaryFormatComparison.ps1 `
+  -TargetFramework net10.0 -Category EndToEnd
+./tools/Run-BinaryFormatComparison.ps1 `
+  -TargetFramework net11.0 -Category EndToEnd
+
+# Fixed-depth paired parser comparisons.
+./tools/Run-BinaryFormatComparison.ps1 `
+  -TargetFramework net10.0 -Category ParseOnly -Job Medium
+./tools/Run-BinaryFormatComparison.ps1 `
+  -TargetFramework net11.0 -Category ParseOnly -Job Medium
+
+# Touki's net10 record-model-to-object materialization phase.
+dotnet run -c Release -f net10.0 --project touki.perf -- `
+  --filter '*BinaryFormattedObjectPerf*' --allCategories MaterializeOnly --job medium
+```
+
+The comparison script creates a clean detached checkout, verifies its commit and status,
+builds it in Release with Touki's pinned SDK, verifies the produced assembly metadata,
+and removes the temporary checkout afterward.
+
+## End-to-end latency
+
+Ratios use `BinaryFormatter` as `1.00`. Lower is better.
+
+### .NET 10 x64 RyuJIT
+
+| Scenario | BinaryFormatter (us/op) | Touki (us/op) | Touki ratio | Upstream `aaa1dd1` (us/op) | Upstream ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 1.006 | 1.256 | 1.25 | 1.740 | 1.73 |
+| `Int32Array_1K` | 0.411 | 0.242 | 0.59 | 0.262 | 0.64 |
+| `ObjectTree_127` | 32.416 | 50.700 | 1.56 | 34.240 | 1.06 |
+| `SerializableCallback` | 1.284 | 1.606 | 1.25 | 2.113 | 1.65 |
+| `SharedCycle_128` | 32.546 | 50.963 | 1.57 | 28.953 | 0.89 |
+| `StringList_128` | 6.232 | 7.245 | 1.16 | 7.151 | 1.15 |
+
+### .NET 11 x64 RyuJIT
+
+| Scenario | BinaryFormatter (us/op) | Touki (us/op) | Touki ratio | Upstream `aaa1dd1` (us/op) | Upstream ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 1.002 | 1.212 | 1.21 | 1.712 | 1.71 |
+| `Int32Array_1K` | 0.890 | 0.484 | 0.56 | 0.533 | 0.62 |
+| `ObjectTree_127` | 52.448 | 88.086 | 1.68 | 61.226 | 1.17 |
+| `SerializableCallback` | 3.403 | 3.951 | 1.16 | 5.626 | 1.65 |
+| `SharedCycle_128` | 55.835 | 90.660 | 1.62 | 53.991 | 0.97 |
+| `StringList_128` | 11.086 | 12.181 | 1.10 | 13.874 | 1.25 |
+
+### .NET Framework 4.8.1 x64 RyuJIT
+
+| Scenario | BinaryFormatter (us/op) | Touki (us/op) | Touki ratio |
+| --- | ---: | ---: | ---: |
+| `CustomObject` | 1.943 | 3.317 | 1.71 |
+| `Int32Array_1K` | 0.620 | 0.527 | 0.85 |
+| `ObjectTree_127` | 82.066 | 158.360 | 1.93 |
+| `SerializableCallback` | 2.227 | 4.703 | 2.11 |
+| `SharedCycle_128` | 85.126 | 167.992 | 1.97 |
+| `StringList_128` | 12.100 | 18.886 | 1.56 |
+
+## End-to-end allocation
+
+The net10 and net11 allocation counts were identical. Lower is better.
+
+### Modern .NET
+
+| Scenario | BinaryFormatter (KiB/op) | Touki (KiB/op) | Touki ratio | Upstream `aaa1dd1` (KiB/op) | Upstream ratio |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 9.20 | 4.07 | 0.44 | 4.17 | 0.45 |
+| `Int32Array_1K` | 9.95 | 4.96 | 0.50 | 5.36 | 0.54 |
+| `ObjectTree_127` | 73.81 | 93.75 | 1.27 | 103.20 | 1.40 |
+| `SerializableCallback` | 10.11 | 5.74 | 0.57 | 5.68 | 0.56 |
+| `SharedCycle_128` | 79.31 | 97.05 | 1.22 | 100.05 | 1.26 |
+| `StringList_128` | 31.36 | 29.44 | 0.94 | 28.72 | 0.92 |
+
+### .NET Framework 4.8.1
+
+| Scenario | BinaryFormatter (B/op) | Touki (B/op) | Touki ratio |
+| --- | ---: | ---: | ---: |
+| `CustomObject` | 10,335 | 5,103 | 0.49 |
+| `Int32Array_1K` | 10,452 | 5,235 | 0.50 |
+| `ObjectTree_127` | 76,978 | 110,390 | 1.43 |
+| `SerializableCallback` | 10,961 | 6,764 | 0.62 |
+| `SharedCycle_128` | 82,538 | 113,629 | 1.38 |
+| `StringList_128` | 33,314 | 31,549 | 0.95 |
+
+## Paired parser baseline
+
+These `MediumRun` rows measure construction of the parsed NRBF record model only. The
+ratio is upstream divided by Touki, so values below `1.00` favor upstream.
+
+### .NET 10 x64 RyuJIT
+
+| Scenario | Touki (us/op) | Upstream (us/op) | Ratio | Touki (KiB/op) | Upstream (KiB/op) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 0.882 | 0.372 | 0.42 | 3.20 | 1.95 |
+| `Int32Array_1K` | 0.208 | 0.194 | 0.93 | 4.48 | 4.48 |
+| `ObjectTree_127` | 18.537 | 11.712 | 0.63 | 58.27 | 53.58 |
+| `SerializableCallback` | 0.779 | 0.331 | 0.43 | 3.55 | 2.46 |
+| `SharedCycle_128` | 13.866 | 8.404 | 0.61 | 50.20 | 39.92 |
+| `StringList_128` | 7.087 | 4.692 | 0.66 | 27.55 | 25.00 |
+
+### .NET 11 x64 RyuJIT
+
+| Scenario | Touki (us/op) | Upstream (us/op) | Ratio | Touki (KiB/op) | Upstream (KiB/op) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 0.974 | 0.360 | 0.38 | 3.20 | 1.95 |
+| `Int32Array_1K` | 0.244 | 0.243 | 1.00 | 4.48 | 4.48 |
+| `ObjectTree_127` | 16.203 | 11.409 | 0.70 | 58.27 | 53.58 |
+| `SerializableCallback` | 0.733 | 0.341 | 0.46 | 3.55 | 2.46 |
+| `SharedCycle_128` | 13.783 | 7.973 | 0.58 | 50.20 | 39.92 |
+| `StringList_128` | 6.250 | 4.513 | 0.73 | 27.55 | 25.00 |
+
+## .NET 10 Touki phase split
+
+`BinaryFormattedObject` construction creates the NRBF record model. `Deserialize()` then
+materializes that model into the result graph. The direct materialization benchmark parses
+a bounded batch of 64 independent record models in `IterationSetup`, deserializes every
+model exactly once in the measured invocation, reports per-model results through
+`OperationsPerInvoke`, and releases the batch in `IterationCleanup`.
+
+The batch is deliberately bounded. Reusing one parsed model would return or retain mutable
+state for some record shapes and would not represent fresh deserialization. Larger batches
+also retain enough decoded graph state to distort graph-heavy timings. A 64-model batch
+amortizes BenchmarkDotNet's invocation timer while keeping that retained state to a few MiB.
+BenchmarkDotNet still reports its expected minimum-iteration-time warning for the cheap
+scenarios because iteration setup forces one measured invocation; the fixed 15-iteration
+`MediumRun` provides the quoted distribution.
+
+### Latency
+
+Materialization share is calculated from the sum of the independently measured phase means.
+The phase sum is within 6.7% of the independently measured end-to-end mean in every scenario.
+
+| Scenario | Decode (us/op) | Materialize (us/op) | Materialize share | Phase sum (us/op) | End-to-end (us/op) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 0.882 | 0.366 | 29% | 1.248 | 1.256 |
+| `Int32Array_1K` | 0.208 | 0.050 | 19% | 0.258 | 0.242 |
+| `ObjectTree_127` | 18.537 | 32.847 | 64% | 51.383 | 50.700 |
+| `SerializableCallback` | 0.779 | 0.836 | 52% | 1.615 | 1.606 |
+| `SharedCycle_128` | 13.866 | 37.188 | 73% | 51.053 | 50.963 |
+| `StringList_128` | 7.087 | 0.615 | 8% | 7.702 | 7.245 |
+
+### Allocation
+
+Phase allocation sums match the independently measured end-to-end allocation at the
+reported precision.
+
+| Scenario | Decode (KiB/op) | Materialize (KiB/op) | Phase sum (KiB/op) | End-to-end (KiB/op) |
+| --- | ---: | ---: | ---: | ---: |
+| `CustomObject` | 3.20 | 0.88 | 4.08 | 4.07 |
+| `Int32Array_1K` | 4.48 | 0.48 | 4.96 | 4.96 |
+| `ObjectTree_127` | 58.27 | 35.48 | 93.75 | 93.75 |
+| `SerializableCallback` | 3.55 | 2.20 | 5.75 | 5.74 |
+| `SharedCycle_128` | 50.20 | 46.85 | 97.05 | 97.05 |
+| `StringList_128` | 27.55 | 1.88 | 29.43 | 29.44 |
+
+## Baseline conclusions
+
+- Touki is faster than `BinaryFormatter` for the primitive array on all measured runtimes
+  and allocates about half as much memory.
+- Touki allocates substantially less than `BinaryFormatter` for custom and callback
+  payloads, but is currently slower.
+- Object trees and cyclic graphs are the largest Touki deficits. On net10, materialization
+  accounts for 64% and 73% of their measured phase sums, respectively; both phases also
+  allocate more than the corresponding `BinaryFormatter` path.
+- String-list cost is parser-dominated: record creation accounts for about 92% of the phase
+  sum. Materializer changes should not be expected to move that scenario substantially.
+- Exact upstream parsing is faster for every non-primitive scenario and allocates less for
+  five of six scenarios. Touki nevertheless wins end-to-end for custom and callback objects,
+  showing that parser and materializer work must be profiled separately.
+- Optimization claims should preserve fresh-object semantics, report both time and
+  allocation, and avoid static caches whose size grows with process lifetime. Callback
+  metadata is cached on `RegisteredTypeResolver`, where growth is bounded by the resolver's
+  finite registration set and lifetime; custom resolvers use per-deserialization metadata.
+
+## First deserializer optimization pass
+
+The first pass was driven by symbol-complete net10 EventPipe traces of the one-shot
+materialization benchmark. Before the changes, collection growth accounted for about 85%
+of sampled tree self-time and 45% of sampled cycle self-time. Cycle deserialization also
+spent 23% in the mandatory `SerializationRecord.Matches` validation performed by
+`ArrayRecord.GetArray(Type)`.
+
+Three changes were retained:
+
+- The deserialized-object dictionary keeps its zero-capacity initial state. After the
+  eighth reachable record, it reserves a capacity hint derived from the record count.
+- The parser stack is local to object-graph deserialization, starts with eight entries, and
+  reserves a larger hint only after traversal reaches that depth. Direct primitive arrays
+  no longer allocate an unused stack object.
+- Completion callbacks use the actual instance type that was already resolved, validated,
+  and instantiated, instead of resolving the serialized type name a second time.
+
+Both capacity hints are capped at 256 entries. Larger graphs grow incrementally based on
+records actually reached, so a payload with many unreachable records cannot force an
+unbounded speculative reservation. Graph state remains scoped to one `Deserialize()` call;
+callback metadata remains bounded by the resolver's registration set rather than a
+process-lifetime type cache.
+
+The resolver-scoped callback cache was remeasured after review. The `SerializableCallback`
+end-to-end row was 1.547 us and 5.78 KiB per operation on modern .NET RyuJIT (baseline
+1.581 us and 5.77 KiB), and 4.654 us and 6.65 KiB on .NET Framework 4.8.1 RyuJIT
+(baseline 4.675 us and 6.64 KiB). Both are within the measured run-to-run envelope.
+
+The fixed-depth comparison below uses the same 64-record one-shot `MediumRun` as the
+baseline. Time deltas are arithmetic differences between means from separate runs, not
+paired estimates. The primitive-array intervals overlap and that row is unchanged within
+measurement uncertainty; the table retains its raw mean delta for completeness.
+
+| Scenario | Baseline (ns/op) | Optimized (ns/op) | Time delta | Baseline (B/op) | Optimized (B/op) | Allocation delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 366.15 | 324.95 | -11.3% | 896 | 920 | +24 B |
+| `Int32Array_1K` | 49.57 | 48.92 | -1.3% | 496 | 456 | -40 B |
+| `ObjectTree_127` | 32,846.76 | 27,524.88 | -16.2% | 36,328 | 34,792 | -1,536 B |
+| `SerializableCallback` | 835.72 | 796.26 | -4.7% | 2,248 | 2,272 | +24 B |
+| `SharedCycle_128` | 37,187.56 | 31,411.94 | -15.5% | 47,972 | 38,884 | -9,088 B |
+| `StringList_128` | 614.95 | 548.55 | -10.8% | 1,928 | 1,952 | +24 B |
+
+### Post-optimization end-to-end confirmation
+
+These adaptive `DefaultJob` runs were captured after the optimization pass. The modern
+tables include a freshly cloned, clean Release build of exact upstream commit `aaa1dd1` in
+the same benchmark process. Times are microseconds per operation; allocations are managed
+KiB per operation.
+
+#### .NET 10 x64 RyuJIT
+
+| Scenario | BinaryFormatter (us) | Touki (us) | Upstream (us) | Touki (KiB) | Upstream (KiB) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 1.059 | 1.263 | 1.740 | 4.09 | 4.17 |
+| `Int32Array_1K` | 0.436 | 0.244 | 0.266 | 4.92 | 5.36 |
+| `ObjectTree_127` | 32.817 | 47.879 | 35.495 | 92.25 | 103.20 |
+| `SerializableCallback` | 1.370 | 1.581 | 2.190 | 5.77 | 5.68 |
+| `SharedCycle_128` | 33.123 | 46.104 | 31.260 | 88.17 | 100.05 |
+| `StringList_128` | 6.680 | 7.652 | 7.572 | 29.46 | 28.72 |
+
+#### .NET 11 x64 RyuJIT
+
+| Scenario | BinaryFormatter (us) | Touki (us) | Upstream (us) | Touki (KiB) | Upstream (KiB) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `CustomObject` | 1.028 | 1.173 | 1.753 | 4.09 | 4.17 |
+| `Int32Array_1K` | 0.441 | 0.242 | 0.281 | 4.92 | 5.36 |
+| `ObjectTree_127` | 32.080 | 43.944 | 32.937 | 92.25 | 103.20 |
+| `SerializableCallback` | 1.372 | 1.537 | 2.157 | 5.77 | 5.68 |
+| `SharedCycle_128` | 32.217 | 45.518 | 30.235 | 88.17 | 100.05 |
+| `StringList_128` | 6.254 | 6.530 | 7.207 | 29.46 | 28.72 |
+
+#### .NET Framework 4.8.1 x64 RyuJIT
+
+| Scenario | BinaryFormatter (us) | Touki (us) | Touki (KiB) |
+| --- | ---: | ---: | ---: |
+| `CustomObject` | 2.111 | 3.239 | 5.01 |
+| `Int32Array_1K` | 0.627 | 0.532 | 5.06 |
+| `ObjectTree_127` | 83.827 | 153.103 | 107.75 |
+| `SerializableCallback` | 2.308 | 4.675 | 6.64 |
+| `SharedCycle_128` | 85.697 | 163.098 | 110.91 |
+| `StringList_128` | 12.083 | 19.026 | 30.83 |
+
+The 24-byte increase on shallow object graphs is the bounded cost of seeding the local
+parser stack. It buys a 3,080-byte stack reduction in the deep cycle and removes the stack
+entirely from direct primitive-array deserialization. Final adaptive end-to-end runs retain
+the graph improvement direction on net10, net11, and .NET Framework. Cross-run percentages
+should still be read as directional because each adaptive matrix was collected separately.
+
+A pooled parser stack was measured and rejected. It reduced managed bytes but made tree
+materialization about 9% slower and cycle materialization about 8% slower in the smoke
+matrix; virtual list operations and pool lifecycle cost more than the removed arrays.
+
+## Class field assignment investigation
+
+The field-assignment investigation uses a dedicated serializable class with 32 independent
+`int` fields. `BinaryFormattedObjectFieldAssignmentPerf` parses a bounded batch of 512
+independent record graphs outside the measured region and materializes each graph exactly
+once. Fixed `MediumRun` results are:
+
+```powershell
+foreach ($tfm in 'net10.0', 'net481') {
+    dotnet run -c Release -f $tfm --project touki.perf -- `
+      --filter '*BinaryFormattedObjectFieldAssignmentPerf*' --job medium
+    dotnet run -c Release -f $tfm --project touki.perf -- `
+      --filter '*ClassFieldAssignmentPerf*' --job medium
+    dotnet run -c Release -f $tfm --project touki.perf -- `
+      --filter '*ClassRecordMemberLookupPerf*' --job medium
+}
+```
+
+| Runtime | Materialize mean | Error | StdDev | Allocated |
+| --- | ---: | ---: | ---: | ---: |
+| .NET 10 x64 RyuJIT | 623.4 ns | 12.19 ns | 17.48 ns | 1,016 B |
+| .NET Framework 4.8.1 x64 RyuJIT | 3.331 us | 0.035 us | 0.049 us | 1.09 KiB |
+
+Fresh net10 EventPipe traces resolved 100% of managed symbols. Within
+`ClassRecordFieldInfoDeserializer.Continue`, member-name lookup and equality were more
+visible than `FieldInfo.SetValue`. The public `ClassRecord` API requires two dictionary
+lookups for version-tolerant deserialization: `HasMember(name)` followed by
+`GetRawValue(name)`.
+
+### Assignment primitive
+
+`ClassFieldAssignmentPerf` compares 32 individual `FieldInfo.SetValue` calls with the only
+portable batch API, `FormatterServices.PopulateObjectMembers`. The preallocated row gives
+the batch API an existing values array. The realistic row allocates and fills the values
+array that the deserializer would need to add.
+
+| Runtime | Method | Mean | Error | Allocated |
+| --- | --- | ---: | ---: | ---: |
+| .NET 10 x64 RyuJIT | `FieldInfo.SetValue` | 143.1 ns | 1.54 ns | 144 B |
+| .NET 10 x64 RyuJIT | `PopulateObjectMembers`, preallocated | 144.3 ns | 10.02 ns | 144 B |
+| .NET 10 x64 RyuJIT | `PopulateObjectMembers`, realistic | 158.7 ns | 1.08 ns | 424 B |
+| .NET Framework 4.8.1 x64 RyuJIT | `FieldInfo.SetValue` | 1.533 us | 0.010 us | 144 B |
+| .NET Framework 4.8.1 x64 RyuJIT | `PopulateObjectMembers`, preallocated | 1.497 us | 0.016 us | 144 B |
+| .NET Framework 4.8.1 x64 RyuJIT | `PopulateObjectMembers`, realistic | 1.519 us | 0.007 us | 425 B |
+
+The preallocated modern-.NET row was bimodal and does not establish a win. Including the
+required values array makes batching 11% slower on modern .NET RyuJIT and nearly triples
+managed allocation on both runtimes. On .NET Framework 4.8.1 RyuJIT, its small mean
+difference is within overlapping confidence intervals and does not justify 281 additional
+bytes per object. Production therefore retains individual `FieldInfo.SetValue` calls.
+
+Runtime-generated setters were not adopted. They require dynamic code, conflict with the
+trim/native-AOT contract on modern .NET, and need a cache whose lifetime and type retention
+would exceed the current per-deserialization state. A Framework-only generated-setter path
+would be a separate design with cold-start, partial-trust, and cache-bound measurements.
+
+### Member lookup
+
+`ClassRecordMemberLookupPerf` measures the current safe two-lookup sequence against direct
+`GetRawValue` when all 32 names are known to exist. The direct row is a lower bound, not a
+valid production implementation: supported version-tolerant payloads may omit fields.
+
+| Runtime | `HasMember` + `GetRawValue` | Known-present `GetRawValue` | Ratio | Allocated |
+| --- | ---: | ---: | ---: | ---: |
+| .NET 10 x64 RyuJIT | 330.9 ns | 187.5 ns | 0.57 | 0 B |
+| .NET Framework 4.8.1 x64 RyuJIT | 1.030 us | 0.682 us | 0.66 | 0 B |
+
+A supported one-lookup API could remove 43% of member-access time on modern .NET and 34%
+on Framework for this shape. Touki cannot reproduce it safely through the current public
+surface: catching `KeyNotFoundException` changes malformed-input cost into allocation and
+exception pressure, private reflection is not trim/AOT-safe, and a local record-layout cache
+adds allocation while relying on undocumented metadata identity. The actionable next step
+is an upstream `ClassRecord.TryGetRawValue(string, out object?)` API in
+`System.Formats.Nrbf`; until that exists, the production field path remains unchanged.
+The paste-ready runtime issue draft is in
+[classrecord-trygetrawvalue-api-proposal.md](classrecord-trygetrawvalue-api-proposal.md).
+
+### Remaining plan
+
+The final traces resolve all managed symbols. They show the following order for further
+work:
+
+1. Preserve `ArrayRecord.GetArray(Type)` validation. Its recursive NRBF type-name matching
+  is now the dominant cycle frame, but bypassing it would weaken payload/type validation.
+  Optimize only through a BCL-supported validated path or an upstream `System.Formats.Nrbf`
+  change.
+2. Pursue a supported one-lookup member accessor in `System.Formats.Nrbf`. Re-run
+  `ClassRecordMemberLookupPerf` and the wide-object materialization benchmark if such an API
+  becomes available; do not substitute exception-driven lookup or private reflection.
+3. Investigate the serialization-constructor path separately. Callback traces point at
+  `PendingSerializationInfo.GetDeserializationConstructor`, parameter discovery, and
+  delegate binding; graph optimizations should not be assumed to help it.
+4. Keep parser work separate. String lists remain decode-dominated, and exact upstream
+  parsing is still the stronger reference for reducing record-model time and allocation.
+5. Re-run the same six-scenario split and all three end-to-end runtime matrices after each
+  retained change. Reject any optimization that improves graph means by trading for an
+  unbounded cache or a material regression in primitive/custom/callback scenarios.

--- a/docs/classrecord-trygetrawvalue-api-proposal.md
+++ b/docs/classrecord-trygetrawvalue-api-proposal.md
@@ -1,0 +1,214 @@
+# Draft: [API Proposal] Add ClassRecord.TryGetRawValue
+
+Target repository: `dotnet/runtime`
+
+The text below follows the current `API Suggestion` issue template. The template
+adds the `api-suggestion` label automatically.
+
+## Background and motivation
+
+`System.Formats.Nrbf.ClassRecord` exposes `HasMember(string)` for checking whether
+a serialized member is present and `GetRawValue(string)` for reading its value.
+Consumers that handle payloads written from different versions of a type need both
+operations because a serialized member can be absent:
+
+```csharp
+if (classRecord.HasMember(memberName))
+{
+    object? value = classRecord.GetRawValue(memberName);
+    // Process value.
+}
+```
+
+This recommended version-tolerant pattern performs two lookups in the same internal
+member-name dictionary. The duplicate lookup becomes measurable when materializing
+objects with many fields or graphs containing many instances of the same class.
+
+A `TryGetRawValue` API would express the operation directly, distinguish an absent
+member from a present member whose value is `null`, and permit a single dictionary
+lookup. It would also avoid exception-driven lookup through `GetRawValue`, which is
+inappropriate for expected version differences.
+
+A 32-member benchmark over a decoded `ClassRecord` produced these fixed `MediumRun`
+results (`IterationCount=15`, `LaunchCount=2`, `WarmupCount=10`):
+
+| Runtime | Two-lookup mean | Error | One-lookup lower bound | Error | Ratio | Allocated |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| .NET 10 x64 RyuJIT | 330.9 ns | 4.35 ns | 187.5 ns | 2.25 ns | 0.57 | 0 B |
+| .NET Framework 4.8.1 x64 RyuJIT | 1.030 us | 0.018 us | 0.682 us | 0.010 us | 0.66 | 0 B |
+
+The known-present row is a lower bound rather than a safe replacement: calling
+`GetRawValue` directly throws when a version-tolerant payload omits a field. It shows
+the upper-bound opportunity from removing the duplicate probe: 43% of the measured
+member-access time on .NET 10 x64 RyuJIT and 34% on .NET Framework 4.8.1 x64 RyuJIT
+for this shape, without adding allocation. These percentages do not measure the proposed
+API itself. A prototype `TryGetRawValue` benchmark is required to quantify the realized
+savings, including its Boolean/out-parameter overhead.
+
+The same investigation found that changing the assignment primitive is not a suitable
+alternative. `FormatterServices.PopulateObjectMembers` requires a per-object values
+array; including that array made a 32-field operation 11% slower on .NET 10 x64 RyuJIT
+and raised allocation from 144 B to 424 B. On .NET Framework 4.8.1 x64 RyuJIT it did
+not establish a meaningful throughput improvement and raised allocation from 144 B to
+425 B.
+
+## API Proposal
+
+```csharp
+namespace System.Formats.Nrbf;
+
+public abstract class ClassRecord : SerializationRecord
+{
+    public bool TryGetRawValue(string memberName, out object? value);
+}
+```
+
+Proposed semantics:
+
+- Returns `true` when `memberName` was present in the serialized payload.
+- Returns `false` when `memberName` was absent and sets `value` to `null`.
+- A return value of `true` does not imply that `value` is non-null. A serialized
+  member that is present with a null value returns `true` and sets `value` to `null`.
+- When the member is present, `value` has exactly the same value and representation
+  that `GetRawValue(memberName)` would return. This includes primitive values,
+  strings, `ClassRecord` instances, and array records.
+- Throws `ArgumentNullException` with `ParamName == "memberName"` when `memberName`
+    is null. This deliberately reports the public parameter name rather than exposing the
+    internal dictionary's `"key"` parameter name.
+
+No nullability attribute such as `NotNullWhen(true)` should be applied to `value`,
+because a present serialized member can legitimately contain null.
+
+A possible implementation sketch, not part of the proposed public API, is:
+
+```csharp
+public object? GetRawValue(string memberName)
+    => GetRawValue(ClassInfo.MemberNames[memberName]);
+
+public bool TryGetRawValue(string memberName, out object? value)
+{
+    ArgumentNullException.ThrowIfNull(memberName);
+
+    if (!ClassInfo.MemberNames.TryGetValue(memberName, out int index))
+    {
+        value = null;
+        return false;
+    }
+
+    value = GetRawValue(index);
+    return true;
+}
+
+private object? GetRawValue(int index)
+{
+    object? value = MemberValues[index];
+    return value is SerializationRecord record ? record.GetValue() : value;
+}
+```
+
+Factoring the existing conversion through an index-based helper keeps
+`GetRawValue` and `TryGetRawValue` behavior aligned while ensuring that the new API
+performs one member-name dictionary lookup.
+
+## API Usage
+
+Version-tolerant member inspection becomes one operation:
+
+```csharp
+if (classRecord.TryGetRawValue("OptionalMember", out object? value))
+{
+    // The member was present. value can still be null.
+    Process(value);
+}
+```
+
+A deserializer can skip fields that were not present in an older payload without
+probing the member-name dictionary twice:
+
+```csharp
+foreach (FieldInfo field in FormatterServices.GetSerializableMembers(type))
+{
+    if (!classRecord.TryGetRawValue(field.Name, out object? rawValue))
+    {
+        continue;
+    }
+
+    object? value = MaterializeValue(rawValue);
+    field.SetValue(instance, value);
+}
+```
+
+The Boolean result disambiguates an absent member from a present null member:
+
+```csharp
+bool present = classRecord.TryGetRawValue("MiddleName", out object? middleName);
+
+// present == false: the payload did not contain MiddleName.
+// present == true && middleName is null: the payload contained a null MiddleName.
+```
+
+## Alternative Designs
+
+### Change `GetRawValue` to return null for a missing member
+
+This would be a breaking behavioral change and could not distinguish a missing member
+from a member that is present with a null value.
+
+### Catch `KeyNotFoundException` from `GetRawValue`
+
+Missing members are expected during version-tolerant deserialization. Using exceptions
+for this path adds exception and allocation pressure and makes malformed or adversarial
+payload shapes more expensive.
+
+### Enumerate `MemberNames` first
+
+A consumer could build a local set or dictionary from `MemberNames`, but this adds
+per-record or per-layout allocation. Linear searches avoid allocation but turn field
+matching into quadratic work for wide classes. Neither option can reuse the internal
+name-to-index lookup already owned by `ClassRecord`.
+
+### Add `GetRawValueOrDefault`
+
+A default-returning API would retain the missing-versus-present-null ambiguity and would
+not communicate member presence to version-tolerant callers.
+
+### Add `TryGetMember<T>` or Try variants for every typed getter
+
+A generic API introduces questions about type mismatches, nullable value types, and
+conversion behavior. Adding Try variants for all typed getters would create a large API
+family. `TryGetRawValue` is the minimal counterpart to the existing general-purpose
+`GetRawValue` API and addresses serializers and inspection tools that already perform
+the `HasMember` plus `GetRawValue` sequence.
+
+### Expose a member index or the internal member dictionary
+
+An index API would expose record-layout details and require additional contracts around
+index stability and bounds. Exposing the dictionary would leak mutable or implementation-
+specific state. The proposed API keeps the current abstraction boundary.
+
+## Risks
+
+This is an additive API with low compatibility risk. It exposes no value that cannot
+already be obtained through `HasMember` and `GetRawValue`.
+
+The main usability risk is interpreting `true` as implying a non-null value. The XML
+documentation and examples should explicitly state that `true` means the member was
+present, not that its value was non-null.
+
+The implementation should preserve `GetRawValue` conversion semantics and use one
+`TryGetValue` operation. Implementing it as `HasMember` followed by `GetRawValue` would
+provide the API convenience but miss the performance and algorithmic motivation.
+
+No new caching is required. The proposal does not retain additional type, record, or
+member-name state and does not change parsing or malformed-payload validation.
+
+## Suggested API tests
+
+- A missing member returns `false` and writes `null` to `value`.
+- A present member whose serialized value is null returns `true` and writes `null`.
+- Primitive, string, class-record, and array-record members return the same value as
+  `GetRawValue`.
+- A member-reference record has the same resolved-value behavior as `GetRawValue`.
+- A null `memberName` throws `ArgumentNullException` with
+    `ParamName == "memberName"`.
+- Calling the method does not mutate the record or member enumeration.

--- a/docs/filtrace-local-demo.md
+++ b/docs/filtrace-local-demo.md
@@ -17,10 +17,10 @@ faster?" - not tool-by-tool instructions.
 ## Setup (one time)
 
 filtrace is published to NuGet (github.com/JeremyKuhne/filtrace). The MCP server
-entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.4.0 on demand via
+entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.0 on demand via
 `dnx` (the .NET 10 SDK tool runner) - no clone or build required. Start it from
 the Command Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*) and
-confirm the 15 `trace_*` tools register in the chat tool picker.
+confirm the 17 `trace_*` tools register in the chat tool picker.
 
 ---
 
@@ -52,9 +52,12 @@ is one.
 > **Prompt:** Enumerating files with Touki's extended-glob matcher feels slow. Where's the time actually going?
 
 **Good:** the agent recognizes this needs a *profile*, not just a benchmark. It
-captures an EventPipe trace of the relevant `touki.perf` benchmark (`-p EP`),
-then drives **rank -> callers -> lines** scoped past the BenchmarkDotNet harness
-to the real work, and reports the hot method/line in plain language. Follow up:
+uses the bundled capture helper to capture the relevant `touki.perf` benchmark,
+retains its run manifest and exact generated-child symbols, then drives
+**rank -> callers -> lines** with `benchmark: true` on root-aware MCP tools and
+reports the hot method/line in plain language. It reads ambiguity, thin-scope,
+provider-state, and source-resolution warnings before interpreting percentages.
+Follow up:
 
 > **Prompt:** Show me that hot source file with the time marked on each line.
 
@@ -107,6 +110,17 @@ benchmark on both TFMs, (3) profile and drill to the hot line with evidence,
 `Allocated`) regressed, (6) offer the next drill. It should reuse the existing
 benchmark/trace rather than starting over.
 
+### 8. "Compare every scenario before and after" (manifest diff/batch)
+
+> **Prompt:** Compare the before and after traces for every parameterized benchmark case. Which targeted frame moved, and did any case regress?
+
+**Good:** the agent uses `trace_batch` for a compact ranking across each capture
+manifest and `trace_diff` to pair cases by exact benchmark + parameters. It keeps
+root/process/BenchmarkDotNet scope consistent, reports scope-share and normalized
+changes, and emits per-operation values only when both manifests have matching
+operation count and unit metadata. It drills individual cases only after the batch
+view identifies them.
+
 ---
 
 ## Warm-up: you already have a trace
@@ -130,6 +144,12 @@ checked out at `../filtrace`; substitute any `.nettrace` / `.speedscope.json`:
 - Reads a net481 hotspot off a net10 EventPipe trace (see step 4).
 - Pastes a raw table and stops, instead of answering the question and offering
   the next drill.
+- Uses a supported file format as proof that a provider was enabled instead of
+  checking `analyses.<name>.captureStatus` and `eventCount`.
+- Trusts a 1.0 frame-name resolution rate for source lines without checking
+  `sourceResolution` and exact PDB identity.
+- Ignores `contributingRecordCount`/line attribution warnings for a thin periodic
+  CPU scope, or applies periodic-sample thresholds to evented speedscope records.
 - On a machine-wide `.etl`, ranks without scoping to a process (see step 5).
 - Guesses at native runtime cost instead of opting into `--native-symbols` to
   resolve it (see step 6).

--- a/docs/performance-investigation-agent-tooling-retrospective.md
+++ b/docs/performance-investigation-agent-tooling-retrospective.md
@@ -1,0 +1,631 @@
+# Performance investigation agent/tooling retrospective
+
+This document reflects on the July 2026 `BinaryFormattedObject` performance
+investigation and identifies changes that would help a future coding agent reach
+trustworthy results faster. It covers the repository's performance-testing guidance,
+the vendored filtrace skill and capture scripts, and the filtrace analyzer itself.
+
+The investigation succeeded: it established reproducible cross-runtime baselines,
+separated decoding from materialization, used profiles to select bounded changes,
+rejected regressions, and produced an upstream API proposal. The recommendations below
+focus on places where the agent had to discover missing workflow rules or compensate for
+tool behavior manually.
+
+Filtrace release [0.6.0](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.0)
+delivered the analyzer, MCP, capture-script, and tool-shipped-skill work tracked by
+[JeremyKuhne/filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42), which
+is closed as completed. Touki consumes that release. The portable performance-workflow
+guidance is still being validated in Touki's local performance-testing overlay before it
+is upleveled to `JeremyKuhne/agent-skills`.
+
+## Executive summary
+
+Filtrace 0.6.0 delivered:
+
+1. Explicit BenchmarkDotNet/root selection with ambiguity diagnostics.
+2. Query-specific contributing-record counts and thin-periodic-sample warnings.
+3. Concurrent same-trace ETLX conversion across MCP calls and processes.
+4. Separate format support, provider enablement, and observed event counts.
+5. Source/PDB resolution separate from managed frame-name resolution.
+6. Isolated BenchmarkDotNet captures with every case, its exact child-build symbols,
+   and machine-readable manifests.
+7. Normalized manifest-aware diff and compact batch analysis.
+
+Separately, Touki's local performance-testing overlay now distinguishes one-shot phase
+measurement from adaptive phase profiling and requires an experiment ledger. Those are
+workflow guidance, not filtrace product features. The current workflow can produce correct
+answers without the manual filtrace workarounds this investigation needed. The remaining
+work is to uplevel the local guidance, exact-source comparison, and reconstructable
+dirty-source provenance to `agent-skills`.
+
+## What worked well
+
+Several parts of the existing guidance materially improved the investigation and should
+remain load-bearing:
+
+- `trace_info` was called before rankings, and the 0.8 managed-symbol threshold prevented
+  trusting traces with unresolved frame names.
+- Self-time, inclusive-time, callers, and source-line views were treated as different
+  questions rather than interchangeable rankings.
+- The before/after loop required the targeted frame to move, not just the benchmark mean.
+  This caught successful dictionary/stack changes and rejected a pooled-stack experiment.
+- Performance conclusions named the runtime and JIT. The modern .NET and .NET Framework
+  results diverged enough that a single-runtime conclusion would have been wrong.
+- Allocation was a first-class result. Eager capacity reservation and realistic
+  `PopulateObjectMembers` batching were rejected because their allocation cost outweighed
+  or erased throughput gains.
+- Exact-source comparison used a clean detached upstream checkout, Release configuration,
+  the repository's pinned SDK, assembly provenance checks, and a separate stream over the
+  same bytes.
+- Mutable one-shot semantics were validated. Parsed NRBF graphs were materialized exactly
+  once, preventing a fast but invalid benchmark that reused mutable record state.
+
+The retrospective should extend these practices rather than replace them.
+
+## Historical friction addressed by filtrace 0.6.0
+
+The subsections below record what happened during the 0.4 investigation. They are retained
+as rationale and regression context; they are not current 0.6 limitations.
+
+### One-shot measurement was a poor profiling harness
+
+The materialization-only benchmark correctly used `IterationSetup` to parse fresh record
+graphs outside the measured region. BenchmarkDotNet consequently forced one invocation
+per iteration. A one-object batch hit timer quantization; a 256-object batch retained
+15-25 MiB of decoded state and distorted tree/cycle timing; a 64-object batch was the
+best measurement compromise.
+
+That compromise still produced sparse EventPipe profiles. A 512-object dedicated field
+benchmark returned `scopeWeight: 32` inside
+`ClassRecordFieldInfoDeserializer.Continue`; for this CPU `.nettrace`, unit sample weights
+made that equivalent to 32 sampled ticks. The global trace held more than 6,000 samples,
+so `trace_info` looked healthy while the selected scope was statistically thin.
+
+For profiling, the better harness already existed: run the adaptive end-to-end benchmark
+and root-scope analysis to `BinaryFormattedObject.Deserialize`. Parsing remains outside
+the selected call subtree, while BenchmarkDotNet can execute enough operations to produce
+a dense phase profile without retaining a large batch of parsed graphs.
+
+### Parameterized captures produced multiple traces without a manifest
+
+One `BinaryFormattedObjectPerf` capture produced six `.nettrace` files, one per scenario.
+The capture script selected and printed commands for only the newest trace. The agent had
+to enumerate files, parse scenario names from filenames, and manually pair before/after
+captures.
+
+This is easy to get wrong when another capture exists in the artifacts directory or when
+two runs overlap. It also makes automated scenario-by-scenario comparison unnecessarily
+expensive.
+
+### The printed symbol path did not identify the traced build
+
+The capture script derives symbols as `<project>/bin/Release/<tfm>`. This repository sets
+custom `BaseOutputPath` and `OutputPath` values, and BenchmarkDotNet profiles a generated
+child build under a path such as:
+
+```text
+artifacts/x64/Release/touki.perf/net10.0/
+  touki.perf-DefaultJob-1/bin/Release/net10.0
+```
+
+Passing the outer perf output allowed method names to resolve but returned `<no source>`
+for Touki lines. Passing the preserved child output resolved exact file/line locations.
+The aggregate symbol-resolution rate remained `1.0` in both cases because it measured
+managed frame names, not portable-PDB source mapping. The agent therefore had a green
+quality signal while line attribution was unusable.
+
+### `trace_info` advertised allocation analysis without allocation events
+
+The raw BenchmarkDotNet EventPipe traces were `.nettrace` files, so filtrace 0.4
+`trace_info` listed
+`alloc` under `availableAnalyses`. `trace_rank(metric: alloc)` then reported that no
+allocation events existed and asked whether allocation sampling had been enabled. The
+tool did not distinguish an enabled provider that observed zero events from a provider
+that was not enabled.
+
+The 0.4 capture script similarly stated that a raw EventPipe trace carried allocation
+events and printed an `alloc` command unconditionally. File format alone does not
+establish that the required provider/events were captured. The then-vendored 0.4 core
+skill made the same unconditional claim for EventPipe allocation and exception data.
+
+### Parallel MCP reads raced on the ETLX cache
+
+Parallel `trace_info`, `trace_rank`, and `trace_lines` calls against the same `.nettrace`
+failed with combinations of:
+
+```text
+Could not find ...nettrace.etlx.new
+The process cannot access ...nettrace.etlx.new because it is being used
+Access to ...nettrace.etlx.new is denied
+```
+
+Calls against different traces were safe. Retrying sequentially succeeded. This is a
+product correctness issue because agent guidance generally encourages parallel read-only
+tool calls, and the MCP surface does not communicate that conversion is a single-writer
+operation.
+
+### Whole-trace quality hid low-quality scopes
+
+Rankings over narrow scopes returned `scopeWeight` values of 2, 10, 20, or 32 and precise
+percentages without a quality warning. For these CPU `.nettrace` inputs, the unit-weight
+samples made those values numerically equal to sampled ticks, but that is not the filtrace
+contract: `scopeWeight` is metric weight, and evented speedscope inputs use
+event-duration deltas.
+The 0.4 tool exposed no distinct scoped sample count. The skill documented rough count
+thresholds (`>=200-300` samples for a method percentage, `>=1,000` for useful line
+distribution), but neither the agent nor the tool can apply them generically from
+`scopeWeight`.
+
+The agent compensated by building wider benchmarks and confirming hypotheses with
+BenchmarkDotNet microbenchmarks. A tool warning would have prompted that escalation
+immediately.
+
+### Before/after trace comparison was manual
+
+The investigation recaptured tree and cycle traces after each retained optimization, then
+manually compared percent-of-scope rows to verify that `Dictionary.Resize`, stack growth,
+and duplicate type resolution moved. Raw sample counts differed between captures, so
+absolute-weight comparison would have been misleading.
+
+A normalized, root-scoped diff would have made this both faster and less error-prone.
+
+### Benchmark output and artifacts needed manual retention
+
+Long adaptive runs produced large terminal output, were sometimes moved to background,
+and reused BenchmarkDotNet's standard result filenames. The investigation used explicit
+`Tee-Object` files to preserve each matrix. Without that discipline, a later run would
+replace the compact report needed for documentation.
+
+The generic skill correctly says to read artifacts rather than scrollback, but it does not
+provide a standard run identifier or result manifest for a multi-run investigation.
+
+## Skill changes and remaining agent-skills work
+
+### 1. Separate measurement harnesses from profiling harnesses
+
+**Owner:** Touki-owned
+[`profiling.md`](../.agents/skills/performance-testing/profiling.md) immediately;
+propose a portable version upstream to `JeremyKuhne/agent-skills` and re-vendor rather
+than editing the pinned performance-testing core.
+
+The local "phase measurement versus phase profiling" section requires:
+
+- For a mutable or consumable intermediate representation, measure phase latency with
+  fresh state in `IterationSetup`, a bounded batch, `OperationsPerInvoke`, and one
+  consumption per item.
+- Sweep at least three batch sizes: one item to expose timer overhead, an intermediate
+  batch, and a larger batch to expose retained-live-set distortion.
+- Treat BenchmarkDotNet's minimum-iteration warning as expected only after documenting why
+  invocation count must remain one.
+- For CPU profiling, prefer an adaptive end-to-end benchmark and root-scope the trace to
+  the phase method. Do not profile the one-shot `IterationSetup` benchmark unless the
+  selected scope has enough samples.
+- Validate phase decomposition by checking that phase allocations add to end-to-end
+  allocation and that phase means approximately add to end-to-end latency.
+
+**Acceptance check:** a future agent facing a parse/materialize split should choose the
+one-shot batch for measurement and the adaptive end-to-end path for profiling without
+first trying 1/256-item profiling batches.
+
+**Status:** implemented in Touki's owned profiling page; candidate for promotion to
+`agent-skills`.
+
+### 2. Make scoped sample sufficiency a mandatory gate
+
+**Owner:** delivered in filtrace 0.6.0 and its tool-shipped skill; Touki's profiling page
+consumes the result.
+
+Use query-specific `contributingRecordCount` (or line-level attributed/unattributed
+counts), never `trace_info.sampleCount`, self-percent, or `scopeWeight`. When capture
+metadata establishes periodic CPU sampling semantics, apply these gates:
+
+- `<200` CPU samples: directional hypothesis only; no percentage claim.
+- `200-999`: method ranking may be usable, but line claims need escalation.
+- `>=1,000`: line attribution may be useful if source resolution is healthy.
+
+The skill should explicitly say that `trace_info.sampleCount` is a whole-trace number and
+cannot establish quality for a narrow root or method. The required count depends on the
+query: records surviving root/process/activity/time filters for rank, records containing
+the focus frame for callers, and records actually attributed to the requested methods and
+source locations for lines.
+
+**Acceptance check:** a 32-sample field-assignment scope from a periodic CPU profile should
+automatically trigger a larger/adaptive harness or ETW recommendation. Evented profiles do
+not use these gates.
+
+**Status:** delivered in filtrace 0.6.0 (#44).
+
+### 3. Correct provider-dependent EventPipe wording
+
+**Owner:** filtrace core skill, vendored into Touki with release 0.6.0.
+
+Change statements that EventPipe "carries" analysis data to say that `.nettrace` can
+carry CPU, allocation, exception, GC, JIT, contention, wait, activity, and thread-pool
+events when the recorder enables each analysis's required providers/keywords. Route based
+on capture metadata and observed events, not the extension.
+
+**Acceptance check:** manual and BenchmarkDotNet capture guidance no longer promises an
+allocation ranking merely because the output is `.nettrace`.
+
+**Status:** delivered in filtrace 0.6.0 (#46 and the shipped skill).
+
+### 4. Allow parallel same-trace MCP analysis
+
+**Owner:** filtrace core and tool-shipped skill.
+
+Coordinate ETLX conversion by canonical path across threads and processes, publish the
+cache atomically, and report cache state rather than requiring consumer serialization.
+
+**Acceptance check:** an agent may run `trace_info`, `trace_rank`, and `trace_lines`
+concurrently against one trace without sidecar races.
+
+**Status:** delivered in filtrace 0.6.0 (#45). The temporary sequential-call workaround
+has been removed from Touki guidance.
+
+### 5. Add an experiment ledger to the performance workflow
+
+**Owner:** Touki-owned `docs/performance-investigation.md` immediately; propose the
+portable workflow upstream to `JeremyKuhne/agent-skills` and re-vendor it.
+
+The local workflow requires a compact ledger for each experiment:
+
+| Hypothesis | Small edit | Discriminating check | Time | Allocation | Target frame | Decision |
+| --- | --- | --- | ---: | ---: | --- | --- |
+
+Record rejected variants as well as retained changes. This investigation rejected eager
+dictionary reservation, pooled parser storage, and realistic batched field assignment.
+Keeping those results prevented revisiting attractive but losing ideas and made the final
+document more defensible.
+
+**Acceptance check:** every optimization pass leaves enough evidence to explain why the
+chosen implementation beat at least the most plausible alternative.
+
+**Status:** implemented in Touki's owned profiling page; candidate for promotion to
+`agent-skills`.
+
+### 6. Add an exact-source oracle recipe
+
+**Owner:** Touki-owned performance investigation documentation immediately; propose the
+portable recipe upstream to `JeremyKuhne/agent-skills` and re-vendor it instead of
+editing pinned authoring/running pages.
+
+For comparisons against another repository:
+
+- use a clean detached checkout at an exact SHA;
+- build Release with the subject repository's pinned SDK;
+- verify assembly informational version/configuration where available;
+- isolate namespace collisions with `extern alias`;
+- pass optional references to BenchmarkDotNet child builds through an environment-backed
+  MSBuild property, not only an outer `/p:` argument;
+- validate semantic parity and fresh mutable state before measuring;
+- remove the temporary checkout afterward.
+
+**Acceptance check:** BenchmarkDotNet's generated child project must include the oracle in
+opt-in runs and ordinary builds must contain no oracle reference or benchmark methods.
+
+**Status:** implemented by this investigation's runner and retained as a portable
+`agent-skills` candidate; it is not a filtrace feature.
+
+### 7. Standardize run IDs and artifact retention
+
+**Owner:** Touki-owned performance investigation documentation immediately; upstream
+filtrace capture scripts for automation; upstream `agent-skills` for portable running
+guidance.
+
+Recommend a unique artifact directory or output stem containing:
+
+```text
+<subject>-<phase>-<variant>-<tfm>-<job>-<timestamp>
+```
+
+A run should retain the compact report, command line, runtime banner, commit SHA, clean or
+dirty status, and trace manifest. For a dirty worktree, retain a reconstructable run-source
+bundle: a binary-capable tracked-file patch plus an archive containing relevant untracked
+and ignored input content and its manifest, or an equivalent complete source snapshot.
+Hashes establish integrity but do not replace the content. Avoid chaining several long
+adaptive runs in one persistent terminal; run one TFM at a time and wait for completion
+before scheduling the next command.
+
+**Acceptance check:** a later benchmark cannot silently overwrite the baseline report used
+for before/after or documentation. A clean checkout at the recorded commit plus the
+run-source bundle reconstructs the hashed source inputs, including untracked and binary
+files, for a dirty experimental run.
+
+**Status:** filtrace 0.6.0 capture manifests deliver isolated run IDs, logs, traces, exact
+child symbols, runtime/source identity, and optional operation metadata (#48/#49). The
+reconstructable dirty-source bundle remains a portable `agent-skills` candidate.
+
+## Capture-script changes delivered in filtrace 0.6.0
+
+These requirements are implemented in filtrace's bundled
+[`Capture-BenchmarkTrace.ps1`](../.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1),
+vendored here from release 0.6.0. Keep the acceptance checks as regression contracts.
+
+### 1. Isolated runs and complete case manifests
+
+The helper generates a unique run ID, isolates its log and BenchmarkDotNet artifacts, and
+holds a same-project/same-TFM capture lock around the shared project output/intermediate
+paths. The generated-child files live under the isolated BenchmarkDotNet artifacts path.
+It enumerates only that run directory and emits JSON as well as concise console output.
+This abridged example matches manifest schema v1:
+
+```json
+{
+  "schemaVersion": 1,
+  "runId": "20260712-012345-5d9f1234",
+  "startedUtc": "2026-07-12T01:23:45.0000000+00:00",
+  "completedUtc": "2026-07-12T01:24:45.0000000+00:00",
+  "command": {
+    "executable": "dotnet",
+    "arguments": ["run", "-c", "Release", "..."]
+  },
+  "project": "touki.perf/touki.perf.csproj",
+  "tfm": "net10.0",
+  "filter": "*BinaryFormattedObjectPerf*",
+  "profiler": "EP",
+  "source": {
+    "repository": ".../touki-binary-formatted-object",
+    "commit": "0123456789abcdef0123456789abcdef01234567"
+  },
+  "paths": {
+    "runDirectory": ".../BenchmarkDotNet.Artifacts/filtrace-runs/20260712-012345-5d9f1234",
+    "artifactsDirectory": ".../filtrace-runs/20260712-012345-5d9f1234/artifacts",
+    "log": ".../filtrace-runs/20260712-012345-5d9f1234/capture.log"
+  },
+  "cases": [
+    {
+      "benchmark": "BinaryFormattedObject_DeserializeRecords",
+      "parameters": "Scenario=ObjectTree_127",
+      "trace": "...ObjectTree_127....nettrace",
+      "speedscope": "...ObjectTree_127....speedscope.json",
+      "symbolsDirectory": "...touki.perf-DefaultJob-1/bin/Release/net10.0",
+      "analyses": {},
+      "commands": [],
+      "warnings": []
+    }
+  ]
+}
+```
+
+Do not select only the globally newest trace. Include every parameterized case and its
+paired files.
+
+**Regression check:** one six-scenario capture returns six case entries. Stale traces are
+never selected. Two simultaneous same-project/same-TFM captures either write disjoint
+logs, artifacts, outer/child outputs, intermediates, binaries, and PDBs without
+cross-contamination, or the second fails immediately with a clear capture-lock message.
+
+### 2. Exact BenchmarkDotNet child output
+
+The helper preserves generated files for EventPipe and ETW, discovers child output
+candidates from the isolated run, and asks filtrace to select the directory whose
+module/PDB identity matches the trace. It respects custom output paths, architecture,
+BenchmarkDotNet artifacts directories, and job names.
+
+**Regression check:** the printed `filtrace lines` command resolves Touki file/line data in
+this repository without the user replacing `<project>/bin/Release/<tfm>` manually.
+
+### 3. Provider-aware next-step commands
+
+After capture, the helper inspects the trace and prints analysis commands only when capture
+metadata says the required provider was enabled. An enabled provider with zero observed
+events supports a valid empty analysis; disabled is unavailable; unknown remains unknown
+rather than being inferred from the extension or a zero event count.
+
+**Regression check:** test one trace with allocation capture enabled and zero allocations,
+one with allocation capture enabled and events, one with allocation capture disabled, and
+one whose provider enablement cannot be determined. The first two print a valid `alloc`
+command; the disabled trace explains how to recapture; the unknown trace reports that
+availability cannot be established and does not present a command as known-valid.
+
+### 4. Agent-friendly output mode
+
+`-Format Text|Json` and `-Quiet` keep full BenchmarkDotNet output in the capture log while
+JSON/stdout carries compact run status, manifest location, warnings, and next steps. This
+avoids routing tens of kilobytes through agent context merely to learn the trace path.
+
+**Regression check:** a successful parameterized capture returns a compact manifest under
+20 KiB regardless of BenchmarkDotNet's iteration log size.
+
+## Filtrace product changes delivered in 0.6.0
+
+All product sections below shipped in release 0.6.0. Their acceptance checks remain useful
+for future regression testing.
+
+### P0: First-class BenchmarkDotNet scoping and root/frame diagnostics
+
+Root-aware CLI and MCP queries accept either the BenchmarkDotNet workload preset
+(`--benchmark` / `benchmark: true`) or an explicit frame root, never both. The preset
+selects the generated `WorkloadAction` wrapper without requiring the caller to know its
+name. Every substring-based root/frame selection reports:
+
+- the number of matching frame definitions;
+- selected frames with module and full signature;
+- matches at multiple stack depths;
+- the exact BenchmarkDotNet workload root selected;
+- a warning when a substring also matches an activity/harness wrapper.
+
+**Regression check:** an MCP caller can isolate measured workload without knowing generated
+`WorkloadAction*` frame names. A benchmark-method substring that matches both an activity
+wrapper and actual method emits ambiguity diagnostics and identifies the deterministic
+outermost root or deepest focus selection, so the caller can narrow it before trusting the
+result.
+
+### P0: Query-specific scoped record counts and quality warnings
+
+Results keep `scopeWeight` as metric weight and expose count fields whose contributing-
+record population matches each query:
+
+- rank: CPU records surviving all process/activity/time/root filters;
+- callers: filtered CPU records containing the focus frame;
+- lines/heatmap: filtered CPU records attributed to the requested method/file and source
+  location, plus a separate unattributed count.
+
+For periodic CPU sample profiles, warnings and hints use the requested
+granularity:
+
+- CPU method scope under 200 samples: directional only.
+- CPU line scope under 1,000 samples: sparse; recommend adaptive/larger harness or ETW.
+- Percentages from very small scopes should be marked low confidence in text and JSON.
+
+Thresholds remain capture-aware because periodic sources use different sample rates.
+For evented speedscope profiles, report contributing-record count separately but do not
+apply periodic-sample thresholds: those records are duration intervals driven by stack
+transitions, not independent samples. For formats where a meaningful record count or
+compatible periodic-sampling semantics are unavailable, omit the count or thresholds.
+
+**Regression check:** a CPU rank with 32 contributing records returns a low-sample warning
+even though the whole periodic-sample trace has more than 6,000 samples. A weighted
+evented speedscope scope with four contributing records and `scopeWeight: 32 ms` reports
+record count `4`, not `32`, and does not apply the 200/1,000 periodic-sample gates. A
+format/profile for which a contributing-record count cannot be defined reports the count
+as unavailable and does not apply count thresholds.
+
+### P0: Concurrency-safe ETLX conversion
+
+**Observed failure:** parallel MCP calls against one trace raced over `.etlx.new`.
+
+The core coordinates conversion by canonical trace path across threads and processes:
+
+1. Check for a valid completed cache.
+2. Acquire the per-trace conversion lock.
+3. Recheck after acquiring it.
+4. Convert to a uniquely named temporary file.
+5. Atomically replace/move to the final cache.
+6. Clean temporary files on failure.
+7. Let waiters reuse the completed cache.
+
+Transient file-not-found/access-denied conversion races no longer reach callers. Diagnostic
+output includes cache state (`hit`, `waited`, `converted`, `recovered`).
+
+**Regression check:** run `trace_info`, two `trace_rank` calls, and `trace_lines` concurrently
+against a trace with no preexisting ETLX. All calls succeed and only one conversion occurs.
+Also test two processes, cancellation during conversion, and a stale `.new` file.
+
+### P0: Format support, capture enablement, and observed events
+
+`trace_info.analyses` reports per-analysis state instead of inferring availability from
+the trace extension. `availableAnalyses` separately lists what the loaded format supports.
+For example:
+
+```json
+{
+  "analyses": {
+    "cpu": {
+      "captureStatus": "enabled",
+      "eventCount": 6673
+    },
+    "alloc": {
+      "captureStatus": "disabled",
+      "eventCount": null
+    },
+    "exceptions": {
+      "captureStatus": "enabled",
+      "eventCount": 0
+    }
+  }
+}
+```
+
+`captureStatus` is `enabled`, `disabled`, or `unknown`. Zero events with enabled
+capture means a valid empty analysis; disabled means unavailable; unknown must remain
+unknown. Report the distinction whenever trace metadata permits it.
+
+**Regression check:** cover enabled-zero, enabled-nonzero, disabled, and unknown provider
+states. The investigation's EventPipe trace must not claim that allocation analysis is
+available solely because its format is `.nettrace`.
+
+### P0: Separate source-resolution quality
+
+`trace_info.sourceResolution` reports portable-PDB/source quality independently of managed
+frame-name resolution:
+
+- modules with matching PDBs;
+- modules with GUID/age mismatch;
+- methods with sequence points;
+- sampled managed frames mapped to source;
+- sampled managed frames named but mapped to `<no source>`;
+- symbol directories searched.
+
+A `symbolResolutionRate` of `1.0` must not imply that `trace_lines` will work.
+
+**Regression check:** passing the outer perf output reports full frame-name resolution but
+poor Touki source resolution and identifies the missing/mismatched module. Passing the
+BenchmarkDotNet child output reports usable Touki sequence points.
+
+### P1: Normalized, scope-aware trace diff
+
+`trace_diff` compares percent-of-scope and normalized capture weights in addition to raw
+metric weight. Direct-trace inputs use consistent root or BenchmarkDotNet preset, process,
+and metric scope and report:
+
+- before/after scope weights;
+- before/after percent of scope;
+- percentage-point change;
+- normalized weight change;
+- frames appearing/disappearing;
+- quality warnings when either scope is thin.
+
+Manifest inputs pair cases by exact benchmark plus parameters. Per-operation normalization
+is offered only when both manifests include an explicit
+operation count and unit; otherwise the tool must not imply per-operation data.
+
+**Regression check:** the modern .NET RyuJIT dictionary optimization should show
+`Dictionary.Resize` moving from roughly 38% to 2% in the tree scenario without manual
+table comparison. Test manifests with absent operation metadata, count without unit, and
+complete count+unit metadata; per-operation output must appear only for the complete case.
+
+### P2: Manifest batch analysis
+
+`batch` / `trace_batch` runs one compact ranking across all manifest cases:
+
+```text
+filtrace batch capture.json --metric cpu --root BinaryFormattedObject.Deserialize
+```
+
+Return a table keyed by benchmark and parameters. This is especially useful for agents,
+which otherwise spend calls discovering and opening each parameterized trace.
+
+**Regression check:** one call ranks custom/tree/callback/cycle traces and flags only the
+cases whose selected scope is sample-starved.
+
+## Delivery order and status
+
+| Order | Change | Outcome | Status |
+| ---: | --- | --- | --- |
+| 1 | BenchmarkDotNet scoping + root/frame diagnostics | Prevents plausible percentages over the wrong subtree | Delivered (#43) |
+| 2 | Query-specific scoped counts and warnings | Prevents plausible quantitative claims from thin scopes | Delivered (#44) |
+| 3 | Measurement-versus-profiling skill guidance | Avoids low-sample one-shot traces immediately | Local; pending `agent-skills` |
+| 4 | ETLX per-trace locking and atomic cache writes | Eliminates tool failures and unsafe parallelism | Delivered (#45) |
+| 5 | Capture enablement/event reporting | Prevents impossible analysis workflows | Delivered (#46/#49) |
+| 6 | Source/PDB resolution diagnostics | Prevents false confidence in line attribution | Delivered (#47/#51) |
+| 7 | Isolated capture manifest + exact child symbols | Removes artifact discovery and overlap hazards | Delivered (#48) |
+| 8 | Normalized root-scoped diff | Speeds before/after validation | Delivered (#52) |
+| 9 | Manifest batch analysis | Reduces calls for parameter matrices | Delivered (#52) |
+
+Filtrace 0.6.0 completed every product/capture item. The remaining promotion work is the
+portable performance-testing guidance and dirty-source provenance discipline.
+
+## 0.6.0 outcome and remaining success metrics
+
+With filtrace 0.6.0, an agent can:
+
+- go from a benchmark filter to a trustworthy scoped method ranking in two tool calls after
+  capture (`trace_info`, then `trace_rank`);
+- get exact source lines without manually searching BenchmarkDotNet output directories;
+- analyze parameterized cases without filesystem enumeration;
+- run independent read-only analysis calls in parallel without cache races;
+- receive a warning before interpreting a CPU scope with fewer than 200 scoped samples,
+  without treating generic metric weight as a sample count;
+- know from `trace_info` whether allocation capture was enabled, disabled, or unknown and
+  how many events were observed;
+- compare a targeted frame before/after without manually normalizing sample counts;
+- preserve capture command, runtime/JIT, commit SHA, run ID, manifest, trace, exact child
+  symbols, and artifact identity.
+
+The remaining `agent-skills` goal is to preserve a reconstructable dirty-state source
+bundle when a benchmark is run against uncommitted tracked, untracked, or binary inputs.
+
+Completing the remaining provenance work will make the workflow more reconstructable. The
+0.6 contracts already reduce plausible-looking conclusions built on the wrong scope, wrong
+PDB, absent events, or statistically thin samples.

--- a/docs/performance-investigation-without-mcp.md
+++ b/docs/performance-investigation-without-mcp.md
@@ -3,8 +3,10 @@
 The primary way to turn a captured benchmark trace into ranked hotspots and
 line-level attribution is the standalone
 [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer - its MCP tools for
-an agent, or the `filtrace` CLI (`dotnet tool install -g KlutzyNinja.Filtrace`)
-when the MCP server is unavailable - see
+an agent, or the `filtrace` CLI (fresh install:
+`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.0`; existing install:
+`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.0`) when the MCP server
+is unavailable - see
 [performance-investigation.md](performance-investigation.md) sections 3a, 3f,
 and 6.
 
@@ -12,7 +14,7 @@ This document is the **last-resort fallback**: the committed PowerShell scripts
 that do the same trace aggregation with no filtrace install at all (for an
 environment where neither the filtrace CLI nor its MCP server is available, or
 when you want a flame-graph SVG, which filtrace does not render). The
-*conceptual* guidance - the JIT-helper folding traps and the `RootFrame` gotcha -
+*conceptual* guidance - the JIT-helper folding traps and scope ambiguity -
 lives in
 [performance-investigation.md](performance-investigation.md) section 3a and
 applies identically here; this doc only covers the script invocations.

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -20,6 +20,12 @@ a tool; drop into them for the mechanics:
   [framework-span-performance.md](framework-span-performance.md) - the catalog
   of measured BCL behaviors. **Check these before measuring** - the answer may
   already be recorded.
+- [binary-formatted-object-performance.md](binary-formatted-object-performance.md) -
+  the persisted NRBF deserialization baseline against `BinaryFormatter` and exact
+  upstream `binaryformat`, including the decode/materialization split and optimization plan.
+- [performance-investigation-agent-tooling-retrospective.md](performance-investigation-agent-tooling-retrospective.md) -
+  lessons from the NRBF investigation and a prioritized backlog for making agent-led
+  benchmark and trace analysis faster and more reliable.
 - [arraypool-performance.md](../.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md) and the
   [`scratch-buffer-strategy`](../.agents/skills/scratch-buffer-strategy/SKILL.md)
   skill - choosing a scratch buffer (zeroed `stackalloc` vs `[SkipLocalsInit]`
@@ -211,17 +217,12 @@ writes a `.speedscope.json` with no admin and no extra package.
 | `[DisassemblyDiagnoser]` | Works | Works (this is how the net481 codegen findings were captured) |
 | `[HardwareCounters]`, `InliningDiagnoser` | Works (Windows, admin) | Works (Windows, admin) |
 
-**Default to net10.0 for the call-tree question.** Its EventPipe path needs no
-admin, no extra package, and the structural answer (which method dominates,
-which subtree is hot) is almost always TFM-independent - the *shape* of the
-call tree is the algorithm, not the JIT. Use the net10.0 profile as the
-structural map, and confirm the magnitude of the win on net481 with the
-BenchmarkDotNet table (which **is** available on both TFMs).
-
-Only reach for the **net481 elevation path** when you need on-CPU attribution
-that the net10.0 shape cannot give you (e.g. you suspect the cost is
-net481-specific slow-span indexing inside one method, not a different call
-tree). That path is `[EtwProfiler]`:
+**Use net10.0 EventPipe for modern-runtime triage, not as a net481 map.** Its
+capture path needs no admin and quickly locates the modern hot region, but .NET
+Framework 4.8.1 RyuJIT inlines and lowers differently enough to move the dominant
+frame entirely. Any claim about the net481 hotspot requires a net481 ETW capture;
+the BenchmarkDotNet table alone confirms throughput/allocation, not attribution.
+The net481 elevation path is `[EtwProfiler]`:
 
 - add the `BenchmarkDotNet.Diagnostics.Windows` package and **consume one of its
   public types** so MSBuild copies it to the output (or set
@@ -258,31 +259,30 @@ graph. Cross-platform, works on Linux/macOS/Windows, **no admin required**.
 
 #### Capture a trace, then rank hotspots (filtrace)
 
-Capturing the trace and *reading* it are two steps. Capture is a plain
-`dotnet run`; the ranked, artifact-folded self/inclusive hotspots come from the
-standalone [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer (section 6), which reads the
-trace BenchmarkDotNet just wrote - no GUI, no PerfView:
+Capturing the trace and *reading* it are two steps. Use filtrace's bundled helper
+to isolate the BenchmarkDotNet run, retain exact generated-child symbols, and emit
+an all-case manifest; the standalone
+[filtrace](https://github.com/JeremyKuhne/filtrace) analyzer (section 6) reads the
+manifest or its traces - no GUI, no PerfView:
 
 ```powershell
-# 1. Run the benchmark under EventPipe (--keepFiles preserves the build so its
-#    PDB GUID survives for line-level work in section 3f; harmless otherwise).
-dotnet run -c Release -f net10.0 --project touki.perf -- `
-    --filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' -p EP --keepFiles
+$handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
+  -Project touki.perf/touki.perf.csproj `
+  -Filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' `
+  -Tfm net10.0 -Format Json | ConvertFrom-Json
 
-$trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
-    -Filter '*GlobEnumeratorExtGlobSingleWithRoot*.nettrace' |
-    Sort-Object LastWriteTime | Select-Object -Last 1).FullName
+$manifest = Get-Content $handoff.manifest -Raw | ConvertFrom-Json
+filtrace batch $handoff.manifest --metric cpu --measure self --benchmark
 
-# 2. Folded self-time + inclusive-time rankings, scoped to a workload frame.
-filtrace cpu $trace --root 'RecordedDirectoryEnumerator.MoveNext' --top 25
-
-# Confirm what a folded JIT-helper artifact is attributable to:
-filtrace callers $trace 'BulkMoveWithWriteBarrier'
+# Drill one case after the compact matrix view identifies it.
+$case = $manifest.cases[0]
+filtrace cpu $case.trace --benchmark --top 25
+filtrace callers $case.trace 'BulkMoveWithWriteBarrier' --benchmark
 ```
 
 An agent that speaks MCP calls `trace_rank` (with `measure: self|inclusive`) /
-`trace_callers` directly on the registered `filtrace` server (section 6) instead
-of shelling out.
+`trace_callers` with `benchmark: true`, or `trace_batch` for the manifest,
+directly on the registered `filtrace` server (section 6) instead of shelling out.
 
 > The committed PowerShell scripts (`Profile-Benchmark.ps1`,
 > `Get-TraceHotspots.ps1`) did this aggregation before filtrace existed and it
@@ -330,13 +330,15 @@ ranked method dominates - hand the `.nettrace` to `filtrace` with the `lines` ve
 > the folded view reattributed a "93% `BulkMoveWithWriteBarrier`" reading to its
 > true owners: the two engine loop bodies `RunEngine` (50.9%) and
 > `RunEngineDirectory` (42.2%), pure compute, no copies.
-
-> **`rootFrame` gotcha.** BenchmarkDotNet wraps the workload in an
+>
+> **Scope-selection gotcha.** BenchmarkDotNet wraps the workload in an
 > `Activity Benchmark(...benchmarkName=Foo...)` frame whose **name contains the
-> benchmark method name**. Scoping with the method name as `--root` / `rootFrame`
-> therefore also matches that wrapper and pulls idle threadpool threads into the
-> ranking. Scope to a frame *inside* the workload instead (an enumerator
-> `MoveNext`, or the first method unique to the system under test).
+> benchmark method name**. A substring root can therefore match both that wrapper
+> and the method. For the whole measured workload, use `--benchmark` /
+> `benchmark: true`, which selects the generated `WorkloadAction` wrapper. For a
+> phase-specific query, use a unique phase method as `--root` / `root` *instead*
+> of the benchmark preset, and inspect the ambiguity diagnostics before trusting
+> percentages.
 
 `EventPipeProfile` values worth knowing:
 
@@ -456,10 +458,13 @@ The profilers above rank *methods*. The standalone
 [filtrace](https://github.com/JeremyKuhne/filtrace) project takes the same trace one
 level deeper: it reads the `.nettrace`/`.etl` through TraceEvent and attributes
 each leaf sample to the **source `file:line` that was executing**, so you can
-see which lines of a hot loop dominate. It is net10-only and runs two ways:
+see which lines of a hot loop dominate. The analyzer runs on .NET 10 but can
+read modern `.nettrace` and net481 ETW `.etl` captures. It has two front ends:
 
-- **Console front end** - `filtrace <verb>` (install once with
-  `dotnet tool install -g KlutzyNinja.Filtrace`).
+- **Console front end** - `filtrace <verb>` (fresh install:
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.0`; existing install:
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.0`). Require
+  `filtrace --version` to print `0.6.0` before invoking the bundled capture helper.
 - **MCP server** - the same queries exposed as tools (`trace_info`,
   `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
   registered `filtrace` server for an agent that speaks MCP. See section 6.
@@ -467,21 +472,18 @@ see which lines of a hot loop dominate. It is net10-only and runs two ways:
 The top-down loop on a single captured trace:
 
 ```powershell
-# 0. Capture a CPU-sampled .nettrace AND keep BDN's build (so its PDB survives).
-dotnet run -c Release -f net10.0 --project touki.perf -- `
-    --filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' -p EP --keepFiles
+# 0. Capture every parameterized case and verify exact generated-child symbols.
+$handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
+  -Project touki.perf/touki.perf.csproj `
+  -Filter '*MsBuildEnumeratePerf3.GlobEnumeratorExtGlobSingleWithRoot' `
+  -Tfm net10.0 -Format Json | ConvertFrom-Json
+$case = (Get-Content $handoff.manifest -Raw | ConvertFrom-Json).cases[0]
 
-$trace = (Get-ChildItem BenchmarkDotNet.Artifacts `
-    -Filter '*GlobEnumeratorExtGlobSingleWithRoot*.nettrace' |
-    Sort-Object LastWriteTime | Select-Object -Last 1).FullName
-# The exact build BDN profiled - its PDB GUID matches the trace:
-$sym = 'artifacts/x64/Release/touki.perf/net10.0/touki.perf-DefaultJob-1/bin/Release/net10.0'
-
-# 1. Method ranking (self + inclusive), JIT-helper artifacts folded.
-filtrace cpu $trace --symbols $sym --top 20
+# 1. Method ranking, scoped to BenchmarkDotNet workload; helpers folded.
+filtrace cpu $case.trace --benchmark --symbols $case.symbolsDirectory --top 20
 
 # 2. Line ranking inside the dominant method.
-filtrace lines $trace --method RunEngine --symbols $sym --top 30
+filtrace lines $case.trace --method RunEngine --symbols $case.symbolsDirectory --top 30
 ```
 
 Verbs and flags: `cpu`/`rank` rank methods (`--root <substr>` scopes to a
@@ -494,15 +496,14 @@ subtree), `callers <frame>` reports a frame's callers, `lines [--method
 > embedded PDB from the image. The analyzer extracts it to a temp standalone PDB
 > when you point `--symbols` (MCP arg `symbols`) at the build-output directory.
 > Without it every managed touki frame resolves to `<no source>`.
-
-> **The symbols build must match the traced build by PDB GUID.**
-> BenchmarkDotNet compiles its *own* isolated copy of `touki.dll` (its own
-> deterministic GUID) into an ephemeral `...-DefaultJob-N/bin/Release/net10.0/`
-> directory and **deletes it during "Artifacts cleanup"** unless you pass
-> `--keepFiles`. Point `--symbols` at *that* surviving directory - not the outer
-> `artifacts/.../touki.perf/net10.0` (a different build, different GUID, which
-> TraceEvent rejects with `FOUND PDB ... has Guid X != Desired Guid Y`).
-
+>
+> **The symbols build must match the traced build by PDB GUID.** The 0.6 capture
+> helper passes `--keepFiles`, discovers logged child outputs, verifies PDB identity
+> through `filtrace info`, and records the exact directory in each manifest case's
+> `symbolsDirectory`. Confirm the relevant module in
+> `trace_info.sourceResolution.matchingPdbModules`; a same-named wrong build appears
+> in `pdbIdentityMismatchModules` rather than silently supplying source lines.
+>
 > **Line attribution stops at inlined-method boundaries.** TraceEvent's
 > IL-offset->source-line map is **per-JITTED-method**; it cannot see inside an
 > inlined callee. A fully-inlined hot helper collapses *all* its samples onto
@@ -510,14 +511,12 @@ subtree), `callers <frame>` reports a frame's callers, `lines [--method
 > entirely on one or two call-site lines (in the extglob case, 93.6% piled onto
 > `ExtGlob.cs:385 return RunEngineCore(...)` and `:410 engine.Run(...)` because
 > the engine is inlined). Two ways through it: drill into the non-inlined tail
-> by scoping `--lines` to the callee (`--lines ExtGlobEngine` surfaced the real
-> internal lines - backtracking machinery ~half, forward walk ~half), or
+> by filtering the line query to the callee (`filtrace lines <trace> --method
+> ExtGlobEngine ...` surfaced the real internal lines - backtracking machinery
+> ~half, forward walk ~half), or
 > temporarily add `[MethodImpl(MethodImplOptions.NoInlining)]` to the callee and
 > re-profile to force a per-method line map (remove it afterwards - it perturbs
 > codegen, same caveat as section 3e).
-
-The TraceEvent embedded-PDB limitation and the proposed upstream fix are written
-up in [traceevent-embedded-pdb.md](traceevent-embedded-pdb.md).
 
 ---
 
@@ -617,20 +616,23 @@ answers method- and line-level questions over MCP - so an agent that speaks MCP
 can drive the whole Layer 2 / Layer 2b loop without shelling out to the
 PowerShell scripts. It also has a console front end (the CLI verbs, section 3f).
 
-Tools it exposes (all take a trace `path`; `trace_rank` selects the family with
-`metric` and the measure with `measure`):
+Tools it exposes (`trace_rank` selects the family with `metric` and the measure
+with `measure`):
 
 | Tool | Answers |
 | --- | --- |
-| `trace_info(path, symbols)` | format / total weight / sample count / symbol-resolution rate / per-thread counts / warnings. **Call first**; a rate below 0.8 means symbols are missing. Folds in the old per-thread listing. |
-| `trace_rank(path, metric, measure, root, fold, top, symbols)` | folded ranking by `metric` (cpu, alloc, exceptions, threadtime) and `measure` (self or inclusive). |
-| `trace_callers(path, frame, root, top)` | who calls a frame - confirms what a JIT-helper artifact is attributable to. |
-| `trace_lines(path, method, fold, top, symbols)` | **line-level** self-time, each leaf sample mapped to `file:line`. Needs `.nettrace`/`.etl` + `symbols`; speedscope yields nothing; `<no source>` = PDB not found. |
-| `trace_heatmap(path, file, fold, symbols)` | per-line self-time heat for one source file, ordered to overlay onto the source. |
-| `trace_diff(before, after, measure, root, fold, top)` | what got slower/faster between two traces. |
-| `trace_gc(path, top)` | GC counts, pauses, and heap summary (`.nettrace`). |
-| `trace_query_events(path, name, skip, take, maxPayload)` | raw event query by name, paged (`.nettrace`). |
-| `trace_export(path, output, format, name, symbols)` | write a speedscope / Chrome-trace flame-graph file. |
+| `trace_info` | Format, frame-name/source quality, analysis provider state/event counts, per-thread counts, warnings. **Call first.** |
+| `trace_rank` | Self/inclusive ranking by cpu, alloc, exceptions, threadtime, contention, wait, or activity. |
+| `trace_callers` | Immediate CPU callers, or callees when requested. |
+| `trace_lines` / `trace_heatmap` | CPU source-line ranking or file heat map with attributed/unattributed record counts. |
+| `trace_tree` | Top-down CPU call tree. |
+| `trace_processes` / `trace_classify` | ETW process inventory or runtime work categories. |
+| `trace_diff` | Normalized/scoped trace diff or exact benchmark+parameter manifest pairing. |
+| `trace_batch` | Compact ranking across every manifest case. |
+| `trace_export` / `trace_timeline` | Flame-graph export or per-bucket temporal activity. |
+| `trace_gc` / `trace_jit` / `trace_threadpool` | Structured runtime reports. |
+| `trace_diskio` | Physical disk I/O by file from an ETW disk capture. |
+| `trace_query_events` | Paged raw events filtered by name/payload/process/thread. |
 
 The `root` gotcha and symbol/`--keepFiles`/inlining caveats are the same as the
 console form - see sections 3a and 3f.
@@ -667,25 +669,25 @@ A concrete, token-efficient loop an agent should follow:
    the benchmark is well-formed (stable Mean/Median, sane direction).
 5. **Confirm** on both TFMs without `--job short`. Read
    `*-report-github.md`, quote only `Mean`/`Ratio`/`Allocated` for changed rows.
-6. **If the bottleneck is unclear**, attach `[EventPipeProfiler(CpuSampling)]`,
-   capture a trace (`dotnet run ... --filter *<Subject>* -p EP --keepFiles` on
-   **net10.0**), then rank it with the `filtrace` analyzer
-   (`filtrace cpu <trace> --root <workload-frame>`, or the `trace_rank` MCP tool; the
+6. **If the bottleneck is unclear**, capture the benchmark with
+  `Capture-BenchmarkTrace.ps1 -Format Json` on **net10.0**, then use
+  `trace_batch` for the manifest and rank a selected case with `benchmark: true`
+  (`filtrace cpu <trace> --benchmark`, or the `trace_rank` MCP tool; the
    PowerShell scripts in
    [performance-investigation-without-mcp.md](performance-investigation-without-mcp.md)
    are the no-filtrace fallback). **Fold the JIT-helper artifacts**
    (`BulkMoveWithWriteBarrier`, `PollGC`, the synthetic `CPU_TIME` leaf) before
    trusting any self-time number - the analyzer does this by default; see
    &sect;3a Trap 2. Profiling is part of the loop: capture a `before/` trace,
-   apply the fix, capture an `after/` trace with the identical filter, and diff.
+  apply the fix, capture an `after/` manifest with the identical filter, and use
+  manifest-aware `trace_diff` / `filtrace diff`.
    EventPipe is net10.0-only; for net481 on-CPU attribution use `[EtwProfiler]`
    (admin) - see the per-TFM table in &sect;3.
 7. **If you need the hot *line*, not just the hot method**, feed the same
    `.nettrace` to `filtrace`: `filtrace lines <trace> --method <method>
    --symbols <build-dir> --top 30` (or the
-   `trace_lines` MCP tool). Capture with `--keepFiles` and point `--symbols` at
-   BDN's surviving `...-DefaultJob-N/bin/Release/net10.0` so the PDB GUID
-   matches; if the ranking collapses onto one or two call-site lines the callee
+  `trace_lines` MCP tool). Use the selected manifest case's verified
+  `symbolsDirectory`; if the ranking collapses onto one or two call-site lines the callee
    is inlined - drill the non-inlined tail or add a temporary `NoInlining`. See
    &sect;3f.
 8. **If a specific loop is slow**, attach `[DisassemblyDiagnoser]` on both TFMs
@@ -717,16 +719,17 @@ A concrete, token-efficient loop an agent should follow:
 A/B + allocations ............ dotnet run -c Release -f <tfm> --project touki.perf -- --filter *X*
 Fast smoke ................... add --job short
 Read the result .............. BenchmarkDotNet.Artifacts/results/*-report-github.md
-Capture a trace .............. dotnet run -c Release -f net10.0 --project touki.perf -- --filter *X* -p EP --keepFiles
-Rank an existing trace ....... filtrace cpu <trace> --root <workload-frame>
+Capture a trace .............. ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 -Project touki.perf/touki.perf.csproj -Filter *X* -Tfm net10.0 -Format Json
+Rank a capture manifest ...... filtrace batch <manifest.json> --metric cpu --benchmark
+Rank a whole BDN workload ..... filtrace cpu <trace> --benchmark
+Rank one phase instead ........ filtrace cpu <trace> --root <phase-frame>
                                folds JIT-helper artifacts + ranks self/inclusive. callers <frame> = who calls it.
 No-server fallback scripts ... ./tools/Profile-Benchmark.ps1 / Get-TraceHotspots.ps1 (see *-without-mcp.md)
 Flame-graph SVG .............. ./tools/speedscope-to-flamegraph.ps1   (or drag the speedscope into speedscope.app)
-Which source LINE? ........... filtrace lines <trace> --method <method> --symbols <build-dir>
-                               net10 .nettrace/.etl + embedded PDB. Capture with --keepFiles; point --symbols
-                               at BDN's ...-DefaultJob-N/bin/Release/net10.0 (PDB GUID must match the trace).
+Which source LINE? ........... filtrace lines <trace> --method <method> --symbols <manifest-case.symbolsDirectory>
+                               net10 .nettrace/.etl + embedded PDB. Confirm sourceResolution exact PDB match.
                                Inlined callee -> samples collapse on the call-site line; drill the tail. See 3f.
-filtrace as an MCP server .... tools: trace_info / trace_rank / trace_callers / trace_lines / trace_heatmap / trace_diff / trace_gc / trace_query_events / trace_export
+filtrace as an MCP server .... 17 tools: orient/rank/callers/lines/heatmap/tree/processes/classify/diff/batch/export/timeline/gc/jit/threadpool/diskio/events
 Where's the time? (in-harness) [EventPipeProfiler(EventPipeProfile.CpuSampling)] -> speedscope.app
                                net10.0 only (no admin); net481 needs [EtwProfiler] (admin) -> .etl
                                FOLD BulkMoveWithWriteBarrier/PollGC/CPU_TIME before reading self-time.

--- a/tools/Run-BinaryFormatComparison.ps1
+++ b/tools/Run-BinaryFormatComparison.ps1
@@ -1,0 +1,139 @@
+<#
+.SYNOPSIS
+    Run the touki BinaryFormattedObject benchmarks against an exact clean build
+    of JeremyKuhne/binaryformat.
+
+.DESCRIPTION
+    Creates a fresh detached checkout of binaryformat commit
+    aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743 outside the touki repository,
+    verifies the checkout is clean, builds the net8.0 library in Release, and
+    exposes the resulting assembly to touki.perf through the
+    BinaryFormatUpstreamAssembly environment-backed MSBuild property.
+
+    The environment property is required because BenchmarkDotNet creates child
+    projects and build processes. A command-line /p: property on the outer
+    dotnet run invocation does not flow into those child builds.
+
+.PARAMETER TargetFramework
+    Modern .NET target to benchmark. The upstream project targets net8.0 and
+    cannot be referenced by the net481 benchmark host.
+
+.PARAMETER Category
+    Benchmark category to run: EndToEnd, ParseOnly, or All.
+
+.PARAMETER Job
+    BenchmarkDotNet job. Default uses the adaptive default job; Medium and Short
+    use the corresponding fixed BenchmarkDotNet jobs.
+
+.PARAMETER Filter
+    BenchmarkDotNet filter glob. Defaults to the full BinaryFormattedObjectPerf
+    class.
+
+.EXAMPLE
+    ./tools/Run-BinaryFormatComparison.ps1 -TargetFramework net10.0 -Category EndToEnd
+
+.EXAMPLE
+    ./tools/Run-BinaryFormatComparison.ps1 -TargetFramework net11.0 -Category ParseOnly -Job Medium
+#>
+param(
+    [ValidateSet("net10.0", "net11.0")]
+    [string]$TargetFramework = "net10.0",
+
+    [ValidateSet("EndToEnd", "ParseOnly", "All")]
+    [string]$Category = "EndToEnd",
+
+    [ValidateSet("Default", "Medium", "Short")]
+    [string]$Job = "Default",
+
+    [string]$Filter = "*BinaryFormattedObjectPerf*"
+)
+
+$ErrorActionPreference = "Stop"
+$commit = "aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743"
+$repository = "https://github.com/JeremyKuhne/binaryformat.git"
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$checkout = Join-Path ([System.IO.Path]::GetTempPath()) "touki-binaryformat-$commit-$([Guid]::NewGuid().ToString('N'))"
+$previousAssembly = $env:BinaryFormatUpstreamAssembly
+
+try {
+    Write-Host "Cloning binaryformat commit $commit..." -ForegroundColor Cyan
+    git clone --quiet --no-checkout $repository $checkout
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to clone $repository (exit $LASTEXITCODE)."
+    }
+
+    git -C $checkout checkout --quiet --detach $commit
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to check out binaryformat commit $commit (exit $LASTEXITCODE)."
+    }
+
+    $actualCommitOutput = git -C $checkout rev-parse HEAD
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to read the binaryformat checkout revision (exit $LASTEXITCODE)."
+    }
+
+    $actualCommit = $actualCommitOutput.Trim()
+    $status = git -C $checkout status --porcelain=v1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Unable to read the binaryformat checkout status (exit $LASTEXITCODE)."
+    }
+
+    if ($actualCommit -ne $commit -or $status) {
+        throw "The binaryformat checkout is not the expected clean commit $commit."
+    }
+
+    $project = Join-Path $checkout "src/binaryformat/binaryformat.csproj"
+    Push-Location $repoRoot
+    try {
+        $sdkVersion = dotnet --version
+        if ($LASTEXITCODE -ne 0) {
+            throw "Unable to resolve the touki .NET SDK (exit $LASTEXITCODE)."
+        }
+
+        Write-Host "Using .NET SDK $sdkVersion from touki/global.json." -ForegroundColor DarkGray
+        Write-Host "Building exact upstream source in Release..." -ForegroundColor Cyan
+        dotnet build $project -c Release
+        if ($LASTEXITCODE -ne 0) {
+            throw "The binaryformat Release build failed (exit $LASTEXITCODE)."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    $assembly = Join-Path $checkout "artifacts/x64/Release/binaryformat/net8.0/binaryformat.dll"
+    if (-not (Test-Path -LiteralPath $assembly)) {
+        throw "The expected upstream assembly was not produced at '$assembly'."
+    }
+
+    $assemblyHash = (Get-FileHash -LiteralPath $assembly -Algorithm SHA256).Hash
+    Write-Host "Upstream assembly SHA-256: $assemblyHash" -ForegroundColor DarkGray
+
+    $env:BinaryFormatUpstreamAssembly = $assembly
+    $benchmarkArguments = @("--filter", $Filter)
+    if ($Category -ne "All") {
+        $benchmarkArguments += @("--allCategories", $Category)
+    }
+
+    if ($Job -ne "Default") {
+        $benchmarkArguments += @("--job", $Job.ToLowerInvariant())
+    }
+
+    Write-Host "Running $Category comparison on $TargetFramework..." -ForegroundColor Cyan
+    Push-Location $repoRoot
+    try {
+        dotnet run -c Release -f $TargetFramework --project touki.perf -- @benchmarkArguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "The benchmark run failed (exit $LASTEXITCODE)."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    $env:BinaryFormatUpstreamAssembly = $previousAssembly
+    if (Test-Path -LiteralPath $checkout) {
+        Remove-Item -LiteralPath $checkout -Recurse -Force
+    }
+}

--- a/tools/Test-AgentFileLinks.ps1
+++ b/tools/Test-AgentFileLinks.ps1
@@ -19,6 +19,11 @@
       .github/agents/**/*.md
       .agents/**/*.md
       docs/agent-customization.md
+    docs/binary-formatted-object-performance.md
+    docs/filtrace-local-demo.md
+    docs/performance-investigation.md
+    docs/performance-investigation-without-mcp.md
+    docs/performance-investigation-agent-tooling-retrospective.md
 
     For each Markdown link of the form `](target)` that is not an external URL,
     `mailto:`, or pure in-page anchor, the script resolves the target relative
@@ -75,6 +80,11 @@ $ScopeEntries = @(
     'AGENTS.md',
     '.github/copilot-instructions.md',
     'docs/agent-customization.md',
+    'docs/binary-formatted-object-performance.md',
+    'docs/filtrace-local-demo.md',
+    'docs/performance-investigation.md',
+    'docs/performance-investigation-without-mcp.md',
+    'docs/performance-investigation-agent-tooling-retrospective.md',
     @{ Dir = '.github/instructions'; Filter = '*.md' },
     @{ Dir = '.github/prompts'; Filter = '*.md' },
     @{ Dir = '.github/agents'; Filter = '*.md' },

--- a/tools/Validate-AgentSkills.ps1
+++ b/tools/Validate-AgentSkills.ps1
@@ -5,12 +5,13 @@
 .DESCRIPTION
     Runs the validator bundled with the vendored manage-skills core over all
     skills, then runs its strict portfolio mode over only the commons-vendored
-    portable cores. Also validates local overlay pins, relationship targets and
-    cycles, and the inventory/category labels in .agents/skills/README.md.
+    portable cores. Also validates local overlay pins and tool-package bindings,
+    relationship targets and cycles, and the inventory/category labels in
+    .agents/skills/README.md.
 
     Exact vendored payloads remain owned by their source repositories. This
-    wrapper adds Touki's consumer-side checks without modifying the bundled
-    validator.
+    wrapper adds Touki's overlay and tool-package binding checks without
+    modifying the bundled validator.
 
 .EXAMPLE
     pwsh tools/Validate-AgentSkills.ps1
@@ -29,7 +30,6 @@ $CatalogPath = Join-Path $SkillsRoot 'README.md'
 $McpPath = Join-Path $RepoRoot '.vscode/mcp.json'
 $BundledValidator = Join-Path $SkillsRoot 'manage-skills/scripts/Validate-Skills.ps1'
 $CommonsRepo = 'https://github.com/JeremyKuhne/agent-skills'
-$FiltraceRepo = 'https://github.com/JeremyKuhne/filtrace'
 $Errors = [System.Collections.Generic.List[string]]::new()
 
 function Add-Error([string] $Message) {
@@ -61,6 +61,95 @@ function Test-MetadataIndentation([string] $Text, [string] $SkillName) {
 
     if ($indents.Count -gt 1) {
         Add-Error ".agents/skills/$SkillName/SKILL.md metadata fields must use one indentation depth."
+    }
+}
+
+function Get-GitObjectHash([string] $Type, [byte[]] $Content) {
+    $header = [System.Text.Encoding]::ASCII.GetBytes("$Type $($Content.Length)`0")
+    $payload = [byte[]]::new($header.Length + $Content.Length)
+    [Array]::Copy($header, 0, $payload, 0, $header.Length)
+    [Array]::Copy($Content, 0, $payload, $header.Length, $Content.Length)
+    $hash = [System.Security.Cryptography.SHA1]::HashData($payload)
+    return [Convert]::ToHexString($hash).ToLowerInvariant()
+}
+
+function Get-GitBlobHash([string] $Path) {
+    $hash = (& git -C $RepoRoot hash-object -- $Path).Trim()
+    if ($LASTEXITCODE -ne 0 -or $hash -notmatch '^[0-9a-f]{40}$') {
+        throw "Could not compute the canonical Git blob hash for '$Path'."
+    }
+    return $hash
+}
+
+function Get-GitFileMode([string] $Path) {
+    if (-not $IsWindows) {
+        $unixMode = [System.IO.File]::GetUnixFileMode($Path)
+        $executeBits = [System.IO.UnixFileMode]::UserExecute -bor
+            [System.IO.UnixFileMode]::GroupExecute -bor
+            [System.IO.UnixFileMode]::OtherExecute
+        return if (($unixMode -band $executeBits) -ne 0) { '100755' } else { '100644' }
+    }
+
+    $relativePath = [System.IO.Path]::GetRelativePath($RepoRoot, $Path).Replace('\', '/')
+    $stageEntry = @(& git -C $RepoRoot ls-files --stage -- $relativePath)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not read the canonical Git mode for '$Path'."
+    }
+    if ($stageEntry.Count -eq 0) { return '100644' }
+    if ($stageEntry.Count -ne 1 -or $stageEntry[0] -notmatch '^(100644|100755) ') {
+        throw "Unsupported Git mode for tool payload file '$Path': $($stageEntry -join '; ')"
+    }
+    return $Matches[1]
+}
+
+function Get-GitTreeHash([string] $Directory, [switch] $ToolPayloadRoot) {
+    $entries = [System.Collections.Generic.List[object]]::new()
+    foreach ($child in Get-ChildItem -LiteralPath $Directory -Force) {
+        if ($ToolPayloadRoot -and $child.Name -eq 'overlay.md') { continue }
+        if ($child.Attributes.HasFlag([System.IO.FileAttributes]::ReparsePoint)) {
+            throw "Tool payload tree hashing does not support reparse points: $($child.FullName)"
+        }
+
+        if ($child.PSIsContainer) {
+            $mode = '40000'
+            $hash = Get-GitTreeHash -Directory $child.FullName
+            $sortName = "$($child.Name)/"
+        }
+        else {
+            $mode = Get-GitFileMode -Path $child.FullName
+            $hash = Get-GitBlobHash -Path $child.FullName
+            $sortName = $child.Name
+        }
+
+        $entries.Add([pscustomobject]@{
+                Mode = $mode
+                Name = $child.Name
+                SortName = $sortName
+                Hash = $hash
+            })
+    }
+
+    $sorted = $entries.ToArray()
+    [Array]::Sort(
+        $sorted,
+        [System.Comparison[object]]{
+            param($left, $right)
+            return [StringComparer]::Ordinal.Compare($left.SortName, $right.SortName)
+        })
+
+    $stream = [System.IO.MemoryStream]::new()
+    try {
+        foreach ($entry in $sorted) {
+            $prefix = [System.Text.Encoding]::UTF8.GetBytes("$($entry.Mode) $($entry.Name)")
+            $stream.Write($prefix, 0, $prefix.Length)
+            $stream.WriteByte(0)
+            $hashBytes = [Convert]::FromHexString($entry.Hash)
+            $stream.Write($hashBytes, 0, $hashBytes.Length)
+        }
+        return Get-GitObjectHash -Type tree -Content $stream.ToArray()
+    }
+    finally {
+        $stream.Dispose()
     }
 }
 
@@ -122,6 +211,9 @@ foreach ($dir in $skillDirs) {
     }
 
     if ($hasOverlay) {
+        if ($binding -notin @('optional-overlay', 'required-overlay')) {
+            Add-Error ".agents/skills/$($dir.Name)/overlay.md requires an overlay-capable metadata.binding."
+        }
         $overlay = Get-Content -Raw -LiteralPath $overlayPath
         if (-not $overlay.StartsWith("---`n") -and -not $overlay.StartsWith("---`r`n")) {
             Add-Error ".agents/skills/$($dir.Name)/overlay.md is missing YAML frontmatter."
@@ -145,6 +237,7 @@ foreach ($dir in $skillDirs) {
         Name = $dir.Name
         Repo = $repo
         Portability = $portability
+        Applicability = $applicability
         Requires = $requires
         Related = $related
         HasOverlay = $hasOverlay
@@ -233,11 +326,11 @@ foreach ($name in $skillData.Keys) {
     }
 
     $skill = $skillData[$name]
-    $expected = if ($skill.Repo -eq $CommonsRepo) {
-        if ($skill.HasOverlay) { 'vendored (portable core) + overlay' } else { 'vendored (portable core)' }
-    }
-    elseif ($skill.Repo -eq $FiltraceRepo) {
+    $expected = if ($skill.Applicability -eq 'tool-shipped') {
         if ($skill.HasOverlay) { 'vendored (tool repo) + overlay' } else { 'vendored (tool repo)' }
+    }
+    elseif ($skill.Repo -eq $CommonsRepo) {
+        if ($skill.HasOverlay) { 'vendored (portable core) + overlay' } else { 'vendored (portable core)' }
     }
     else {
         $skill.Portability
@@ -265,15 +358,48 @@ foreach ($name in $catalogEntries.Keys) {
 }
 
 if ($skillData.ContainsKey('filtrace') -and (Test-Path -LiteralPath $McpPath -PathType Leaf)) {
-    $filtraceSkill = Get-Content -Raw -LiteralPath (Join-Path $SkillsRoot 'filtrace/SKILL.md')
-    $filtracePin = (Get-Scalar $filtraceSkill 'github-pinned' $true).TrimStart('v')
     $mcp = Get-Content -Raw -LiteralPath $McpPath
     $packageMatch = [regex]::Match($mcp, 'KlutzyNinja\.Filtrace\.Mcp@([^"\s]+)')
     if (-not $packageMatch.Success) {
         Add-Error '.vscode/mcp.json must pin KlutzyNinja.Filtrace.Mcp explicitly.'
     }
-    elseif ($packageMatch.Groups[1].Value -ne $filtracePin) {
-        Add-Error "Filtrace MCP pin '$($packageMatch.Groups[1].Value)' must match skill pin '$filtracePin'."
+    else {
+        $filtraceOverlayPath = Join-Path $SkillsRoot 'filtrace/overlay.md'
+        if (-not (Test-Path -LiteralPath $filtraceOverlayPath -PathType Leaf)) {
+            Add-Error '.agents/skills/filtrace/overlay.md must bind the filtrace package.'
+        }
+        else {
+            $filtraceOverlay = Get-Content -Raw -LiteralPath $filtraceOverlayPath
+            $packageVersion = $packageMatch.Groups[1].Value
+            $corePin = Get-Scalar $filtraceOverlay 'core-pin'
+            $coreRepo = Get-Scalar $filtraceOverlay 'core-repo'
+            $coreTreeSha = Get-Scalar $filtraceOverlay 'core-tree-sha'
+            $runtimePin = Get-Scalar $filtraceOverlay 'runtime-pin'
+            if ($corePin -notmatch '^[0-9a-f]{40}$') {
+                Add-Error 'Filtrace overlay core-pin must be an exact 40-character source commit while overlay support is unpublished.'
+            }
+            if ($coreRepo -ne 'https://github.com/JeremyKuhne/filtrace') {
+                Add-Error "Filtrace overlay core-repo '$coreRepo' is not the canonical repository."
+            }
+            if ($coreTreeSha -notmatch '^[0-9a-f]{40}$') {
+                Add-Error 'Filtrace overlay core-tree-sha must be a 40-character lowercase SHA.'
+            }
+            else {
+                $actualTreeSha = Get-GitTreeHash -Directory (Join-Path $SkillsRoot 'filtrace') -ToolPayloadRoot
+                if ($actualTreeSha -ne $coreTreeSha) {
+                    Add-Error "Filtrace payload tree '$actualTreeSha' must match overlay core-tree-sha '$coreTreeSha'."
+                }
+            }
+            if ($runtimePin -ne $packageVersion) {
+                Add-Error "Filtrace overlay runtime-pin '$runtimePin' must match MCP package pin '$packageVersion'."
+            }
+            if (-not $filtraceOverlay.Contains("KlutzyNinja.Filtrace.Mcp@$packageVersion")) {
+                Add-Error "Filtrace overlay must bind the MCP package pin '$packageVersion'."
+            }
+            if (-not $filtraceOverlay.Contains("--version $packageVersion")) {
+                Add-Error "Filtrace overlay must bind the CLI package pin '$packageVersion'."
+            }
+        }
     }
 }
 

--- a/tools/Validate-AgentSkills.ps1
+++ b/tools/Validate-AgentSkills.ps1
@@ -87,7 +87,11 @@ function Get-GitFileMode([string] $Path) {
         $executeBits = [System.IO.UnixFileMode]::UserExecute -bor
             [System.IO.UnixFileMode]::GroupExecute -bor
             [System.IO.UnixFileMode]::OtherExecute
-        return if (($unixMode -band $executeBits) -ne 0) { '100755' } else { '100644' }
+        if (($unixMode -band $executeBits) -ne 0) {
+            return '100755'
+        }
+
+        return '100644'
     }
 
     $relativePath = [System.IO.Path]::GetRelativePath($RepoRoot, $Path).Replace('\', '/')

--- a/tools/Validate-AgentSkills.ps1
+++ b/tools/Validate-AgentSkills.ps1
@@ -74,7 +74,8 @@ function Get-GitObjectHash([string] $Type, [byte[]] $Content) {
 }
 
 function Get-GitBlobHash([string] $Path) {
-    $hash = (& git -C $RepoRoot hash-object -- $Path).Trim()
+    $relativePath = [System.IO.Path]::GetRelativePath($RepoRoot, $Path).Replace('\', '/')
+    $hash = (& git -C $RepoRoot hash-object -- $relativePath).Trim()
     if ($LASTEXITCODE -ne 0 -or $hash -notmatch '^[0-9a-f]{40}$') {
         throw "Could not compute the canonical Git blob hash for '$Path'."
     }

--- a/touki.aot.tests/BinaryFormattedObjectAotTests.cs
+++ b/touki.aot.tests/BinaryFormattedObjectAotTests.cs
@@ -1,0 +1,298 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Runtime.Serialization;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Touki.Resources;
+
+[TestClass]
+public class BinaryFormattedObjectAotTests
+{
+    private const string RegisteredPayloadData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAMAAAAETmFtZQZO
+        dW1iZXIETmV4dAEABAghVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXlsb2FkAgAAAAIAAAAGAwAAAARyb290KgAAAAoL
+        """;
+
+    private const string ListInt32Data = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAH5TeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5MaXN0YDFbW1N5c3RlbS5JbnQzMiwg
+        bXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRl
+        MDg5XV0DAAAABl9pdGVtcwVfc2l6ZQhfdmVyc2lvbgcAAAgICAkCAAAABQAAAAUAAAAPAgAAAAgAAAAIAQAAAAIAAAADAAAA
+        BQAAAAgAAAAAAAAAAAAAAAAAAAAL
+        """;
+
+    private const string RegisteredPayloadArrayData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAcBAAAAAAEAAAACAAAABCFUb3VraS5SZXNvdXJjZXMuUmVnaXN0ZXJlZFBheWxvYWQC
+        AAAACQMAAAAJBAAAAAUDAAAAIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAMAAAAETmFtZQZOdW1iZXIETmV4
+        dAEABAghVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXlsb2FkAgAAAAIAAAAGBQAAAAVmaXJzdAEAAAAKAQQAAAADAAAA
+        BgYAAAAGc2Vjb25kAgAAAAoL
+        """;
+
+    private const string RegisteredPayloadMatrixData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAcBAAAAAgIAAAABAAAAAgAAAAQhVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXls
+        b2FkAgAAAAkDAAAACQQAAAAFAwAAACFUb3VraS5SZXNvdXJjZXMuUmVnaXN0ZXJlZFBheWxvYWQDAAAABE5hbWUGTnVtYmVy
+        BE5leHQBAAQIIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAIAAAACAAAABgUAAAAEbGVmdAEAAAAKAQQAAAAD
+        AAAABgYAAAAFcmlnaHQCAAAACgs=
+        """;
+
+    private const string CallbackPayloadData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAH1RvdWtpLlJlc291cmNlcy5DYWxsYmFja1BheWxvYWQBAAAABVZhbHVlAQIA
+        AAAGAwAAAAhjYWxsYmFjaws=
+        """;
+
+    private const string SerializablePayloadData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAI1RvdWtpLlJlc291cmNlcy5TZXJpYWxpemFibGVQYXlsb2FkAQAAAAVWYWx1
+        ZQECAAAABgMAAAASc2VyaWFsaXphdGlvbi1pbmZvCw==
+        """;
+
+    private const string ObjectReferenceSingletonData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAKFRvdWtpLlJlc291cmNlcy5PYmplY3RSZWZlcmVuY2VTaW5nbGV0b24AAAAA
+        AgAAAAs=
+        """;
+
+    private const string NodeWithNodeStructData = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAIlRvdWtpLlJlc291cmNlcy5Ob2RlV2l0aE5vZGVTdHJ1Y3QCAAAABVZhbHVl
+        Ck5vZGVTdHJ1Y3QBBBpUb3VraS5SZXNvdXJjZXMuTm9kZVN0cnVjdAIAAAACAAAABgMAAAAEcm9vdAX8////GlRvdWtpLlJl
+        c291cmNlcy5Ob2RlU3RydWN0AQAAAAROb2RlBCJUb3VraS5SZXNvdXJjZXMuTm9kZVdpdGhOb2RlU3RydWN0AgAAAAIAAAAJ
+        AQAAAAs=
+        """;
+
+    [TestMethod]
+    public void BindToType_RegisteredType_RootsMembersForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        TypeName typeName = TypeName.Parse(typeof(RegisteredPayload).AssemblyQualifiedName!);
+
+        Type type = resolver.BindToType(typeName);
+
+        Assert.AreSame(typeof(RegisteredPayload), type);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredType_RootsMembersForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        using MemoryStream stream = new(Convert.FromBase64String(RegisteredPayloadData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        RegisteredPayload payload = (RegisteredPayload)formatted.Deserialize();
+
+        Assert.AreEqual("root", payload.Name);
+        Assert.AreEqual(42, payload.Number);
+        Assert.IsNull(payload.Next);
+    }
+
+    [TestMethod]
+    public void Deserialize_DefaultFrameworkType_RootsMembersForAot()
+    {
+        using MemoryStream stream = new(Convert.FromBase64String(ListInt32Data));
+        BinaryFormattedObject formatted = new(stream);
+
+        List<int> values = (List<int>)formatted.Deserialize();
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 5, 8 }, values);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredArray_RootsArrayForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        resolver.Register<RegisteredPayload[]>();
+        using MemoryStream stream = new(Convert.FromBase64String(RegisteredPayloadArrayData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        RegisteredPayload[] payload = (RegisteredPayload[])formatted.Deserialize();
+
+        Assert.AreEqual(2, payload.Length);
+        Assert.AreEqual("first", payload[0].Name);
+        Assert.AreEqual("second", payload[1].Name);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredRectangularArray_RootsArrayForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        resolver.Register<RegisteredPayload[,]>();
+        using MemoryStream stream = new(Convert.FromBase64String(RegisteredPayloadMatrixData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        RegisteredPayload[,] payload = (RegisteredPayload[,])formatted.Deserialize();
+
+        Assert.AreEqual(1, payload.GetLength(0));
+        Assert.AreEqual(2, payload.GetLength(1));
+        Assert.AreEqual("left", payload[0, 0].Name);
+        Assert.AreEqual("right", payload[0, 1].Name);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredCallbacks_RootsPrivateMethodsForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<CallbackPayload>();
+        using MemoryStream stream = new(Convert.FromBase64String(CallbackPayloadData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        CallbackPayload payload = (CallbackPayload)formatted.Deserialize();
+
+        Assert.AreEqual("callback", payload.Value);
+        Assert.IsTrue(payload.OnDeserializingCalled);
+        Assert.IsTrue(payload.OnDeserializedCalled);
+        Assert.IsTrue(payload.CallbackCalled);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredISerializable_RootsPrivateConstructorForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<SerializablePayload>();
+        using MemoryStream stream = new(Convert.FromBase64String(SerializablePayloadData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        SerializablePayload payload = (SerializablePayload)formatted.Deserialize();
+
+        Assert.AreEqual("serialization-info", payload.Value);
+        Assert.IsTrue(payload.ConstructorCalled);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredObjectReference_RootsReplacementForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<ObjectReferenceSingleton>();
+        using MemoryStream stream = new(Convert.FromBase64String(ObjectReferenceSingletonData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        object payload = formatted.Deserialize();
+
+        Assert.AreSame(ObjectReferenceSingleton.Value, payload);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredSerializationInfoFixup_RootsUpdateForAot()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<NodeWithNodeStruct>();
+        resolver.Register<NodeStruct>();
+        using MemoryStream stream = new(Convert.FromBase64String(NodeWithNodeStructData));
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        NodeWithNodeStruct payload = (NodeWithNodeStruct)formatted.Deserialize();
+
+        Assert.AreSame(payload, payload.NodeStruct.Node);
+    }
+}
+
+#pragma warning disable CA5362 // The self-reference is part of the serialized test contract.
+
+[Serializable]
+internal sealed class RegisteredPayload
+{
+#pragma warning disable CS0649 // Fields are populated by BinaryFormattedObject.
+    public string Name = string.Empty;
+    public int Number;
+    public RegisteredPayload? Next;
+#pragma warning restore CS0649
+}
+
+#pragma warning restore CA5362
+
+[Serializable]
+internal sealed class CallbackPayload : IDeserializationCallback
+{
+    public string Value = string.Empty;
+
+    [NonSerialized]
+    public bool OnDeserializingCalled;
+
+    [NonSerialized]
+    public bool OnDeserializedCalled;
+
+    [NonSerialized]
+    public bool CallbackCalled;
+
+    [OnDeserializing]
+    private void OnDeserializing(StreamingContext context) => OnDeserializingCalled = true;
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context) => OnDeserializedCalled = true;
+
+    public void OnDeserialization(object? sender) => CallbackCalled = true;
+}
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+[Serializable]
+internal sealed class SerializablePayload : ISerializable
+{
+    private SerializablePayload(SerializationInfo info, StreamingContext context)
+    {
+        Value = info.GetString("Value") ?? string.Empty;
+        ConstructorCalled = true;
+    }
+
+    public string Value = string.Empty;
+
+    [NonSerialized]
+    public bool ConstructorCalled;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Value", Value);
+}
+
+[Serializable]
+internal sealed class ObjectReferenceSingleton : IObjectReference
+{
+    private ObjectReferenceSingleton()
+    {
+    }
+
+    internal static ObjectReferenceSingleton Value { get; } = new();
+
+    public object GetRealObject(StreamingContext context) => Value;
+}
+
+#pragma warning disable CA5362 // The back-pointer is intentional test data for graph deserialization.
+
+[Serializable]
+internal sealed class NodeWithNodeStruct
+{
+    public string Value = string.Empty;
+#pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
+    public NodeStruct NodeStruct;
+#pragma warning restore CS0649
+}
+
+[Serializable]
+internal struct NodeStruct : ISerializable
+{
+    private NodeStruct(SerializationInfo info, StreamingContext context)
+    {
+        Node = (NodeWithNodeStruct?)info.GetValue("Node", typeof(NodeWithNodeStruct));
+    }
+
+    public NodeWithNodeStruct? Node;
+
+    public readonly void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Node", Node, typeof(NodeWithNodeStruct));
+}
+
+#pragma warning restore CA5362
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki.aot.tests/touki.aot.tests.csproj
+++ b/touki.aot.tests/touki.aot.tests.csproj
@@ -73,4 +73,10 @@
     <ProjectReference Include="..\touki\touki.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(PublishAot)' == 'true'">
+    <!-- MSTest discovers these methods by reflection. Root the assembly so ILC compiles the test bodies and their
+         Register<T> calls even though this project deliberately omits the experimental MSTest AOT runner. -->
+    <TrimmerRootAssembly Include="$(AssemblyName)" />
+  </ItemGroup>
+
 </Project>

--- a/touki.perf/BinaryFormattedObjectFieldAssignmentPerf.cs
+++ b/touki.perf/BinaryFormattedObjectFieldAssignmentPerf.cs
@@ -1,0 +1,205 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.Serialization.Formatters.Binary;
+using Touki.Resources;
+
+namespace touki.perf;
+
+#pragma warning disable SYSLIB0011 // BinaryFormatter is used only to create trusted benchmark input.
+#pragma warning disable CA2300 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA2301 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA2302 // Only trusted payloads generated during GlobalSetup are deserialized.
+
+/// <summary>
+///  Measures materialization of a class with enough fields to isolate reflection field-assignment cost.
+/// </summary>
+[MemoryDiagnoser]
+public class BinaryFormattedObjectFieldAssignmentPerf
+{
+    private const int MaterializationBatchSize = 512;
+
+    private System.IO.MemoryStream _stream = null!;
+    private RegisteredTypeResolver _resolver = null!;
+    private BinaryFormattedObject[] _materializationBatch = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+#if NET
+        AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+#endif
+
+        BinaryFormattedObjectWidePayload payload = BinaryFormattedObjectWidePayload.Create();
+        byte[] payloadBytes;
+
+        using (System.IO.MemoryStream serializationStream = new())
+        {
+            BinaryFormatter serializer = new();
+            serializer.Serialize(serializationStream, payload);
+            payloadBytes = serializationStream.ToArray();
+        }
+
+        _stream = new(payloadBytes, writable: false);
+        _resolver = new RegisteredTypeResolver().Register<BinaryFormattedObjectWidePayload>();
+
+        BinaryFormattedObjectWidePayload first = DeserializeForValidation();
+        BinaryFormattedObjectWidePayload second = DeserializeForValidation();
+        if (!first.IsValid() || !second.IsValid() || ReferenceEquals(first, second))
+        {
+            throw new InvalidOperationException("Wide-object deserialization validation failed.");
+        }
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _stream?.Dispose();
+
+    [IterationSetup]
+    public void SetupMaterializationBatch()
+    {
+        BinaryFormattedObject[] batch = new BinaryFormattedObject[MaterializationBatchSize];
+        for (int index = 0; index < batch.Length; index++)
+        {
+            _stream.Position = 0;
+            batch[index] = new BinaryFormattedObject(_stream, _resolver);
+        }
+
+        _materializationBatch = batch;
+    }
+
+    [IterationCleanup]
+    public void CleanupMaterializationBatch() => _materializationBatch = null!;
+
+    [Benchmark(Baseline = true, OperationsPerInvoke = MaterializationBatchSize)]
+    public object DeserializeRecords()
+    {
+        object result = null!;
+        foreach (BinaryFormattedObject formattedObject in _materializationBatch)
+        {
+            result = formattedObject.Deserialize();
+        }
+
+        return result;
+    }
+
+    private BinaryFormattedObjectWidePayload DeserializeForValidation()
+    {
+        _stream.Position = 0;
+        BinaryFormattedObject formattedObject = new(_stream, _resolver);
+        return (BinaryFormattedObjectWidePayload)formattedObject.Deserialize();
+    }
+}
+
+[Serializable]
+internal sealed class BinaryFormattedObjectWidePayload
+{
+    public int Field00;
+    public int Field01;
+    public int Field02;
+    public int Field03;
+    public int Field04;
+    public int Field05;
+    public int Field06;
+    public int Field07;
+    public int Field08;
+    public int Field09;
+    public int Field10;
+    public int Field11;
+    public int Field12;
+    public int Field13;
+    public int Field14;
+    public int Field15;
+    public int Field16;
+    public int Field17;
+    public int Field18;
+    public int Field19;
+    public int Field20;
+    public int Field21;
+    public int Field22;
+    public int Field23;
+    public int Field24;
+    public int Field25;
+    public int Field26;
+    public int Field27;
+    public int Field28;
+    public int Field29;
+    public int Field30;
+    public int Field31;
+
+    internal static BinaryFormattedObjectWidePayload Create()
+        => new()
+        {
+            Field00 = 100,
+            Field01 = 101,
+            Field02 = 102,
+            Field03 = 103,
+            Field04 = 104,
+            Field05 = 105,
+            Field06 = 106,
+            Field07 = 107,
+            Field08 = 108,
+            Field09 = 109,
+            Field10 = 110,
+            Field11 = 111,
+            Field12 = 112,
+            Field13 = 113,
+            Field14 = 114,
+            Field15 = 115,
+            Field16 = 116,
+            Field17 = 117,
+            Field18 = 118,
+            Field19 = 119,
+            Field20 = 120,
+            Field21 = 121,
+            Field22 = 122,
+            Field23 = 123,
+            Field24 = 124,
+            Field25 = 125,
+            Field26 = 126,
+            Field27 = 127,
+            Field28 = 128,
+            Field29 = 129,
+            Field30 = 130,
+            Field31 = 131
+        };
+
+    internal bool IsValid()
+        => Field00 == 100
+            && Field01 == 101
+            && Field02 == 102
+            && Field03 == 103
+            && Field04 == 104
+            && Field05 == 105
+            && Field06 == 106
+            && Field07 == 107
+            && Field08 == 108
+            && Field09 == 109
+            && Field10 == 110
+            && Field11 == 111
+            && Field12 == 112
+            && Field13 == 113
+            && Field14 == 114
+            && Field15 == 115
+            && Field16 == 116
+            && Field17 == 117
+            && Field18 == 118
+            && Field19 == 119
+            && Field20 == 120
+            && Field21 == 121
+            && Field22 == 122
+            && Field23 == 123
+            && Field24 == 124
+            && Field25 == 125
+            && Field26 == 126
+            && Field27 == 127
+            && Field28 == 128
+            && Field29 == 129
+            && Field30 == 130
+            && Field31 == 131;
+}
+
+#pragma warning restore CA2302
+#pragma warning restore CA2301
+#pragma warning restore CA2300
+#pragma warning restore SYSLIB0011

--- a/touki.perf/BinaryFormattedObjectPerf.cs
+++ b/touki.perf/BinaryFormattedObjectPerf.cs
@@ -1,0 +1,677 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+#if BINARYFORMAT_UPSTREAM
+extern alias BinaryFormatUpstream;
+
+using UpstreamBinaryFormattedObject = BinaryFormatUpstream::BinaryFormat.BinaryFormattedObject;
+#endif
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using BenchmarkDotNet.Configs;
+using Touki.Resources;
+
+namespace touki.perf;
+
+#pragma warning disable SYSLIB0011 // BinaryFormatter is the intentional benchmark baseline.
+#pragma warning disable SYSLIB0050 // Serialization infrastructure is required by the benchmark payload.
+#pragma warning disable CA2300 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA2301 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA2302 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA5362 // Cycles and shared references are intentional benchmark inputs.
+
+/// <summary>
+///  Compares trusted NRBF deserialization through <see cref="BinaryFormatter"/> and
+///  <see cref="BinaryFormattedObject"/> on .NET Framework 4.8.1 RyuJIT and modern .NET RyuJIT.
+/// </summary>
+/// <remarks>
+///  Payload creation, serialization, type registration, and semantic validation happen outside the measured region.
+///  Both end-to-end methods consume identical bytes from reusable streams. The parse-only row measures NRBF decoding
+///  separately without comparing it to complete deserialization. On .NET 10, the materialization-only row deserializes
+///  a bounded batch of independently parsed record graphs exactly once each. When <c>BINARYFORMAT_UPSTREAM</c> is
+///  defined, the same operations also run against <c>JeremyKuhne/binaryformat</c> commit
+///  <c>aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743</c>.
+/// </remarks>
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class BinaryFormattedObjectPerf
+{
+#if BINARYFORMAT_UPSTREAM
+    private const string BinaryFormatUpstreamCommit = "aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743";
+#endif
+#if NET10_0
+    private const int MaterializationBatchSize = 64;
+#endif
+    private const int PrimitiveArrayLength = 1024;
+    private const int StringListCount = 128;
+    private const int TreeDepth = 7;
+    private const int GraphNodeCount = 128;
+    private const int SerializableValueCount = 256;
+
+    private BinaryFormatter _binaryFormatter = null!;
+    private System.IO.MemoryStream _binaryFormatterStream = null!;
+    private System.IO.MemoryStream _binaryFormattedObjectStream = null!;
+#if BINARYFORMAT_UPSTREAM
+    private System.IO.MemoryStream _upstreamBinaryFormattedObjectStream = null!;
+#endif
+#if NET10_0
+    private BinaryFormattedObject[] _materializationBatch = null!;
+#endif
+    private RegisteredTypeResolver _resolver = null!;
+
+    [Params(
+        "Int32Array_1K",
+        "StringList_128",
+        "CustomObject",
+        "ObjectTree_127",
+        "SharedCycle_128",
+        "SerializableCallback")]
+    public string Scenario { get; set; } = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+#if NET
+        AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+#endif
+#if BINARYFORMAT_UPSTREAM
+        System.Reflection.Assembly upstreamAssembly = typeof(UpstreamBinaryFormattedObject).Assembly;
+        System.Reflection.AssemblyInformationalVersionAttribute? upstreamVersionAttribute =
+            System.Reflection.CustomAttributeExtensions.GetCustomAttribute<
+                System.Reflection.AssemblyInformationalVersionAttribute>(upstreamAssembly);
+        System.Reflection.AssemblyConfigurationAttribute? upstreamConfigurationAttribute =
+            System.Reflection.CustomAttributeExtensions.GetCustomAttribute<
+                System.Reflection.AssemblyConfigurationAttribute>(upstreamAssembly);
+        string? upstreamVersion = upstreamVersionAttribute?.InformationalVersion;
+        if (upstreamVersion is null
+            || !upstreamVersion.EndsWith($"+{BinaryFormatUpstreamCommit}", StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"The upstream BinaryFormat assembly must be built from commit '{BinaryFormatUpstreamCommit}'.");
+        }
+
+        if (upstreamConfigurationAttribute?.Configuration != "Release")
+        {
+            throw new InvalidOperationException("The upstream BinaryFormat assembly must be built in Release.");
+        }
+#endif
+
+        object payload = CreatePayload();
+        byte[] payloadBytes;
+
+        using (System.IO.MemoryStream serializationStream = new())
+        {
+            BinaryFormatter serializer = new();
+            serializer.Serialize(serializationStream, payload);
+            payloadBytes = serializationStream.ToArray();
+        }
+
+        _binaryFormatter = new();
+        _binaryFormatterStream = new(payloadBytes, writable: false);
+        _binaryFormattedObjectStream = new(payloadBytes, writable: false);
+#if BINARYFORMAT_UPSTREAM
+        _upstreamBinaryFormattedObjectStream = new(payloadBytes, writable: false);
+#endif
+        _resolver = CreateResolver();
+
+        ValidateRepeatedDeserialization(
+            DeserializeWithBinaryFormatterForValidation(),
+            DeserializeWithBinaryFormatterForValidation());
+        ValidateRepeatedDeserialization(
+            DeserializeWithBinaryFormattedObjectForValidation(),
+            DeserializeWithBinaryFormattedObjectForValidation());
+#if BINARYFORMAT_UPSTREAM
+        ValidateRepeatedDeserialization(
+            DeserializeWithUpstreamBinaryFormattedObjectForValidation(),
+            DeserializeWithUpstreamBinaryFormattedObjectForValidation());
+#endif
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _binaryFormatterStream?.Dispose();
+        _binaryFormattedObjectStream?.Dispose();
+#if BINARYFORMAT_UPSTREAM
+        _upstreamBinaryFormattedObjectStream?.Dispose();
+#endif
+    }
+
+    private object DeserializeWithBinaryFormatterForValidation()
+    {
+        _binaryFormatterStream.Position = 0;
+        return _binaryFormatter.Deserialize(_binaryFormatterStream);
+    }
+
+    private object DeserializeWithBinaryFormattedObjectForValidation()
+    {
+        _binaryFormattedObjectStream.Position = 0;
+        BinaryFormattedObject formattedObject = new(_binaryFormattedObjectStream, _resolver);
+        return formattedObject.Deserialize();
+    }
+
+#if BINARYFORMAT_UPSTREAM
+    private object DeserializeWithUpstreamBinaryFormattedObjectForValidation()
+    {
+        _upstreamBinaryFormattedObjectStream.Position = 0;
+        UpstreamBinaryFormattedObject formattedObject = new(_upstreamBinaryFormattedObjectStream);
+        return formattedObject.Deserialize();
+    }
+#endif
+
+    [BenchmarkCategory("EndToEnd"), Benchmark(Baseline = true)]
+    public object BinaryFormatter_Deserialize()
+    {
+        _binaryFormatterStream.Position = 0;
+        return _binaryFormatter.Deserialize(_binaryFormatterStream);
+    }
+
+    [BenchmarkCategory("EndToEnd"), Benchmark]
+    public object BinaryFormattedObject_ParseAndDeserialize()
+    {
+        _binaryFormattedObjectStream.Position = 0;
+        BinaryFormattedObject formattedObject = new(_binaryFormattedObjectStream, _resolver);
+        return formattedObject.Deserialize();
+    }
+
+#if BINARYFORMAT_UPSTREAM
+    [BenchmarkCategory("EndToEnd"), Benchmark]
+    public object BinaryFormatAaa1dd1_ParseAndDeserialize()
+    {
+        _upstreamBinaryFormattedObjectStream.Position = 0;
+        UpstreamBinaryFormattedObject formattedObject = new(_upstreamBinaryFormattedObjectStream);
+        return formattedObject.Deserialize();
+    }
+#endif
+
+    [BenchmarkCategory("ParseOnly"), Benchmark(Baseline = true)]
+    public BinaryFormattedObject BinaryFormattedObject_Parse()
+    {
+        _binaryFormattedObjectStream.Position = 0;
+        return new BinaryFormattedObject(_binaryFormattedObjectStream, _resolver);
+    }
+
+#if BINARYFORMAT_UPSTREAM
+    [BenchmarkCategory("ParseOnly"), Benchmark]
+    public UpstreamBinaryFormattedObject BinaryFormatAaa1dd1_Parse()
+    {
+        _upstreamBinaryFormattedObjectStream.Position = 0;
+        return new UpstreamBinaryFormattedObject(_upstreamBinaryFormattedObjectStream);
+    }
+#endif
+
+#if NET10_0
+    [IterationSetup(Target = nameof(BinaryFormattedObject_DeserializeRecords))]
+    public void SetupMaterializationBatch()
+    {
+        BinaryFormattedObject[] batch = new BinaryFormattedObject[MaterializationBatchSize];
+        for (int index = 0; index < batch.Length; index++)
+        {
+            _binaryFormattedObjectStream.Position = 0;
+            batch[index] = new BinaryFormattedObject(_binaryFormattedObjectStream, _resolver);
+        }
+
+        _materializationBatch = batch;
+    }
+
+    [IterationCleanup(Target = nameof(BinaryFormattedObject_DeserializeRecords))]
+    public void CleanupMaterializationBatch() => _materializationBatch = null!;
+
+    [BenchmarkCategory("MaterializeOnly"), Benchmark(Baseline = true, OperationsPerInvoke = MaterializationBatchSize)]
+    public object BinaryFormattedObject_DeserializeRecords()
+    {
+        object result = null!;
+        foreach (BinaryFormattedObject formattedObject in _materializationBatch)
+        {
+            result = formattedObject.Deserialize();
+        }
+
+        return result;
+    }
+#endif
+
+    private void ValidateRepeatedDeserialization(object first, object second)
+    {
+        ValidateResult(first);
+        ValidateResult(second);
+
+        if (!AreResultsIndependent(first, second))
+        {
+            throw new InvalidOperationException(
+                $"Repeated deserialization for scenario '{Scenario}' reused mutable result state.");
+        }
+    }
+
+    private object CreatePayload()
+        => Scenario switch
+        {
+            "Int32Array_1K" => CreateInt32Array(PrimitiveArrayLength),
+            "StringList_128" => CreateStringList(),
+            "CustomObject" => CreateCustomObject(),
+            "ObjectTree_127" => CreateObjectTree(),
+            "SharedCycle_128" => CreateSharedCycle(),
+            "SerializableCallback" => new BinaryFormattedObjectSerializablePayload(
+                "serialization-info",
+                CreateInt32Array(SerializableValueCount)),
+            _ => throw new InvalidOperationException($"Unknown benchmark scenario '{Scenario}'.")
+        };
+
+    private RegisteredTypeResolver CreateResolver()
+    {
+        RegisteredTypeResolver resolver = new();
+
+        switch (Scenario)
+        {
+            case "CustomObject":
+                resolver.Register<BinaryFormattedObjectCustomPayload>();
+                break;
+            case "ObjectTree_127":
+                resolver.Register<BinaryFormattedObjectTreeNode>();
+                break;
+            case "SharedCycle_128":
+                resolver.Register<BinaryFormattedObjectGraph>();
+                resolver.Register<BinaryFormattedObjectGraphNode>();
+                resolver.Register<BinaryFormattedObjectGraphNode[]>();
+                break;
+            case "SerializableCallback":
+                resolver.Register<BinaryFormattedObjectSerializablePayload>();
+                break;
+        }
+
+        return resolver;
+    }
+
+    private static int[] CreateInt32Array(int length)
+    {
+        int[] values = new int[length];
+        for (int index = 0; index < values.Length; index++)
+        {
+            values[index] = (index * 3) - 7;
+        }
+
+        return values;
+    }
+
+    private static List<string> CreateStringList()
+    {
+        List<string> values = new(StringListCount);
+        for (int index = 0; index < StringListCount; index++)
+        {
+            values.Add($"NRBF benchmark value {index}");
+        }
+
+        return values;
+    }
+
+    private static BinaryFormattedObjectCustomPayload CreateCustomObject()
+        => new()
+        {
+            Id = 42,
+            Name = "representative custom payload",
+            CreatedUtc = new DateTime(2026, 7, 11, 12, 34, 56, DateTimeKind.Utc),
+            Values = CreateInt32Array(64)
+        };
+
+    private static BinaryFormattedObjectTreeNode CreateObjectTree()
+    {
+        int nextValue = 0;
+        return CreateObjectTree(TreeDepth, ref nextValue)!;
+    }
+
+    private static BinaryFormattedObjectTreeNode? CreateObjectTree(int depth, ref int nextValue)
+    {
+        if (depth == 0)
+        {
+            return null;
+        }
+
+        int value = nextValue++;
+        return new BinaryFormattedObjectTreeNode
+        {
+            Value = value,
+            Name = $"node {value}",
+            Left = CreateObjectTree(depth - 1, ref nextValue),
+            Right = CreateObjectTree(depth - 1, ref nextValue)
+        };
+    }
+
+    private static BinaryFormattedObjectGraph CreateSharedCycle()
+    {
+        BinaryFormattedObjectGraphNode[] nodes = new BinaryFormattedObjectGraphNode[GraphNodeCount];
+        for (int index = 0; index < nodes.Length; index++)
+        {
+            nodes[index] = new BinaryFormattedObjectGraphNode { Value = index };
+        }
+
+        for (int index = 0; index < nodes.Length; index++)
+        {
+            nodes[index].Next = nodes[(index + 1) % nodes.Length];
+            nodes[index].Shared = nodes[(index * 17) % nodes.Length];
+        }
+
+        return new BinaryFormattedObjectGraph
+        {
+            Entry = nodes[0],
+            Nodes = nodes
+        };
+    }
+
+    private void ValidateResult(object result)
+    {
+        bool isValid = Scenario switch
+        {
+            "Int32Array_1K" => IsValidInt32Array(result),
+            "StringList_128" => IsValidStringList(result),
+            "CustomObject" => IsValidCustomObject(result),
+            "ObjectTree_127" => IsValidObjectTree(result),
+            "SharedCycle_128" => IsValidSharedCycle(result),
+            "SerializableCallback" => IsValidSerializableCallback(result),
+            _ => false
+        };
+
+        if (!isValid)
+        {
+            throw new InvalidOperationException($"Deserialized result for scenario '{Scenario}' is invalid.");
+        }
+    }
+
+    private static bool IsValidInt32Array(object result)
+    {
+        if (result is not int[] values || values.Length != PrimitiveArrayLength)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < values.Length; index++)
+        {
+            if (values[index] != (index * 3) - 7)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidStringList(object result)
+    {
+        if (result is not List<string> values || values.Count != StringListCount)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < values.Count; index++)
+        {
+            if (values[index] != $"NRBF benchmark value {index}")
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidCustomObject(object result)
+    {
+        if (result is not BinaryFormattedObjectCustomPayload payload
+            || payload.Id != 42
+            || payload.Name != "representative custom payload"
+            || payload.CreatedUtc != new DateTime(2026, 7, 11, 12, 34, 56, DateTimeKind.Utc)
+            || payload.CreatedUtc.Kind != DateTimeKind.Utc
+            || payload.Values.Length != 64)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < payload.Values.Length; index++)
+        {
+            if (payload.Values[index] != (index * 3) - 7)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidObjectTree(object result)
+    {
+        if (result is not BinaryFormattedObjectTreeNode root)
+        {
+            return false;
+        }
+
+        int expectedValue = 0;
+        return IsValidObjectTree(root, TreeDepth, ref expectedValue) && expectedValue == 127;
+    }
+
+    private static bool IsValidObjectTree(
+        BinaryFormattedObjectTreeNode? node,
+        int depth,
+        ref int expectedValue)
+    {
+        if (depth == 0)
+        {
+            return node is null;
+        }
+
+        if (node is null || node.Value != expectedValue || node.Name != $"node {expectedValue}")
+        {
+            return false;
+        }
+
+        expectedValue++;
+        return IsValidObjectTree(node.Left, depth - 1, ref expectedValue)
+            && IsValidObjectTree(node.Right, depth - 1, ref expectedValue);
+    }
+
+    private static bool IsValidSharedCycle(object result)
+    {
+        if (result is not BinaryFormattedObjectGraph graph
+            || graph.Nodes.Length != GraphNodeCount
+            || !ReferenceEquals(graph.Entry, graph.Nodes[0])
+            || !ReferenceEquals(graph.Nodes[^1].Next, graph.Entry))
+        {
+            return false;
+        }
+
+        for (int index = 0; index < graph.Nodes.Length; index++)
+        {
+            BinaryFormattedObjectGraphNode node = graph.Nodes[index];
+            if (node.Value != index
+                || !ReferenceEquals(node.Next, graph.Nodes[(index + 1) % graph.Nodes.Length])
+                || !ReferenceEquals(node.Shared, graph.Nodes[(index * 17) % graph.Nodes.Length]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsValidSerializableCallback(object result)
+    {
+        if (result is not BinaryFormattedObjectSerializablePayload payload
+            || payload.Name != "serialization-info"
+            || payload.Values.Length != SerializableValueCount
+            || payload.SerializationConstructorCallCount != 1
+            || payload.CallbackCallCount != 1
+            || payload.Checksum != 96128)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < payload.Values.Length; index++)
+        {
+            if (payload.Values[index] != (index * 3) - 7)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private bool AreResultsIndependent(object first, object second)
+        => Scenario switch
+        {
+            "Int32Array_1K" => !ReferenceEquals(first, second),
+            "StringList_128" => first is List<string> firstValues
+                && second is List<string> secondValues
+                && AreStringListsIndependent(firstValues, secondValues),
+            "CustomObject" => first is BinaryFormattedObjectCustomPayload firstPayload
+                && second is BinaryFormattedObjectCustomPayload secondPayload
+                && !ReferenceEquals(firstPayload, secondPayload)
+                && !ReferenceEquals(firstPayload.Values, secondPayload.Values),
+            "ObjectTree_127" => first is BinaryFormattedObjectTreeNode firstRoot
+                && second is BinaryFormattedObjectTreeNode secondRoot
+                && AreObjectTreesIndependent(firstRoot, secondRoot),
+            "SharedCycle_128" => first is BinaryFormattedObjectGraph firstGraph
+                && second is BinaryFormattedObjectGraph secondGraph
+                && AreGraphsIndependent(firstGraph, secondGraph),
+            "SerializableCallback" => first is BinaryFormattedObjectSerializablePayload firstPayload
+                && second is BinaryFormattedObjectSerializablePayload secondPayload
+                && !ReferenceEquals(firstPayload, secondPayload)
+                && !ReferenceEquals(firstPayload.Values, secondPayload.Values),
+            _ => false
+        };
+
+    private static bool AreStringListsIndependent(List<string> first, List<string> second)
+    {
+        if (ReferenceEquals(first, second))
+        {
+            return false;
+        }
+
+        string secondFirstValue = second[0];
+        first[0] = "mutated validation value";
+        return second[0] == secondFirstValue;
+    }
+
+    private static bool AreObjectTreesIndependent(
+        BinaryFormattedObjectTreeNode? first,
+        BinaryFormattedObjectTreeNode? second)
+    {
+        if (first is null || second is null)
+        {
+            return first is null && second is null;
+        }
+
+        return !ReferenceEquals(first, second)
+            && AreObjectTreesIndependent(first.Left, second.Left)
+            && AreObjectTreesIndependent(first.Right, second.Right);
+    }
+
+    private static bool AreGraphsIndependent(
+        BinaryFormattedObjectGraph first,
+        BinaryFormattedObjectGraph second)
+    {
+        if (ReferenceEquals(first, second)
+            || ReferenceEquals(first.Entry, second.Entry)
+            || ReferenceEquals(first.Nodes, second.Nodes)
+            || first.Nodes.Length != second.Nodes.Length)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < first.Nodes.Length; index++)
+        {
+            if (ReferenceEquals(first.Nodes[index], second.Nodes[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+[Serializable]
+internal sealed class BinaryFormattedObjectCustomPayload
+{
+    public int Id;
+    public string Name = string.Empty;
+    public DateTime CreatedUtc;
+    public int[] Values = [];
+}
+
+[Serializable]
+internal sealed class BinaryFormattedObjectTreeNode
+{
+    public int Value;
+    public string Name = string.Empty;
+    public BinaryFormattedObjectTreeNode? Left;
+    public BinaryFormattedObjectTreeNode? Right;
+}
+
+[Serializable]
+internal sealed class BinaryFormattedObjectGraph
+{
+    public BinaryFormattedObjectGraphNode Entry = null!;
+    public BinaryFormattedObjectGraphNode[] Nodes = [];
+}
+
+[Serializable]
+internal sealed class BinaryFormattedObjectGraphNode
+{
+    public int Value;
+    public BinaryFormattedObjectGraphNode? Next;
+    public BinaryFormattedObjectGraphNode? Shared;
+}
+
+[Serializable]
+internal sealed class BinaryFormattedObjectSerializablePayload : ISerializable
+{
+    internal BinaryFormattedObjectSerializablePayload(string name, int[] values)
+    {
+        Name = name;
+        Values = values;
+    }
+
+    private BinaryFormattedObjectSerializablePayload(SerializationInfo info, StreamingContext context)
+    {
+        Name = info.GetString(nameof(Name)) ?? string.Empty;
+        Values = (int[]?)info.GetValue(nameof(Values), typeof(int[])) ?? [];
+        SerializationConstructorCallCount++;
+    }
+
+    public string Name;
+    public int[] Values;
+
+    [NonSerialized]
+    public int SerializationConstructorCallCount;
+
+    [NonSerialized]
+    public int CallbackCallCount;
+
+    [NonSerialized]
+    public int Checksum;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue(nameof(Name), Name);
+        info.AddValue(nameof(Values), Values, typeof(int[]));
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        int checksum = 0;
+        foreach (int value in Values)
+        {
+            checksum += value;
+        }
+
+        Checksum = checksum;
+        CallbackCallCount++;
+    }
+}
+
+#pragma warning restore CA5362
+#pragma warning restore CA2302
+#pragma warning restore CA2301
+#pragma warning restore CA2300
+#pragma warning restore SYSLIB0050
+#pragma warning restore SYSLIB0011

--- a/touki.perf/ClassFieldAssignmentPerf.cs
+++ b/touki.perf/ClassFieldAssignmentPerf.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace touki.perf;
+
+#pragma warning disable SYSLIB0050 // Serialization infrastructure is intentionally benchmarked.
+
+/// <summary>
+///  Compares portable reflection-based ways to assign all serializable fields of an object.
+/// </summary>
+[MemoryDiagnoser]
+public class ClassFieldAssignmentPerf
+{
+    private MemberInfo[] _members = null!;
+    private object?[] _values = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        BinaryFormattedObjectWidePayload payload = BinaryFormattedObjectWidePayload.Create();
+        _members = FormatterServices.GetSerializableMembers(typeof(BinaryFormattedObjectWidePayload));
+        _values = FormatterServices.GetObjectData(payload, _members);
+
+        if (FieldInfo_SetValue() is not BinaryFormattedObjectWidePayload direct || !direct.IsValid()
+            || FormatterServices_PopulateObjectMembers() is not BinaryFormattedObjectWidePayload batch
+            || !batch.IsValid()
+            || FormatterServices_WithPerObjectValuesArray() is not BinaryFormattedObjectWidePayload realisticBatch
+            || !realisticBatch.IsValid())
+        {
+            throw new InvalidOperationException("Field-assignment benchmark validation failed.");
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public object FieldInfo_SetValue()
+    {
+        object instance = CreateUninitializedObject();
+        for (int index = 0; index < _members.Length; index++)
+        {
+            ((FieldInfo)_members[index]).SetValue(instance, _values[index]);
+        }
+
+        return instance;
+    }
+
+    [Benchmark]
+    public object FormatterServices_PopulateObjectMembers()
+    {
+        object instance = CreateUninitializedObject();
+        return FormatterServices.PopulateObjectMembers(instance, _members, _values);
+    }
+
+    [Benchmark]
+    public object FormatterServices_WithPerObjectValuesArray()
+    {
+        object?[] values = new object?[_values.Length];
+        Array.Copy(_values, values, values.Length);
+
+        object instance = CreateUninitializedObject();
+        return FormatterServices.PopulateObjectMembers(instance, _members, values);
+    }
+
+    private static object CreateUninitializedObject()
+        =>
+#if NET
+            System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(
+                typeof(BinaryFormattedObjectWidePayload));
+#else
+            FormatterServices.GetUninitializedObject(typeof(BinaryFormattedObjectWidePayload));
+#endif
+}
+
+#pragma warning restore SYSLIB0050

--- a/touki.perf/ClassRecordMemberLookupPerf.cs
+++ b/touki.perf/ClassRecordMemberLookupPerf.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Formats.Nrbf;
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using Touki.Resources;
+
+namespace touki.perf;
+
+#pragma warning disable SYSLIB0011 // BinaryFormatter is used only to create trusted benchmark input.
+#pragma warning disable SYSLIB0050 // Serialization infrastructure is intentionally benchmarked.
+#pragma warning disable CA2300 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA2301 // Only trusted payloads generated during GlobalSetup are deserialized.
+#pragma warning disable CA2302 // Only trusted payloads generated during GlobalSetup are deserialized.
+
+/// <summary>
+///  Measures the duplicate member-name lookup required by the public <see cref="ClassRecord"/> API.
+/// </summary>
+[MemoryDiagnoser]
+public class ClassRecordMemberLookupPerf
+{
+    private const int ExpectedChecksum = 3696;
+
+    private ClassRecord _classRecord = null!;
+    private string[] _memberNames = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+#if NET
+        AppContext.SetSwitch("System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization", true);
+#endif
+
+        byte[] payloadBytes;
+        using (System.IO.MemoryStream serializationStream = new())
+        {
+            BinaryFormatter serializer = new();
+            serializer.Serialize(serializationStream, BinaryFormattedObjectWidePayload.Create());
+            payloadBytes = serializationStream.ToArray();
+        }
+
+        using System.IO.MemoryStream stream = new(payloadBytes, writable: false);
+        BinaryFormattedObject formattedObject = new(stream);
+        _classRecord = (ClassRecord)formattedObject.RootRecord;
+
+        MemberInfo[] members = FormatterServices.GetSerializableMembers(typeof(BinaryFormattedObjectWidePayload));
+        _memberNames = new string[members.Length];
+        for (int index = 0; index < members.Length; index++)
+        {
+            _memberNames[index] = members[index].Name;
+        }
+
+        if (HasMember_ThenGetRawValue() != ExpectedChecksum
+            || GetRawValue_KnownPresent() != ExpectedChecksum)
+        {
+            throw new InvalidOperationException("Class-record member lookup validation failed.");
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public int HasMember_ThenGetRawValue()
+    {
+        int checksum = 0;
+        foreach (string memberName in _memberNames)
+        {
+            if (_classRecord.HasMember(memberName))
+            {
+                checksum += (int)_classRecord.GetRawValue(memberName)!;
+            }
+        }
+
+        return checksum;
+    }
+
+    [Benchmark]
+    public int GetRawValue_KnownPresent()
+    {
+        int checksum = 0;
+        foreach (string memberName in _memberNames)
+        {
+            checksum += (int)_classRecord.GetRawValue(memberName)!;
+        }
+
+        return checksum;
+    }
+}
+
+#pragma warning restore CA2302
+#pragma warning restore CA2301
+#pragma warning restore CA2300
+#pragma warning restore SYSLIB0050
+#pragma warning restore SYSLIB0011

--- a/touki.perf/touki.perf.csproj
+++ b/touki.perf/touki.perf.csproj
@@ -24,6 +24,10 @@
     <!-- Don’t advertise “I am a test container/server” to VS/VS Code -->
     <DisableTestingPlatformServerCapability>true</DisableTestingPlatformServerCapability>
 
+    <!-- BinaryFormatter is used only as the trusted-data baseline for NRBF deserialization benchmarks. -->
+    <EnableUnsafeBinaryFormatterSerialization
+      Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">true</EnableUnsafeBinaryFormatterSerialization>
+
     <!--
       We don't want to have implicit usings as we're retargeting System.IO to Microsoft.IO
       in our GlobalUsings.cs file for .NET Framework.
@@ -38,6 +42,9 @@
     <PackageReference Include="Microsoft.Build" />
     <!-- Oracle reference for the FileSystemGlobbing dialect comparison benchmarks. -->
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" />
+    <!-- Restores the removed BinaryFormatter implementation for the modern benchmark hosts. -->
+    <PackageReference Include="System.Runtime.Serialization.Formatters"
+                      Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>
@@ -46,6 +53,26 @@
     <ProjectReference Include="..\touki.msbuildshim\touki.msbuildshim.csproj" />
     <ProjectReference Include="..\touki\touki.csproj" AdditionalProperties="TargetFramework=$(DependencyTargetFramework)" />
   </ItemGroup>
+
+  <!--
+    Optional exact-source baseline for https://github.com/JeremyKuhne/binaryformat at
+    aaa1dd1bf7ee8ce626b82c3c55343dfee4a71743. Use tools/Run-BinaryFormatComparison.ps1 to create a clean detached
+    checkout, build it in Release, and propagate the assembly path to BenchmarkDotNet child builds. The comparison is
+    modern-.NET-only because the upstream project does not target .NET Framework.
+  -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And Exists('$(BinaryFormatUpstreamAssembly)')">
+    <Reference Include="BinaryFormat" HintPath="$(BinaryFormatUpstreamAssembly)" Private="true">
+      <Aliases>BinaryFormatUpstream</Aliases>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="EnableBinaryFormatUpstreamBenchmark"
+          BeforeTargets="CoreCompile"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And Exists('$(BinaryFormatUpstreamAssembly)')">
+    <PropertyGroup>
+      <DefineConstants>$(DefineConstants);BINARYFORMAT_UPSTREAM</DefineConstants>
+    </PropertyGroup>
+  </Target>
 
   <!--
     Recorded file-system snapshots replayed by MsBuildEnumeratePerf3. Committed as

--- a/touki.tests/Touki/RegisteredTypeResolverTests.cs
+++ b/touki.tests/Touki/RegisteredTypeResolverTests.cs
@@ -1,0 +1,173 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections;
+using System.Formats.Nrbf;
+using System.Reflection.Metadata;
+using System.Runtime.Serialization;
+using Touki.Resources;
+
+namespace Touki;
+
+[TestClass]
+public class RegisteredTypeResolverTests
+{
+    [TestMethod]
+    public void Register_CustomType_ReturnsResolverAndResolvesType()
+    {
+        RegisteredTypeResolver resolver = new();
+
+        RegisteredTypeResolver result = resolver.Register<RegisteredPayload>();
+
+        result.Should().BeSameAs(resolver);
+        resolver.BindToType(TypeName.Parse(typeof(RegisteredPayload).AssemblyQualifiedName!))
+            .Should().BeSameAs(typeof(RegisteredPayload));
+    }
+
+    [TestMethod]
+    public void BindToType_RegisteredType_ReturnsType()
+    {
+        ITypeResolver resolver = new RegisteredTypeResolver().Register<RegisteredPayload>();
+        TypeName typeName = TypeName.Parse(typeof(RegisteredPayload).AssemblyQualifiedName!);
+
+        resolver.BindToType(typeName).Should().BeSameAs(typeof(RegisteredPayload));
+    }
+
+    [TestMethod]
+    public void BindToType_DefaultFrameworkTypes_ReturnsTypes()
+    {
+        Type[] frameworkTypes =
+        [
+            typeof(byte),
+            typeof(sbyte),
+            typeof(short),
+            typeof(ushort),
+            typeof(int),
+            typeof(uint),
+            typeof(long),
+            typeof(ulong),
+            typeof(float),
+            typeof(double),
+            typeof(char),
+            typeof(bool),
+            typeof(string),
+            typeof(decimal),
+            typeof(DateTime),
+            typeof(TimeSpan),
+            typeof(nint),
+            typeof(nuint),
+            typeof(NotSupportedException),
+            typeof(List<bool>),
+            typeof(List<char>),
+            typeof(List<string>),
+            typeof(List<sbyte>),
+            typeof(List<byte>),
+            typeof(List<short>),
+            typeof(List<ushort>),
+            typeof(List<int>),
+            typeof(List<uint>),
+            typeof(List<long>),
+            typeof(List<ulong>),
+            typeof(List<float>),
+            typeof(List<double>),
+            typeof(List<decimal>),
+            typeof(List<DateTime>),
+            typeof(List<TimeSpan>),
+            typeof(byte[]),
+            typeof(sbyte[]),
+            typeof(short[]),
+            typeof(ushort[]),
+            typeof(int[]),
+            typeof(uint[]),
+            typeof(long[]),
+            typeof(ulong[]),
+            typeof(float[]),
+            typeof(double[]),
+            typeof(char[]),
+            typeof(bool[]),
+            typeof(string[]),
+            typeof(decimal[]),
+            typeof(DateTime[]),
+            typeof(TimeSpan[]),
+            typeof(object[]),
+            typeof(ArrayList),
+            typeof(Hashtable)
+        ];
+
+        RegisteredTypeResolver resolver = new();
+
+        foreach (Type frameworkType in frameworkTypes)
+        {
+            TypeName typeName = TypeName.Parse(frameworkType.AssemblyQualifiedName!);
+            resolver.BindToType(typeName).Should().BeSameAs(frameworkType);
+        }
+    }
+
+    [TestMethod]
+    public void BindToType_FrameworkGenericIdentity_ReturnsModernType()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.ListInt32);
+        ClassRecord rootRecord = (ClassRecord)formatted.RootRecord;
+        RegisteredTypeResolver resolver = new();
+
+        resolver.BindToType(rootRecord.TypeName).Should().BeSameAs(typeof(List<int>));
+    }
+
+    [TestMethod]
+    public void BindToType_NullTypeName_ThrowsArgumentNullException()
+    {
+        RegisteredTypeResolver resolver = new();
+
+        Action action = () => resolver.BindToType(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void BindToType_VariableBoundArrayWithRegisteredSzArray_ThrowsSerializationException()
+    {
+        RegisteredTypeResolver resolver = new();
+        TypeName variableBoundArray = TypeName.Parse(typeof(int).MakeArrayType(1).AssemblyQualifiedName!);
+
+        Action action = () => resolver.BindToType(variableBoundArray);
+
+        action.Should().Throw<SerializationException>().WithMessage("*is not registered*");
+    }
+
+    [TestMethod]
+    public void BindToType_DrawingType_ThrowsSerializationException()
+    {
+        RegisteredTypeResolver resolver = new();
+        TypeName bitmap = TypeName.Parse("System.Drawing.Bitmap, System.Drawing");
+
+        Action action = () => resolver.BindToType(bitmap);
+
+        action.Should().Throw<SerializationException>().WithMessage("*is not registered*");
+    }
+
+    [TestMethod]
+    public void TryBindToType_RegisteredType_ReturnsTrueAndType()
+    {
+        ITypeResolver resolver = new RegisteredTypeResolver().Register<RegisteredPayload>();
+        TypeName typeName = TypeName.Parse(typeof(RegisteredPayload).AssemblyQualifiedName!);
+
+        bool result = resolver.TryBindToType(typeName, out Type? type);
+
+        result.Should().BeTrue();
+        type.Should().BeSameAs(typeof(RegisteredPayload));
+    }
+
+    [TestMethod]
+    public void TryBindToType_UnregisteredType_ReturnsFalseAndNull()
+    {
+        ITypeResolver resolver = new RegisteredTypeResolver();
+        TypeName typeName = TypeName.Parse("System.Drawing.Bitmap, System.Drawing");
+
+        bool result = resolver.TryBindToType(typeName, out Type? type);
+
+        result.Should().BeFalse();
+        type.Should().BeNull();
+    }
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObject.Security.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObject.Security.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+using System.Text;
+using Touki.Resources.BinaryFormat;
+
+namespace Touki.Resources;
+
+[TestClass]
+[DoNotParallelize]
+public class BinaryFormattedObjectSecurityTests
+{
+    [TestMethod]
+    public void GetCapacityHint_AtAndAboveLimit_CapsCapacity()
+    {
+        BinaryFormatDeserializer.GetCapacityHint(256).Should().Be(256);
+        BinaryFormatDeserializer.GetCapacityHint(257).Should().Be(256);
+    }
+
+    [TestMethod]
+    public void Constructor_MalformedPayload_ThrowsSerializationException()
+    {
+        using MemoryStream stream = new([0, 1, 2, 3]);
+
+        Action action = () => _ = new BinaryFormattedObject(stream);
+
+        action.Should().Throw<SerializationException>();
+    }
+
+    [TestMethod]
+    public void Deserialize_DecodableValueTypeSelfCycle_ThrowsSerializationException()
+    {
+        const int classId = 1;
+        const int libraryId = 2;
+
+        using MemoryStream stream = new();
+        using (System.IO.BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write((byte)SerializationRecordType.SerializedStreamHeader);
+            writer.Write(classId);
+            writer.Write(classId);
+            writer.Write(1);
+            writer.Write(0);
+
+            writer.Write((byte)SerializationRecordType.BinaryLibrary);
+            writer.Write(libraryId);
+            writer.Write(typeof(SelfReferencingStruct).Assembly.FullName!);
+
+            writer.Write((byte)SerializationRecordType.ClassWithMembersAndTypes);
+            writer.Write(classId);
+            writer.Write(typeof(SelfReferencingStruct).FullName!);
+            writer.Write(1);
+            writer.Write(nameof(SelfReferencingStruct.Value));
+            writer.Write((byte)4); // BinaryType.Class ([MS-NRBF] 2.1.2.2)
+            writer.Write(typeof(SelfReferencingStruct).FullName!);
+            writer.Write(libraryId);
+            writer.Write(libraryId);
+
+            writer.Write((byte)SerializationRecordType.MemberReference);
+            writer.Write(classId);
+            writer.Write((byte)SerializationRecordType.MessageEnd);
+        }
+
+        stream.Position = 0;
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<SelfReferencingStruct>();
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<SerializationException>();
+    }
+
+    [TestMethod]
+    public void Deserialize_UnregisteredCallbackType_DoesNotInvokeUserCode()
+    {
+        CallbackPayload.InvocationCount = 0;
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.CallbackPayload);
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<SerializationException>().WithMessage("*is not registered*");
+        CallbackPayload.InvocationCount.Should().Be(0);
+    }
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObject.Security.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObject.Security.cs
@@ -33,38 +33,7 @@ public class BinaryFormattedObjectSecurityTests
     [TestMethod]
     public void Deserialize_DecodableValueTypeSelfCycle_ThrowsSerializationException()
     {
-        const int classId = 1;
-        const int libraryId = 2;
-
-        using MemoryStream stream = new();
-        using (System.IO.BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
-        {
-            writer.Write((byte)SerializationRecordType.SerializedStreamHeader);
-            writer.Write(classId);
-            writer.Write(classId);
-            writer.Write(1);
-            writer.Write(0);
-
-            writer.Write((byte)SerializationRecordType.BinaryLibrary);
-            writer.Write(libraryId);
-            writer.Write(typeof(SelfReferencingStruct).Assembly.FullName!);
-
-            writer.Write((byte)SerializationRecordType.ClassWithMembersAndTypes);
-            writer.Write(classId);
-            writer.Write(typeof(SelfReferencingStruct).FullName!);
-            writer.Write(1);
-            writer.Write(nameof(SelfReferencingStruct.Value));
-            writer.Write((byte)4); // BinaryType.Class ([MS-NRBF] 2.1.2.2)
-            writer.Write(typeof(SelfReferencingStruct).FullName!);
-            writer.Write(libraryId);
-            writer.Write(libraryId);
-
-            writer.Write((byte)SerializationRecordType.MemberReference);
-            writer.Write(classId);
-            writer.Write((byte)SerializationRecordType.MessageEnd);
-        }
-
-        stream.Position = 0;
+        using MemoryStream stream = CreateValueTypeSelfCyclePayload(typeof(SelfReferencingStruct));
         RegisteredTypeResolver resolver = new();
         resolver.Register<SelfReferencingStruct>();
         BinaryFormattedObject formatted = new(stream, resolver);
@@ -72,6 +41,21 @@ public class BinaryFormattedObjectSecurityTests
         Action action = () => formatted.Deserialize();
 
         action.Should().Throw<SerializationException>();
+    }
+
+    [TestMethod]
+    public void Deserialize_ISerializableValueTypeSelfCycle_DoesNotInvokeSerializationConstructor()
+    {
+        SelfReferencingSerializableStruct.InvocationCount = 0;
+        using MemoryStream stream = CreateValueTypeSelfCyclePayload(typeof(SelfReferencingSerializableStruct));
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<SelfReferencingSerializableStruct>();
+        BinaryFormattedObject formatted = new(stream, resolver);
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<SerializationException>();
+        SelfReferencingSerializableStruct.InvocationCount.Should().Be(0);
     }
 
     [TestMethod]
@@ -85,5 +69,42 @@ public class BinaryFormattedObjectSecurityTests
 
         action.Should().Throw<SerializationException>().WithMessage("*is not registered*");
         CallbackPayload.InvocationCount.Should().Be(0);
+    }
+
+    private static MemoryStream CreateValueTypeSelfCyclePayload(Type type)
+    {
+        const int classId = 1;
+        const int libraryId = 2;
+
+        MemoryStream stream = new();
+        using (System.IO.BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write((byte)SerializationRecordType.SerializedStreamHeader);
+            writer.Write(classId);
+            writer.Write(classId);
+            writer.Write(1);
+            writer.Write(0);
+
+            writer.Write((byte)SerializationRecordType.BinaryLibrary);
+            writer.Write(libraryId);
+            writer.Write(type.Assembly.FullName!);
+
+            writer.Write((byte)SerializationRecordType.ClassWithMembersAndTypes);
+            writer.Write(classId);
+            writer.Write(type.FullName!);
+            writer.Write(1);
+            writer.Write(nameof(SelfReferencingStruct.Value));
+            writer.Write((byte)4); // BinaryType.Class ([MS-NRBF] 2.1.2.2)
+            writer.Write(type.FullName!);
+            writer.Write(libraryId);
+            writer.Write(libraryId);
+
+            writer.Write((byte)SerializationRecordType.MemberReference);
+            writer.Write(classId);
+            writer.Write((byte)SerializationRecordType.MessageEnd);
+        }
+
+        stream.Position = 0;
+        return stream;
     }
 }

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectDefaultTypeTests.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectDefaultTypeTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections;
+using System.Formats.Nrbf;
+using System.Globalization;
+using System.Text;
+
+namespace Touki.Resources;
+
+[TestClass]
+public class BinaryFormattedObjectDefaultTypeTests
+{
+    [TestMethod]
+    public void Deserialize_FrameworkIntPtrPayload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.IntPtr);
+
+        formatted.Deserialize().Should().Be((nint)42);
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkUIntPtrPayload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.UIntPtr);
+
+        formatted.Deserialize().Should().Be((nuint)42);
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkNotSupportedExceptionPayload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.NotSupportedException);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<NotSupportedException>();
+        ((NotSupportedException)result).Message.Should().Be("not supported");
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkDecimalPayload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.Decimal);
+
+        formatted.Deserialize().Should().Be(12345.6789m);
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkTimeSpanPayload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.TimeSpan);
+
+        formatted.Deserialize().Should().Be(TimeSpan.FromMinutes(90));
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkPrimitiveArrayPayload_ReturnsValues()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.Int32Array);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<int[]>();
+        ((int[])result).Should().Equal(2, 3, 5, 7);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(PrimitiveArrayData))]
+    public void Deserialize_FrameworkPrimitiveArrayPayload_ReturnsTypedValues(
+        byte primitiveType,
+        Array expected)
+    {
+        using MemoryStream stream = CreatePrimitiveArrayPayload(primitiveType, expected);
+        BinaryFormattedObject formatted = new(stream);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType(expected.GetType());
+        ((IEnumerable)result).Cast<object>().Should().Equal(expected.Cast<object>());
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkStringArrayPayload_ReturnsValues()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.StringArray);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<string[]>();
+        ((string?[])result).Should().Equal("first", null, "third");
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkArrayListPayload_ReturnsValues()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.ArrayList);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<ArrayList>();
+        ((ArrayList)result).Cast<object?>().Should().Equal(1, "two", null);
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkHashtablePayload_ReturnsValues()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.Hashtable);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<Hashtable>();
+        Hashtable hashtable = (Hashtable)result;
+        hashtable["one"].Should().Be(1);
+        hashtable["two"].Should().Be(2);
+    }
+
+    public static IEnumerable<object[]> PrimitiveArrayData()
+    {
+        yield return [(byte)1, new bool[] { true, false, true }];
+        yield return [(byte)2, new byte[] { 0, 42, byte.MaxValue }];
+        yield return [(byte)3, new char[] { 'A', '\0', '\u03a9' }];
+        yield return [(byte)5, new decimal[] { -1.5m, 0m, decimal.MaxValue }];
+        yield return [(byte)6, new double[] { -1.5, 0, double.PositiveInfinity }];
+        yield return [(byte)7, new short[] { short.MinValue, 0, short.MaxValue }];
+        yield return [(byte)8, new int[] { int.MinValue, 0, int.MaxValue }];
+        yield return [(byte)9, new long[] { long.MinValue, 0, long.MaxValue }];
+        yield return [(byte)10, new sbyte[] { sbyte.MinValue, 0, sbyte.MaxValue }];
+        yield return [(byte)11, new float[] { -1.5f, 0, float.PositiveInfinity }];
+        yield return [(byte)12, new TimeSpan[] { TimeSpan.FromTicks(-1), TimeSpan.FromDays(2) }];
+        yield return [(byte)13, new DateTime[] { new(2000, 1, 2, 3, 4, 5, DateTimeKind.Utc), DateTime.MinValue }];
+        yield return [(byte)14, new ushort[] { 0, 42, ushort.MaxValue }];
+        yield return [(byte)15, new uint[] { 0, 42, uint.MaxValue }];
+        yield return [(byte)16, new ulong[] { 0, 42, ulong.MaxValue }];
+    }
+
+    private static MemoryStream CreatePrimitiveArrayPayload(byte primitiveType, Array values)
+    {
+        MemoryStream stream = new();
+        using (System.IO.BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write((byte)SerializationRecordType.SerializedStreamHeader);
+            writer.Write(1);
+            writer.Write(-1);
+            writer.Write(1);
+            writer.Write(0);
+
+            writer.Write((byte)SerializationRecordType.ArraySinglePrimitive);
+            writer.Write(1);
+            writer.Write(values.Length);
+            writer.Write(primitiveType);
+
+            foreach (object value in values)
+            {
+                WritePrimitiveValue(writer, primitiveType, value);
+            }
+
+            writer.Write((byte)SerializationRecordType.MessageEnd);
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static void WritePrimitiveValue(System.IO.BinaryWriter writer, byte primitiveType, object value)
+    {
+        switch (primitiveType)
+        {
+            case 1:
+                writer.Write((bool)value);
+                break;
+            case 2:
+                writer.Write((byte)value);
+                break;
+            case 3:
+                writer.Write((char)value);
+                break;
+            case 5:
+                writer.Write(((decimal)value).ToString(CultureInfo.InvariantCulture));
+                break;
+            case 6:
+                writer.Write((double)value);
+                break;
+            case 7:
+                writer.Write((short)value);
+                break;
+            case 8:
+                writer.Write((int)value);
+                break;
+            case 9:
+                writer.Write((long)value);
+                break;
+            case 10:
+                writer.Write((sbyte)value);
+                break;
+            case 11:
+                writer.Write((float)value);
+                break;
+            case 12:
+                writer.Write(((TimeSpan)value).Ticks);
+                break;
+            case 13:
+                writer.Write(((DateTime)value).ToBinary());
+                break;
+            case 14:
+                writer.Write((ushort)value);
+                break;
+            case 15:
+                writer.Write((uint)value);
+                break;
+            case 16:
+                writer.Write((ulong)value);
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown primitive type '{primitiveType}'.");
+        }
+    }
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectFixtures.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectFixtures.cs
@@ -124,6 +124,13 @@ internal static class BinaryFormattedObjectFixtures
         AgAAAAs=
         """;
 
+    internal const string NullObjectReferenceContainer = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAFpOdWxsT2JqZWN0UmVmZXJlbmNlRml4dHVyZUdlbmVyYXRvciwgVmVyc2lvbj0wLjAuMC4w
+        LCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPW51bGwFAQAAACxUb3VraS5SZXNvdXJjZXMuTnVsbE9iamVjdFJlZmVy
+        ZW5jZUNvbnRhaW5lcgEAAAAFVmFsdWUEI1RvdWtpLlJlc291cmNlcy5OdWxsT2JqZWN0UmVmZXJlbmNlAgAAAAIAAAAJAwAAAAUD
+        AAAAI1RvdWtpLlJlc291cmNlcy5OdWxsT2JqZWN0UmVmZXJlbmNlAQAAAAZNYXJrZXIACAIAAAAqAAAACw==
+        """;
+
     internal const string NullableSerializablePayloadNull = """
         AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
         bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAK1RvdWtpLlJlc291cmNlcy5OdWxsYWJsZVNlcmlhbGl6YWJsZVBheWxvYWQB

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectFixtures.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectFixtures.cs
@@ -131,6 +131,13 @@ internal static class BinaryFormattedObjectFixtures
         AAAAI1RvdWtpLlJlc291cmNlcy5OdWxsT2JqZWN0UmVmZXJlbmNlAQAAAAZNYXJrZXIACAIAAAAqAAAACw==
         """;
 
+    internal const string NullMemberObjectReference = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAGBOdWxsTWVtYmVyT2JqZWN0UmVmZXJlbmNlRml4dHVyZUdlbmVyYXRvciwgVmVyc2lvbj0w
+        LjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPW51bGwFAQAAAClUb3VraS5SZXNvdXJjZXMuTnVsbE1lbWJl
+        ck9iamVjdFJlZmVyZW5jZQEAAAAGTWVtYmVyAgIAAAAJAwAAAAUDAAAAKVRvdWtpLlJlc291cmNlcy5OdWxsT2JqZWN0UmVmZXJl
+        bmNlTWVtYmVyAAAAAAIAAAAL
+        """;
+
     internal const string NullableSerializablePayloadNull = """
         AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
         bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAK1RvdWtpLlJlc291cmNlcy5OdWxsYWJsZVNlcmlhbGl6YWJsZVBheWxvYWQB

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectFixtures.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectFixtures.cs
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Resources;
+
+internal static class BinaryFormattedObjectFixtures
+{
+    internal const string Int32 = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAAxTeXN0ZW0uSW50MzIBAAAAB21fdmFsdWUACCoAAAAL
+        """;
+
+    internal const string ListInt32 = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAH5TeXN0ZW0uQ29sbGVjdGlvbnMuR2VuZXJpYy5MaXN0YDFbW1N5c3RlbS5JbnQzMiwg
+        bXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1uZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRl
+        MDg5XV0DAAAABl9pdGVtcwVfc2l6ZQhfdmVyc2lvbgcAAAgICAkCAAAABQAAAAUAAAAPAgAAAAgAAAAIAQAAAAIAAAADAAAA
+        BQAAAAgAAAAAAAAAAAAAAAAAAAAL
+        """;
+
+    internal const string DateTime = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAA9TeXN0ZW0uRGF0ZVRpbWUCAAAABXRpY2tzCGRhdGVEYXRhAAAJEAAY3wgJrN0IABjf
+        CAms3UgL
+        """;
+
+    internal const string RegisteredPayload = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAMAAAAETmFtZQZO
+        dW1iZXIETmV4dAEABAghVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXlsb2FkAgAAAAIAAAAGAwAAAARyb290KgAAAAoL
+        """;
+
+    internal const string RegisteredPayloadCycle = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAMAAAAETmFtZQZO
+        dW1iZXIETmV4dAEABAghVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXlsb2FkAgAAAAIAAAAGAwAAAAVjeWNsZQcAAAAJ
+        AQAAAAs=
+        """;
+
+    internal const string RegisteredPayloadArray = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAcBAAAAAAEAAAACAAAABCFUb3VraS5SZXNvdXJjZXMuUmVnaXN0ZXJlZFBheWxvYWQC
+        AAAACQMAAAAJBAAAAAUDAAAAIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAMAAAAETmFtZQZOdW1iZXIETmV4
+        dAEABAghVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXlsb2FkAgAAAAIAAAAGBQAAAAVmaXJzdAEAAAAKAQQAAAADAAAA
+        BgYAAAAGc2Vjb25kAgAAAAoL
+        """;
+
+    internal const string CallbackPayload = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAH1RvdWtpLlJlc291cmNlcy5DYWxsYmFja1BheWxvYWQBAAAABVZhbHVlAQIA
+        AAAGAwAAAAhjYWxsYmFjaws=
+        """;
+
+    internal const string SerializablePayload = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAI1RvdWtpLlJlc291cmNlcy5TZXJpYWxpemFibGVQYXlsb2FkAQAAAAVWYWx1
+        ZQECAAAABgMAAAASc2VyaWFsaXphdGlvbi1pbmZvCw==
+        """;
+
+    internal const string IntPtr = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAA1TeXN0ZW0uSW50UHRyAQAAAAV2YWx1ZQAJKgAAAAAAAAAL
+        """;
+
+    internal const string UIntPtr = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAA5TeXN0ZW0uVUludFB0cgEAAAAFdmFsdWUAECoAAAAAAAAACw==
+        """;
+
+    internal const string NotSupportedException = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAABxTeXN0ZW0uTm90U3VwcG9ydGVkRXhjZXB0aW9uDAAAAAlDbGFzc05hbWUHTWVzc2Fn
+        ZQREYXRhDklubmVyRXhjZXB0aW9uB0hlbHBVUkwQU3RhY2tUcmFjZVN0cmluZxZSZW1vdGVTdGFja1RyYWNlU3RyaW5nEFJl
+        bW90ZVN0YWNrSW5kZXgPRXhjZXB0aW9uTWV0aG9kB0hSZXN1bHQGU291cmNlDVdhdHNvbkJ1Y2tldHMBAQMDAQEBAAEAAQce
+        U3lzdGVtLkNvbGxlY3Rpb25zLklEaWN0aW9uYXJ5EFN5c3RlbS5FeGNlcHRpb24ICAIGAgAAABxTeXN0ZW0uTm90U3VwcG9y
+        dGVkRXhjZXB0aW9uBgMAAAANbm90IHN1cHBvcnRlZAoKCgoKAAAAAAoVFROACgoL
+        """;
+
+    internal const string Decimal = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAA5TeXN0ZW0uRGVjaW1hbAQAAAAFZmxhZ3MCaGkCbG8DbWlkAAAAAAgICAgAAAQAAAAA
+        ABXNWwcAAAAACw==
+        """;
+
+    internal const string TimeSpan = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAAA9TeXN0ZW0uVGltZVNwYW4BAAAABl90aWNrcwAJAJymkgwAAAAL
+        """;
+
+    internal const string Int32Array = """
+        AAEAAAD/////AQAAAAAAAAAPAQAAAAQAAAAIAgAAAAMAAAAFAAAABwAAAAs=
+        """;
+
+    internal const string StringArray = """
+        AAEAAAD/////AQAAAAAAAAARAQAAAAMAAAAGAgAAAAVmaXJzdAoGAwAAAAV0aGlyZAs=
+        """;
+
+    internal const string SharedReferencePayload = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAJlRvdWtpLlJlc291cmNlcy5TaGFyZWRSZWZlcmVuY2VQYXlsb2FkAgAAAAVG
+        aXJzdAZTZWNvbmQEBCFUb3VraS5SZXNvdXJjZXMuUmVnaXN0ZXJlZFBheWxvYWQCAAAAIVRvdWtpLlJlc291cmNlcy5SZWdp
+        c3RlcmVkUGF5bG9hZAIAAAACAAAACQMAAAAJAwAAAAUDAAAAIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAMA
+        AAAETmFtZQZOdW1iZXIETmV4dAEABAghVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXlsb2FkAgAAAAIAAAAGBAAAAAZz
+        aGFyZWQRAAAACgs=
+        """;
+
+    internal const string SerializableCycle = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAIVRvdWtpLlJlc291cmNlcy5TZXJpYWxpemFibGVDeWNsZQIAAAAFVmFsdWUE
+        TmV4dAAECCFUb3VraS5SZXNvdXJjZXMuU2VyaWFsaXphYmxlQ3ljbGUCAAAAAgAAACoAAAAJAQAAAAs=
+        """;
+
+    internal const string NodeWithNodeStruct = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAIlRvdWtpLlJlc291cmNlcy5Ob2RlV2l0aE5vZGVTdHJ1Y3QCAAAABVZhbHVl
+        Ck5vZGVTdHJ1Y3QBBBpUb3VraS5SZXNvdXJjZXMuTm9kZVN0cnVjdAIAAAACAAAABgMAAAAEcm9vdAX8////GlRvdWtpLlJl
+        c291cmNlcy5Ob2RlU3RydWN0AQAAAAROb2RlBCJUb3VraS5SZXNvdXJjZXMuTm9kZVdpdGhOb2RlU3RydWN0AgAAAAIAAAAJ
+        AQAAAAs=
+        """;
+
+    internal const string ArrayBackReference = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAcBAAAAAAEAAAACAAAABCJUb3VraS5SZXNvdXJjZXMuQXJyYXlCYWNrUmVmZXJlbmNl
+        AgAAAAX9////IlRvdWtpLlJlc291cmNlcy5BcnJheUJhY2tSZWZlcmVuY2UCAAAABVZhbHVlBUFycmF5AAQIJFRvdWtpLlJl
+        c291cmNlcy5BcnJheUJhY2tSZWZlcmVuY2VbXQIAAAACAAAACwAAAAkBAAAAAfv////9////FgAAAAkBAAAACw==
+        """;
+
+    internal const string ObjectReferenceSingleton = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAKFRvdWtpLlJlc291cmNlcy5PYmplY3RSZWZlcmVuY2VTaW5nbGV0b24AAAAA
+        AgAAAAs=
+        """;
+
+    internal const string NullableSerializablePayloadNull = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAK1RvdWtpLlJlc291cmNlcy5OdWxsYWJsZVNlcmlhbGl6YWJsZVBheWxvYWQB
+        AAAABVZhbHVlA25TeXN0ZW0uTnVsbGFibGVgMVtbU3lzdGVtLkludDMyLCBtc2NvcmxpYiwgVmVyc2lvbj00LjAuMC4wLCBD
+        dWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPWI3N2E1YzU2MTkzNGUwODldXQIAAAAKCw==
+        """;
+
+    internal const string NullableSerializablePayloadValue = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAK1RvdWtpLlJlc291cmNlcy5OdWxsYWJsZVNlcmlhbGl6YWJsZVBheWxvYWQB
+        AAAABVZhbHVlAwxTeXN0ZW0uSW50MzICAAAACAgqAAAACw==
+        """;
+
+    internal const string RegisteredPayloadMatrix = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAcBAAAAAgIAAAABAAAAAgAAAAQhVG91a2kuUmVzb3VyY2VzLlJlZ2lzdGVyZWRQYXls
+        b2FkAgAAAAkDAAAACQQAAAAFAwAAACFUb3VraS5SZXNvdXJjZXMuUmVnaXN0ZXJlZFBheWxvYWQDAAAABE5hbWUGTnVtYmVy
+        BE5leHQBAAQIIVRvdWtpLlJlc291cmNlcy5SZWdpc3RlcmVkUGF5bG9hZAIAAAACAAAABgUAAAAEbGVmdAEAAAAKAQQAAAAD
+        AAAABgYAAAAFcmlnaHQCAAAACgs=
+        """;
+
+    internal const string CallbackStructField = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAJ1RvdWtpLlJlc291cmNlcy5DYWxsYmFja1N0cnVjdENvbnRhaW5lcgEAAAAF
+        VmFsdWUEHlRvdWtpLlJlc291cmNlcy5DYWxsYmFja1N0cnVjdAIAAAACAAAABf3///8eVG91a2kuUmVzb3VyY2VzLkNhbGxi
+        YWNrU3RydWN0AQAAAAVWYWx1ZQAIAgAAACoAAAAL
+        """;
+
+    internal const string CallbackStructArray = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAcBAAAAAAEAAAACAAAABB5Ub3VraS5SZXNvdXJjZXMuQ2FsbGJhY2tTdHJ1Y3QCAAAA
+        Bf3///8eVG91a2kuUmVzb3VyY2VzLkNhbGxiYWNrU3RydWN0AQAAAAVWYWx1ZQAIAgAAACoAAAAB/P////3///8rAAAACw==
+        """;
+
+    internal const string FanOutPayload = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAHVRvdWtpLlJlc291cmNlcy5GYW5PdXRQYXlsb2FkAgAAAAVGaXJzdAZTZWNv
+        bmQEBBtUb3VraS5SZXNvdXJjZXMuRmFuT3V0T3duZXICAAAAG1RvdWtpLlJlc291cmNlcy5GYW5PdXRPd25lcgIAAAACAAAA
+        CQMAAAAJBAAAAAUDAAAAG1RvdWtpLlJlc291cmNlcy5GYW5PdXRPd25lcgEAAAAFVmFsdWUEG1RvdWtpLlJlc291cmNlcy5G
+        YW5PdXRWYWx1ZQIAAAACAAAACQUAAAABBAAAAAMAAAAJBQAAAAUFAAAAG1RvdWtpLlJlc291cmNlcy5GYW5PdXRWYWx1ZQEA
+        AAAFVmFsdWUACAIAAAAqAAAACw==
+        """;
+
+    internal const string ArrayList = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuQXJyYXlMaXN0AwAAAAZfaXRlbXMFX3NpemUIX3Zl
+        cnNpb24FAAAICAkCAAAAAwAAAAMAAAAQAgAAAAQAAAAICAEAAAAGAwAAAAN0d28NAgs=
+        """;
+
+    internal const string Hashtable = """
+        AAEAAAD/////AQAAAAAAAAAEAQAAABxTeXN0ZW0uQ29sbGVjdGlvbnMuSGFzaHRhYmxlBwAAAApMb2FkRmFjdG9yB1ZlcnNp
+        b24IQ29tcGFyZXIQSGFzaENvZGVQcm92aWRlcghIYXNoU2l6ZQRLZXlzBlZhbHVlcwAAAwMABQULCBxTeXN0ZW0uQ29sbGVj
+        dGlvbnMuSUNvbXBhcmVyJFN5c3RlbS5Db2xsZWN0aW9ucy5JSGFzaENvZGVQcm92aWRlcgjsUTg/AgAAAAoKAwAAAAkCAAAA
+        CQMAAAAQAgAAAAIAAAAGBAAAAANvbmUGBQAAAAN0d28QAwAAAAIAAAAICAEAAAAICAIAAAAL
+        """;
+
+    internal const string ConvergingCallbackStruct = """
+        AAEAAAD/////AQAAAAAAAAAMAgAAAEdGaXh0dXJlR2VuZXJhdG9yLCBWZXJzaW9uPTAuMC4wLjAsIEN1bHR1cmU9bmV1dHJh
+        bCwgUHVibGljS2V5VG9rZW49bnVsbAUBAAAAK1RvdWtpLlJlc291cmNlcy5Db252ZXJnaW5nQ2FsbGJhY2tDb250YWluZXIB
+        AAAABVZhbHVlBChUb3VraS5SZXNvdXJjZXMuQ29udmVyZ2luZ0NhbGxiYWNrU3RydWN0AgAAAAIAAAAF/f///yhUb3VraS5S
+        ZXNvdXJjZXMuQ29udmVyZ2luZ0NhbGxiYWNrU3RydWN0AgAAAAVGaXJzdAZTZWNvbmQCAgIAAAAJBAAAAAkEAAAABQQAAAAe
+        VG91a2kuUmVzb3VyY2VzLkNhbGxiYWNrU3RydWN0AQAAAAVWYWx1ZQAIAgAAACoAAAAL
+        """;
+
+    internal static BinaryFormattedObject Parse(
+        string payload,
+        RegisteredTypeResolver? typeResolver = null)
+    {
+        using MemoryStream stream = new(Convert.FromBase64String(payload));
+        return new BinaryFormattedObject(stream, typeResolver);
+    }
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectGraphTests.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectGraphTests.cs
@@ -103,6 +103,21 @@ public class BinaryFormattedObjectGraphTests
     }
 
     [TestMethod]
+    public void Deserialize_IObjectReferenceContainingNullReplacement_ReturnsReplacement()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<NullMemberObjectReference>();
+        resolver.Register<NullObjectReferenceMember>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.NullMemberObjectReference,
+            resolver);
+
+        object payload = formatted.Deserialize();
+
+        payload.Should().BeSameAs(NullMemberObjectReference.Replacement);
+    }
+
+    [TestMethod]
     public void Deserialize_NullNullableSerializationValue_ReturnsNull()
     {
         RegisteredTypeResolver resolver = new();

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectGraphTests.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectGraphTests.cs
@@ -87,6 +87,22 @@ public class BinaryFormattedObjectGraphTests
     }
 
     [TestMethod]
+    public void Deserialize_ISerializableObjectReferenceReturningNull_AppliesNullFixup()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<NullObjectReferenceContainer>();
+        resolver.Register<NullObjectReference>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.NullObjectReferenceContainer,
+            resolver);
+
+        NullObjectReferenceContainer payload = (NullObjectReferenceContainer)formatted.Deserialize();
+
+        payload.Value.Should().BeNull();
+        payload.ValueType.Should().Be(typeof(NullObjectReference));
+    }
+
+    [TestMethod]
     public void Deserialize_NullNullableSerializationValue_ReturnsNull()
     {
         RegisteredTypeResolver resolver = new();

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectGraphTests.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectGraphTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Resources;
+
+[TestClass]
+public class BinaryFormattedObjectGraphTests
+{
+    [TestMethod]
+    public void Deserialize_SharedReference_PreservesIdentity()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<SharedReferencePayload>();
+        resolver.Register<RegisteredPayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.SharedReferencePayload,
+            resolver);
+
+        SharedReferencePayload payload = (SharedReferencePayload)formatted.Deserialize();
+
+        payload.First.Should().BeSameAs(payload.Second);
+        payload.First.Name.Should().Be("shared");
+        payload.First.Number.Should().Be(17);
+    }
+
+    [TestMethod]
+    public void Deserialize_ISerializableSelfCycle_PreservesReference()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<SerializableCycle>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.SerializableCycle,
+            resolver);
+
+        SerializableCycle payload = (SerializableCycle)formatted.Deserialize();
+
+        payload.Value.Should().Be(42);
+        payload.Next.Should().BeSameAs(payload);
+    }
+
+    [TestMethod]
+    public void Deserialize_ISerializableStructBackPointer_AppliesFieldFixup()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<NodeWithNodeStruct>();
+        resolver.Register<NodeStruct>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.NodeWithNodeStruct,
+            resolver);
+
+        NodeWithNodeStruct payload = (NodeWithNodeStruct)formatted.Deserialize();
+
+        payload.Value.Should().Be("root");
+        payload.NodeStruct.Node.Should().BeSameAs(payload);
+    }
+
+    [TestMethod]
+    public void Deserialize_ISerializableStructArrayBackPointer_AppliesArrayFixups()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<ArrayBackReference>();
+        resolver.Register<ArrayBackReference[]>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.ArrayBackReference,
+            resolver);
+
+        ArrayBackReference[] payload = (ArrayBackReference[])formatted.Deserialize();
+
+        payload.Select(static item => item.Value).Should().Equal(11, 22);
+        payload[0].Array.Should().BeSameAs(payload);
+        payload[1].Array.Should().BeSameAs(payload);
+    }
+
+    [TestMethod]
+    public void Deserialize_IObjectReferenceRoot_ReturnsReplacement()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<ObjectReferenceSingleton>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.ObjectReferenceSingleton,
+            resolver);
+
+        object payload = formatted.Deserialize();
+
+        payload.Should().BeSameAs(ObjectReferenceSingleton.Value);
+    }
+
+    [TestMethod]
+    public void Deserialize_NullNullableSerializationValue_ReturnsNull()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<NullableSerializablePayload>();
+        resolver.Register<int?>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.NullableSerializablePayloadNull,
+            resolver);
+
+        NullableSerializablePayload payload = (NullableSerializablePayload)formatted.Deserialize();
+
+        payload.Value.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Deserialize_NonNullNullableSerializationValue_ReturnsValue()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<NullableSerializablePayload>();
+        resolver.Register<int?>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.NullableSerializablePayloadValue,
+            resolver);
+
+        NullableSerializablePayload payload = (NullableSerializablePayload)formatted.Deserialize();
+
+        payload.Value.Should().Be(42);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredRectangularArray_ReturnsArray()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        resolver.Register<RegisteredPayload[,]>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.RegisteredPayloadMatrix,
+            resolver);
+
+        RegisteredPayload[,] payload = (RegisteredPayload[,])formatted.Deserialize();
+
+        payload.Rank.Should().Be(2);
+        payload.GetLength(0).Should().Be(1);
+        payload.GetLength(1).Should().Be(2);
+        payload[0, 0].Name.Should().Be("left");
+        payload[0, 1].Name.Should().Be("right");
+    }
+
+    [TestMethod]
+    public void Deserialize_CallbackStructField_ReappliesMutatedValue()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<CallbackStructContainer>();
+        resolver.Register<CallbackStruct>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.CallbackStructField,
+            resolver);
+
+        CallbackStructContainer payload = (CallbackStructContainer)formatted.Deserialize();
+
+        payload.Value.Value.Should().Be(142);
+        payload.Value.CallbackCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Deserialize_CallbackStructArray_ReappliesMutatedValues()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<CallbackStruct>();
+        resolver.Register<CallbackStruct[]>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.CallbackStructArray,
+            resolver);
+
+        CallbackStruct[] payload = (CallbackStruct[])formatted.Deserialize();
+
+        payload.Select(static item => item.Value).Should().Equal(142, 143);
+        payload.Select(static item => item.CallbackCalled).Should().OnlyContain(static called => called);
+    }
+
+    [TestMethod]
+    public void Deserialize_SharedDelayedValue_CompletesAllDependentCallbacks()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<FanOutPayload>();
+        resolver.Register<FanOutOwner>();
+        resolver.Register<FanOutValue>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.FanOutPayload,
+            resolver);
+
+        FanOutPayload payload = (FanOutPayload)formatted.Deserialize();
+
+        payload.First.CallbackCalled.Should().BeTrue();
+        payload.Second.CallbackCalled.Should().BeTrue();
+        payload.First.Value.Should().BeSameAs(payload.Second.Value);
+        ((FanOutValue)payload.First.Value).Value.Should().Be(42);
+    }
+
+    [TestMethod]
+    public void Deserialize_SharedCallbackStruct_PropagatesAllConvergingCopies()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<ConvergingCallbackContainer>();
+        resolver.Register<ConvergingCallbackStruct>();
+        resolver.Register<CallbackStruct>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.ConvergingCallbackStruct,
+            resolver);
+
+        ConvergingCallbackContainer payload = (ConvergingCallbackContainer)formatted.Deserialize();
+
+        CallbackStruct first = (CallbackStruct)payload.Value.First;
+        CallbackStruct second = (CallbackStruct)payload.Value.Second;
+        first.Value.Should().Be(142);
+        first.CallbackCalled.Should().BeTrue();
+        second.Value.Should().Be(142);
+        second.CallbackCalled.Should().BeTrue();
+    }
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectPayloads.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectPayloads.cs
@@ -1,0 +1,263 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Runtime.Serialization;
+
+namespace Touki.Resources;
+
+#pragma warning disable CA5362 // The cycle is intentional test data for graph deserialization.
+
+[Serializable]
+internal sealed class RegisteredPayload
+{
+#pragma warning disable CS0649 // Fields are populated by BinaryFormattedObject.
+    public string Name = string.Empty;
+    public int Number;
+    public RegisteredPayload? Next;
+#pragma warning restore CS0649
+}
+
+#pragma warning restore CA5362
+
+[Serializable]
+internal sealed class CallbackPayload : IDeserializationCallback
+{
+    public string Value = string.Empty;
+
+    [NonSerialized]
+    public bool OnDeserializingCalled;
+
+    [NonSerialized]
+    public bool OnDeserializedCalled;
+
+    [NonSerialized]
+    public bool CallbackCalled;
+
+    internal static int InvocationCount { get; set; }
+
+    [OnDeserializing]
+    private void OnDeserializing(StreamingContext context)
+    {
+        OnDeserializingCalled = true;
+        InvocationCount++;
+    }
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        OnDeserializedCalled = true;
+        InvocationCount++;
+    }
+
+    public void OnDeserialization(object? sender)
+    {
+        CallbackCalled = true;
+        InvocationCount++;
+    }
+}
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+[Serializable]
+internal sealed class SerializablePayload : ISerializable
+{
+    private SerializablePayload(SerializationInfo info, StreamingContext context)
+    {
+        Value = info.GetString("Value") ?? string.Empty;
+        ConstructorCalled = true;
+    }
+
+    public string Value = string.Empty;
+
+    [NonSerialized]
+    public bool ConstructorCalled;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Value", Value);
+}
+
+[Serializable]
+internal sealed class SharedReferencePayload
+{
+#pragma warning disable CS0649 // Fields are populated by BinaryFormattedObject.
+    public RegisteredPayload First = null!;
+    public RegisteredPayload Second = null!;
+#pragma warning restore CS0649
+}
+
+#pragma warning disable CA5362 // Cycles are intentional test data for graph deserialization.
+
+[Serializable]
+internal sealed class SerializableCycle : ISerializable
+{
+    private SerializableCycle(SerializationInfo info, StreamingContext context)
+    {
+        Value = info.GetInt32("Value");
+        Next = (SerializableCycle?)info.GetValue("Next", typeof(SerializableCycle));
+    }
+
+    public int Value;
+    public SerializableCycle? Next;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue("Value", Value);
+        info.AddValue("Next", Next);
+    }
+}
+
+[Serializable]
+internal sealed class NodeWithNodeStruct
+{
+    public string Value = string.Empty;
+#pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
+    public NodeStruct NodeStruct;
+#pragma warning restore CS0649
+}
+
+[Serializable]
+internal struct NodeStruct : ISerializable
+{
+    private NodeStruct(SerializationInfo info, StreamingContext context)
+    {
+        Node = (NodeWithNodeStruct?)info.GetValue("Node", typeof(NodeWithNodeStruct));
+    }
+
+    public NodeWithNodeStruct? Node;
+
+    public readonly void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Node", Node, typeof(NodeWithNodeStruct));
+}
+
+[Serializable]
+internal struct ArrayBackReference : ISerializable
+{
+    private ArrayBackReference(SerializationInfo info, StreamingContext context)
+    {
+        Value = info.GetInt32("Value");
+        Array = (ArrayBackReference[]?)info.GetValue("Array", typeof(ArrayBackReference[]));
+    }
+
+    public int Value;
+    public ArrayBackReference[]? Array;
+
+    public readonly void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        info.AddValue("Value", Value);
+        info.AddValue("Array", Array);
+    }
+}
+
+[Serializable]
+internal sealed class ObjectReferenceSingleton : IObjectReference
+{
+    private ObjectReferenceSingleton()
+    {
+    }
+
+    internal static ObjectReferenceSingleton Value { get; } = new();
+
+    public object GetRealObject(StreamingContext context) => Value;
+}
+
+#pragma warning restore CA5362
+
+[Serializable]
+internal sealed class NullableSerializablePayload : ISerializable
+{
+    private NullableSerializablePayload(SerializationInfo info, StreamingContext context)
+    {
+        Value = (int?)info.GetValue("Value", typeof(int?));
+    }
+
+    public int? Value;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Value", Value, typeof(int?));
+}
+
+[Serializable]
+internal sealed class CallbackStructContainer
+{
+#pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
+    public CallbackStruct Value;
+#pragma warning restore CS0649
+}
+
+[Serializable]
+internal struct CallbackStruct
+{
+    public int Value;
+
+    [NonSerialized]
+    public bool CallbackCalled;
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+    {
+        Value += 100;
+        CallbackCalled = true;
+    }
+}
+
+[Serializable]
+internal sealed class FanOutPayload
+{
+    public FanOutOwner First = null!;
+    public FanOutOwner Second = null!;
+}
+
+[Serializable]
+internal sealed class FanOutOwner
+{
+    public object Value = null!;
+
+    [NonSerialized]
+    public bool CallbackCalled;
+
+    [OnDeserialized]
+    private void OnDeserialized(StreamingContext context)
+        => CallbackCalled = true;
+}
+
+[Serializable]
+internal struct FanOutValue : ISerializable
+{
+    private FanOutValue(SerializationInfo info, StreamingContext context)
+    {
+        Value = info.GetInt32("Value");
+    }
+
+    public int Value;
+
+    public readonly void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Value", Value);
+}
+
+[Serializable]
+internal sealed class ConvergingCallbackContainer
+{
+#pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
+    public ConvergingCallbackStruct Value;
+#pragma warning restore CS0649
+}
+
+[Serializable]
+internal struct ConvergingCallbackStruct
+{
+#pragma warning disable CS0649 // Fields are populated by BinaryFormattedObject.
+    public object First;
+    public object Second;
+#pragma warning restore CS0649
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.
+
+[Serializable]
+internal struct SelfReferencingStruct
+{
+#pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
+    public object? Value;
+#pragma warning restore CS0649
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectPayloads.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectPayloads.cs
@@ -196,6 +196,24 @@ internal sealed class NullObjectReference : IObjectReference, ISerializable
         => info.AddValue("Marker", Marker);
 }
 
+[Serializable]
+internal sealed class NullMemberObjectReference : IObjectReference
+{
+#pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
+    public object? Member;
+#pragma warning restore CS0649
+
+    internal static object Replacement { get; } = new();
+
+    public object GetRealObject(StreamingContext context) => Replacement;
+}
+
+[Serializable]
+internal sealed class NullObjectReferenceMember : IObjectReference
+{
+    public object GetRealObject(StreamingContext context) => null!;
+}
+
 #pragma warning restore CA5362
 
 [Serializable]

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectPayloads.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectPayloads.cs
@@ -161,6 +161,41 @@ internal sealed class ObjectReferenceSingleton : IObjectReference
     public object GetRealObject(StreamingContext context) => Value;
 }
 
+[Serializable]
+internal sealed class NullObjectReferenceContainer : ISerializable
+{
+    private NullObjectReferenceContainer(SerializationInfo info, StreamingContext context)
+    {
+        SerializationInfoEnumerator enumerator = info.GetEnumerator();
+        ValueType = enumerator.MoveNext() ? enumerator.ObjectType : null;
+        Value = info.GetValue("Value", typeof(object));
+    }
+
+    public object? Value;
+
+    [NonSerialized]
+    public Type? ValueType;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Value", Value, typeof(object));
+}
+
+[Serializable]
+internal sealed class NullObjectReference : IObjectReference, ISerializable
+{
+    private NullObjectReference(SerializationInfo info, StreamingContext context)
+    {
+        Marker = info.GetInt32("Marker");
+    }
+
+    public int Marker;
+
+    public object GetRealObject(StreamingContext context) => null!;
+
+    public void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Marker", Marker);
+}
+
 #pragma warning restore CA5362
 
 [Serializable]
@@ -260,4 +295,20 @@ internal struct SelfReferencingStruct
 #pragma warning disable CS0649 // Field is populated by BinaryFormattedObject.
     public object? Value;
 #pragma warning restore CS0649
+}
+
+[Serializable]
+internal struct SelfReferencingSerializableStruct : ISerializable
+{
+    private SelfReferencingSerializableStruct(SerializationInfo info, StreamingContext context)
+    {
+        InvocationCount++;
+        Value = info.GetValue("Value", typeof(object));
+    }
+
+    internal static int InvocationCount { get; set; }
+    public object? Value;
+
+    public readonly void GetObjectData(SerializationInfo info, StreamingContext context)
+        => info.AddValue("Value", Value, typeof(object));
 }

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectTests.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectTests.cs
@@ -1,0 +1,298 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Touki.Resources;
+
+[TestClass]
+[DoNotParallelize]
+public class BinaryFormattedObjectTests
+{
+    [TestMethod]
+    public void Constructor_NullStream_ThrowsArgumentNullException()
+    {
+        Action action = () => _ = new BinaryFormattedObject(null!);
+
+        action.Should().Throw<ArgumentNullException>();
+    }
+
+    [TestMethod]
+    public void Constructor_ValidPayload_LeavesStreamOpen()
+    {
+        using MemoryStream stream = new(Convert.FromBase64String(BinaryFormattedObjectFixtures.Int32));
+
+        _ = new BinaryFormattedObject(stream);
+
+        stream.CanRead.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Constructor_NonZeroLowerBoundArray_ThrowsNotSupportedException()
+    {
+        using MemoryStream stream = CreateNonZeroLowerBoundArrayPayload();
+
+        Action action = () => _ = new BinaryFormattedObject(stream);
+
+        action.Should().Throw<NotSupportedException>();
+    }
+
+    [TestMethod]
+    public void Indexer_RootRecordId_ReturnsRootRecord()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.Int32);
+
+        formatted.RecordMap[formatted.RootRecord.Id].Should().BeSameAs(formatted.RootRecord);
+        formatted[formatted.RootRecord.Id].Should().BeSameAs(formatted.RootRecord);
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkInt32Payload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.Int32);
+
+        formatted.Deserialize().Should().Be(42);
+    }
+
+    [TestMethod]
+    public void Deserialize_CalledTwice_ThrowsInvalidOperationException()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.Int32);
+        _ = formatted.Deserialize();
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already been deserialized*");
+    }
+
+    [TestMethod]
+    public void Deserialize_FirstCallFails_SecondCallThrowsInvalidOperationException()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.RegisteredPayloadArray,
+            resolver);
+        Action firstCall = () => formatted.Deserialize();
+        firstCall.Should().Throw<SerializationException>();
+
+        Action secondCall = () => formatted.Deserialize();
+
+        secondCall.Should().Throw<InvalidOperationException>()
+            .WithMessage("*already been deserialized*");
+    }
+
+    [TestMethod]
+    public async Task Deserialize_ConcurrentCalls_OnlyOneSucceeds()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(BinaryFormattedObjectFixtures.Int32);
+        using Barrier barrier = new(3);
+        Task<(object? Result, Exception? Exception)> first = Task.Run(Deserialize);
+        Task<(object? Result, Exception? Exception)> second = Task.Run(Deserialize);
+        barrier.SignalAndWait();
+
+        (object? Result, Exception? Exception)[] outcomes = await Task.WhenAll(first, second).ConfigureAwait(false);
+
+        outcomes.Count(static outcome => Equals(outcome.Result, 42) && outcome.Exception is null).Should().Be(1);
+        outcomes.Count(static outcome => outcome.Result is null
+            && outcome.Exception is InvalidOperationException).Should().Be(1);
+
+        (object? Result, Exception? Exception) Deserialize()
+        {
+            barrier.SignalAndWait();
+            try
+            {
+                return (formatted.Deserialize(), null);
+            }
+            catch (Exception exception)
+            {
+                return (null, exception);
+            }
+        }
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkListPayload_ReturnsValues()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.ListInt32);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<List<int>>();
+        ((List<int>)result).Should().Equal(1, 2, 3, 5, 8);
+    }
+
+    [TestMethod]
+    public void Deserialize_FrameworkDateTimePayload_ReturnsValue()
+    {
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.DateTime);
+
+        formatted.Deserialize().Should().Be(new DateTime(2025, 6, 15, 12, 34, 56, DateTimeKind.Utc));
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredType_ReturnsObject()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.RegisteredPayload,
+            resolver);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<RegisteredPayload>();
+        RegisteredPayload payload = (RegisteredPayload)result;
+        payload.Name.Should().Be("root");
+        payload.Number.Should().Be(42);
+        payload.Next.Should().BeNull();
+    }
+
+    [TestMethod]
+    public void Deserialize_CyclicRegisteredType_PreservesReference()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.RegisteredPayloadCycle,
+            resolver);
+
+        RegisteredPayload payload = (RegisteredPayload)formatted.Deserialize();
+
+        payload.Name.Should().Be("cycle");
+        payload.Next.Should().BeSameAs(payload);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredArrayAndElement_ReturnsArray()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        resolver.Register<RegisteredPayload[]>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.RegisteredPayloadArray,
+            resolver);
+
+        object result = formatted.Deserialize();
+
+        result.Should().BeOfType<RegisteredPayload[]>();
+        RegisteredPayload[] payloads = (RegisteredPayload[])result;
+        payloads.Select(static payload => payload.Name).Should().Equal("first", "second");
+        payloads.Select(static payload => payload.Number).Should().Equal(1, 2);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredCallbackType_InvokesCallbacks()
+    {
+        CallbackPayload.InvocationCount = 0;
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<CallbackPayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.CallbackPayload,
+            resolver);
+
+        CallbackPayload payload = (CallbackPayload)formatted.Deserialize();
+
+        payload.Value.Should().Be("callback");
+        payload.OnDeserializingCalled.Should().BeTrue();
+        payload.OnDeserializedCalled.Should().BeTrue();
+        payload.CallbackCalled.Should().BeTrue();
+        CallbackPayload.InvocationCount.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void Deserialize_CustomResolverCallbackType_InvokesCallbacks()
+    {
+        CallbackPayload.InvocationCount = 0;
+        using MemoryStream stream = new(Convert.FromBase64String(BinaryFormattedObjectFixtures.CallbackPayload));
+        BinaryFormattedObject formatted = new(stream, new CallbackTypeResolver());
+
+        CallbackPayload payload = (CallbackPayload)formatted.Deserialize();
+
+        payload.OnDeserializingCalled.Should().BeTrue();
+        payload.OnDeserializedCalled.Should().BeTrue();
+        payload.CallbackCalled.Should().BeTrue();
+        CallbackPayload.InvocationCount.Should().Be(3);
+    }
+
+    [TestMethod]
+    public void Deserialize_RegisteredISerializableType_InvokesSerializationConstructor()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<SerializablePayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.SerializablePayload,
+            resolver);
+
+        SerializablePayload payload = (SerializablePayload)formatted.Deserialize();
+
+        payload.Value.Should().Be("serialization-info");
+        payload.ConstructorCalled.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Deserialize_ArrayTypeNotRegistered_ThrowsSerializationException()
+    {
+        RegisteredTypeResolver resolver = new();
+        resolver.Register<RegisteredPayload>();
+        BinaryFormattedObject formatted = BinaryFormattedObjectFixtures.Parse(
+            BinaryFormattedObjectFixtures.RegisteredPayloadArray,
+            resolver);
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<SerializationException>().WithMessage("*is not registered*");
+    }
+
+    private static MemoryStream CreateNonZeroLowerBoundArrayPayload()
+    {
+        MemoryStream stream = new();
+        using (System.IO.BinaryWriter writer = new(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write((byte)SerializationRecordType.SerializedStreamHeader);
+            writer.Write(1);
+            writer.Write(-1);
+            writer.Write(1);
+            writer.Write(0);
+
+            writer.Write((byte)SerializationRecordType.BinaryArray);
+            writer.Write(1);
+            writer.Write((byte)3); // BinaryArrayType.SingleOffset ([MS-NRBF] 2.4.3.2)
+            writer.Write(1);
+            writer.Write(1);
+            writer.Write(1);
+            writer.Write((byte)0); // BinaryType.Primitive ([MS-NRBF] 2.1.2.2)
+            writer.Write((byte)8); // PrimitiveType.Int32 ([MS-NRBF] 2.1.1.6)
+            writer.Write(42);
+            writer.Write((byte)SerializationRecordType.MessageEnd);
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    private sealed class CallbackTypeResolver : ITypeResolver
+    {
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        public Type BindToType(System.Reflection.Metadata.TypeName typeName)
+            => typeName.FullName == typeof(CallbackPayload).FullName
+                ? typeof(CallbackPayload)
+                : throw new SerializationException($"Type '{typeName.AssemblyQualifiedName}' is not registered.");
+
+        public bool TryBindToType(
+            System.Reflection.Metadata.TypeName typeName,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All), NotNullWhen(true)] out Type? type)
+        {
+            type = typeName.FullName == typeof(CallbackPayload).FullName
+                ? typeof(CallbackPayload)
+                : null;
+            return type is not null;
+        }
+    }
+}

--- a/touki.tests/Touki/Resources/BinaryFormattedObjectTests.cs
+++ b/touki.tests/Touki/Resources/BinaryFormattedObjectTests.cs
@@ -3,6 +3,7 @@
 // See LICENSE file in the project root for full license information
 
 using System.Formats.Nrbf;
+using System.Reflection;
 using System.Runtime.Serialization;
 using System.Text;
 
@@ -38,6 +39,29 @@ public class BinaryFormattedObjectTests
         Action action = () => _ = new BinaryFormattedObject(stream);
 
         action.Should().Throw<NotSupportedException>();
+    }
+
+    [TestMethod]
+    public void Constructor_StreamThrowsKeyNotFoundException_PropagatesException()
+    {
+        KeyNotFoundException exception = new("user stream failure");
+        using ThrowingReadStream stream = new(exception);
+
+        Action action = () => _ = new BinaryFormattedObject(stream);
+
+        action.Should().Throw<KeyNotFoundException>().Which.Should().BeSameAs(exception);
+    }
+
+    [TestMethod]
+    public void Constructor_TargetInvocationExceptionWithoutInner_ThrowsSerializationException()
+    {
+        TargetInvocationException exception = new("user stream failure", inner: null);
+        using ThrowingReadStream stream = new(exception);
+
+        Action action = () => _ = new BinaryFormattedObject(stream);
+
+        action.Should().Throw<SerializationException>()
+            .Which.InnerException.Should().BeSameAs(exception);
     }
 
     [TestMethod]
@@ -222,6 +246,31 @@ public class BinaryFormattedObjectTests
     }
 
     [TestMethod]
+    public void Deserialize_ResolverThrowsKeyNotFoundException_PropagatesException()
+    {
+        KeyNotFoundException exception = new("user resolver failure");
+        using MemoryStream stream = new(Convert.FromBase64String(BinaryFormattedObjectFixtures.RegisteredPayload));
+        BinaryFormattedObject formatted = new(stream, new ThrowingTypeResolver(exception));
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<KeyNotFoundException>().Which.Should().BeSameAs(exception);
+    }
+
+    [TestMethod]
+    public void Deserialize_TargetInvocationExceptionWithoutInner_ThrowsSerializationException()
+    {
+        TargetInvocationException exception = new("user resolver failure", inner: null);
+        using MemoryStream stream = new(Convert.FromBase64String(BinaryFormattedObjectFixtures.RegisteredPayload));
+        BinaryFormattedObject formatted = new(stream, new ThrowingTypeResolver(exception));
+
+        Action action = () => formatted.Deserialize();
+
+        action.Should().Throw<SerializationException>()
+            .Which.InnerException.Should().BeSameAs(exception);
+    }
+
+    [TestMethod]
     public void Deserialize_RegisteredISerializableType_InvokesSerializationConstructor()
     {
         RegisteredTypeResolver resolver = new();
@@ -294,5 +343,47 @@ public class BinaryFormattedObjectTests
                 : null;
             return type is not null;
         }
+    }
+
+    private sealed class ThrowingTypeResolver(Exception exception) : ITypeResolver
+    {
+        [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+        public Type BindToType(System.Reflection.Metadata.TypeName typeName) => throw exception;
+
+        public bool TryBindToType(
+            System.Reflection.Metadata.TypeName typeName,
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All), NotNullWhen(true)] out Type? type)
+            => throw exception;
+    }
+
+    private sealed class ThrowingReadStream(Exception exception) : System.IO.Stream
+    {
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => throw exception;
+
+        public override int ReadByte() => throw exception;
+
+        public override long Seek(long offset, System.IO.SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
     }
 }

--- a/touki/Touki/ITypeResolver.cs
+++ b/touki/Touki/ITypeResolver.cs
@@ -12,13 +12,13 @@ namespace Touki;
 public interface ITypeResolver
 {
     /// <summary>
-    ///  Resolves the given type name against the specified library. Throws if the type cannot be resolved.
+    ///  Resolves the given type name. Throws if the type cannot be resolved.
     /// </summary>
     [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
     Type BindToType(TypeName typeName);
 
     /// <summary>
-    ///  Tries to resolve the given type name against the specified library.
+    ///  Tries to resolve the given type name.
     /// </summary>
     bool TryBindToType(
         TypeName typeName,

--- a/touki/Touki/ITypeResolver.cs
+++ b/touki/Touki/ITypeResolver.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Reflection.Metadata;
+
+namespace Touki;
+
+/// <summary>
+///  Resolver for types.
+/// </summary>
+public interface ITypeResolver
+{
+    /// <summary>
+    ///  Resolves the given type name against the specified library. Throws if the type cannot be resolved.
+    /// </summary>
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    Type BindToType(TypeName typeName);
+
+    /// <summary>
+    ///  Tries to resolve the given type name against the specified library.
+    /// </summary>
+    bool TryBindToType(
+        TypeName typeName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All), NotNullWhen(true)] out Type? type);
+}

--- a/touki/Touki/RegisteredTypeResolver.cs
+++ b/touki/Touki/RegisteredTypeResolver.cs
@@ -1,0 +1,248 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Type-name matching and defaults adapted from dotnet/winforms at
+// 73f0222ea7a75610ba883cac9807bd3a003b6d53 (MIT licensed):
+// src/System.Private.Windows.Core/src/System/Private/Windows/Nrbf/CoreNrbfSerializer.cs
+// src/System.Private.Windows.Core/src/System/Reflection/Metadata/TypeNameComparer.cs
+
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Runtime.Serialization;
+using Touki.Resources.BinaryFormat;
+
+namespace Touki;
+
+/// <summary>
+///  Maps type names to types registered through trim-safe generic calls.
+/// </summary>
+/// <remarks>
+///  <para>
+///   <see cref="Register{T}"/> roots all members of each registered type for trimming and native AOT. Resolution never
+///   loads an assembly or discovers a type dynamically.
+///  </para>
+///  <para>
+///   Types are matched by full name without requiring assembly identities to match. This supports mapping type names
+///   written by .NET Framework to their modern .NET equivalents.
+///  </para>
+///  <para>
+///   The dependency-free framework types supported by Windows Forms binary format handling are registered by default.
+///  </para>
+/// </remarks>
+public sealed class RegisteredTypeResolver : ITypeResolver
+{
+    private readonly Dictionary<TypeName, Type> _types = [with(FullNameTypeNameComparer.Instance)];
+    private readonly ConcurrentDictionary<Type, SerializationEvents> _serializationEvents = [];
+
+    /// <summary>
+    ///  Creates a resolver containing the default framework type registrations.
+    /// </summary>
+    public RegisteredTypeResolver()
+    {
+        RegisterFrameworkTypes();
+    }
+
+    /// <summary>
+    ///  Registers <typeparamref name="T"/> and roots all of its members for trimming and native AOT.
+    /// </summary>
+    /// <typeparam name="T">The type to register.</typeparam>
+    /// <returns>This resolver.</returns>
+    /// <exception cref="InvalidOperationException">
+    ///  A different type with the same full name has already been registered.
+    /// </exception>
+    public RegisteredTypeResolver Register<
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>()
+    {
+        Type type = typeof(T);
+        TypeName typeName = TypeName.Parse(type.AssemblyQualifiedName!);
+
+        if (_types.TryGetValue(typeName, out Type? registeredType) && registeredType != type)
+        {
+            throw new InvalidOperationException(
+                $"Type name '{type.FullName}' is already registered for '{registeredType.AssemblyQualifiedName}'.");
+        }
+
+        _types[typeName] = type;
+        return this;
+    }
+
+    /// <summary>
+    ///  Resolves <paramref name="typeName"/> to a registered type.
+    /// </summary>
+    /// <param name="typeName">The type name to resolve.</param>
+    /// <returns>The registered type.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="typeName"/> is <see langword="null"/>.</exception>
+    /// <exception cref="SerializationException">No matching type has been registered.</exception>
+    [return: DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+    public Type BindToType(TypeName typeName)
+    {
+        ArgumentNullException.ThrowIfNull(typeName);
+
+        if (_types.TryGetValue(typeName, out Type? type))
+        {
+            return type;
+        }
+
+        throw new SerializationException($"Type '{typeName.AssemblyQualifiedName}' is not registered.");
+    }
+
+    bool ITypeResolver.TryBindToType(
+        TypeName typeName,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All), NotNullWhen(true)] out Type? type)
+    {
+        ArgumentNullException.ThrowIfNull(typeName);
+        return _types.TryGetValue(typeName, out type);
+    }
+
+    [UnconditionalSuppressMessage(
+        "ReflectionAnalysis",
+        "IL2111:UnrecognizedReflectionPattern",
+        Justification = "The type is annotated before it passes through the resolver-bounded cache callback.")]
+    internal SerializationEvents GetSerializationEvents(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+        => _serializationEvents.GetOrAdd(type, SerializationEvents.Create);
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute' require dynamic access otherwise can break functionality when trimming application code",
+        Justification = "NotSupportedException.TargetSite is not accessed during deserialization.")]
+    private void RegisterFrameworkTypes()
+    {
+        Register<byte>();
+        Register<sbyte>();
+        Register<short>();
+        Register<ushort>();
+        Register<int>();
+        Register<uint>();
+        Register<long>();
+        Register<ulong>();
+        Register<float>();
+        Register<double>();
+        Register<char>();
+        Register<bool>();
+        Register<string>();
+        Register<decimal>();
+        Register<DateTime>();
+        Register<TimeSpan>();
+        Register<nint>();
+        Register<nuint>();
+        Register<NotSupportedException>();
+
+        Register<List<bool>>();
+        Register<List<char>>();
+        Register<List<string>>();
+        Register<List<sbyte>>();
+        Register<List<byte>>();
+        Register<List<short>>();
+        Register<List<ushort>>();
+        Register<List<int>>();
+        Register<List<uint>>();
+        Register<List<long>>();
+        Register<List<ulong>>();
+        Register<List<float>>();
+        Register<List<double>>();
+        Register<List<decimal>>();
+        Register<List<DateTime>>();
+        Register<List<TimeSpan>>();
+
+        Register<byte[]>();
+        Register<sbyte[]>();
+        Register<short[]>();
+        Register<ushort[]>();
+        Register<int[]>();
+        Register<uint[]>();
+        Register<long[]>();
+        Register<ulong[]>();
+        Register<float[]>();
+        Register<double[]>();
+        Register<char[]>();
+        Register<bool[]>();
+        Register<string[]>();
+        Register<decimal[]>();
+        Register<DateTime[]>();
+        Register<TimeSpan[]>();
+        Register<object[]>();
+
+        Register<ArrayList>();
+        Register<Hashtable>();
+    }
+
+    private sealed class FullNameTypeNameComparer : IEqualityComparer<TypeName>
+    {
+        internal static FullNameTypeNameComparer Instance { get; } = new();
+
+        public bool Equals(TypeName? left, TypeName? right)
+        {
+            if (left is null || right is null)
+            {
+                return left is null && right is null;
+            }
+
+            if (left.IsArray || right.IsArray)
+            {
+                return left.IsArray
+                    && right.IsArray
+                    && left.IsSZArray == right.IsSZArray
+                    && left.GetArrayRank() == right.GetArrayRank()
+                    && Equals(left.GetElementType(), right.GetElementType());
+            }
+
+            if (left.IsConstructedGenericType || right.IsConstructedGenericType)
+            {
+                if (!left.IsConstructedGenericType
+                    || !right.IsConstructedGenericType
+                    || !Equals(left.GetGenericTypeDefinition(), right.GetGenericTypeDefinition()))
+                {
+                    return false;
+                }
+
+                ImmutableArray<TypeName> leftArguments = left.GetGenericArguments();
+                ImmutableArray<TypeName> rightArguments = right.GetGenericArguments();
+                if (leftArguments.Length != rightArguments.Length)
+                {
+                    return false;
+                }
+
+                for (int index = 0; index < leftArguments.Length; index++)
+                {
+                    if (!Equals(leftArguments[index], rightArguments[index]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return string.Equals(left.FullName, right.FullName, StringComparison.Ordinal);
+        }
+
+        public int GetHashCode(TypeName typeName)
+        {
+            if (typeName.IsArray)
+            {
+                return HashCode.Combine(
+                    typeName.IsSZArray,
+                    typeName.GetArrayRank(),
+                    GetHashCode(typeName.GetElementType()));
+            }
+
+            if (typeName.IsConstructedGenericType)
+            {
+                HashCode hashCode = new();
+                hashCode.Add(GetHashCode(typeName.GetGenericTypeDefinition()));
+                foreach (TypeName argument in typeName.GetGenericArguments())
+                {
+                    hashCode.Add(GetHashCode(argument));
+                }
+
+                return hashCode.ToHashCode();
+            }
+
+            return StringComparer.Ordinal.GetHashCode(typeName.FullName);
+        }
+    }
+}

--- a/touki/Touki/Resources/BinaryFormat/ArrayRecordDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ArrayRecordDeserializer.cs
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal sealed class ArrayRecordDeserializer : ObjectRecordDeserializer
+{
+    private readonly ArrayRecord _arrayRecord;
+    private readonly Type _elementType;
+    private readonly Array _arrayOfClassRecords;
+    private readonly Array _arrayOfT;
+    private readonly int[] _lengths;
+    private readonly int[] _indices;
+    private bool _hasFixups;
+    private bool _canIterate;
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling",
+        Justification = "The exact array type is supplied by a generic registration and is therefore available to AOT.")]
+    internal ArrayRecordDeserializer(ArrayRecord arrayRecord, IDeserializer deserializer)
+        : base(arrayRecord, deserializer)
+    {
+        Debug.Assert(
+            arrayRecord.RecordType is not
+                (SerializationRecordType.ArraySingleString or SerializationRecordType.ArraySinglePrimitive));
+
+        _arrayRecord = arrayRecord;
+        Type expectedArrayType = deserializer.TypeResolver.BindToType(arrayRecord.TypeName);
+        _elementType = expectedArrayType.GetElementType()!;
+
+        _arrayOfClassRecords = arrayRecord.GetArray(expectedArrayType);
+        _lengths = arrayRecord.Lengths.ToArray();
+        Object = _arrayOfT = Array.CreateInstance(_elementType, _lengths);
+        _indices = new int[_lengths.Length];
+        _canIterate = _arrayOfT.Length > 0;
+    }
+
+    internal override SerializationRecordId Continue()
+    {
+        int[] indices = _indices;
+        int[] lengths = _lengths;
+
+        while (_canIterate)
+        {
+            (object? memberValue, SerializationRecordId reference) =
+                UnwrapMemberValue(_arrayOfClassRecords.GetValue(indices));
+
+            if (ReferenceEquals(s_missingValueSentinel, memberValue))
+            {
+                return reference;
+            }
+
+            _arrayOfT.SetValue(memberValue, indices);
+
+            ArrayUpdater? updater = null;
+            if (memberValue is not null && !reference.Equals(default) && memberValue.GetType().IsValueType)
+            {
+                updater = new ArrayUpdater(_arrayRecord.Id, reference, [.. indices]);
+                Deserializer.TrackValueTypeUpdater(updater);
+            }
+
+            if (memberValue is not null && DoesValueNeedUpdated(memberValue, reference))
+            {
+                _hasFixups = true;
+                Deserializer.PendValueUpdater(updater ?? new ArrayUpdater(_arrayRecord.Id, reference, [.. indices]));
+            }
+
+            int dimension = indices.Length - 1;
+            while (dimension >= 0)
+            {
+                indices[dimension]++;
+                if (indices[dimension] < lengths[dimension])
+                {
+                    break;
+                }
+
+                indices[dimension] = 0;
+                dimension--;
+            }
+
+            if (dimension < 0)
+            {
+                _canIterate = false;
+            }
+        }
+
+        if (!_hasFixups)
+        {
+            Deserializer.CompleteObject(_arrayRecord.Id);
+        }
+
+        return default;
+    }
+
+    internal static Array GetArraySinglePrimitive(SerializationRecord record)
+        => record switch
+        {
+            SZArrayRecord<bool> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<byte> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<sbyte> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<char> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<short> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<ushort> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<int> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<uint> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<long> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<ulong> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<float> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<double> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<decimal> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<DateTime> primitiveArray => primitiveArray.GetArray(),
+            SZArrayRecord<TimeSpan> primitiveArray => primitiveArray.GetArray(),
+            _ => throw new NotSupportedException()
+        };
+
+    [UnconditionalSuppressMessage(
+        "AOT",
+        "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute' may break functionality when AOT compiling",
+        Justification = "The exact array type is supplied by a generic registration and is therefore available to AOT.")]
+    internal static Array? GetRectangularArrayOfPrimitives(
+        ArrayRecord arrayRecord,
+        ITypeResolver typeResolver)
+    {
+        if (arrayRecord.Rank <= 1 || arrayRecord.TypeName.GetElementType().IsArray)
+        {
+            return null;
+        }
+
+        Type expectedArrayType = typeResolver.BindToType(arrayRecord.TypeName);
+        Type elementType = expectedArrayType.GetElementType()!;
+        while (elementType.IsArray)
+        {
+            elementType = elementType.GetElementType()!;
+        }
+
+        if (!HasBuiltInSupport(elementType))
+        {
+            return null;
+        }
+
+        return arrayRecord.GetArray(expectedArrayType);
+
+        static bool HasBuiltInSupport(Type type)
+            => type == typeof(string)
+            || type == typeof(bool)
+            || type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(char)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong)
+            || type == typeof(float)
+            || type == typeof(double)
+            || type == typeof(decimal)
+            || type == typeof(DateTime)
+            || type == typeof(TimeSpan);
+    }
+}

--- a/touki/Touki/Resources/BinaryFormat/ArrayUpdater.cs
+++ b/touki/Touki/Resources/BinaryFormat/ArrayUpdater.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal sealed class ArrayUpdater : ValueUpdater
+{
+    private readonly int[] _indices;
+
+    internal ArrayUpdater(SerializationRecordId objectId, SerializationRecordId valueId, int[] indices)
+        : base(objectId, valueId)
+    {
+        _indices = indices;
+    }
+
+    internal override void UpdateValue(IDictionary<SerializationRecordId, object> objects)
+    {
+        object value = objects[ValueId];
+        Array array = (Array)objects[ObjectId];
+        array.SetValue(value, _indices);
+    }
+}

--- a/touki/Touki/Resources/BinaryFormat/BinaryFormatDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/BinaryFormatDeserializer.cs
@@ -88,30 +88,33 @@ internal sealed class BinaryFormatDeserializer : IDeserializer
     {
         DeserializeRoot(_rootId);
 
-        int pendingCount = _pendingSerializationInfo?.Count ?? 0;
         while (_pendingSerializationInfo is not null && _pendingSerializationInfo.Count > 0)
         {
-            PendingSerializationInfo pending = _pendingSerializationInfo.Dequeue();
-
-            if (--pendingCount >= 0
-                && _pendingSerializationInfo.Count != 0
-                && _incompleteDependencies is not null
-                && _incompleteDependencies.TryGetValue(
-                    pending.ObjectId,
-                    out HashSet<SerializationRecordId>? dependencies))
+            int passCount = _pendingSerializationInfo.Count;
+            bool madeProgress = false;
+            for (int index = 0; index < passCount; index++)
             {
-                if (dependencies.Count > 0)
+                PendingSerializationInfo pending = _pendingSerializationInfo.Dequeue();
+                if (_incompleteDependencies is not null
+                    && _incompleteDependencies.TryGetValue(
+                        pending.ObjectId,
+                        out HashSet<SerializationRecordId>? dependencies)
+                    && dependencies.Count > 0)
                 {
                     _pendingSerializationInfo.Enqueue(pending);
                     continue;
                 }
 
-                Debug.Fail("Completed dependencies should have been removed from the dictionary.");
+                pending.Populate(_deserializedObjects, _streamingContext);
+                _pendingSerializationInfoIds?.Remove(pending.ObjectId);
+                ((IDeserializer)this).CompleteObject(pending.ObjectId);
+                madeProgress = true;
             }
 
-            pending.Populate(_deserializedObjects, _streamingContext);
-            _pendingSerializationInfoIds?.Remove(pending.ObjectId);
-            ((IDeserializer)this).CompleteObject(pending.ObjectId);
+            if (!madeProgress)
+            {
+                throw new SerializationException("The serialized object graph could not be completed.");
+            }
         }
 
         if (_incompleteObjects.Count > 0 || (_pendingUpdates is not null && _pendingUpdates.Count > 0))

--- a/touki/Touki/Resources/BinaryFormat/BinaryFormatDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/BinaryFormatDeserializer.cs
@@ -1,0 +1,394 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal sealed class BinaryFormatDeserializer : IDeserializer
+{
+    private const int InitialParserStackCapacity = 8;
+
+    // Do not reserve in proportion to a record map that may contain many unreachable records.
+    private const int MaximumCapacityHint = 256;
+
+    private readonly IReadOnlyDictionary<SerializationRecordId, SerializationRecord> _recordMap;
+    private readonly ITypeResolver _typeResolver;
+    private readonly StreamingContext _streamingContext;
+    private readonly Dictionary<SerializationRecordId, object> _deserializedObjects = [];
+    private readonly HashSet<SerializationRecordId> _incompleteObjects = [];
+    private readonly Queue<SerializationRecordId> _pendingCompletions = [];
+    private readonly SerializationRecordId _rootId;
+
+    private Queue<PendingSerializationInfo>? _pendingSerializationInfo;
+    private HashSet<SerializationRecordId>? _pendingSerializationInfoIds;
+    private Dictionary<SerializationRecordId, HashSet<SerializationRecordId>>? _incompleteDependencies;
+    private HashSet<ValueUpdater>? _pendingUpdates;
+    private Dictionary<SerializationRecordId, List<ValueUpdater>>? _valueTypeUpdaters;
+    private Dictionary<Type, SerializationEvents>? _serializationEvents;
+    private List<(SerializationRecordId Id, Action<StreamingContext> Callback)>? _onDeserializedCallbacks;
+    private List<(SerializationRecordId Id, IDeserializationCallback Callback)>? _onDeserializationCallbacks;
+
+    private BinaryFormatDeserializer(
+        SerializationRecordId rootId,
+        IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap,
+        ITypeResolver typeResolver,
+        StreamingContext streamingContext)
+    {
+        _rootId = rootId;
+        _recordMap = recordMap;
+        _typeResolver = typeResolver;
+        _streamingContext = streamingContext;
+    }
+
+    StreamingContext IDeserializer.StreamingContext => _streamingContext;
+
+    HashSet<SerializationRecordId> IDeserializer.IncompleteObjects => _incompleteObjects;
+
+    IDictionary<SerializationRecordId, object> IDeserializer.DeserializedObjects => _deserializedObjects;
+
+    ITypeResolver IDeserializer.TypeResolver => _typeResolver;
+
+    SerializationEvents IDeserializer.GetSerializationEvents(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+    {
+        if (_typeResolver is RegisteredTypeResolver registeredTypeResolver)
+        {
+            return registeredTypeResolver.GetSerializationEvents(type);
+        }
+
+        _serializationEvents ??= [];
+        if (!_serializationEvents.TryGetValue(type, out SerializationEvents? events))
+        {
+            events = SerializationEvents.Create(type);
+            _serializationEvents.Add(type, events);
+        }
+
+        return events;
+    }
+
+    internal static object Deserialize(
+        SerializationRecordId rootId,
+        IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap,
+        ITypeResolver typeResolver,
+        StreamingContext streamingContext)
+    {
+        BinaryFormatDeserializer deserializer = new(rootId, recordMap, typeResolver, streamingContext);
+        return deserializer.Deserialize();
+    }
+
+    private object Deserialize()
+    {
+        DeserializeRoot(_rootId);
+
+        int pendingCount = _pendingSerializationInfo?.Count ?? 0;
+        while (_pendingSerializationInfo is not null && _pendingSerializationInfo.Count > 0)
+        {
+            PendingSerializationInfo pending = _pendingSerializationInfo.Dequeue();
+
+            if (--pendingCount >= 0
+                && _pendingSerializationInfo.Count != 0
+                && _incompleteDependencies is not null
+                && _incompleteDependencies.TryGetValue(
+                    pending.ObjectId,
+                    out HashSet<SerializationRecordId>? dependencies))
+            {
+                if (dependencies.Count > 0)
+                {
+                    _pendingSerializationInfo.Enqueue(pending);
+                    continue;
+                }
+
+                Debug.Fail("Completed dependencies should have been removed from the dictionary.");
+            }
+
+            pending.Populate(_deserializedObjects, _streamingContext);
+            _pendingSerializationInfoIds?.Remove(pending.ObjectId);
+            ((IDeserializer)this).CompleteObject(pending.ObjectId);
+        }
+
+        if (_incompleteObjects.Count > 0 || (_pendingUpdates is not null && _pendingUpdates.Count > 0))
+        {
+            throw new SerializationException("The serialized object graph could not be completed.");
+        }
+
+        if (_onDeserializedCallbacks is not null)
+        {
+            foreach ((SerializationRecordId id, Action<StreamingContext> callback) in _onDeserializedCallbacks)
+            {
+                callback(_streamingContext);
+                ReapplyValueType(id);
+            }
+        }
+
+        if (_onDeserializationCallbacks is not null)
+        {
+            foreach ((SerializationRecordId id, IDeserializationCallback callback) in _onDeserializationCallbacks)
+            {
+                callback.OnDeserialization(null);
+                ReapplyValueType(id);
+            }
+        }
+
+        return _deserializedObjects[_rootId];
+    }
+
+    private void DeserializeRoot(SerializationRecordId rootId)
+    {
+        object root = DeserializeNew(rootId);
+        if (root is not ObjectRecordDeserializer parser)
+        {
+            return;
+        }
+
+        Stack<ObjectRecordDeserializer> parserStack = new(capacity: InitialParserStackCapacity);
+        parserStack.Push(parser);
+#if NET
+        bool parserStackCapacityHintApplied = false;
+#endif
+
+        while (parserStack.Count > 0)
+        {
+            ObjectRecordDeserializer currentParser = parserStack.Pop();
+
+            SerializationRecordId requiredId;
+            while (!(requiredId = currentParser.Continue()).Equals(default))
+            {
+                if (DeserializeNew(requiredId) is ObjectRecordDeserializer requiredParser)
+                {
+#if NET
+                    if (!parserStackCapacityHintApplied
+                        && parserStack.Count >= InitialParserStackCapacity - 1
+                        && _recordMap.Count > InitialParserStackCapacity)
+                    {
+                        parserStack.EnsureCapacity(GetCapacityHint(_recordMap.Count));
+                        parserStackCapacityHintApplied = true;
+                    }
+#endif
+
+                    parserStack.Push(currentParser);
+                    parserStack.Push(requiredParser);
+                    break;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        object DeserializeNew(SerializationRecordId id)
+        {
+            SerializationRecord record = _recordMap[id];
+
+            object? value = record.RecordType switch
+            {
+                SerializationRecordType.BinaryObjectString => ((PrimitiveTypeRecord<string>)record).Value,
+                SerializationRecordType.MemberPrimitiveTyped => ((PrimitiveTypeRecord)record).Value,
+                SerializationRecordType.ArraySingleString => ((SZArrayRecord<string>)record).GetArray(),
+                SerializationRecordType.ArraySinglePrimitive =>
+                    ArrayRecordDeserializer.GetArraySinglePrimitive(record),
+                SerializationRecordType.BinaryArray =>
+                    ArrayRecordDeserializer.GetRectangularArrayOfPrimitives((ArrayRecord)record, _typeResolver),
+                _ => null
+            };
+
+            if (value is not null)
+            {
+                AddDeserializedObject(record.Id, value);
+                return value;
+            }
+
+            if (!_incompleteObjects.Add(id))
+            {
+                throw new SerializationException("The serialized object graph contains an unsupported cycle.");
+            }
+
+            ObjectRecordDeserializer recordDeserializer = ObjectRecordDeserializer.Create(record, this);
+            AddDeserializedObject(id, recordDeserializer.Object);
+            return recordDeserializer;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void AddDeserializedObject(SerializationRecordId id, object value)
+    {
+#if NET
+        if (_deserializedObjects.Count == 7 && _recordMap.Count > 7)
+        {
+            _deserializedObjects.EnsureCapacity(GetCapacityHint(_recordMap.Count));
+        }
+#endif
+
+        _deserializedObjects.Add(id, value);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int GetCapacityHint(int count) => Math.Min(count, MaximumCapacityHint);
+
+    void IDeserializer.PendSerializationInfo(PendingSerializationInfo pending)
+    {
+        _pendingSerializationInfo ??= new();
+        _pendingSerializationInfo.Enqueue(pending);
+        _pendingSerializationInfoIds ??= [];
+        _pendingSerializationInfoIds.Add(pending.ObjectId);
+    }
+
+    void IDeserializer.PendValueUpdater(ValueUpdater updater)
+    {
+        _pendingUpdates ??= [];
+        _pendingUpdates.Add(updater);
+
+        _incompleteDependencies ??= [];
+
+        if (_incompleteDependencies.TryGetValue(
+            updater.ObjectId,
+            out HashSet<SerializationRecordId>? dependencies))
+        {
+            dependencies.Add(updater.ValueId);
+        }
+        else
+        {
+            _incompleteDependencies.Add(updater.ObjectId, [updater.ValueId]);
+        }
+    }
+
+    void IDeserializer.TrackValueTypeUpdater(ValueUpdater updater)
+    {
+        _valueTypeUpdaters ??= [];
+        if (!_valueTypeUpdaters.TryGetValue(updater.ValueId, out List<ValueUpdater>? updaters))
+        {
+            updaters = [];
+            _valueTypeUpdaters.Add(updater.ValueId, updaters);
+        }
+
+        updaters.Add(updater);
+    }
+
+    [UnconditionalSuppressMessage(
+        "Trimming",
+        "IL2072:'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.All'",
+        Justification = "The instance was created from the fully annotated type returned by ITypeResolver.BindToType.")]
+    void IDeserializer.CompleteObject(SerializationRecordId id)
+    {
+        _pendingCompletions.Enqueue(id);
+
+        while (_pendingCompletions.Count > 0)
+        {
+            SerializationRecordId completedId = _pendingCompletions.Dequeue();
+            _incompleteObjects.Remove(completedId);
+
+            if (_incompleteDependencies is not null
+                && _incompleteDependencies.TryGetValue(
+                    completedId,
+                    out HashSet<SerializationRecordId>? completedDependencies)
+                && completedDependencies.Count == 0)
+            {
+                _incompleteDependencies.Remove(completedId);
+
+                if (_pendingSerializationInfoIds is not null
+                    && _pendingSerializationInfoIds.Contains(completedId))
+                {
+                    continue;
+                }
+            }
+
+            if (_recordMap[completedId] is ClassRecord
+                && (_incompleteDependencies is null || !_incompleteDependencies.ContainsKey(completedId)))
+            {
+                object instance = _deserializedObjects[completedId];
+                Type type = instance.GetType();
+
+                Action<StreamingContext>? onDeserialized = ((IDeserializer)this)
+                    .GetSerializationEvents(type)
+                    .GetOnDeserialized(instance);
+                if (onDeserialized is not null)
+                {
+                    _onDeserializedCallbacks ??= [];
+                    _onDeserializedCallbacks.Add((completedId, onDeserialized));
+                }
+
+                if (instance is IDeserializationCallback callback)
+                {
+                    _onDeserializationCallbacks ??= [];
+                    _onDeserializationCallbacks.Add((completedId, callback));
+                }
+
+                if (instance is IObjectReference objectReference)
+                {
+                    _deserializedObjects[completedId] = objectReference.GetRealObject(_streamingContext);
+                }
+            }
+
+            if (_incompleteDependencies is null)
+            {
+                continue;
+            }
+
+            Debug.Assert(_pendingUpdates is not null);
+
+            foreach (KeyValuePair<SerializationRecordId, HashSet<SerializationRecordId>> pair
+                in _incompleteDependencies)
+            {
+                SerializationRecordId incompleteId = pair.Key;
+                HashSet<SerializationRecordId> dependencies = pair.Value;
+
+                if (!dependencies.Remove(completedId))
+                {
+                    continue;
+                }
+
+                _pendingUpdates!.RemoveWhere((ValueUpdater updater) =>
+                {
+                    if (!updater.ValueId.Equals(completedId))
+                    {
+                        return false;
+                    }
+
+                    updater.UpdateValue(_deserializedObjects);
+                    return true;
+                });
+
+                if (dependencies.Count != 0)
+                {
+                    continue;
+                }
+
+                _pendingCompletions.Enqueue(incompleteId);
+            }
+        }
+    }
+
+    private void ReapplyValueType(SerializationRecordId id)
+        => ReapplyValueType(id, []);
+
+    private void ReapplyValueType(SerializationRecordId id, HashSet<SerializationRecordId> visited)
+    {
+        if (!visited.Add(id))
+        {
+            return;
+        }
+
+        if (_valueTypeUpdaters is not null
+            && _valueTypeUpdaters.TryGetValue(id, out List<ValueUpdater>? updaters))
+        {
+            foreach (ValueUpdater updater in updaters)
+            {
+                updater.UpdateValue(_deserializedObjects);
+
+                if (_deserializedObjects[updater.ObjectId].GetType().IsValueType)
+                {
+                    ReapplyValueType(updater.ObjectId, visited);
+                }
+            }
+        }
+
+        visited.Remove(id);
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/ClassRecordDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ClassRecordDeserializer.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal abstract class ClassRecordDeserializer : ObjectRecordDeserializer
+{
+    private readonly bool _onlyAllowPrimitives;
+
+    private protected ClassRecordDeserializer(
+        ClassRecord classRecord,
+        object instance,
+        IDeserializer deserializer)
+        : base(classRecord, deserializer)
+    {
+        Object = instance;
+        _onlyAllowPrimitives = instance is IObjectReference;
+    }
+
+    internal static ObjectRecordDeserializer Create(ClassRecord classRecord, IDeserializer deserializer)
+    {
+        Type type = deserializer.TypeResolver.BindToType(classRecord.TypeName);
+        if (!type.IsSerializable)
+        {
+            throw new SerializationException($"Type '{type}' is not marked as serializable.");
+        }
+
+        object instance =
+#if NET
+            RuntimeHelpers.GetUninitializedObject(type);
+#else
+            System.Runtime.Serialization.FormatterServices.GetUninitializedObject(type);
+#endif
+
+        deserializer.GetSerializationEvents(type).GetOnDeserializing(instance)?.Invoke(deserializer.StreamingContext);
+
+        return typeof(ISerializable).IsAssignableFrom(type)
+            ? new ClassRecordSerializationInfoDeserializer(classRecord, instance, type, deserializer)
+            : new ClassRecordFieldInfoDeserializer(classRecord, instance, type, deserializer);
+    }
+
+    private protected override void ValidateNewMemberObjectValue(object value)
+    {
+        if (!_onlyAllowPrimitives)
+        {
+            return;
+        }
+
+        Type type = value.GetType();
+        if (type.IsArray)
+        {
+            type = type.GetElementType()!;
+        }
+
+        if (!type.IsPrimitive && !type.IsEnum && type != typeof(string))
+        {
+            throw new SerializationException(
+                $"IObjectReference type '{Object.GetType()}' can only contain primitive values, not '{type}'.");
+        }
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/ClassRecordFieldInfoDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ClassRecordFieldInfoDeserializer.cs
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Reflection;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal sealed class ClassRecordFieldInfoDeserializer : ClassRecordDeserializer
+{
+    private readonly ClassRecord _classRecord;
+    private readonly MemberInfo[] _fieldInfo;
+    private readonly bool _isValueType;
+    private int _currentFieldIndex;
+    private bool _hasFixups;
+
+    internal ClassRecordFieldInfoDeserializer(
+        ClassRecord classRecord,
+        object instance,
+        Type type,
+        IDeserializer deserializer)
+        : base(classRecord, instance, deserializer)
+    {
+        _classRecord = classRecord;
+#pragma warning disable IL2067 // FormatterServices.GetSerializableMembers is not attributed correctly.
+        _fieldInfo = System.Runtime.Serialization.FormatterServices.GetSerializableMembers(type);
+#pragma warning restore IL2067
+        _isValueType = type.IsValueType;
+    }
+
+    internal override SerializationRecordId Continue()
+    {
+        while (_currentFieldIndex < _fieldInfo.Length)
+        {
+            FieldInfo field = (FieldInfo)_fieldInfo[_currentFieldIndex];
+            if (!_classRecord.HasMember(field.Name))
+            {
+                _currentFieldIndex++;
+                continue;
+            }
+
+            (object? memberValue, SerializationRecordId reference) =
+                UnwrapMemberValue(_classRecord.GetRawValue(field.Name));
+
+            if (ReferenceEquals(s_missingValueSentinel, memberValue))
+            {
+                return reference;
+            }
+
+            field.SetValue(Object, memberValue);
+
+            FieldValueUpdater? updater = null;
+            if (memberValue is not null && !reference.Equals(default) && memberValue.GetType().IsValueType)
+            {
+                updater = new FieldValueUpdater(_classRecord.Id, reference, field);
+                Deserializer.TrackValueTypeUpdater(updater);
+            }
+
+            if (memberValue is not null && DoesValueNeedUpdated(memberValue, reference))
+            {
+                _hasFixups = true;
+                Deserializer.PendValueUpdater(
+                    updater ?? new FieldValueUpdater(_classRecord.Id, reference, field));
+            }
+
+            _currentFieldIndex++;
+        }
+
+        if (!_hasFixups || !_isValueType)
+        {
+            Deserializer.CompleteObject(_classRecord.Id);
+        }
+
+        return default;
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/ClassRecordSerializationInfoDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ClassRecordSerializationInfoDeserializer.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDeserializer
+{
+    private readonly ClassRecord _classRecord;
+    private readonly SerializationInfo _serializationInfo;
+    private readonly IEnumerator<string> _memberNamesIterator;
+
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+    private readonly Type _type;
+
+    private bool _canIterate;
+
+    internal ClassRecordSerializationInfoDeserializer(
+        ClassRecord classRecord,
+        object instance,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        Type type,
+        IDeserializer deserializer)
+        : base(classRecord, instance, deserializer)
+    {
+        _classRecord = classRecord;
+        _type = type;
+        _serializationInfo = new(type, BinaryFormattedObject.DefaultConverter);
+        _memberNamesIterator = _classRecord.MemberNames.GetEnumerator();
+        _canIterate = _memberNamesIterator.MoveNext();
+    }
+
+    internal override SerializationRecordId Continue()
+    {
+        if (_canIterate)
+        {
+            do
+            {
+                string memberName = _memberNamesIterator.Current;
+                (object? memberValue, SerializationRecordId reference) =
+                    UnwrapMemberValue(_classRecord.GetRawValue(memberName));
+
+                if (ReferenceEquals(s_missingValueSentinel, memberValue))
+                {
+                    return reference;
+                }
+
+                if (memberValue is not null && DoesValueNeedUpdated(memberValue, reference))
+                {
+                    Deserializer.PendValueUpdater(new SerializationInfoValueUpdater(
+                        _classRecord.Id,
+                        reference,
+                        _serializationInfo,
+                        memberName));
+                }
+
+                _serializationInfo.AddValue(memberName, memberValue);
+            }
+            while (_memberNamesIterator.MoveNext());
+
+            _canIterate = false;
+        }
+
+        Deserializer.PendSerializationInfo(new PendingSerializationInfo(
+            _classRecord.Id,
+            _serializationInfo,
+            _type));
+
+        return default;
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/ClassRecordSerializationInfoDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ClassRecordSerializationInfoDeserializer.cs
@@ -61,7 +61,8 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
                         _classRecord.Id,
                         reference,
                         _serializationInfo,
-                        memberName));
+                        memberName,
+                        memberValue.GetType()));
                 }
 
                 _serializationInfo.AddValue(memberName, memberValue);

--- a/touki/Touki/Resources/BinaryFormat/ClassRecordSerializationInfoDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ClassRecordSerializationInfoDeserializer.cs
@@ -16,6 +16,9 @@ internal sealed class ClassRecordSerializationInfoDeserializer : ClassRecordDese
 {
     private readonly ClassRecord _classRecord;
     private readonly SerializationInfo _serializationInfo;
+
+    // MemberNames is exposed only as IEnumerable<string>. Retain one iterator so traversal can resume after resolving
+    // a dependency without copying the names or restarting enumeration.
     private readonly IEnumerator<string> _memberNamesIterator;
 
     [DynamicallyAccessedMembers(

--- a/touki/Touki/Resources/BinaryFormat/FieldValueUpdater.cs
+++ b/touki/Touki/Resources/BinaryFormat/FieldValueUpdater.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Reflection;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal sealed class FieldValueUpdater : ValueUpdater
+{
+    private readonly FieldInfo _field;
+
+    internal FieldValueUpdater(SerializationRecordId objectId, SerializationRecordId valueId, FieldInfo field)
+        : base(objectId, valueId)
+    {
+        _field = field;
+    }
+
+    internal override void UpdateValue(IDictionary<SerializationRecordId, object> objects)
+    {
+        object newValue = objects[ValueId];
+        _field.SetValue(objects[ObjectId], newValue);
+    }
+}

--- a/touki/Touki/Resources/BinaryFormat/IDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/IDeserializer.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal interface IDeserializer
+{
+    StreamingContext StreamingContext { get; }
+
+    HashSet<SerializationRecordId> IncompleteObjects { get; }
+
+    IDictionary<SerializationRecordId, object> DeserializedObjects { get; }
+
+    ITypeResolver TypeResolver { get; }
+
+    SerializationEvents GetSerializationEvents(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type);
+
+    void PendValueUpdater(ValueUpdater updater);
+
+    void TrackValueTypeUpdater(ValueUpdater updater);
+
+    void PendSerializationInfo(PendingSerializationInfo pending);
+
+    void CompleteObject(SerializationRecordId id);
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/ObjectRecordDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ObjectRecordDeserializer.cs
@@ -64,7 +64,11 @@ internal abstract class ObjectRecordDeserializer
                 return (s_missingValueSentinel, id);
             }
 
-            ValidateNewMemberObjectValue(value);
+            if (value is not null)
+            {
+                ValidateNewMemberObjectValue(value);
+            }
+
             return (value, id);
         }
     }

--- a/touki/Touki/Resources/BinaryFormat/ObjectRecordDeserializer.cs
+++ b/touki/Touki/Resources/BinaryFormat/ObjectRecordDeserializer.cs
@@ -1,0 +1,89 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal abstract class ObjectRecordDeserializer
+{
+    private protected static readonly object s_missingValueSentinel = new();
+
+    private protected ObjectRecordDeserializer(SerializationRecord objectRecord, IDeserializer deserializer)
+    {
+        Deserializer = deserializer;
+        ObjectRecord = objectRecord;
+    }
+
+    internal SerializationRecord ObjectRecord { get; }
+
+    [AllowNull]
+    internal object Object { get; private protected set; }
+
+    private protected IDeserializer Deserializer { get; }
+
+    internal abstract SerializationRecordId Continue();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected (object? value, SerializationRecordId id) UnwrapMemberValue(object? memberValue)
+    {
+        if (memberValue is null)
+        {
+            return (null, default);
+        }
+
+        if (memberValue is not SerializationRecord serializationRecord)
+        {
+            return (memberValue, default);
+        }
+
+        if (serializationRecord.RecordType is SerializationRecordType.BinaryObjectString)
+        {
+            PrimitiveTypeRecord<string> stringRecord = (PrimitiveTypeRecord<string>)serializationRecord;
+            return (stringRecord.Value, stringRecord.Id);
+        }
+
+        if (serializationRecord.RecordType is SerializationRecordType.MemberPrimitiveTyped)
+        {
+            return (((PrimitiveTypeRecord)serializationRecord).Value, default);
+        }
+
+        return TryGetObject(serializationRecord.Id);
+
+        (object? value, SerializationRecordId id) TryGetObject(SerializationRecordId id)
+        {
+            if (!Deserializer.DeserializedObjects.TryGetValue(id, out object? value))
+            {
+                return (s_missingValueSentinel, id);
+            }
+
+            ValidateNewMemberObjectValue(value);
+            return (value, id);
+        }
+    }
+
+    private protected virtual void ValidateNewMemberObjectValue(object value)
+    {
+    }
+
+    private protected bool DoesValueNeedUpdated(object value, SerializationRecordId valueRecord)
+        => !valueRecord.Equals(default)
+            && (value is IObjectReference
+                || (Deserializer.IncompleteObjects.Contains(valueRecord) && value.GetType().IsValueType));
+
+    internal static ObjectRecordDeserializer Create(SerializationRecord record, IDeserializer deserializer)
+        => record switch
+        {
+            ClassRecord classRecord => ClassRecordDeserializer.Create(classRecord, deserializer),
+            _ => new ArrayRecordDeserializer((ArrayRecord)record, deserializer)
+        };
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/PendingSerializationInfo.cs
+++ b/touki/Touki/Resources/BinaryFormat/PendingSerializationInfo.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+internal sealed class PendingSerializationInfo
+{
+    private readonly SerializationInfo _info;
+
+    [DynamicallyAccessedMembers(
+        DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+    private readonly Type _type;
+
+    internal PendingSerializationInfo(
+        SerializationRecordId objectId,
+        SerializationInfo info,
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        Type type)
+    {
+        ObjectId = objectId;
+        _info = info;
+        _type = type;
+    }
+
+    internal SerializationRecordId ObjectId { get; }
+
+    internal void Populate(IDictionary<SerializationRecordId, object> objects, StreamingContext context)
+    {
+        object instance = objects[ObjectId];
+        ConstructorInfo constructor = GetDeserializationConstructor(_type);
+        constructor.Invoke(instance, [_info, context]);
+    }
+
+    private static ConstructorInfo GetDeserializationConstructor(
+        [DynamicallyAccessedMembers(
+            DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+        Type type)
+    {
+        foreach (ConstructorInfo constructor in type.GetConstructors(
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+        {
+            ParameterInfo[] parameters = constructor.GetParameters();
+            if (parameters.Length == 2
+                && parameters[0].ParameterType == typeof(SerializationInfo)
+                && parameters[1].ParameterType == typeof(StreamingContext))
+            {
+                return constructor;
+            }
+        }
+
+        throw new SerializationException(
+            $"Type '{type.FullName}' does not have a serialization constructor.");
+    }
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormat/SerializationEvents.cs
+++ b/touki/Touki/Resources/BinaryFormat/SerializationEvents.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal sealed class SerializationEvents
+{
+    private static readonly SerializationEvents s_noEvents = new();
+
+    private readonly List<MethodInfo>? _onDeserializingMethods;
+    private readonly List<MethodInfo>? _onDeserializedMethods;
+
+    private SerializationEvents()
+    {
+    }
+
+    private SerializationEvents(
+        List<MethodInfo>? onDeserializingMethods,
+        List<MethodInfo>? onDeserializedMethods)
+    {
+        _onDeserializingMethods = onDeserializingMethods;
+        _onDeserializedMethods = onDeserializedMethods;
+    }
+
+    internal static SerializationEvents Create(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type type)
+    {
+        List<MethodInfo>? onDeserializingMethods = GetMethodsWithAttribute(
+            typeof(OnDeserializingAttribute),
+            type);
+        List<MethodInfo>? onDeserializedMethods = GetMethodsWithAttribute(
+            typeof(OnDeserializedAttribute),
+            type);
+
+        return onDeserializingMethods is null && onDeserializedMethods is null
+            ? s_noEvents
+            : new SerializationEvents(onDeserializingMethods, onDeserializedMethods);
+    }
+
+    private static List<MethodInfo>? GetMethodsWithAttribute(
+        Type attribute,
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] Type? type)
+    {
+        List<MethodInfo>? attributedMethods = null;
+
+        Type? baseType = type;
+        while (baseType is not null && baseType != typeof(object))
+        {
+            MethodInfo[] methods = baseType.GetMethods(
+                BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+
+            foreach (MethodInfo method in methods)
+            {
+                if (method.IsDefined(attribute, inherit: false))
+                {
+                    attributedMethods ??= [];
+                    attributedMethods.Add(method);
+                }
+            }
+
+            baseType = baseType.BaseType;
+        }
+
+        attributedMethods?.Reverse();
+        return attributedMethods;
+    }
+
+    internal Action<StreamingContext>? GetOnDeserialized(object instance)
+        => AddOnDelegate(instance, _onDeserializedMethods);
+
+    internal Action<StreamingContext>? GetOnDeserializing(object instance)
+        => AddOnDelegate(instance, _onDeserializingMethods);
+
+    private static Action<StreamingContext>? AddOnDelegate(object instance, List<MethodInfo>? methods)
+    {
+        Action<StreamingContext>? handler = null;
+
+        if (methods is not null)
+        {
+            foreach (MethodInfo method in methods)
+            {
+                Action<StreamingContext> callback =
+#if NET
+                    method.CreateDelegate<Action<StreamingContext>>(instance);
+#else
+                    (Action<StreamingContext>)method.CreateDelegate(typeof(Action<StreamingContext>), instance);
+#endif
+                handler += callback;
+            }
+        }
+
+        return handler;
+    }
+}

--- a/touki/Touki/Resources/BinaryFormat/SerializationExtensions.cs
+++ b/touki/Touki/Resources/BinaryFormat/SerializationExtensions.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal static class SerializationExtensions
+{
+    internal static SerializationException ConvertToSerializationException(this Exception exception)
+        => exception is SerializationException serializationException
+            ? serializationException
+#if NET
+            : (SerializationException)System.Runtime.ExceptionServices.ExceptionDispatchInfo.SetRemoteStackTrace(
+                new SerializationException(exception.Message, exception),
+                exception.StackTrace ?? string.Empty);
+#else
+            : new SerializationException(exception.Message, exception);
+#endif
+}

--- a/touki/Touki/Resources/BinaryFormat/SerializationInfoExtensions.cs
+++ b/touki/Touki/Resources/BinaryFormat/SerializationInfoExtensions.cs
@@ -24,6 +24,6 @@ internal static class SerializationInfoExtensions
 #endif
 
     [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicMethods, typeof(SerializationInfo))]
-    internal static void UpdateValue(this SerializationInfo info, string name, object value, Type type)
-        => s_updateValue(info, name, value, type);
+    internal static void UpdateValue(this SerializationInfo info, string name, object? value, Type type)
+        => s_updateValue(info, name, value!, type);
 }

--- a/touki/Touki/Resources/BinaryFormat/SerializationInfoExtensions.cs
+++ b/touki/Touki/Resources/BinaryFormat/SerializationInfoExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal static class SerializationInfoExtensions
+{
+    private static readonly Action<SerializationInfo, string, object, Type> s_updateValue =
+#if NET
+        typeof(SerializationInfo)
+            .GetMethod("UpdateValue", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+            .CreateDelegate<Action<SerializationInfo, string, object, Type>>();
+#else
+        (Action<SerializationInfo, string, object, Type>)typeof(SerializationInfo)
+            .GetMethod("UpdateValue", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+            .CreateDelegate(typeof(Action<SerializationInfo, string, object, Type>));
+#endif
+
+    [DynamicDependency(DynamicallyAccessedMemberTypes.NonPublicMethods, typeof(SerializationInfo))]
+    internal static void UpdateValue(this SerializationInfo info, string name, object value, Type type)
+        => s_updateValue(info, name, value, type);
+}

--- a/touki/Touki/Resources/BinaryFormat/SerializationInfoValueUpdater.cs
+++ b/touki/Touki/Resources/BinaryFormat/SerializationInfoValueUpdater.cs
@@ -14,21 +14,24 @@ internal sealed class SerializationInfoValueUpdater : ValueUpdater
 {
     private readonly SerializationInfo _info;
     private readonly string _name;
+    private readonly Type _serializedType;
 
     internal SerializationInfoValueUpdater(
         SerializationRecordId objectId,
         SerializationRecordId valueId,
         SerializationInfo info,
-        string name)
+        string name,
+        Type serializedType)
         : base(objectId, valueId)
     {
         _info = info;
         _name = name;
+        _serializedType = serializedType;
     }
 
     internal override void UpdateValue(IDictionary<SerializationRecordId, object> objects)
     {
-        object newValue = objects[ValueId];
-        _info.UpdateValue(_name, newValue, newValue.GetType());
+        object? newValue = objects[ValueId];
+        _info.UpdateValue(_name, newValue, newValue?.GetType() ?? _serializedType);
     }
 }

--- a/touki/Touki/Resources/BinaryFormat/SerializationInfoValueUpdater.cs
+++ b/touki/Touki/Resources/BinaryFormat/SerializationInfoValueUpdater.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Runtime.Serialization;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal sealed class SerializationInfoValueUpdater : ValueUpdater
+{
+    private readonly SerializationInfo _info;
+    private readonly string _name;
+
+    internal SerializationInfoValueUpdater(
+        SerializationRecordId objectId,
+        SerializationRecordId valueId,
+        SerializationInfo info,
+        string name)
+        : base(objectId, valueId)
+    {
+        _info = info;
+        _name = name;
+    }
+
+    internal override void UpdateValue(IDictionary<SerializationRecordId, object> objects)
+    {
+        object newValue = objects[ValueId];
+        _info.UpdateValue(_name, newValue, newValue.GetType());
+    }
+}

--- a/touki/Touki/Resources/BinaryFormat/ValueUpdater.cs
+++ b/touki/Touki/Resources/BinaryFormat/ValueUpdater.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+
+namespace Touki.Resources.BinaryFormat;
+
+internal abstract class ValueUpdater
+{
+    private protected ValueUpdater(SerializationRecordId objectId, SerializationRecordId valueId)
+    {
+        ObjectId = objectId;
+        ValueId = valueId;
+    }
+
+    internal SerializationRecordId ValueId { get; }
+
+    internal SerializationRecordId ObjectId { get; }
+
+    internal abstract void UpdateValue(IDictionary<SerializationRecordId, object> objects);
+}

--- a/touki/Touki/Resources/BinaryFormattedObject.cs
+++ b/touki/Touki/Resources/BinaryFormattedObject.cs
@@ -21,8 +21,8 @@ namespace Touki.Resources;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   Constructing this type parses the payload without instantiating any reference type other than
-///   <see cref="string"/>. Call <see cref="Deserialize"/> to instantiate the graph.
+///   Constructing this type parses the payload into serialization records without instantiating payload-defined
+///   types. Call <see cref="Deserialize"/> to instantiate the graph.
 ///  </para>
 ///  <para>
 ///   Deserialization can invoke serialization constructors, <see cref="ISerializable"/> implementations,

--- a/touki/Touki/Resources/BinaryFormattedObject.cs
+++ b/touki/Touki/Resources/BinaryFormattedObject.cs
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+// Adapted from dotnet/runtime at 7aa830a03599a8255c2c4abf2947afc5b346cc6f (MIT licensed):
+// src/libraries/System.Resources.Extensions/src/System/Resources/Extensions/BinaryFormat/
+
+using System.Formats.Nrbf;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using System.Runtime.Serialization;
+using System.Threading;
+using Touki.Resources.BinaryFormat;
+
+namespace Touki.Resources;
+
+#pragma warning disable SYSLIB0050 // Type or member is obsolete.
+
+/// <summary>
+///  Represents an object graph encoded in the .NET Remoting Binary Format (NRBF).
+/// </summary>
+/// <remarks>
+///  <para>
+///   Constructing this type parses the payload without instantiating any reference type other than
+///   <see cref="string"/>. Call <see cref="Deserialize"/> to instantiate the graph.
+///  </para>
+///  <para>
+///   Deserialization can invoke serialization constructors, <see cref="ISerializable"/> implementations,
+///   <see cref="IDeserializationCallback"/>, and methods marked with serialization callback attributes. Register only
+///   trusted types and deserialize only trusted payloads.
+///  </para>
+/// </remarks>
+public sealed class BinaryFormattedObject
+{
+    private static readonly PayloadOptions s_payloadOptions = new()
+    {
+        UndoTruncatedTypeNames = true
+    };
+
+    private static readonly StreamingContext s_streamingContext = new(StreamingContextStates.All);
+    private readonly ITypeResolver _typeResolver;
+    private int _deserializationStarted;
+
+    internal static FormatterConverter DefaultConverter { get; } = new();
+
+    /// <summary>
+    ///  Creates an object model by parsing <paramref name="stream"/>.
+    /// </summary>
+    /// <param name="stream">The readable stream containing an NRBF payload.</param>
+    /// <param name="typeResolver">
+    ///  The resolver containing every type that may be instantiated. A resolver containing the default framework types
+    ///  is created when this value is <see langword="null"/>.
+    /// </param>
+    /// <remarks>The supplied stream remains open.</remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    /// <exception cref="SerializationException">The payload is malformed.</exception>
+    /// <exception cref="NotSupportedException">
+    ///  The payload uses an unsupported NRBF feature, such as an array with non-zero lower bounds.
+    /// </exception>
+    public BinaryFormattedObject(Stream stream, ITypeResolver? typeResolver = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+
+        _typeResolver = typeResolver ?? new RegisteredTypeResolver();
+
+        try
+        {
+            RootRecord = NrbfDecoder.Decode(
+                stream,
+                out IReadOnlyDictionary<SerializationRecordId, SerializationRecord> recordMap,
+                options: s_payloadOptions,
+                leaveOpen: true);
+
+            RecordMap = recordMap;
+        }
+        catch (Exception exception)
+            when (exception is ArgumentException or InvalidCastException or ArithmeticException or IOException)
+        {
+            throw exception.ConvertToSerializationException();
+        }
+        catch (TargetInvocationException exception)
+        {
+            throw ExceptionDispatchInfo.Capture(exception.InnerException!).SourceException
+                .ConvertToSerializationException();
+        }
+    }
+
+    /// <summary>
+    ///  Deserializes the parsed object graph.
+    /// </summary>
+    /// <returns>The root object.</returns>
+    /// <exception cref="SerializationException">
+    ///  The graph is malformed, a required type is not registered, or a registered type cannot be deserialized.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">This method has already been called.</exception>
+    /// <remarks>
+    ///  This is a one-shot operation, including when deserialization fails. Registered serialization constructors and
+    ///  callbacks can throw additional exceptions.
+    /// </remarks>
+    public object Deserialize()
+    {
+        if (Interlocked.Exchange(ref _deserializationStarted, 1) != 0)
+        {
+            throw new InvalidOperationException("The parsed object graph has already been deserialized.");
+        }
+
+        try
+        {
+            return BinaryFormatDeserializer.Deserialize(
+                RootRecord.Id,
+                RecordMap,
+                _typeResolver,
+                s_streamingContext);
+        }
+        catch (Exception exception)
+            when (exception is ArgumentException or InvalidCastException or ArithmeticException or IOException)
+        {
+            throw exception.ConvertToSerializationException();
+        }
+        catch (TargetInvocationException exception)
+        {
+            throw ExceptionDispatchInfo.Capture(exception.InnerException!).SourceException
+                .ConvertToSerializationException();
+        }
+    }
+
+    /// <summary>
+    ///  Gets the root serialization record.
+    /// </summary>
+    public SerializationRecord RootRecord { get; }
+
+    /// <summary>
+    ///  Gets the serialization records indexed by identifier.
+    /// </summary>
+    public IReadOnlyDictionary<SerializationRecordId, SerializationRecord> RecordMap { get; }
+
+    /// <summary>
+    ///  Gets a serialization record by identifier.
+    /// </summary>
+    /// <param name="id">The record identifier.</param>
+    public SerializationRecord this[SerializationRecordId id] => RecordMap[id];
+}
+
+#pragma warning restore SYSLIB0050 // Type or member is obsolete.

--- a/touki/Touki/Resources/BinaryFormattedObject.cs
+++ b/touki/Touki/Resources/BinaryFormattedObject.cs
@@ -74,7 +74,11 @@ public sealed class BinaryFormattedObject
             RecordMap = recordMap;
         }
         catch (Exception exception)
-            when (exception is ArgumentException or InvalidCastException or ArithmeticException or IOException)
+            when (exception is ArgumentException
+                or InvalidCastException
+                or ArithmeticException
+                or IOException
+                or KeyNotFoundException)
         {
             throw exception.ConvertToSerializationException();
         }
@@ -113,7 +117,11 @@ public sealed class BinaryFormattedObject
                 s_streamingContext);
         }
         catch (Exception exception)
-            when (exception is ArgumentException or InvalidCastException or ArithmeticException or IOException)
+            when (exception is ArgumentException
+                or InvalidCastException
+                or ArithmeticException
+                or IOException
+                or KeyNotFoundException)
         {
             throw exception.ConvertToSerializationException();
         }

--- a/touki/Touki/Resources/BinaryFormattedObject.cs
+++ b/touki/Touki/Resources/BinaryFormattedObject.cs
@@ -77,14 +77,13 @@ public sealed class BinaryFormattedObject
             when (exception is ArgumentException
                 or InvalidCastException
                 or ArithmeticException
-                or IOException
-                or KeyNotFoundException)
+                or IOException)
         {
             throw exception.ConvertToSerializationException();
         }
         catch (TargetInvocationException exception)
         {
-            throw ExceptionDispatchInfo.Capture(exception.InnerException!).SourceException
+            throw ExceptionDispatchInfo.Capture(exception.InnerException ?? exception).SourceException
                 .ConvertToSerializationException();
         }
     }
@@ -120,14 +119,13 @@ public sealed class BinaryFormattedObject
             when (exception is ArgumentException
                 or InvalidCastException
                 or ArithmeticException
-                or IOException
-                or KeyNotFoundException)
+                or IOException)
         {
             throw exception.ConvertToSerializationException();
         }
         catch (TargetInvocationException exception)
         {
-            throw ExceptionDispatchInfo.Capture(exception.InnerException!).SourceException
+            throw ExceptionDispatchInfo.Capture(exception.InnerException ?? exception).SourceException
                 .ConvertToSerializationException();
         }
     }

--- a/touki/touki.csproj
+++ b/touki/touki.csproj
@@ -66,6 +66,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Formats.Nrbf" />
+
     <!--
       CsWin32 generates the Win32 interop needed by both Framework polyfills and shared
       Windows-only providers (e.g. Touki.Io.Clipboard). Referenced on both TFMs so the


### PR DESCRIPTION
## Summary

- add a trim-safe, allow-listed `BinaryFormattedObject` NRBF materializer with registered type resolution, object graph fixups, callbacks, `ISerializable`, arrays, and one-shot semantics
- add cross-TFM correctness, malformed-input, graph, primitive-array, concurrency, and NativeAOT coverage
- add BinaryFormatter/upstream comparison benchmarks, field-assignment investigations, performance records, and the `ClassRecord.TryGetRawValue` API proposal
- consume filtrace 0.6 tooling and the unreleased overlay-capable skill source with exact provenance, while documenting current BenchmarkDotNet/helper compatibility limits

## Safety

`BinaryFormattedObject` is explicitly for trusted NRBF payloads and trusted registered types. Deserialization may execute serialization constructors, callbacks, `ISerializable`, and `IObjectReference` behavior. Materialization is atomically one-shot, including failed attempts.

## Validation

- `dotnet build touki.slnx`
- full Debug and Release suites executed; the only failures were six existing interactive Windows clipboard tests on each TFM because this noninteractive agent host cannot open/set the clipboard
- complete Debug and Release suites excluding only `Touki.Io.ClipboardTests` and `Touki.Io.Providers.WindowsClipboardProviderTests` passed with exit code 0
- `dotnet publish touki.aot.tests/touki.aot.tests.csproj -c Release -r win-x64` with the reflection-discovered AOT test assembly rooted
- agent-file, skill provenance, relative-link, markdownlint, and whitespace gates
- callback cache confirmation: 1.547 us / 5.78 KiB on modern .NET RyuJIT and 4.654 us / 6.65 KiB on .NET Framework 4.8.1 RyuJIT, within the recorded baseline envelope