### PR TITLE
Consume filtrace 0.6.3

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -40,10 +40,10 @@ a skill would need to change to be reused in another repo: `portable` (generic),
 `metadata.github-*` provenance in its `SKILL.md`) paired with a local `overlay.md`
 that carries the touki-specific cross-references and example links.
 `vendored (tool repo) + overlay` is an exact skill payload from the tool's own
-repository plus a consumer-owned `overlay.md`. Filtrace is temporarily pinned to
-the exact source revision that enabled overlays while its executable packages
-remain at release 0.6.0. Do not hand-edit a vendored core; update it from an exact
-tool release or source revision.
+repository plus a consumer-owned `overlay.md`. Filtrace is pinned to the exact
+`v0.6.1` tool release together with its executable packages. Do not
+hand-edit a vendored core; update it from an exact tool release or source
+revision.
 
 ## Disambiguation
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -41,7 +41,7 @@ a skill would need to change to be reused in another repo: `portable` (generic),
 that carries the touki-specific cross-references and example links.
 `vendored (tool repo) + overlay` is an exact skill payload from the tool's own
 repository plus a consumer-owned `overlay.md`. Filtrace is pinned to the exact
-`v0.6.2` tool release together with its executable packages. Do not
+`v0.6.3` tool release together with its executable packages. Do not
 hand-edit a vendored core; update it from an exact tool release or source
 revision.
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -41,7 +41,7 @@ a skill would need to change to be reused in another repo: `portable` (generic),
 that carries the touki-specific cross-references and example links.
 `vendored (tool repo) + overlay` is an exact skill payload from the tool's own
 repository plus a consumer-owned `overlay.md`. Filtrace is pinned to the exact
-`v0.6.1` tool release together with its executable packages. Do not
+`v0.6.2` tool release together with its executable packages. Do not
 hand-edit a vendored core; update it from an exact tool release or source
 revision.
 

--- a/.agents/skills/filtrace/SKILL.md
+++ b/.agents/skills/filtrace/SKILL.md
@@ -258,25 +258,31 @@ Run `filtrace <verb> --help` for the full option set of any verb.
 
 ## Scope and symbols
 
-- **Scope to one process.** The verbs that read a multi-process `.etl`
-  (`cpu`, `threadtime`, `rank`, `callers`, `lines`, `heatmap`, `tree`, `classify`,
-  `timeline`) auto-scope to the busiest process tree. Run `processes` first to see the
-   capture, then `--process <name>` to override. The CLI also accepts `--all-processes`
-   to widen; MCP tools support automatic or named-process scope, not an all-process
-   aggregate.
-  `alloc` / `exceptions` read a single-process `.nettrace` and have no process
-  options.
-- **Scope to the benchmark.** For every root-aware stack analysis of a
-   BenchmarkDotNet capture, scope to its `WorkloadAction` wrapper. In the CLI, pass
-   `--benchmark` to every verb that offers it. In MCP, pass
-   `benchmark: true` to `trace_rank`, `trace_callers`, `trace_tree`,
-   `trace_classify`, and `trace_export`. The wrapper includes warmup and actual
-   iterations and excludes harness/overhead scaffolding. Do not guess a benchmark
-   method substring: root/frame warnings report the total match count, then list up to
-   25 full definitions and 10 depths per definition with omitted-count markers, plus
-   which outermost/deepest definition was selected. Narrow an ambiguous selector before
-   trusting percentages. `lines` / `heatmap` have no root scope; narrow them by
-   method/file and treat percentages as whole-trace.
+<!-- filtrace:begin scopes -->
+**Implemented scope inventory:**
+
+- **Named process:** CLI `info`, `rank`, `cpu`, `threadtime`, `callers`, `lines`,
+  `heatmap`, `tree`, `classify`, `timeline`, `diff`, `batch`, and `export`; MCP
+  `trace_info`, `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`,
+  `trace_tree`, `trace_classify`, `trace_timeline`, `trace_diff`, `trace_batch`, and
+  `trace_export`. These auto-scope a multi-process `.etl` to the busiest process tree.
+  Run `processes` / `trace_processes` first to inspect the capture, then set
+  `--process <name>` / `process` to override. CLI verbs expose `--all-processes`
+  where an aggregate is supported; MCP has no all-process aggregate.
+- **Root subtree:** CLI `rank`, `cpu`, `alloc`, `exceptions`, `threadtime`, `callers`,
+  `tree`, `classify`, `diff`, `batch`, and `export`; MCP `trace_rank`,
+  `trace_callers`, `trace_tree`, `trace_classify`, `trace_diff`, `trace_batch`, and
+  `trace_export`. Set `--root <frame>` / `root` to keep the subtree under a frame.
+- **BenchmarkDotNet workload:** CLI `rank`, `cpu`, `alloc`, `exceptions`,
+  `threadtime`, `callers`, `tree`, `classify`, `diff`, `batch`, and `export` accept
+  `--benchmark`; MCP `trace_rank`, `trace_callers`, `trace_tree`, `trace_classify`,
+  `trace_diff`, `trace_batch`, and `trace_export` accept `benchmark: true`. The
+  preset isolates the `WorkloadAction` subtree from harness and overhead scaffolding;
+  it is mutually exclusive with an explicit root. `lines` / `heatmap` are not
+  root-aware, so narrow them by method/file and treat percentages as process-scoped
+  whole-trace values.
+<!-- filtrace:end scopes -->
+
 - **Scope to a time window.** `rank --time <start>,<end>` (milliseconds relative to
   the trace start, either bound optional: `1000,5000`, `1000,`, or `,5000`) keeps
   only the samples anchored in the window. It applies to every metric, so it zooms
@@ -374,12 +380,14 @@ The recurring ways a .NET trace investigation goes wrong:
 4. **BenchmarkDotNet captures include the harness - scope with `--benchmark` by
    default, not as an afterthought.** A raw ranking (or export) of a BDN trace is
    mixed with orchestrator and overhead scaffolding outside your `[Benchmark]`.
-   In the CLI, pass `--benchmark` to every verb that offers it; in MCP, pass
-   `benchmark: true` to `trace_rank`, `trace_callers`, `trace_tree`,
-   `trace_classify`, and `trace_export`. The wrapper includes warmup and actual
-   workload iterations; it excludes harness/overhead scaffolding, not warmup. This
-   applies especially to export - a flame graph with the harness left in is not just
-   noisy, its proportions are wrong. Do not substitute a benchmark method substring:
+   In the CLI, pass `--benchmark` to `rank`, `cpu`, `alloc`, `exceptions`,
+   `threadtime`, `callers`, `tree`, `classify`, `diff`, `batch`, and `export`; in
+   MCP, pass `benchmark: true` to `trace_rank`, `trace_callers`, `trace_tree`,
+   `trace_classify`, `trace_diff`, `trace_batch`, and `trace_export`. The wrapper
+   includes warmup and actual workload iterations; it excludes harness/overhead
+   scaffolding, not warmup. This applies especially to export - a flame graph with
+   the harness left in is not just noisy, its proportions are wrong. Do not
+   substitute a benchmark method substring:
    if root/frame warnings report multiple definitions or depths, narrow the selector
    before trusting the result. `lines` / `heatmap` cannot preserve root scope; narrow
    them with their method/file filter and treat percentages as whole-trace.

--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -1,31 +1,30 @@
 ---
 core: filtrace
-core-pin: a04fdd8cae33af5dd8fb5a25329c8c75eb7dea73
+core-pin: v0.6.1
 core-repo: https://github.com/JeremyKuhne/filtrace
-core-tree-sha: 43e5f226a606a25da9917b68d29c828a9e95aa4c
-runtime-pin: 0.6.0
+core-tree-sha: b9c89b9bd0a698356fe5c81984abf27a5875f87f
+runtime-pin: 0.6.1
 ---
 
 # Touki overlay - filtrace
 
 Repository-specific bindings for the tool-shipped [filtrace](SKILL.md) core.
 The upstream-owned [skill](SKILL.md), [README](README.md), and [scripts](scripts/)
-match standalone
-[JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace) source commit
-`a04fdd8cae33af5dd8fb5a25329c8c75eb7dea73` (skill tree
-`43e5f226a606a25da9917b68d29c828a9e95aa4c`). That unreleased revision enables
-consumer overlays; the executable packages remain pinned to release `0.6.0`.
+match standalone [JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)
+tag `v0.6.1` (commit `e2fb75392576ca4a35bfe7e82dcefb511f1ded1e`,
+skill tree `b9c89b9bd0a698356fe5c81984abf27a5875f87f`). The executable
+packages and vendored skill are pinned to the same release.
 
 ## Bindings
 
 - **MCP server** - registered in [.vscode/mcp.json](../../../.vscode/mcp.json)
-  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.0`, exposing the seventeen `trace_*`
+  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.1`, exposing the seventeen `trace_*`
   tools an agent calls directly. No clone or build is required.
 - **CLI, fresh install** -
-  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.0`.
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.1`.
 - **CLI, existing install** -
-  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.0`.
-- Run `filtrace --version` and require `0.6.0` before passing that executable
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.1`.
+- Run `filtrace --version` and require `0.6.1` before passing that executable
   to the capture helpers. Installing does not upgrade an older global tool.
 - Touki's [profiling](../performance-testing/profiling.md) and
   [graphical-viewers](../performance-testing/graphical-viewers.md) pages drive
@@ -33,38 +32,24 @@ consumer overlays; the executable packages remain pinned to release `0.6.0`.
 - [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) remains
   Touki-specific because it wraps the local net481 benchmark workflow.
 
-## Upstream follow-up
+## Release 0.6.1
 
-Release 0.6.0 completes
-[filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42): first-class
-BenchmarkDotNet scoping and ambiguity diagnostics, query-specific contributing
-record counts, ETLX conversion coordination, provider enablement/event state,
-source/PDB quality, isolated all-case capture manifests, normalized
-manifest-aware diff, and batch analysis.
+Release 0.6.1 closes
+[filtrace#55](https://github.com/JeremyKuhne/filtrace/issues/55), which Touki
+reported while exercising BenchmarkDotNet 0.16.0-preview.1. The bundled helper
+now verifies hashed parameterized artifacts through their embedded benchmark
+identity, preserves runtime metadata, preflights the filtrace version and schema,
+and keeps the 20 KiB limit on compact agent output rather than the durable
+manifest. Ordinary filenames retain a guarded exact-name and execution-order
+fallback only when case counts and distinct capture timestamps align; otherwise
+identity remains unavailable. Default EventPipe activity state also remains
+unknown without provider evidence, and the skill's scope inventory now matches
+the implemented tools.
 
-The implementation supports process and BenchmarkDotNet scoping for
-manifest-aware `diff` and `batch`, but the current core's scope inventories do
-not list those tools. Its process-scope inventory also omits `export`. Correct
-those generic reference lists in filtrace and re-vendor a later source revision;
-do not patch the pinned core here.
-
-The 0.6 capture helper also accepts any discovered `filtrace` executable without
-checking its version or response schema. Add a helper-side compatibility
-preflight upstream; Touki's profiling workflow performs the version check before
-invoking the pinned payload.
-
-Touki uses BenchmarkDotNet 0.16.0-preview.1. Its log escapes quotes inside
-`--benchmarkName`, writes parameter displays as `[Scenario=...]`, and emits
-`// Runtime=...` environment lines. The 0.6 helper's parser does not fully
-understand that shape, so verify every manifest case has nonempty `benchmark`
-and `parameters` before using manifest-aware `batch` or `diff`. Analyze direct
-trace paths when identity is incomplete; never guess case pairing.
-
-The 0.6 helper also caps the on-disk manifest at 20 KiB. Split broad filters
-before capture rather than relying on the compact-stdout fallback for a large
-case matrix. Treat `activity` as unavailable unless the application EventSource
-provider was explicitly enabled; the default BenchmarkDotNet EventPipe capture
-does not establish that provider merely because the helper sidecar says enabled.
+Touki no longer carries consumer-side workarounds for those issues. Preserve the
+helper's fail-closed behavior: when an unidentified case is excluded from
+manifest-aware batch or pairing, analyze that trace directly rather than guessing
+its benchmark or parameters.
 
 ## Concrete fold-list hit
 
@@ -77,12 +62,11 @@ walked struct contained no GC references. The frame was an attribution artifact;
 
 ## Updating
 
-Until overlay support is released, copy the complete upstream-owned payload from
-an exact filtrace source revision and record that revision in `core-pin`. When a
-published release contains the overlay contract, copy the payload from its exact
-tag, set `core-pin` to that version, and update the CLI/MCP package pins together.
-Never hand-edit the tool-shipped core; fix generic content upstream and re-vendor
-it.
+Copy the complete upstream-owned payload from an exact filtrace tag, record that
+tag in `core-pin`, and update the CLI/MCP package pins together. Record the exact
+payload tree in `core-tree-sha`; it catches release-copy drift independently of
+the human-readable pin. Never hand-edit the tool-shipped core; fix generic
+content upstream and re-vendor it.
 
 After updating, review these bindings and run `tools/Validate-AgentFiles.ps1`,
 `tools/Validate-AgentSkills.ps1`, and `tools/Test-AgentFileLinks.ps1`.

--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -1,9 +1,9 @@
 ---
 core: filtrace
-core-pin: v0.6.1
+core-pin: v0.6.2
 core-repo: https://github.com/JeremyKuhne/filtrace
-core-tree-sha: b9c89b9bd0a698356fe5c81984abf27a5875f87f
-runtime-pin: 0.6.1
+core-tree-sha: cfb836bcffc3c038b6bd00317db66007bd495b68
+runtime-pin: 0.6.2
 ---
 
 # Touki overlay - filtrace
@@ -11,20 +11,20 @@ runtime-pin: 0.6.1
 Repository-specific bindings for the tool-shipped [filtrace](SKILL.md) core.
 The upstream-owned [skill](SKILL.md), [README](README.md), and [scripts](scripts/)
 match standalone [JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)
-tag `v0.6.1` (commit `e2fb75392576ca4a35bfe7e82dcefb511f1ded1e`,
-skill tree `b9c89b9bd0a698356fe5c81984abf27a5875f87f`). The executable
+tag `v0.6.2` (commit `df38c9977e02503917623163a577f57da7e0e296`,
+skill tree `cfb836bcffc3c038b6bd00317db66007bd495b68`). The executable
 packages and vendored skill are pinned to the same release.
 
 ## Bindings
 
 - **MCP server** - registered in [.vscode/mcp.json](../../../.vscode/mcp.json)
-  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.1`, exposing the seventeen `trace_*`
+  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.2`, exposing the seventeen `trace_*`
   tools an agent calls directly. No clone or build is required.
 - **CLI, fresh install** -
-  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.1`.
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.2`.
 - **CLI, existing install** -
-  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.1`.
-- Run `filtrace --version` and require `0.6.1` before passing that executable
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.2`.
+- Run `filtrace --version` and require `0.6.2` before passing that executable
   to the capture helpers. Installing does not upgrade an older global tool.
 - Touki's [profiling](../performance-testing/profiling.md) and
   [graphical-viewers](../performance-testing/graphical-viewers.md) pages drive
@@ -32,7 +32,7 @@ packages and vendored skill are pinned to the same release.
 - [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) remains
   Touki-specific because it wraps the local net481 benchmark workflow.
 
-## Release 0.6.1
+## Releases 0.6.1 and 0.6.2
 
 Release 0.6.1 closes
 [filtrace#55](https://github.com/JeremyKuhne/filtrace/issues/55), which Touki
@@ -50,6 +50,11 @@ Touki no longer carries consumer-side workarounds for those issues. Preserve the
 helper's fail-closed behavior: when an unidentified case is excluded from
 manifest-aware batch or pairing, analyze that trace directly rather than guessing
 its benchmark or parameters.
+
+Release 0.6.2 fixes duplicate manifest-wide runtime summaries discovered while
+Touki consumed 0.6.1. The helper now prefers richer final summaries, preserves
+unmatched per-case runtimes from partial multi-runtime runs, and ignores
+BenchmarkDotNet job-characteristic rows that begin with `Runtime=`.
 
 ## Concrete fold-list hit
 

--- a/.agents/skills/filtrace/overlay.md
+++ b/.agents/skills/filtrace/overlay.md
@@ -1,9 +1,9 @@
 ---
 core: filtrace
-core-pin: v0.6.2
+core-pin: v0.6.3
 core-repo: https://github.com/JeremyKuhne/filtrace
-core-tree-sha: cfb836bcffc3c038b6bd00317db66007bd495b68
-runtime-pin: 0.6.2
+core-tree-sha: c67fe9a898fea1824e19583cce342577cdcde82b
+runtime-pin: 0.6.3
 ---
 
 # Touki overlay - filtrace
@@ -11,20 +11,20 @@ runtime-pin: 0.6.2
 Repository-specific bindings for the tool-shipped [filtrace](SKILL.md) core.
 The upstream-owned [skill](SKILL.md), [README](README.md), and [scripts](scripts/)
 match standalone [JeremyKuhne/filtrace](https://github.com/JeremyKuhne/filtrace)
-tag `v0.6.2` (commit `df38c9977e02503917623163a577f57da7e0e296`,
-skill tree `cfb836bcffc3c038b6bd00317db66007bd495b68`). The executable
+tag `v0.6.3` (commit `0749a3015f39297cfe9678e5a18ffb99f6c98da8`,
+skill tree `c67fe9a898fea1824e19583cce342577cdcde82b`). The executable
 packages and vendored skill are pinned to the same release.
 
 ## Bindings
 
 - **MCP server** - registered in [.vscode/mcp.json](../../../.vscode/mcp.json)
-  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.2`, exposing the seventeen `trace_*`
+  as `dnx KlutzyNinja.Filtrace.Mcp@0.6.3`, exposing the seventeen `trace_*`
   tools an agent calls directly. No clone or build is required.
 - **CLI, fresh install** -
-  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.2`.
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.3`.
 - **CLI, existing install** -
-  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.2`.
-- Run `filtrace --version` and require `0.6.2` before passing that executable
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.3`.
+- Run `filtrace --version` and require `0.6.3` before passing that executable
   to the capture helpers. Installing does not upgrade an older global tool.
 - Touki's [profiling](../performance-testing/profiling.md) and
   [graphical-viewers](../performance-testing/graphical-viewers.md) pages drive
@@ -32,7 +32,7 @@ packages and vendored skill are pinned to the same release.
 - [tools/Capture-EtwTrace.ps1](../../../tools/Capture-EtwTrace.ps1) remains
   Touki-specific because it wraps the local net481 benchmark workflow.
 
-## Releases 0.6.1 and 0.6.2
+## Releases 0.6.1 through 0.6.3
 
 Release 0.6.1 closes
 [filtrace#55](https://github.com/JeremyKuhne/filtrace/issues/55), which Touki
@@ -55,6 +55,10 @@ Release 0.6.2 fixes duplicate manifest-wide runtime summaries discovered while
 Touki consumed 0.6.1. The helper now prefers richer final summaries, preserves
 unmatched per-case runtimes from partial multi-runtime runs, and ignores
 BenchmarkDotNet job-characteristic rows that begin with `Runtime=`.
+
+Release 0.6.3 canonicalizes each case's runtime with the same `Runtime = ...`
+representation, preserves indented BenchmarkDotNet rows, and avoids duplicate
+PowerShell 5.1-safe string copies.
 
 ## Concrete fold-list hit
 

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -8,7 +8,7 @@
     Wraps the "record a trace, then analyze it" loop for a BenchmarkDotNet perf
     project. Run it from the repository root. Each invocation passes a run-specific
     `--artifacts` directory and `--keepFiles`, enumerates every profiler output in
-    that run, and emits a compact manifest with parameterized benchmark identity,
+    that run, and emits a durable manifest with parameterized benchmark identity,
     trace pairs, runtime/source identity, and exact symbols when verified:
 
       - EventPipe (-Profiler EP, the default): cross-platform, no elevation, single
@@ -79,8 +79,10 @@
     Path or command name for the dotnet host. Defaults to dotnet from PATH.
 
 .PARAMETER FiltracePath
-    Path or command name for filtrace. Used after capture to verify which logged
-    BenchmarkDotNet child output has an exact PDB match for each trace.
+    Path or command name for filtrace. When it resolves, the helper verifies version
+    0.6.0 or newer and info JSON schema 8 before capture, then uses it to verify which
+    logged BenchmarkDotNet child output has an exact PDB match for each trace. When it
+    does not resolve, recorder-established analysis statuses remain the fallback.
 
 .PARAMETER Format
     Final result format: Text (default) or Json. BenchmarkDotNet output always stays
@@ -136,12 +138,17 @@ function Write-CaptureMetadata([string]$TracePath, [System.Collections.IDictiona
 }
 
 function Write-RunManifest([string]$Path, [System.Collections.IDictionary]$Manifest) {
-    $maxManifestBytes = 20KB
-    $json = $Manifest | ConvertTo-Json -Depth 8 -Compress
+    $maxManifestBytes = 16MB
+    try {
+        $json = $Manifest | ConvertTo-Json -Depth 8 -Compress
+    }
+    catch {
+        throw "Capture manifest could not be serialized at '$Path': $($_.Exception.Message)"
+    }
     $encoding = New-Object System.Text.UTF8Encoding($false)
     $manifestBytes = $encoding.GetByteCount($json)
     if ($manifestBytes -ge $maxManifestBytes) {
-        throw "Capture manifest is $manifestBytes UTF-8 bytes; it must stay under 20 KiB. Narrow the benchmark filter or split the capture into fewer cases."
+        throw "Capture manifest is $manifestBytes UTF-8 bytes; the durable manifest safety limit is 16 MiB. Narrow the benchmark filter or split the capture into fewer cases."
     }
 
     [System.IO.File]::WriteAllText($Path, $json, $encoding)
@@ -180,6 +187,7 @@ function Get-CaptureCases([string]$ArtifactsDirectory, [string]$CaptureProfiler)
                 benchmark = $null
                 parameters = $null
                 benchmarkDisplay = $null
+                runtime = $null
                 capturedUtc = $file.LastWriteTimeUtc.ToString('O')
                 trace = $null
                 speedscope = $null
@@ -245,38 +253,85 @@ function Get-LocalDirectoryCandidate([string]$Path) {
     }
 }
 
-function Set-BenchmarkIdentities([System.Collections.IDictionary[]]$CaptureCases, [string]$CaptureLog) {
-    $benchmarksById = @{}
+function Set-BenchmarkIdentities(
+    [System.Collections.IDictionary[]]$CaptureCases,
+    [string]$CaptureLog,
+    [string]$FiltraceCommand,
+    [bool]$CanInspectTraces) {
     $benchmarksInExecutionOrder = New-Object 'System.Collections.Generic.List[System.Collections.IDictionary]'
     $currentDisplay = $null
+    $pendingBenchmark = $null
     foreach ($line in Get-Content -LiteralPath $CaptureLog) {
         if ($line -match '^// Benchmark: (.+)$') {
             $currentDisplay = $Matches[1]
+            $pendingBenchmark = $null
+            continue
+        }
+
+        # Comment-prefixed runtime rows belong to the active Execute block. The
+        # unprefixed Runtime rows are the final report table and stay manifest-wide.
+        if ($null -ne $pendingBenchmark -and $line -match '^//\s*Runtime\s*=') {
+            $pendingBenchmark.runtime = [string]::new($line.ToCharArray())
+            $pendingBenchmark = $null
             continue
         }
 
         if ($null -ne $currentDisplay -and
-            $line -match '--benchmarkName\s+(?:"([^"]+)"|(\S+)).*--benchmarkId\s+(\d+)') {
-            $benchmarkId = [int]$Matches[3]
-            if (-not $benchmarksById.ContainsKey($benchmarkId)) {
-                $benchmarkName = if ($Matches[1]) { $Matches[1] } else { $Matches[2] }
-                $benchmarksById[$benchmarkId] = [ordered]@{
-                    benchmarkId = $benchmarkId
-                    benchmark = $benchmarkName
-                    parameters = Get-BenchmarkParameters $currentDisplay
-                    benchmarkDisplay = $currentDisplay
-                }
-                $benchmarksInExecutionOrder.Add($benchmarksById[$benchmarkId])
+            $line -match '--benchmarkName\s+(.+?)(?=\s+--[A-Za-z])') {
+            $benchmarkNameArgument = $Matches[1]
+            if ($line -notmatch '--benchmarkId\s+(\d+)') { continue }
+            $benchmarkId = [int]$Matches[1]
+            $fullBenchmarkName = ConvertFrom-BenchmarkNameArgumentFull $benchmarkNameArgument
+            $benchmark = [ordered]@{
+                benchmarkId = $benchmarkId
+                benchmark = Get-BenchmarkName $fullBenchmarkName
+                fullBenchmarkName = $fullBenchmarkName
+                parameters = Get-BenchmarkParameters $currentDisplay
+                benchmarkDisplay = $currentDisplay
+                runtime = $null
+                assigned = $false
             }
+            $benchmarksInExecutionOrder.Add($benchmark)
+            $pendingBenchmark = $benchmark
         }
     }
 
-    foreach ($benchmarkName in @($benchmarksInExecutionOrder.benchmark | Select-Object -Unique)) {
-        $benchmarks = @($benchmarksInExecutionOrder | Where-Object { $_.benchmark -eq $benchmarkName })
-        $prefix = "$benchmarkName-"
+    if ($CanInspectTraces) {
+        foreach ($captureCase in $CaptureCases) {
+            if (-not $captureCase.trace) { continue }
+            $traceBenchmarkName = Get-TraceBenchmarkName $captureCase.trace $FiltraceCommand
+            if ([string]::IsNullOrWhiteSpace($traceBenchmarkName)) { continue }
+            $matches = @(
+                $benchmarksInExecutionOrder |
+                    Where-Object {
+                        -not $_.assigned -and
+                        $_.fullBenchmarkName -ceq $traceBenchmarkName
+                    }
+            )
+            if ($matches.Count -ne 1) { continue }
+            Set-CaptureCaseIdentity $captureCase $matches[0]
+            $matches[0].assigned = $true
+        }
+    }
+
+    $benchmarkNames = @(
+        $benchmarksInExecutionOrder.benchmark |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Select-Object -Unique
+    )
+    foreach ($benchmarkName in $benchmarkNames) {
+        $benchmarks = @(
+            $benchmarksInExecutionOrder |
+                Where-Object { -not $_.assigned -and $_.benchmark -eq $benchmarkName }
+        )
         $cases = @(
             $CaptureCases |
-                Where-Object { $_.id.StartsWith($prefix, [StringComparison]::Ordinal) } |
+                Where-Object {
+                    $null -eq $_.benchmarkId -and
+                    $_.id -notmatch '-hash\d+(?:-|$)' -and
+                    ($_.id.StartsWith("$benchmarkName-", [StringComparison]::Ordinal) -or
+                        $_.id.StartsWith("$benchmarkName(", [StringComparison]::Ordinal))
+                } |
                 Sort-Object { $_.capturedUtc }, { $_.id }
         )
         if ($benchmarks.Count -ne $cases.Count) { continue }
@@ -290,15 +345,83 @@ function Set-BenchmarkIdentities([System.Collections.IDictionary[]]$CaptureCases
         }
 
         for ($index = 0; $index -lt $cases.Count; $index++) {
-            $cases[$index].benchmarkId = $benchmarks[$index].benchmarkId
-            $cases[$index].benchmark = $benchmarks[$index].benchmark
-            $cases[$index].parameters = $benchmarks[$index].parameters
-            $cases[$index].benchmarkDisplay = $benchmarks[$index].benchmarkDisplay
+            Set-CaptureCaseIdentity $cases[$index] $benchmarks[$index]
+            $benchmarks[$index].assigned = $true
         }
     }
 }
 
+function Set-CaptureCaseIdentity(
+    [System.Collections.IDictionary]$CaptureCase,
+    [System.Collections.IDictionary]$Benchmark) {
+    $CaptureCase.benchmarkId = $Benchmark.benchmarkId
+    $CaptureCase.benchmark = $Benchmark.benchmark
+    $CaptureCase.parameters = $Benchmark.parameters
+    $CaptureCase.benchmarkDisplay = $Benchmark.benchmarkDisplay
+    $CaptureCase.runtime = $Benchmark.runtime
+}
+
+function Get-TraceBenchmarkName([string]$TracePath, [string]$FiltraceCommand) {
+    try {
+        $global:LASTEXITCODE = 0
+        $json = & $FiltraceCommand events $TracePath `
+            --name 'BenchmarkDotNet.EngineEventSource/Benchmark/Start' `
+            --take 2 --max-payload 4096 --format json 2>$null | Out-String
+        if ($LASTEXITCODE -ne 0) { return $null }
+        $result = ($json | ConvertFrom-Json).result
+        $events = @(
+            $result.events |
+                Where-Object {
+                    $_.provider -ceq 'BenchmarkDotNet.EngineEventSource' -and
+                    $_.eventName -ceq 'Benchmark/Start'
+                }
+        )
+            if ([int]$result.totalMatched -ne 1 -or $events.Count -ne 1) { return $null }
+        $payload = [string]$events[0].payload
+        $prefix = 'benchmarkName='
+        if (-not $payload.StartsWith($prefix, [StringComparison]::Ordinal)) { return $null }
+        return $payload.Substring($prefix.Length)
+    }
+    catch {
+        return $null
+    }
+}
+
+function ConvertFrom-BenchmarkNameArgumentFull([string]$BenchmarkNameArgument) {
+    if ([string]::IsNullOrWhiteSpace($BenchmarkNameArgument)) { return $null }
+
+    $decoded = [regex]::Replace(
+        $BenchmarkNameArgument.Trim(),
+        '(?:\\+u0026#34;|&#34;|&quot;)',
+        '"').Trim('"').Replace('\"', '"')
+    if ([string]::IsNullOrWhiteSpace($decoded)) { return $null }
+    return $decoded
+}
+
+function ConvertFrom-BenchmarkNameArgument([string]$BenchmarkNameArgument) {
+    return Get-BenchmarkName (ConvertFrom-BenchmarkNameArgumentFull $BenchmarkNameArgument)
+}
+
+function Get-BenchmarkName([string]$FullBenchmarkName) {
+    if ([string]::IsNullOrWhiteSpace($FullBenchmarkName)) { return $null }
+    $parameters = $FullBenchmarkName.IndexOf('(')
+    if ($parameters -ge 0) {
+        return $FullBenchmarkName.Substring(0, $parameters)
+    }
+    return $FullBenchmarkName
+}
+
 function Get-BenchmarkParameters([string]$BenchmarkDisplay) {
+    $trimmedDisplay = $BenchmarkDisplay.TrimEnd()
+    if ($trimmedDisplay.EndsWith(']', [StringComparison]::Ordinal)) {
+        $openBracket = $trimmedDisplay.LastIndexOf('[')
+        if ($openBracket -ge 0) {
+            return $trimmedDisplay.Substring(
+                $openBracket + 1,
+                $trimmedDisplay.Length - $openBracket - 2)
+        }
+    }
+
     $close = $BenchmarkDisplay.LastIndexOf('): ', [StringComparison]::Ordinal)
     if ($close -lt 0) { return '' }
     $open = $BenchmarkDisplay.IndexOf('(')
@@ -339,7 +462,7 @@ function Get-DefaultCaptureStatuses([string]$CaptureProfiler, [bool]$HasRawTrace
 
     return [ordered]@{
         cpu = 'enabled'; alloc = 'disabled'; exceptions = 'enabled';
-        contention = 'enabled'; wait = 'disabled'; activity = 'enabled';
+        contention = 'enabled'; wait = 'disabled'; activity = 'unknown';
         gcstats = 'enabled'; jitstats = 'enabled'; threadpool = 'enabled';
         events = 'enabled'
     }
@@ -403,6 +526,95 @@ function Get-TraceInfoResult(
     }
     catch {
         return $null
+    }
+}
+
+function Get-ObjectPropertyInfo($Object, [string]$Name) {
+    if ($null -eq $Object) { return $null }
+    return $Object.PSObject.Properties[$Name]
+}
+
+function Assert-FiltraceCompatibility([string]$FiltraceCommand) {
+    $minimumVersion = [Version]'0.6.0'
+    $expectedSchemaVersion = 8
+    $upgradeGuidance = 'Upgrade with: dotnet tool update -g KlutzyNinja.Filtrace'
+
+    try {
+        $global:LASTEXITCODE = 0
+        $versionOutput = (& $FiltraceCommand --version 2>$null | Out-String).Trim()
+        $versionExitCode = $LASTEXITCODE
+        $versionMatch = [regex]::Match($versionOutput, '(?<!\d)(\d+\.\d+\.\d+)')
+        if ($versionExitCode -ne 0 -or -not $versionMatch.Success) {
+            throw 'the --version query did not return a semantic version'
+        }
+
+        $resolvedVersion = [Version]$versionMatch.Groups[1].Value
+        if ($resolvedVersion -lt $minimumVersion) {
+            throw "version $resolvedVersion is older than required version $minimumVersion"
+        }
+    }
+    catch {
+        throw "Resolved filtrace '$FiltraceCommand' is incompatible: $($_.Exception.Message). $upgradeGuidance"
+    }
+
+    $preflightTrace = Join-Path (
+        [System.IO.Path]::GetTempPath()) "filtrace-preflight-$([Guid]::NewGuid().ToString('N')).speedscope.json"
+    try {
+        $profile = [ordered]@{
+            '$schema' = 'https://www.speedscope.app/file-format-schema.json'
+            shared = [ordered]@{ frames = @([ordered]@{ name = 'preflight' }) }
+            profiles = @(
+                [ordered]@{
+                    type = 'sampled'
+                    name = 'preflight'
+                    unit = 'milliseconds'
+                    startValue = 0
+                    endValue = 1
+                    samples = ,([int[]]@(0))
+                    weights = @(1)
+                }
+            )
+            activeProfileIndex = 0
+            exporter = 'filtrace compatibility preflight'
+            name = 'filtrace compatibility preflight'
+        } | ConvertTo-Json -Depth 6 -Compress
+        $encoding = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($preflightTrace, $profile, $encoding)
+
+        $global:LASTEXITCODE = 0
+        $infoJson = & $FiltraceCommand info $preflightTrace --format json 2>$null | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            throw 'info --format json returned a nonzero exit code'
+        }
+
+        $infoEnvelope = $infoJson | ConvertFrom-Json
+        $schemaVersionProperty = Get-ObjectPropertyInfo $infoEnvelope 'schemaVersion'
+        $resultProperty = Get-ObjectPropertyInfo $infoEnvelope 'result'
+        $infoResult = $null
+        if ($null -ne $resultProperty) { $infoResult = $resultProperty.Value }
+        $analysesProperty = Get-ObjectPropertyInfo $infoResult 'analyses'
+        $analyses = $null
+        if ($null -ne $analysesProperty) { $analyses = $analysesProperty.Value }
+        $cpuProperty = Get-ObjectPropertyInfo $analyses 'cpu'
+        $cpuAnalysis = $null
+        if ($null -ne $cpuProperty) { $cpuAnalysis = $cpuProperty.Value }
+        $captureStatusProperty = Get-ObjectPropertyInfo $cpuAnalysis 'captureStatus'
+        $eventCountProperty = Get-ObjectPropertyInfo $cpuAnalysis 'eventCount'
+        if ($null -eq $schemaVersionProperty -or
+            [int]$schemaVersionProperty.Value -ne $expectedSchemaVersion -or
+            $null -eq $resultProperty -or
+            $null -eq $analysesProperty -or
+            $null -eq $cpuProperty -or
+            $null -eq $captureStatusProperty -or
+            $null -eq $eventCountProperty) {
+            throw "info --format json did not match schema $expectedSchemaVersion"
+        }
+    }
+    catch {
+        throw "Resolved filtrace '$FiltraceCommand' is incompatible: $($_.Exception.Message). $upgradeGuidance"
+    }
+    finally {
+        Remove-Item -LiteralPath $preflightTrace -Force -ErrorAction SilentlyContinue
     }
 }
 
@@ -500,6 +712,12 @@ function Get-CaseCommands(
 
 function Get-CaseWarnings([System.Collections.IDictionary]$CaptureCase) {
     $warnings = New-Object 'System.Collections.Generic.List[string]'
+    if ($null -eq $CaptureCase.benchmarkId -or
+        [string]::IsNullOrWhiteSpace($CaptureCase.benchmark) -or
+        $null -eq $CaptureCase.parameters -or
+        [string]::IsNullOrWhiteSpace($CaptureCase.benchmarkDisplay)) {
+        $warnings.Add('benchmark identity unavailable or ambiguous; do not use this case with manifest batch/diff; analyze the trace directly')
+    }
     foreach ($name in $CaptureCase.analyses.Keys) {
         $status = $CaptureCase.analyses[$name].captureStatus
         if ($status -eq 'disabled') {
@@ -708,6 +926,11 @@ if ($ElevatedChild -and -not (Test-Elevated)) {
     exit 1
 }
 
+$filtraceAvailable = $null -ne (Get-Command $FiltracePath -ErrorAction SilentlyContinue)
+if ($filtraceAvailable) {
+    Assert-FiltraceCompatibility $FiltracePath
+}
+
 # ETW kernel sessions require Administrator. When not elevated, relaunch this script
 # in an elevated window, then wait for it.
 # -WorkingDirectory anchors the child at the repo root so BenchmarkDotNet.Artifacts
@@ -855,7 +1078,7 @@ if ($captureCases.Count -eq 0) {
     Write-Error "No capture files found in $artifacts. Did the capture run?" -ErrorAction Continue
     exit 1
 }
-Set-BenchmarkIdentities $captureCases $log
+Set-BenchmarkIdentities $captureCases $log $FiltracePath $filtraceAvailable
 if ($hasOperationCount) {
     foreach ($captureCase in $captureCases) {
         $captureCase.operationCount = $OperationCount
@@ -867,7 +1090,6 @@ if ($hasOperationCount) {
 # preserves BenchmarkDotNet's generated build output for manual follow-up.
 $symbols = Join-Path (Split-Path -Parent $projFile.FullName) "bin/Release/$Tfm"
 $symbolCandidates = @(Get-SymbolCandidates $log $symbols)
-$filtraceAvailable = $null -ne (Get-Command $FiltracePath -ErrorAction SilentlyContinue)
 foreach ($captureCase in $captureCases) {
     $captureCase.symbolCandidates = $symbolCandidates
     if ($captureCase.trace -and $filtraceAvailable) {
@@ -919,7 +1141,10 @@ $manifest = [ordered]@{
     source = Get-SourceIdentity $projFile.DirectoryName
     runtimes = @(
         Get-Content -LiteralPath $log |
-            Where-Object { $_ -match '^Runtime = ' } |
+            Where-Object { $_ -match '^(?://\s*)?Runtime\s*=' } |
+            # Strip Get-Content's provider ETS properties; the 5.1 JSON serializer
+            # otherwise recurses through PSProvider and can exhaust memory.
+            ForEach-Object { [string]::new($_.ToCharArray()) } |
             Sort-Object -Unique
     )
     paths = [ordered]@{

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -154,6 +154,45 @@ function Write-RunManifest([string]$Path, [System.Collections.IDictionary]$Manif
     [System.IO.File]::WriteAllText($Path, $json, $encoding)
 }
 
+function Get-RuntimeSummaries([string]$LogPath) {
+    $finalSummaries = New-Object 'System.Collections.Generic.List[string]'
+    $caseSummaries = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($logLine in Get-Content -LiteralPath $LogPath) {
+        # Strip Get-Content's provider ETS properties; the 5.1 JSON serializer
+        # otherwise recurses through PSProvider and can exhaust memory.
+        $line = [string]::new($logLine.ToCharArray()).Trim()
+        if ($line -match '^Runtime\s+=\s*(.+)$') {
+            $finalSummaries.Add("Runtime = $($Matches[1].Trim())")
+        }
+        elseif ($line -match '^//\s*Runtime\s*=\s*(.+)$') {
+            $caseSummaries.Add("Runtime = $($Matches[1].Trim())")
+        }
+    }
+
+    # Final report rows carry configuration details such as GC mode. Replace only
+    # the per-case identity they enrich; preserve unmatched per-case rows when a
+    # failed or partial multi-runtime run omitted its final report row.
+    $summaries = New-Object 'System.Collections.Generic.List[string]'
+    foreach ($finalSummary in $finalSummaries | Sort-Object -Unique) {
+        $summaries.Add($finalSummary)
+    }
+    foreach ($caseSummary in $caseSummaries | Sort-Object -Unique) {
+        $coveredByFinalSummary = $false
+        foreach ($finalSummary in $finalSummaries) {
+            if ($finalSummary -eq $caseSummary -or
+                $finalSummary.StartsWith("$caseSummary; ", [StringComparison]::Ordinal)) {
+                $coveredByFinalSummary = $true
+                break
+            }
+        }
+        if (-not $coveredByFinalSummary) {
+            $summaries.Add($caseSummary)
+        }
+    }
+
+    return @($summaries | Sort-Object -Unique)
+}
+
 function Get-CaptureCases([string]$ArtifactsDirectory, [string]$CaptureProfiler) {
     $maxCases = 256
     $casesByStem = @{}
@@ -1139,14 +1178,7 @@ $manifest = [ordered]@{
     profiler = $Profiler
     process = $Process
     source = Get-SourceIdentity $projFile.DirectoryName
-    runtimes = @(
-        Get-Content -LiteralPath $log |
-            Where-Object { $_ -match '^(?://\s*)?Runtime\s*=' } |
-            # Strip Get-Content's provider ETS properties; the 5.1 JSON serializer
-            # otherwise recurses through PSProvider and can exhaust memory.
-            ForEach-Object { [string]::new($_.ToCharArray()) } |
-            Sort-Object -Unique
-    )
+    runtimes = @(Get-RuntimeSummaries $log)
     paths = [ordered]@{
         runDirectory = $runDirectory
         artifactsDirectory = $artifacts

--- a/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
+++ b/.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1
@@ -154,18 +154,26 @@ function Write-RunManifest([string]$Path, [System.Collections.IDictionary]$Manif
     [System.IO.File]::WriteAllText($Path, $json, $encoding)
 }
 
+function ConvertTo-RuntimeSummary([string]$LogLine) {
+    # Strip Get-Content's provider ETS properties; the 5.1 JSON serializer
+    # otherwise recurses through PSProvider and can exhaust memory.
+    $line = [string]::new($LogLine.ToCharArray()).Trim()
+    if ($line -match '^(?://\s*)?Runtime\s*=\s*(.+)$') {
+        return "Runtime = $($Matches[1].Trim())"
+    }
+
+    return $null
+}
+
 function Get-RuntimeSummaries([string]$LogPath) {
     $finalSummaries = New-Object 'System.Collections.Generic.List[string]'
     $caseSummaries = New-Object 'System.Collections.Generic.List[string]'
     foreach ($logLine in Get-Content -LiteralPath $LogPath) {
-        # Strip Get-Content's provider ETS properties; the 5.1 JSON serializer
-        # otherwise recurses through PSProvider and can exhaust memory.
-        $line = [string]::new($logLine.ToCharArray()).Trim()
-        if ($line -match '^Runtime\s+=\s*(.+)$') {
-            $finalSummaries.Add("Runtime = $($Matches[1].Trim())")
+        if ($logLine -match '^\s*Runtime\s+=\s*(.+)$') {
+            $finalSummaries.Add((ConvertTo-RuntimeSummary $logLine))
         }
-        elseif ($line -match '^//\s*Runtime\s*=\s*(.+)$') {
-            $caseSummaries.Add("Runtime = $($Matches[1].Trim())")
+        elseif ($logLine -match '^\s*//\s*Runtime\s*=\s*(.+)$') {
+            $caseSummaries.Add((ConvertTo-RuntimeSummary $logLine))
         }
     }
 
@@ -307,10 +315,11 @@ function Set-BenchmarkIdentities(
             continue
         }
 
-        # Comment-prefixed runtime rows belong to the active Execute block. The
-        # unprefixed Runtime rows are the final report table and stay manifest-wide.
-        if ($null -ne $pendingBenchmark -and $line -match '^//\s*Runtime\s*=') {
-            $pendingBenchmark.runtime = [string]::new($line.ToCharArray())
+        # Comment-prefixed runtime rows belong to the active Execute block. Spaced
+        # unprefixed `Runtime =` rows are final summaries handled manifest-wide;
+        # compact `Runtime=` rows are job characteristics and are not summaries.
+        if ($null -ne $pendingBenchmark -and $line -match '^\s*//\s*Runtime\s*=') {
+            $pendingBenchmark.runtime = ConvertTo-RuntimeSummary $line
             $pendingBenchmark = $null
             continue
         }

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -18,8 +18,8 @@ that `batch` and `diff` can consume:
 
 ```powershell
 $filtraceVersion = (& filtrace --version | Select-Object -First 1).Trim()
-if ($filtraceVersion -ne '0.6.2') {
-  throw "filtrace 0.6.2 is required; found '$filtraceVersion'."
+if ($filtraceVersion -ne '0.6.3') {
+  throw "filtrace 0.6.3 is required; found '$filtraceVersion'."
 }
 
 $handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
@@ -64,7 +64,7 @@ means should approximately add to the end-to-end mean. A large gap usually means
 setup leaked into one measurement, mutable state was reused, or the batch changed
 GC/live-set behavior.
 
-**Use the filtrace 0.6.2 evidence contracts:**
+**Use the filtrace 0.6.3 evidence contracts:**
 
 - Read `trace_info.analyses.<name>` before interpreting a metric.
   `captureStatus: enabled` plus `eventCount: 0` is a valid empty analysis;

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -18,8 +18,8 @@ that `batch` and `diff` can consume:
 
 ```powershell
 $filtraceVersion = (& filtrace --version | Select-Object -First 1).Trim()
-if ($filtraceVersion -ne '0.6.1') {
-  throw "filtrace 0.6.1 is required; found '$filtraceVersion'."
+if ($filtraceVersion -ne '0.6.2') {
+  throw "filtrace 0.6.2 is required; found '$filtraceVersion'."
 }
 
 $handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
@@ -64,7 +64,7 @@ means should approximately add to the end-to-end mean. A large gap usually means
 setup leaked into one measurement, mutable state was reused, or the batch changed
 GC/live-set behavior.
 
-**Use the filtrace 0.6.1 evidence contracts:**
+**Use the filtrace 0.6.2 evidence contracts:**
 
 - Read `trace_info.analyses.<name>` before interpreting a metric.
   `captureStatus: enabled` plus `eventCount: 0` is a valid empty analysis;

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -18,8 +18,8 @@ that `batch` and `diff` can consume:
 
 ```powershell
 $filtraceVersion = (& filtrace --version | Select-Object -First 1).Trim()
-if ($filtraceVersion -ne '0.6.0') {
-  throw "filtrace 0.6.0 is required; found '$filtraceVersion'."
+if ($filtraceVersion -ne '0.6.1') {
+  throw "filtrace 0.6.1 is required; found '$filtraceVersion'."
 }
 
 $handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
@@ -29,10 +29,6 @@ $handoff = & ./.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1 `
 
 $manifest = Get-Content $handoff.manifest -Raw | ConvertFrom-Json
 $manifest.cases | Select-Object benchmark, parameters, trace, symbolsDirectory, warnings
-
-if ($manifest.cases.Where({ -not $_.benchmark -or -not $_.parameters }).Count -ne 0) {
-  throw 'Manifest case identity is incomplete; analyze direct trace paths instead.'
-}
 
 # Rank all parameterized cases compactly, then drill one case with rank/callers/lines.
 filtrace batch $handoff.manifest --metric cpu --benchmark
@@ -68,18 +64,21 @@ means should approximately add to the end-to-end mean. A large gap usually means
 setup leaked into one measurement, mutable state was reused, or the batch changed
 GC/live-set behavior.
 
-**Use the filtrace 0.6 evidence contracts:**
+**Use the filtrace 0.6.1 evidence contracts:**
 
 - Read `trace_info.analyses.<name>` before interpreting a metric.
   `captureStatus: enabled` plus `eventCount: 0` is a valid empty analysis;
   `disabled` is unavailable; `unknown` remains unknown. Preserve the capture
   helper's `<trace>.filtrace.json` sidecar with the trace.
-- For Touki's BenchmarkDotNet 0.16.0-preview.1 logs, require nonempty
-  `benchmark` and `parameters` on every case before using manifest-aware
-  `batch`/`diff`; the 0.6 helper can leave identity incomplete. Split broad
-  captures before the helper's 20 KiB on-disk manifest limit. Treat `activity`
-  as unavailable unless the application EventSource provider was explicitly
-  enabled, regardless of the default helper sidecar.
+- For Touki's BenchmarkDotNet 0.16.0-preview.1 captures, the helper verifies hashed
+  parameterized artifacts against the benchmark identity embedded in each trace.
+  Ordinary filenames may use exact benchmark name plus execution order only when
+  case counts and distinct capture timestamps align. Any case left unidentified
+  stays out of manifest-aware `batch`/`diff` pairing; analyze that trace directly
+  rather than inferring an identity. Durable manifests have a 16 MiB safety limit;
+  only the agent-facing JSON handoff is capped at 20 KiB. Treat `activity` according
+  to its reported provider state; the default capture leaves it unknown without
+  provider evidence.
 - Read `sourceResolution` separately from managed frame-name resolution. Require
   the relevant module in `matchingPdbModules`; use `pdbIdentityMismatchModules`,
   `highestUnmappedModules`, and `highestUnmappedMethods` to diagnose `<no source>`.

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,7 +8,7 @@
         },
         // filtrace trace-analysis MCP server, consumed from the published
         // KlutzyNinja.Filtrace.Mcp package (github.com/JeremyKuhne/filtrace),
-        // pinned to published release 0.6.2 with the vendored skill.
+        // pinned to published release 0.6.3 with the vendored skill.
         // `dnx` (the .NET 10 SDK tool runner) downloads and runs the package on
         // demand; `--yes` auto-confirms the one-time download. No local clone or
         // build required. Restart this server after changing the package pin.
@@ -16,7 +16,7 @@
             "type": "stdio",
             "command": "dnx",
             "args": [
-                "KlutzyNinja.Filtrace.Mcp@0.6.2",
+                "KlutzyNinja.Filtrace.Mcp@0.6.3",
                 "--yes"
             ]
         }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,8 +8,7 @@
         },
         // filtrace trace-analysis MCP server, consumed from the published
         // KlutzyNinja.Filtrace.Mcp package (github.com/JeremyKuhne/filtrace),
-        // pinned to published release 0.6.0. The vendored skill may be pinned
-        // independently to an exact source revision.
+        // pinned to published release 0.6.1 with the vendored skill.
         // `dnx` (the .NET 10 SDK tool runner) downloads and runs the package on
         // demand; `--yes` auto-confirms the one-time download. No local clone or
         // build required. Restart this server after changing the package pin.
@@ -17,7 +16,7 @@
             "type": "stdio",
             "command": "dnx",
             "args": [
-                "KlutzyNinja.Filtrace.Mcp@0.6.0",
+                "KlutzyNinja.Filtrace.Mcp@0.6.1",
                 "--yes"
             ]
         }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -8,7 +8,7 @@
         },
         // filtrace trace-analysis MCP server, consumed from the published
         // KlutzyNinja.Filtrace.Mcp package (github.com/JeremyKuhne/filtrace),
-        // pinned to published release 0.6.1 with the vendored skill.
+        // pinned to published release 0.6.2 with the vendored skill.
         // `dnx` (the .NET 10 SDK tool runner) downloads and runs the package on
         // demand; `--yes` auto-confirms the one-time download. No local clone or
         // build required. Restart this server after changing the package pin.
@@ -16,7 +16,7 @@
             "type": "stdio",
             "command": "dnx",
             "args": [
-                "KlutzyNinja.Filtrace.Mcp@0.6.1",
+                "KlutzyNinja.Filtrace.Mcp@0.6.2",
                 "--yes"
             ]
         }

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -42,7 +42,7 @@ Currently wired up:
 | Server | Purpose |
 | ------ | ------- |
 | `microsoft-learn` (`https://learn.microsoft.com/api/mcp`) | Current official .NET BCL docs and reference content. Used by the [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) workflow when verifying modern API shapes before deciding whether to polyfill. |
-| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.1`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The [overlay](../.agents/skills/filtrace/overlay.md) pins the vendored skill and executable packages to the same release. |
+| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.2`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The [overlay](../.agents/skills/filtrace/overlay.md) pins the vendored skill and executable packages to the same release. |
 
 After changing a workspace MCP package pin, run **MCP: Restart Server** and choose
 the server (or reload the VS Code window) before relying on newly added tools or

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -42,7 +42,7 @@ Currently wired up:
 | Server | Purpose |
 | ------ | ------- |
 | `microsoft-learn` (`https://learn.microsoft.com/api/mcp`) | Current official .NET BCL docs and reference content. Used by the [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) workflow when verifying modern API shapes before deciding whether to polyfill. |
-| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.0`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The package remains at 0.6.0 while the [overlay](../.agents/skills/filtrace/overlay.md) pins the unreleased overlay-capable skill source independently. |
+| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.1`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The [overlay](../.agents/skills/filtrace/overlay.md) pins the vendored skill and executable packages to the same release. |
 
 After changing a workspace MCP package pin, run **MCP: Restart Server** and choose
 the server (or reload the VS Code window) before relying on newly added tools or

--- a/docs/agent-customization.md
+++ b/docs/agent-customization.md
@@ -42,7 +42,7 @@ Currently wired up:
 | Server | Purpose |
 | ------ | ------- |
 | `microsoft-learn` (`https://learn.microsoft.com/api/mcp`) | Current official .NET BCL docs and reference content. Used by the [`polyfill-dotnet-api`](../.agents/skills/polyfill-dotnet-api/SKILL.md) workflow when verifying modern API shapes before deciding whether to polyfill. |
-| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.2`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The [overlay](../.agents/skills/filtrace/overlay.md) pins the vendored skill and executable packages to the same release. |
+| `filtrace` (`KlutzyNinja.Filtrace.Mcp@0.6.3`) | Published .NET trace-analysis runtime used by the [`filtrace`](../.agents/skills/filtrace/SKILL.md) workflow. The [overlay](../.agents/skills/filtrace/overlay.md) pins the vendored skill and executable packages to the same release. |
 
 After changing a workspace MCP package pin, run **MCP: Restart Server** and choose
 the server (or reload the VS Code window) before relying on newly added tools or

--- a/docs/filtrace-local-demo.md
+++ b/docs/filtrace-local-demo.md
@@ -17,7 +17,7 @@ faster?" - not tool-by-tool instructions.
 ## Setup (one time)
 
 filtrace is published to NuGet (github.com/JeremyKuhne/filtrace). The MCP server
-entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.2 on demand via
+entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.3 on demand via
 `dnx` (the .NET 10 SDK tool runner) - no clone or build required. Start it from
 the Command Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*) and
 confirm the 17 `trace_*` tools register in the chat tool picker.

--- a/docs/filtrace-local-demo.md
+++ b/docs/filtrace-local-demo.md
@@ -17,7 +17,7 @@ faster?" - not tool-by-tool instructions.
 ## Setup (one time)
 
 filtrace is published to NuGet (github.com/JeremyKuhne/filtrace). The MCP server
-entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.0 on demand via
+entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.1 on demand via
 `dnx` (the .NET 10 SDK tool runner) - no clone or build required. Start it from
 the Command Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*) and
 confirm the 17 `trace_*` tools register in the chat tool picker.

--- a/docs/filtrace-local-demo.md
+++ b/docs/filtrace-local-demo.md
@@ -17,7 +17,7 @@ faster?" - not tool-by-tool instructions.
 ## Setup (one time)
 
 filtrace is published to NuGet (github.com/JeremyKuhne/filtrace). The MCP server
-entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.1 on demand via
+entry in [.vscode/mcp.json](../.vscode/mcp.json) runs version 0.6.2 on demand via
 `dnx` (the .NET 10 SDK tool runner) - no clone or build required. Start it from
 the Command Palette (*MCP: List Servers* -> `filtrace` -> *Start Server*) and
 confirm the 17 `trace_*` tools register in the chat tool picker.

--- a/docs/performance-investigation-agent-tooling-retrospective.md
+++ b/docs/performance-investigation-agent-tooling-retrospective.md
@@ -14,9 +14,11 @@ tool behavior manually.
 Filtrace release [0.6.0](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.0)
 delivered the analyzer, MCP, capture-script, and tool-shipped-skill work tracked by
 [JeremyKuhne/filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42), which
-is closed as completed. Touki consumes that release. The portable performance-workflow
-guidance is still being validated in Touki's local performance-testing overlay before it
-is upleveled to `JeremyKuhne/agent-skills`.
+is closed as completed. Touki now consumes release
+[0.6.1](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.1), which hardens
+that workflow for BenchmarkDotNet 0.16 captures. The portable performance-workflow
+guidance is still being validated in Touki's local performance-testing overlay before
+it is upleveled to `JeremyKuhne/agent-skills`.
 
 ## Executive summary
 
@@ -339,7 +341,8 @@ reconstructable dirty-source bundle remains a portable `agent-skills` candidate.
 
 These requirements are implemented in filtrace's bundled
 [`Capture-BenchmarkTrace.ps1`](../.agents/skills/filtrace/scripts/Capture-BenchmarkTrace.ps1),
-vendored here from release 0.6.0. Keep the acceptance checks as regression contracts.
+first delivered in release 0.6.0 and retained in the current vendored helper. Keep
+the acceptance checks as regression contracts.
 
 ### 1. Isolated runs and complete case manifests
 
@@ -424,8 +427,9 @@ availability cannot be established and does not present a command as known-valid
 JSON/stdout carries compact run status, manifest location, warnings, and next steps. This
 avoids routing tens of kilobytes through agent context merely to learn the trace path.
 
-**Regression check:** a successful parameterized capture returns a compact manifest under
-20 KiB regardless of BenchmarkDotNet's iteration log size.
+**Regression check:** a successful parameterized capture keeps the agent-facing JSON
+handoff under 20 KiB regardless of BenchmarkDotNet's iteration log size, while the
+complete durable manifest remains available under its separate 16 MiB safety limit.
 
 ## Filtrace product changes delivered in 0.6.0
 

--- a/docs/performance-investigation-agent-tooling-retrospective.md
+++ b/docs/performance-investigation-agent-tooling-retrospective.md
@@ -15,10 +15,10 @@ Filtrace release [0.6.0](https://github.com/JeremyKuhne/filtrace/releases/tag/v0
 delivered the analyzer, MCP, capture-script, and tool-shipped-skill work tracked by
 [JeremyKuhne/filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42), which
 is closed as completed. Touki now consumes release
-[0.6.1](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.1), which hardens
-that workflow for BenchmarkDotNet 0.16 captures. The portable performance-workflow
-guidance is still being validated in Touki's local performance-testing overlay before
-it is upleveled to `JeremyKuhne/agent-skills`.
+[0.6.2](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.2), which includes
+the 0.6.1 BenchmarkDotNet 0.16 capture hardening and fixes duplicate runtime summaries.
+The portable performance-workflow guidance is still being validated in Touki's local
+performance-testing overlay before it is upleveled to `JeremyKuhne/agent-skills`.
 
 ## Executive summary
 

--- a/docs/performance-investigation-agent-tooling-retrospective.md
+++ b/docs/performance-investigation-agent-tooling-retrospective.md
@@ -15,10 +15,11 @@ Filtrace release [0.6.0](https://github.com/JeremyKuhne/filtrace/releases/tag/v0
 delivered the analyzer, MCP, capture-script, and tool-shipped-skill work tracked by
 [JeremyKuhne/filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42), which
 is closed as completed. Touki now consumes release
-[0.6.2](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.2), which includes
-the 0.6.1 BenchmarkDotNet 0.16 capture hardening and fixes duplicate runtime summaries.
-The portable performance-workflow guidance is still being validated in Touki's local
-performance-testing overlay before it is upleveled to `JeremyKuhne/agent-skills`.
+[0.6.3](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.3), which includes
+the 0.6.1 BenchmarkDotNet 0.16 capture hardening and the 0.6.2/0.6.3 runtime-summary
+normalization fixes. The portable performance-workflow guidance is still being
+validated in Touki's local performance-testing overlay before it is upleveled to
+`JeremyKuhne/agent-skills`.
 
 ## Executive summary
 

--- a/docs/performance-investigation-without-mcp.md
+++ b/docs/performance-investigation-without-mcp.md
@@ -4,8 +4,8 @@ The primary way to turn a captured benchmark trace into ranked hotspots and
 line-level attribution is the standalone
 [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer - its MCP tools for
 an agent, or the `filtrace` CLI (fresh install:
-`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.0`; existing install:
-`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.0`) when the MCP server
+`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.1`; existing install:
+`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.1`) when the MCP server
 is unavailable - see
 [performance-investigation.md](performance-investigation.md) sections 3a, 3f,
 and 6.

--- a/docs/performance-investigation-without-mcp.md
+++ b/docs/performance-investigation-without-mcp.md
@@ -4,8 +4,8 @@ The primary way to turn a captured benchmark trace into ranked hotspots and
 line-level attribution is the standalone
 [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer - its MCP tools for
 an agent, or the `filtrace` CLI (fresh install:
-`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.2`; existing install:
-`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.2`) when the MCP server
+`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.3`; existing install:
+`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.3`) when the MCP server
 is unavailable - see
 [performance-investigation.md](performance-investigation.md) sections 3a, 3f,
 and 6.

--- a/docs/performance-investigation-without-mcp.md
+++ b/docs/performance-investigation-without-mcp.md
@@ -4,8 +4,8 @@ The primary way to turn a captured benchmark trace into ranked hotspots and
 line-level attribution is the standalone
 [filtrace](https://github.com/JeremyKuhne/filtrace) analyzer - its MCP tools for
 an agent, or the `filtrace` CLI (fresh install:
-`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.1`; existing install:
-`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.1`) when the MCP server
+`dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.2`; existing install:
+`dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.2`) when the MCP server
 is unavailable - see
 [performance-investigation.md](performance-investigation.md) sections 3a, 3f,
 and 6.

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -462,9 +462,9 @@ see which lines of a hot loop dominate. The analyzer runs on .NET 10 but can
 read modern `.nettrace` and net481 ETW `.etl` captures. It has two front ends:
 
 - **Console front end** - `filtrace <verb>` (fresh install:
-  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.1`; existing install:
-  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.1`). Require
-  `filtrace --version` to print `0.6.1` before invoking the bundled capture helper.
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.2`; existing install:
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.2`). Require
+  `filtrace --version` to print `0.6.2` before invoking the bundled capture helper.
 - **MCP server** - the same queries exposed as tools (`trace_info`,
   `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
   registered `filtrace` server for an agent that speaks MCP. See section 6.

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -462,9 +462,9 @@ see which lines of a hot loop dominate. The analyzer runs on .NET 10 but can
 read modern `.nettrace` and net481 ETW `.etl` captures. It has two front ends:
 
 - **Console front end** - `filtrace <verb>` (fresh install:
-  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.2`; existing install:
-  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.2`). Require
-  `filtrace --version` to print `0.6.2` before invoking the bundled capture helper.
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.3`; existing install:
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.3`). Require
+  `filtrace --version` to print `0.6.3` before invoking the bundled capture helper.
 - **MCP server** - the same queries exposed as tools (`trace_info`,
   `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
   registered `filtrace` server for an agent that speaks MCP. See section 6.

--- a/docs/performance-investigation.md
+++ b/docs/performance-investigation.md
@@ -462,9 +462,9 @@ see which lines of a hot loop dominate. The analyzer runs on .NET 10 but can
 read modern `.nettrace` and net481 ETW `.etl` captures. It has two front ends:
 
 - **Console front end** - `filtrace <verb>` (fresh install:
-  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.0`; existing install:
-  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.0`). Require
-  `filtrace --version` to print `0.6.0` before invoking the bundled capture helper.
+  `dotnet tool install -g KlutzyNinja.Filtrace --version 0.6.1`; existing install:
+  `dotnet tool update -g KlutzyNinja.Filtrace --version 0.6.1`). Require
+  `filtrace --version` to print `0.6.1` before invoking the bundled capture helper.
 - **MCP server** - the same queries exposed as tools (`trace_info`,
   `trace_rank`, `trace_callers`, `trace_lines`, `trace_heatmap`) on the
   registered `filtrace` server for an agent that speaks MCP. See section 6.

--- a/tools/Validate-AgentSkills.ps1
+++ b/tools/Validate-AgentSkills.ps1
@@ -380,8 +380,12 @@ if ($skillData.ContainsKey('filtrace') -and (Test-Path -LiteralPath $McpPath -Pa
             $coreRepo = Get-Scalar $filtraceOverlay 'core-repo'
             $coreTreeSha = Get-Scalar $filtraceOverlay 'core-tree-sha'
             $runtimePin = Get-Scalar $filtraceOverlay 'runtime-pin'
-            if ($corePin -notmatch '^[0-9a-f]{40}$') {
-                Add-Error 'Filtrace overlay core-pin must be an exact 40-character source commit while overlay support is unpublished.'
+            $releasePinMatch = [regex]::Match($corePin, '^v(\d+\.\d+\.\d+)$')
+            if ($corePin -notmatch '^[0-9a-f]{40}$' -and -not $releasePinMatch.Success) {
+                Add-Error 'Filtrace overlay core-pin must be an exact source commit or stable release tag.'
+            }
+            elseif ($releasePinMatch.Success -and $releasePinMatch.Groups[1].Value -ne $runtimePin) {
+                Add-Error "Filtrace overlay release pin '$corePin' must match runtime-pin '$runtimePin'."
             }
             if ($coreRepo -ne 'https://github.com/JeremyKuhne/filtrace') {
                 Add-Error "Filtrace overlay core-repo '$coreRepo' is not the canonical repository."


### PR DESCRIPTION
## Summary

- pin the filtrace CLI, MCP server, and vendored skill to release `v0.6.3`
- vendor the exact released skill payload and record source commit `0749a3015f39297cfe9678e5a18ffb99f6c98da8` / tree `c67fe9a898fea1824e19583cce342577cdcde82b`
- consume the hardened BenchmarkDotNet capture helper that resolves Touki's filtrace#55 follow-ups
- normalize manifest-wide and per-case runtime summaries through filtrace 0.6.2/0.6.3 fixes prompted by this PR's review
- update Touki's profiling guidance and provenance validator for stable release tags

## Validation

- `pwsh tools/Validate-AgentFiles.ps1`
- `pwsh tools/Validate-AgentSkills.ps1` on Windows and Ubuntu
- `pwsh tools/Test-AgentFileLinks.ps1`
- markdownlint over the agent-files CI scope
- filtrace `Test-CaptureBenchmarkTrace.ps1` under PowerShell 7 and Windows PowerShell 5.1
- isolated installs of `KlutzyNinja.Filtrace@0.6.3` and `KlutzyNinja.Filtrace.Mcp@0.6.3`
- MCP initialize / tools-list handshake: 17 tools
- `dotnet build -c Release`
- `dotnet test` (22,051 tests, 0 failures, 248 expected skips)
- `dotnet test -c Release` (22,051 tests, 0 failures, 248 expected skips)

Upstream fixes: JeremyKuhne/filtrace#59 and JeremyKuhne/filtrace#60.

Closes JeremyKuhne/filtrace#55 follow-up consumption in Touki.