### PR TITLE
Add TOUKI0011 stackalloc-size and TOUKI0021 file-name analyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.16.0-preview.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <!-- Referencing our own package for the sample project to document consumption. -->
-    <PackageVersion Include="KlutzyNinja.Touki" Version="0.2.0-alpha.1" />
+    <PackageVersion Include="KlutzyNinja.Touki" Version="0.5.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />

--- a/README.md
+++ b/README.md
@@ -90,11 +90,15 @@ stack, and keep types easy to find by file name.
 | TOUKI0030 | Use `ValueStringBuilder` to build strings | Warning |
 
 Every rule can be re-scoped or turned off per directory through
-`.editorconfig`, and two of them take configuration of their own:
+`.editorconfig`, and TOUKI0011 and TOUKI0021 take options of their own:
 
 ```ini
+# Severity, available on every rule
 dotnet_diagnostic.TOUKI0030.severity = none
+
+# Rule-specific options
 dotnet_code_quality.TOUKI0011.max_stackalloc_bytes = 512
+dotnet_code_quality.TOUKI0021.file_name_detail_separators = .-
 ```
 
 See [Analyzers Shipped in the Package](docs/analyzers.md) for what each rule

--- a/README.md
+++ b/README.md
@@ -32,11 +32,14 @@ Some of the design goals include:
   [polyfill layout doc](.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md) for the full list)
 - A `DisposableBase` with double-disposal protection and disposal
   tracking helpers for diagnosing leaks
+- [Roslyn analyzers](docs/analyzers.md) that ship in the package and run
+  automatically - no separate analyzer package to install
 - Much more!
 
 ## Overviews
 
 - [Configuring Your Project for Touki](sample/README.md)
+- [Analyzers Shipped in the Package](docs/analyzers.md)
 - [Reducing String Allocations with Touki](docs/strings.md)
 - [Low-Allocation Collections](docs/collections.md)
 - [Buffers, Span Readers, and Span Writers](docs/buffers.md)
@@ -63,6 +66,39 @@ PM> Install-Package KlutzyNinja.Touki
 
 
 [View on NuGet.org](https://www.nuget.org/packages/KlutzyNinja.Touki/)
+
+## Analyzers
+
+The package includes Roslyn analyzers. They are delivered inside
+`KlutzyNinja.Touki` itself, so referencing the package is all it takes - there
+is nothing extra to install and nothing to switch on.
+
+They encode the conventions the library is built on: avoid hidden struct
+copies, release resources deterministically, keep large scratch buffers off the
+stack, and keep types easy to find by file name.
+
+| ID | Rule | Default severity |
+|----|------|------------------|
+| TOUKI0001 | Use pattern matching for null checks | Warning |
+| TOUKI0002 | Defensive copy of a struct | Hidden |
+| TOUKI0003 | Defensive copy of a non-copyable struct | Warning |
+| TOUKI0004 | By-value copy of a non-copyable struct | Warning |
+| TOUKI0010 | Dispose a `[MustDispose]` value deterministically | Warning |
+| TOUKI0011 | Avoid large `stackalloc` allocations | Warning |
+| TOUKI0020 | Declare one type per file | Warning |
+| TOUKI0021 | File name should match the type it declares | Warning |
+| TOUKI0030 | Use `ValueStringBuilder` to build strings | Warning |
+
+Every rule can be re-scoped or turned off per directory through
+`.editorconfig`, and two of them take configuration of their own:
+
+```ini
+dotnet_diagnostic.TOUKI0030.severity = none
+dotnet_code_quality.TOUKI0011.max_stackalloc_bytes = 512
+```
+
+See [Analyzers Shipped in the Package](docs/analyzers.md) for what each rule
+flags, why, and how to configure it.
 
 ## Requirements
 

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -1,0 +1,239 @@
+# Touki Analyzers
+
+`KlutzyNinja.Touki` ships a set of Roslyn analyzers **inside the package**. There is no
+separate analyzer package to install and no configuration required to turn them on -
+adding the package reference is enough, and the rules start running on the next build
+and in the IDE.
+
+The analyzers encode the conventions this library is built on: avoid hidden struct
+copies, release resources deterministically, keep scratch buffers off the stack once
+they get large, and keep types easy to find by file name.
+
+## Rules
+
+| ID | Rule | Category | Default severity | Configurable | Requires |
+|----|------|----------|------------------|--------------|----------|
+| [TOUKI0001](#touki0001) | Use pattern matching for null checks | Usage | Warning | - | - |
+| [TOUKI0002](#touki0002) | Defensive copy of a struct | Reliability | **Hidden** | - | - |
+| [TOUKI0003](#touki0003) | Defensive copy of a non-copyable struct | Reliability | Warning | - | `[NonCopyable]` |
+| [TOUKI0004](#touki0004) | By-value copy of a non-copyable struct | Reliability | Warning | - | `[NonCopyable]` |
+| [TOUKI0010](#touki0010) | Dispose a `[MustDispose]` value deterministically | Reliability | Warning | - | `[MustDispose]` |
+| [TOUKI0011](#touki0011) | Avoid large `stackalloc` allocations | Reliability | Warning | Yes | - |
+| [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | - | - |
+| [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
+| [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
+
+Rules that list a requirement only fire on code that opts in by applying the named
+attribute. The rest apply to any C# the compiler hands them.
+
+Generated code is excluded from every rule.
+
+---
+
+## TOUKI0001
+
+**Use pattern matching for null checks.** Reports `== null` and `!= null` and suggests
+`is null` and `is not null`. The diagnostic is reported on the operator token, so the
+squiggle lands on exactly the text to change.
+
+```csharp
+if (value != null)   // TOUKI0001
+if (value is not null)
+```
+
+## TOUKI0002
+
+**Defensive copy of a struct.** Accessing a non-`readonly` instance member through a
+read-only location - an `in` parameter, a `readonly` field from outside its constructor,
+a `ref readonly` local or return - silently copies the struct, runs the member against
+the copy, and discards it. Any mutation the member performed is lost, and the copy costs
+whatever the struct costs.
+
+This rule ships **Hidden** on purpose. It is high volume, and on .NET Framework some hits
+come from BCL structs whose members are not `readonly` there and are only avoidable by
+decomposing the field. Raise it locally when you want to audit:
+
+```ini
+dotnet_diagnostic.TOUKI0002.severity = suggestion
+```
+
+## TOUKI0003
+
+**Defensive copy of a non-copyable struct.** The same defect as TOUKI0002, but on a type
+marked `[Touki.NonCopyable]`, where a copy is never acceptable. Warning by default.
+
+## TOUKI0004
+
+**By-value copy of a non-copyable struct.** Reports passing, returning, assigning,
+declaring, or boxing a `[NonCopyable]` value by value. The message names the mechanism
+and the remedy, which differ: an argument can be passed by `ref`/`in`, but a
+`[NonCopyable]` field in a copyable struct is fixed by marking the containing type
+instead.
+
+Creating a value (`new`, a factory, `default`) is treated as a move rather than a copy
+and is not reported.
+
+Apply the marker to a type that owns a resource whose duplication would be a bug:
+
+```csharp
+[NonCopyable]
+public ref struct BufferScope<T> { }
+```
+
+## TOUKI0010
+
+**Dispose a `[MustDispose]` value deterministically.** Reports a value of a type marked
+`[Touki.MustDispose]` that is not consumed by a `using` declaration or statement and not
+disposed in a `finally`. Use it for types where finalization is not a backstop - pooled
+buffers, ref structs, ref-counted handles.
+
+```csharp
+using ValueStringBuilder builder = new(stackalloc char[256]);
+```
+
+A ref struct cannot be used inside a lambda, so where the builder must be mutated through
+`ref` (which a `using` variable forbids), call `ToString()` and then `Dispose()`
+explicitly in a `try`/`finally`.
+
+## TOUKI0011
+
+**Avoid large `stackalloc` allocations.** Stack space is a fixed per-thread budget, and
+overrunning it raises `StackOverflowException`, which cannot be caught and terminates the
+process. Reports a `stackalloc` whose total size exceeds the configured maximum, which
+defaults to **1024 bytes**.
+
+```csharp
+Span<byte> small = stackalloc byte[256];    // fine
+Span<byte> large = stackalloc byte[2048];   // TOUKI0011
+```
+
+Rent from `ArrayPool<T>` instead, or use `BufferScope<T>`, which seeds from the stack and
+falls back to the pool when the request outgrows the seed:
+
+```csharp
+using BufferScope<char> buffer = new(stackalloc char[256], requestedLength);
+```
+
+Configure the threshold in bytes:
+
+```ini
+dotnet_code_quality.TOUKI0011.max_stackalloc_bytes = 512
+```
+
+The rule only reports what it can size from source: a compile-time constant length with a
+primitive, enum, pointer, or native-integer element type. A run-time length or a custom
+struct element is left alone, because the total is not knowable at compile time. Native
+integers and pointers are counted as 8 bytes.
+
+## TOUKI0020
+
+**Declare one type per file**, nested types included. A nested type must live in its own
+file, which does not stop it from being nested - the containing type is re-declared as a
+`partial` shell. A `partial` declaration that only hosts nested types is not counted as
+one of the file's own types, and repeated `partial` declarations of the same type fold
+into the first.
+
+```
+Value.cs                 // partial struct Value - its own members
+Value.TypeFlagOfT.cs     // partial struct Value { class TypeFlag<T> }
+```
+
+There is no code fix, because Roslyn's built-in **Move type to `<Name>.cs`** refactoring
+already does the job. The diagnostic is reported on the type identifier, which is exactly
+where that refactoring is offered.
+
+## TOUKI0021
+
+**File name should match the type it declares.** The companion to TOUKI0020: once each
+file holds one type, the file name should say which one.
+
+A nested type may be named either way, and detail may follow the name after an approved
+separator:
+
+```
+Foo.cs            // class Foo
+Foo.Windows.cs    // class Foo, platform detail
+Foo-Windows.cs    // same, different separator
+Foo.Bar.cs        // class Bar nested in Foo
+Bar.cs            // also fine for that nested Bar
+FooWindows.cs     // TOUKI0021 - no separator, so this is a different name
+```
+
+Configure the approved separators as the set of characters to allow. The default is
+`.-_`:
+
+```ini
+dotnet_code_quality.TOUKI0021.file_name_detail_separators = .-
+```
+
+Comparison is ordinal, so `foo.cs` is reported for type `Foo` even on a case-insensitive
+file system. Files that declare no types - global usings, assembly-level attributes - are
+not reported.
+
+## TOUKI0030
+
+**Use `ValueStringBuilder` to build strings.** Reports a `StringBuilder` that is only used
+to build a string locally, where `Touki.Text.ValueStringBuilder` would do the same work
+without the managed allocation.
+
+```csharp
+using ValueStringBuilder builder = new(stackalloc char[256]);
+builder.Append(value);
+return builder.ToString();
+```
+
+`ValueStringBuilder` is a `ref struct`, so the rule deliberately stays silent wherever it
+could not be substituted - a builder stored in a field, returned, passed as an argument,
+captured by a lambda, put in an array, assigned to a wider local, or used in an `async`
+method or iterator. A warning you cannot act on is worse than no warning, so anything the
+rule cannot prove is safe to convert is left alone.
+
+---
+
+## Configuring severity
+
+Every rule responds to the standard `.editorconfig` severity keys, and can be scoped to a
+directory by placing an `.editorconfig` there:
+
+```ini
+[*.cs]
+dotnet_diagnostic.TOUKI0030.severity = none
+```
+
+Severities are `none`, `silent`, `suggestion`, `warning`, and `error`. If you build with
+`TreatWarningsAsErrors`, note that only `warning` and above break the build - `suggestion`
+keeps a rule visible in the IDE without failing CI.
+
+This is how touki scopes rules against its own ported code. `touki/Framework/Polyfills/`
+holds polyfills ported as faithfully as possible from `dotnet/runtime` so future updates
+stay easy to diff, so the rules that would force an idiomatic rewrite of that code are
+turned off just for that folder.
+
+## Code fixes
+
+`MakeMemberReadonlyCodeFixProvider` fixes TOUKI0002 and TOUKI0003 by marking the accessed
+member `readonly`, which tells the compiler it does not mutate and removes the need for
+the copy. It supports Fix All. The fix is only offered when the member is declared in
+source; if the member really does mutate, marking it `readonly` produces a compiler error
+you can act on.
+
+## Marker attributes
+
+Two rules are opt-in through public attributes in the `Touki` namespace:
+
+- `[NonCopyable]` - the type owns something that must not be duplicated. Drives TOUKI0003
+  and TOUKI0004.
+- `[MustDispose]` - the type owns a resource that must be released on every path. Drives
+  TOUKI0010.
+
+## Release history
+
+| Release | Rules added |
+|---------|-------------|
+| 0.4.0 | TOUKI0001, TOUKI0002, TOUKI0003, TOUKI0004, TOUKI0010 |
+| 0.5.0 | TOUKI0020, TOUKI0030 |
+| unreleased | TOUKI0011, TOUKI0021 |
+
+The authoritative list lives in
+[AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and
+[AnalyzerReleases.Unshipped.md](../touki.analyzers/AnalyzerReleases.Unshipped.md).

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -19,17 +19,33 @@ internal static class AnalyzerTestHarness
     ///  Runs <paramref name="analyzer"/> against <paramref name="source"/> and returns the
     ///  analyzer-produced diagnostics.
     /// </summary>
-    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(DiagnosticAnalyzer analyzer, string source)
+    /// <param name="options">
+    ///  Optional <c>.editorconfig</c> values made visible to the analyzer.
+    /// </param>
+    /// <param name="fileName">
+    ///  Optional path for the parsed tree. Analyzers that inspect the file name need one; the default leaves
+    ///  the tree pathless, matching an in-memory compilation.
+    /// </param>
+    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        DiagnosticAnalyzer analyzer,
+        string source,
+        IReadOnlyDictionary<string, string>? options = null,
+        string? fileName = null)
     {
-        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, path: fileName ?? string.Empty);
 
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
             syntaxTrees: [syntaxTree],
             references: s_references.Value,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
 
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers([analyzer]);
+        AnalyzerOptions analyzerOptions = new(
+            additionalFiles: [],
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(
+                options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
+
+        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
 
         return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
     }

--- a/touki.analyzers.tests/FileNameMatchesTypeAnalyzerTests.cs
+++ b/touki.analyzers.tests/FileNameMatchesTypeAnalyzerTests.cs
@@ -1,0 +1,282 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class FileNameMatchesTypeAnalyzerTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source,
+        string? fileName,
+        string? separators = null)
+    {
+        Dictionary<string, string>? options = separators is null
+            ? null
+            : new Dictionary<string, string> { [FileNameMatchesTypeAnalyzer.DetailSeparatorsOption] = separators };
+
+        return await AnalyzerTestHarness
+            .GetDiagnosticsAsync(new FileNameMatchesTypeAnalyzer(), source, options, fileName)
+            .ConfigureAwait(false);
+    }
+
+    private const string SimpleType = """
+        class Foo
+        {
+        }
+        """;
+
+    private const string NestedType = """
+        partial class Foo
+        {
+            class Bar
+            {
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NameMatches_ReportsNothing()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "Foo.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NameDiffers_ReportsDiagnostic()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(FileNameMatchesTypeAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_MessageNamesFileAndType()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("Other").And.Contain("Foo");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_CaseDiffers_ReportsDiagnostic()
+    {
+        // Comparison is ordinal so that casing is right even on a case-insensitive file system.
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "foo.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    [DataRow("Foo.Windows.cs")]
+    [DataRow("Foo-Windows.cs")]
+    [DataRow("Foo_Windows.cs")]
+    public async Task AnalyzeSyntaxTree_DetailAfterDefaultSeparator_ReportsNothing(string fileName)
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, fileName).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_DetailWithoutSeparator_ReportsDiagnostic()
+    {
+        // 'FooWindows' is a different name, not 'Foo' with detail.
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "FooWindows.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    [DataRow("Foo.Bar.cs")]
+    [DataRow("Bar.cs")]
+    public async Task AnalyzeSyntaxTree_NestedType_AcceptsEitherName(string fileName)
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(NestedType, fileName).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    [DataRow("Foo.Middle.Leaf.cs")]
+    [DataRow("Foo.Middle.cs")]
+    [DataRow("Leaf.cs")]
+    public async Task AnalyzeSyntaxTree_DeeplyNestedType_AcceptsAnyLevel(string fileName)
+    {
+        string source = """
+            partial class Foo
+            {
+                partial class Middle
+                {
+                    class Leaf
+                    {
+                    }
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, fileName).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NestedNameUnrelatedToFile_ReportsDiagnostic()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(NestedType, "Unrelated.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_TypeInNamespace_ReportsNothing()
+    {
+        string source = """
+            namespace Some.Space;
+
+            class Foo
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Foo.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_GenericType_MatchesUnadornedName()
+    {
+        string source = """
+            class Foo<T>
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Foo.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_Enum_ReportsNothing()
+    {
+        string source = """
+            enum Color
+            {
+                Red
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Color.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_Delegate_ReportsNothing()
+    {
+        string source = "delegate void Handler();";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Handler.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NoTypeDeclared_ReportsNothing()
+    {
+        string source = """
+            using System;
+
+            [assembly: CLSCompliant(false)]
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "GlobalUsings.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NoFilePath_ReportsNothing()
+    {
+        // An in-memory tree has no name to match against.
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, fileName: null).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_GeneratedCode_ReportsNothing()
+    {
+        string source = "// <auto-generated/>\n" + SimpleType;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConfiguredSeparatorsNarrowed_ReportsDiagnostic()
+    {
+        // Underscore is dropped from the approved set, so 'Foo_Windows' no longer reads as detail.
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(SimpleType, "Foo_Windows.cs", separators: ".-").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConfiguredSeparatorsWidened_ReportsNothing()
+    {
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(SimpleType, "Foo+Windows.cs", separators: "+").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("   ")]
+    public async Task AnalyzeSyntaxTree_UnusableConfiguredSeparators_FallsBackToDefault(string separators)
+    {
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(SimpleType, "Foo.Windows.cs", separators).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NestedDottedPath_MatchesWhenDotIsNotASeparator()
+    {
+        // With '.' dropped from the approved set, 'Foo.Bar' can no longer read as 'Foo' plus detail, so this
+        // only passes because the nested type's dotted path is itself a candidate.
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(NestedType, "Foo.Bar.cs", separators: "-").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_DetailAfterDroppedSeparator_ReportsDiagnostic()
+    {
+        // Same configuration, but 'Other' is not a nested type, so there is no candidate to match.
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(NestedType, "Foo.Other.cs", separators: "-").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_PathWithDirectories_MatchesOnFileNameOnly()
+    {
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(SimpleType, "/src/deep/path/Foo.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/FileNameMatchesTypeAnalyzerTests.cs
+++ b/touki.analyzers.tests/FileNameMatchesTypeAnalyzerTests.cs
@@ -240,6 +240,16 @@ public class FileNameMatchesTypeAnalyzerTests
     }
 
     [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConfiguredSeparatorsPadded_IsHonored()
+    {
+        // Padding around the set must not silently drop the setting back to the default.
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(SimpleType, "Foo+Windows.cs", separators: "  +  ").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
     [DataRow("")]
     [DataRow("   ")]
     public async Task AnalyzeSyntaxTree_UnusableConfiguredSeparators_FallsBackToDefault(string separators)

--- a/touki.analyzers.tests/StackAllocSizeAnalyzerTests.cs
+++ b/touki.analyzers.tests/StackAllocSizeAnalyzerTests.cs
@@ -253,6 +253,29 @@ public class StackAllocSizeAnalyzerTests
     }
 
     [TestMethod]
+    [DataRow(" 4096")]
+    [DataRow("4096 ")]
+    [DataRow("  4096  ")]
+    public async Task AnalyzeStackAlloc_ConfiguredMaxPadded_IsHonored(string maxBytes)
+    {
+        // Padding around the value must not silently drop the setting back to the default.
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[2048];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, maxBytes).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
     [DataRow("not-a-number")]
     [DataRow("0")]
     [DataRow("-1")]

--- a/touki.analyzers.tests/StackAllocSizeAnalyzerTests.cs
+++ b/touki.analyzers.tests/StackAllocSizeAnalyzerTests.cs
@@ -1,0 +1,339 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class StackAllocSizeAnalyzerTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source,
+        string? maxBytes = null)
+    {
+        Dictionary<string, string>? options = maxBytes is null
+            ? null
+            : new Dictionary<string, string> { [StackAllocSizeAnalyzer.MaxBytesOption] = maxBytes };
+
+        return await AnalyzerTestHarness.GetDiagnosticsAsync(new StackAllocSizeAnalyzer(), source, options)
+            .ConfigureAwait(false);
+    }
+
+    private const string Usings = """
+        using System;
+
+        """;
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_ByteArrayOverDefault_ReportsDiagnostic()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[2048];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(StackAllocSizeAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_CharArray_UsesTwoBytesPerElement()
+    {
+        // 600 chars is 1200 bytes, which is over the 1024 default even though the count is not.
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<char> buffer = stackalloc char[600];
+                    buffer[0] = 'a';
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("1200").And.Contain("1024");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_ExactlyAtLimit_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[1024];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_TypicalSeedBuffer_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<char> buffer = stackalloc char[256];
+                    buffer[0] = 'a';
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_ConstantLength_IsEvaluated()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                private const int Size = 4096;
+
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[Size];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("4096");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_RuntimeLength_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use(int length)
+                {
+                    Span<byte> buffer = stackalloc byte[length];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_EnumElement_UsesUnderlyingTypeSize()
+    {
+        // DayOfWeek is backed by int, so 512 elements is 2048 bytes.
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<DayOfWeek> buffer = stackalloc DayOfWeek[512];
+                    buffer[0] = DayOfWeek.Monday;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("2048");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_CustomStructElement_ReportsNothing()
+    {
+        // The layout of a custom struct is not knowable from source, so it is left alone.
+        string source = Usings + """
+            struct Point
+            {
+                public int X;
+                public int Y;
+            }
+
+            class Sample
+            {
+                void Use()
+                {
+                    Span<Point> buffer = stackalloc Point[4096];
+                    buffer[0] = default;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_PointerElement_UsesEightBytes()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                unsafe void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[8];
+                    byte** pointers = stackalloc byte*[256];
+                    pointers[0] = null;
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("2048");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_ConfiguredMaxLowered_ReportsDiagnostic()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[512];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, maxBytes: "256").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("512").And.Contain("256");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_ConfiguredMaxRaised_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[2048];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, maxBytes: "4096").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    [DataRow("not-a-number")]
+    [DataRow("0")]
+    [DataRow("-1")]
+    [DataRow("")]
+    public async Task AnalyzeStackAlloc_UnusableConfiguredMax_FallsBackToDefault(string maxBytes)
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> buffer = stackalloc byte[2048];
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, maxBytes).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain($"{StackAllocSizeAnalyzer.DefaultMaxBytes}");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_ImplicitlyTyped_UsesInitializerCount()
+    {
+        // 'stackalloc[] { 1, 2, 3 }' is three ints, so 12 bytes.
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<int> buffer = stackalloc[] { 1, 2, 3 };
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, maxBytes: "8").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("12");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_OmittedLengthWithInitializer_UsesInitializerCount()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<int> buffer = stackalloc int[] { 1, 2, 3, 4 };
+                    buffer[0] = 1;
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, maxBytes: "8").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("16");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeStackAlloc_MultipleOversizedAllocations_ReportsEach()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                void Use()
+                {
+                    Span<byte> first = stackalloc byte[2048];
+                    Span<byte> second = stackalloc byte[4096];
+                    first[0] = second[0];
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(2);
+    }
+}

--- a/touki.analyzers.tests/TestAnalyzerConfigOptions.cs
+++ b/touki.analyzers.tests/TestAnalyzerConfigOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Dictionary-backed <see cref="AnalyzerConfigOptions"/> that stands in for the values an
+///  <c>.editorconfig</c> would supply.
+/// </summary>
+internal sealed class TestAnalyzerConfigOptions(IReadOnlyDictionary<string, string> options) : AnalyzerConfigOptions
+{
+    public static TestAnalyzerConfigOptions Empty { get; } = new(new Dictionary<string, string>());
+
+    public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value) =>
+        options.TryGetValue(key, out value);
+}

--- a/touki.analyzers.tests/TestAnalyzerConfigOptionsProvider.cs
+++ b/touki.analyzers.tests/TestAnalyzerConfigOptionsProvider.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Supplies the same <see cref="TestAnalyzerConfigOptions"/> for every syntax tree, which is
+///  all the single-file analyzer fixtures need.
+/// </summary>
+internal sealed class TestAnalyzerConfigOptionsProvider(TestAnalyzerConfigOptions options)
+    : AnalyzerConfigOptionsProvider
+{
+    public override AnalyzerConfigOptions GlobalOptions => options;
+
+    public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => options;
+
+    public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => options;
+}

--- a/touki.analyzers/AnalyzerReleases.Shipped.md
+++ b/touki.analyzers/AnalyzerReleases.Shipped.md
@@ -1,2 +1,26 @@
 ; Shipped analyzer releases
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+;
+; Release headings must be numeric, so they name the version line rather than the exact
+; package version. The 0.4.0 rules first shipped in the 0.4.0-alpha.1 prerelease, which is
+; also when touki.analyzers began packing into KlutzyNinja.Touki. 0.5.0 was the first
+; stable release.
+
+## Release 0.4.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TOUKI0001 | Usage | Warning | Use 'is null' / 'is not null' for null comparisons
+TOUKI0002 | Reliability | Hidden | Defensive copy of a struct
+TOUKI0003 | Reliability | Warning | Defensive copy of a [NonCopyable] struct
+TOUKI0004 | Reliability | Warning | By-value copy of a [NonCopyable] struct
+TOUKI0010 | Reliability | Warning | [MustDispose] value is not deterministically disposed
+
+## Release 0.5.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TOUKI0020 | Maintainability | Warning | More than one type declared in a file, nested types included
+TOUKI0030 | Performance | Warning | StringBuilder allocated to build a string that ValueStringBuilder could build

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -4,10 +4,5 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-TOUKI0001 | Usage | Warning | Use 'is null' / 'is not null' for null comparisons
-TOUKI0002 | Reliability | Hidden | Defensive copy of a struct
-TOUKI0003 | Reliability | Warning | Defensive copy of a [NonCopyable] struct
-TOUKI0004 | Reliability | Warning | By-value copy of a [NonCopyable] struct
-TOUKI0010 | Reliability | Warning | [MustDispose] value is not deterministically disposed
-TOUKI0020 | Maintainability | Warning | More than one type declared in a file, nested types included
-TOUKI0030 | Performance | Warning | StringBuilder allocated to build a string that ValueStringBuilder could build
+TOUKI0011 | Reliability | Warning | stackalloc larger than the configured maximum byte size
+TOUKI0021 | Maintainability | Warning | File name does not match a type declared in the file

--- a/touki.analyzers/DefensiveCopyAnalyzer.cs
+++ b/touki.analyzers/DefensiveCopyAnalyzer.cs
@@ -62,8 +62,6 @@ public sealed class DefensiveCopyAnalyzer : DiagnosticAnalyzer
     /// <summary>The diagnostic id for a defensive copy of a <c>[NonCopyable]</c> struct.</summary>
     public const string NonCopyableDefensiveCopyId = "TOUKI0003";
 
-    private const string HelpLinkUri = "https://github.com/JeremyKuhne/touki";
-
     private static readonly DiagnosticDescriptor s_defensiveCopy = new(
         id: DefensiveCopyId,
         title: "Defensive copy of a struct",
@@ -72,7 +70,7 @@ public sealed class DefensiveCopyAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Hidden,
         isEnabledByDefault: true,
         description: "Accessing a non-readonly instance member through a read-only location copies the struct, runs the member against the copy, then discards it.",
-        helpLinkUri: HelpLinkUri);
+        helpLinkUri: HelpLinks.ForRule(DefensiveCopyId));
 
     private static readonly DiagnosticDescriptor s_nonCopyableDefensiveCopy = new(
         id: NonCopyableDefensiveCopyId,
@@ -82,7 +80,7 @@ public sealed class DefensiveCopyAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "A type marked [NonCopyable] must not be copied. Accessing a non-readonly member through a read-only location creates a discarded defensive copy.",
-        helpLinkUri: HelpLinkUri);
+        helpLinkUri: HelpLinks.ForRule(NonCopyableDefensiveCopyId));
 
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics =
         ImmutableArray.Create(s_defensiveCopy, s_nonCopyableDefensiveCopy);

--- a/touki.analyzers/FileNameMatchesTypeAnalyzer.cs
+++ b/touki.analyzers/FileNameMatchesTypeAnalyzer.cs
@@ -1,0 +1,217 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports files whose name does not match a type declared in them, so that a type can be found from its
+///  file name alone.
+/// </summary>
+/// <remarks>
+///  <para>
+///   A nested type may be named either way: <c>Bar</c> nested in <c>Foo</c> is matched by both
+///   <c>Foo.Bar.cs</c> and <c>Bar.cs</c>.
+///  </para>
+///  <para>
+///   Detail may follow the type name when introduced by an approved separator, so <c>Foo.Windows.cs</c>,
+///   <c>Foo-Windows.cs</c>, and <c>Foo_Windows.cs</c> all match <c>Foo</c>. The approved separators default
+///   to <see cref="DefaultDetailSeparators"/> and are configured per path in <c>.editorconfig</c> as the set
+///   of characters to allow:
+///   <code>dotnet_code_quality.TOUKI0021.file_name_detail_separators = .-</code>
+///  </para>
+///  <para>
+///   Comparison is ordinal, so casing must match even on a case-insensitive file system. A file that
+///   declares no types is not reported, and neither is a tree with no path.
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0021";
+
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that overrides the characters allowed to introduce trailing detail in a
+    ///  file name. The value is the set of characters, for example <c>.-</c>.
+    /// </summary>
+    public const string DetailSeparatorsOption = "dotnet_code_quality.TOUKI0021.file_name_detail_separators";
+
+    /// <summary>
+    ///  The characters allowed to introduce trailing detail when <see cref="DetailSeparatorsOption"/> is not
+    ///  configured.
+    /// </summary>
+    public const string DefaultDetailSeparators = ".-_";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "File name should match the type it declares",
+        messageFormat: "File name '{0}' does not match type '{1}'",
+        category: "Maintainability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A file should be named for the type it declares so the type can be found from the file name. A nested type may use either its own name or its containing type's dotted path, and detail may follow the name after an approved separator.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    // Cache the supported-diagnostics array so the property does not allocate a new array on every access.
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // The rule is about the file as a whole. Only member lists are walked, which keeps the walk
+        // proportional to the number of declarations rather than to the size of the file.
+        context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+    }
+
+    private static void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        // An in-memory tree has no path to match against.
+        if (string.IsNullOrEmpty(context.Tree.FilePath)
+            || context.Tree.GetRoot(context.CancellationToken) is not CompilationUnitSyntax compilationUnit)
+        {
+            return;
+        }
+
+        List<string> candidates = [];
+        SyntaxToken firstIdentifier = default;
+        CollectNames(compilationUnit.Members, prefix: null, candidates, ref firstIdentifier);
+
+        if (candidates.Count == 0)
+        {
+            // Global usings, assembly attributes, and the like name nothing.
+            return;
+        }
+
+        string fileName = Path.GetFileNameWithoutExtension(context.Tree.FilePath);
+        string separators = GetDetailSeparators(context);
+
+        foreach (string candidate in candidates)
+        {
+            if (Matches(fileName, candidate, separators))
+            {
+                return;
+            }
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(s_rule, firstIdentifier.GetLocation(), fileName, firstIdentifier.ValueText));
+    }
+
+    /// <summary>
+    ///  Adds every name a file declaring <paramref name="members"/> may be called to
+    ///  <paramref name="candidates"/>, and records the first type's identifier in
+    ///  <paramref name="firstIdentifier"/>. A nested type contributes both its own name and its dotted path.
+    /// </summary>
+    private static void CollectNames(
+        SyntaxList<MemberDeclarationSyntax> members,
+        string? prefix,
+        List<string> candidates,
+        ref SyntaxToken firstIdentifier)
+    {
+        foreach (MemberDeclarationSyntax member in members)
+        {
+            if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)
+            {
+                CollectNames(namespaceDeclaration.Members, prefix, candidates, ref firstIdentifier);
+                continue;
+            }
+
+            SyntaxToken identifier = GetIdentifier(member);
+
+            // Anything that is not a named type declaration names nothing. An extension block is a type
+            // declaration with no identifier, so this excludes it as well.
+            if (identifier.IsKind(SyntaxKind.None))
+            {
+                continue;
+            }
+
+            if (firstIdentifier.IsKind(SyntaxKind.None))
+            {
+                firstIdentifier = identifier;
+            }
+
+            string name = identifier.ValueText;
+            string qualified = prefix is null ? name : $"{prefix}.{name}";
+
+            candidates.Add(name);
+
+            if (prefix is not null)
+            {
+                candidates.Add(qualified);
+            }
+
+            // Only class, struct, interface, and record bodies can hold a nested type.
+            if (member is TypeDeclarationSyntax typeDeclaration)
+            {
+                CollectNames(typeDeclaration.Members, qualified, candidates, ref firstIdentifier);
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Returns the identifier of <paramref name="member"/>, or a <see cref="SyntaxKind.None"/> token when it
+    ///  does not declare a named type. The test is on the identifier rather than on the node type because the
+    ///  analyzer is built against a Roslyn version that predates the extension-block syntax.
+    /// </summary>
+    private static SyntaxToken GetIdentifier(MemberDeclarationSyntax member) => member switch
+    {
+        BaseTypeDeclarationSyntax type => type.Identifier,
+        DelegateDeclarationSyntax declaration => declaration.Identifier,
+        _ => default
+    };
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="fileName"/> is <paramref name="candidate"/>, either
+    ///  exactly or followed by detail introduced by one of <paramref name="separators"/>.
+    /// </summary>
+    private static bool Matches(string fileName, string candidate, string separators)
+    {
+        if (!fileName.StartsWith(candidate, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (fileName.Length == candidate.Length)
+        {
+            return true;
+        }
+
+        return separators.IndexOf(fileName[candidate.Length]) >= 0;
+    }
+
+    private static string GetDetailSeparators(SyntaxTreeAnalysisContext context)
+    {
+        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree);
+
+        if (options.TryGetValue(DetailSeparatorsOption, out string? value))
+        {
+            string separators = value.Trim();
+
+            // An empty value is far more likely to be a mistake than a deliberate "allow no detail".
+            if (separators.Length > 0)
+            {
+                return separators;
+            }
+        }
+
+        return DefaultDetailSeparators;
+    }
+}

--- a/touki.analyzers/HelpLinks.cs
+++ b/touki.analyzers/HelpLinks.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Builds the <c>helpLinkUri</c> for a diagnostic descriptor.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Every rule is documented in <c>docs/analyzers.md</c> under a heading that is its diagnostic id, so the
+///   anchor is derived from the id rather than written out. That keeps the link and the rule from drifting
+///   apart when a rule is renumbered.
+///  </para>
+/// </remarks>
+internal static class HelpLinks
+{
+    private const string DocumentationUri = "https://github.com/JeremyKuhne/touki/blob/main/docs/analyzers.md";
+
+    /// <summary>
+    ///  Returns the documentation link for <paramref name="diagnosticId"/>.
+    /// </summary>
+    internal static string ForRule(string diagnosticId) =>
+        $"{DocumentationUri}#{diagnosticId.ToLowerInvariant()}";
+}

--- a/touki.analyzers/MustDisposeAnalyzer.cs
+++ b/touki.analyzers/MustDisposeAnalyzer.cs
@@ -76,7 +76,7 @@ public sealed class MustDisposeAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "A type marked [MustDispose] owns a resource that must be released on every path. Consume the value with a 'using' declaration or statement, or dispose it in a 'try'/'finally'.",
-        helpLinkUri: "https://github.com/JeremyKuhne/touki");
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
 
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
 

--- a/touki.analyzers/NonCopyableByValueAnalyzer.cs
+++ b/touki.analyzers/NonCopyableByValueAnalyzer.cs
@@ -66,7 +66,7 @@ public sealed class NonCopyableByValueAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "A type marked [NonCopyable] owns a resource that must not be duplicated. Where feasible pass or alias it by reference ('ref'/'in'/'ref readonly'); otherwise redesign so the value is not copied by value.",
-        helpLinkUri: "https://github.com/JeremyKuhne/touki");
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
 
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
 

--- a/touki.analyzers/OneTypePerFileAnalyzer.cs
+++ b/touki.analyzers/OneTypePerFileAnalyzer.cs
@@ -70,7 +70,7 @@ public sealed class OneTypePerFileAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "A file should declare a single type, nested types included, so that types are easy to find by file name. A 'partial' declaration that only hosts nested types and repeated 'partial' declarations of the same type do not count as additional types.",
-        helpLinkUri: "https://github.com/JeremyKuhne/touki");
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
 
     // Cache the supported-diagnostics array so the property does not allocate a new array on every access.
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];

--- a/touki.analyzers/PreferValueStringBuilderAnalyzer.cs
+++ b/touki.analyzers/PreferValueStringBuilderAnalyzer.cs
@@ -84,7 +84,7 @@ public sealed class PreferValueStringBuilderAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "A 'StringBuilder' that only builds a string inside the method that creates it allocates the builder and its chunks on the heap. 'Touki.Text.ValueStringBuilder' seeded with a stack buffer does the same work without allocating, renting from the shared array pool only when the content outgrows the buffer.",
-        helpLinkUri: "https://github.com/JeremyKuhne/touki");
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
 
     // Cache the supported-diagnostics array so the property does not allocate a new array on every access.
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];

--- a/touki.analyzers/StackAllocSizeAnalyzer.cs
+++ b/touki.analyzers/StackAllocSizeAnalyzer.cs
@@ -51,8 +51,9 @@ public sealed class StackAllocSizeAnalyzer : DiagnosticAnalyzer
     /// </summary>
     public const int DefaultMaxBytes = 1024;
 
-    // Native integers and pointers are 8 bytes in the 64-bit processes this library targets.
-    // Reporting the larger of the two possible widths keeps the rule from under-reporting on x64.
+    // A native integer or pointer is 4 bytes in a 32-bit process and 8 in a 64-bit one, and which of those
+    // runs is not knowable when the analyzer sees the code. Assume the larger so the rule reports a size at
+    // least as large as the allocation will really be rather than under-reporting it.
     private const long NativeIntegerSize = 8;
 
     private static readonly DiagnosticDescriptor s_rule = new(
@@ -237,7 +238,7 @@ public sealed class StackAllocSizeAnalyzer : DiagnosticAnalyzer
         AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Node.SyntaxTree);
 
         return options.TryGetValue(MaxBytesOption, out string? value)
-            && int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int maxBytes)
+            && int.TryParse(value.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out int maxBytes)
             && maxBytes > 0
                 ? maxBytes
                 : DefaultMaxBytes;

--- a/touki.analyzers/StackAllocSizeAnalyzer.cs
+++ b/touki.analyzers/StackAllocSizeAnalyzer.cs
@@ -1,0 +1,245 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using System.Globalization;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports <see langword="stackalloc"/> expressions whose total size exceeds a configurable
+///  byte threshold, defaulting to <see cref="DefaultMaxBytes"/> bytes.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Stack space is a fixed, per-thread budget. Overrunning it raises
+///   <c>StackOverflowException</c>, which cannot be caught and terminates the process. Large
+///   scratch buffers should be rented from <c>ArrayPool&lt;T&gt;</c> or acquired through
+///   <c>BufferScope&lt;T&gt;</c>, which falls back to the pool when the request outgrows its
+///   stack seed.
+///  </para>
+///  <para>
+///   Only allocations with a compile-time constant length and a primitive, enum, pointer, or
+///   native-integer element type are evaluated. A run-time length or a custom struct element
+///   is not reported, because the total size is not knowable from source.
+///  </para>
+///  <para>
+///   The threshold is configured per path in <c>.editorconfig</c>:
+///   <code>dotnet_code_quality.TOUKI0011.max_stackalloc_bytes = 512</code>
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class StackAllocSizeAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0011";
+
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that overrides the maximum allowed size, in bytes.
+    /// </summary>
+    public const string MaxBytesOption = "dotnet_code_quality.TOUKI0011.max_stackalloc_bytes";
+
+    /// <summary>
+    ///  The maximum allowed size, in bytes, when <see cref="MaxBytesOption"/> is not configured.
+    /// </summary>
+    public const int DefaultMaxBytes = 1024;
+
+    // Native integers and pointers are 8 bytes in the 64-bit processes this library targets.
+    // Reporting the larger of the two possible widths keeps the rule from under-reporting on x64.
+    private const long NativeIntegerSize = 8;
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Avoid large stackalloc allocations",
+        messageFormat: "'stackalloc' of {0} bytes exceeds the maximum of {1} bytes; rent from ArrayPool<T> or use BufferScope<T>",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Large 'stackalloc' allocations risk an uncatchable StackOverflowException. Use a pooled buffer instead.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    // Cache the supported-diagnostics array so the property does not allocate a new array on every access.
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(s_rule);
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(
+            AnalyzeStackAlloc,
+            SyntaxKind.StackAllocArrayCreationExpression,
+            SyntaxKind.ImplicitStackAllocArrayCreationExpression);
+    }
+
+    private static void AnalyzeStackAlloc(SyntaxNodeAnalysisContext context)
+    {
+        if (!TryGetElementTypeAndCount(context, out ITypeSymbol? elementType, out long elementCount)
+            || !TryGetElementSize(elementType, out long elementSize))
+        {
+            return;
+        }
+
+        // elementCount is bounded by int.MaxValue and elementSize by 16, so this cannot overflow.
+        long totalBytes = elementSize * elementCount;
+
+        // Read the configured threshold last; the size calculation above is the cheaper filter.
+        int maxBytes = GetMaxBytes(context);
+
+        if (totalBytes <= maxBytes)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(s_rule, context.Node.GetLocation(), totalBytes, maxBytes));
+    }
+
+    private static bool TryGetElementTypeAndCount(
+        SyntaxNodeAnalysisContext context,
+        out ITypeSymbol? elementType,
+        out long elementCount)
+    {
+        elementType = null;
+        elementCount = 0;
+
+        switch (context.Node)
+        {
+            case StackAllocArrayCreationExpressionSyntax { Type: ArrayTypeSyntax arrayType } stackAlloc:
+                elementType = context.SemanticModel.GetTypeInfo(arrayType.ElementType, context.CancellationToken).Type;
+                return TryGetExplicitCount(context, arrayType, stackAlloc.Initializer, out elementCount);
+
+            case ImplicitStackAllocArrayCreationExpressionSyntax implicitStackAlloc:
+                elementType = GetImplicitElementType(context);
+                elementCount = implicitStackAlloc.Initializer.Expressions.Count;
+                return true;
+
+            default:
+                return false;
+        }
+    }
+
+    private static bool TryGetExplicitCount(
+        SyntaxNodeAnalysisContext context,
+        ArrayTypeSyntax arrayType,
+        InitializerExpressionSyntax? initializer,
+        out long elementCount)
+    {
+        elementCount = 0;
+
+        if (arrayType.RankSpecifiers.Count != 1 || arrayType.RankSpecifiers[0].Sizes.Count != 1)
+        {
+            return false;
+        }
+
+        ExpressionSyntax size = arrayType.RankSpecifiers[0].Sizes[0];
+
+        if (size is OmittedArraySizeExpressionSyntax)
+        {
+            // 'stackalloc int[] { 1, 2, 3 }' takes its length from the initializer.
+            if (initializer is null)
+            {
+                return false;
+            }
+
+            elementCount = initializer.Expressions.Count;
+            return true;
+        }
+
+        Optional<object?> constant = context.SemanticModel.GetConstantValue(size, context.CancellationToken);
+
+        if (!constant.HasValue)
+        {
+            // A run-time length cannot be evaluated here.
+            return false;
+        }
+
+        // These are the integral types a length expression is allowed to have.
+        long count = constant.Value switch
+        {
+            int value => value,
+            uint value => value,
+            long value => value,
+            ulong value when value <= long.MaxValue => (long)value,
+            _ => 0
+        };
+
+        if (count <= 0)
+        {
+            return false;
+        }
+
+        elementCount = count;
+        return true;
+    }
+
+    private static ITypeSymbol? GetImplicitElementType(SyntaxNodeAnalysisContext context)
+    {
+        // 'stackalloc[] { ... }' is typed as 'T*' or as 'Span<T>' depending on the target.
+        ITypeSymbol? type = context.SemanticModel.GetTypeInfo(context.Node, context.CancellationToken).Type;
+
+        return type switch
+        {
+            IPointerTypeSymbol pointer => pointer.PointedAtType,
+            INamedTypeSymbol { TypeArguments.Length: 1 } span => span.TypeArguments[0],
+            _ => null
+        };
+    }
+
+    private static bool TryGetElementSize(ITypeSymbol? elementType, out long elementSize)
+    {
+        elementSize = 0;
+
+        if (elementType is null)
+        {
+            return false;
+        }
+
+        // An enum occupies the same space as the primitive it is built on.
+        if (elementType is INamedTypeSymbol { EnumUnderlyingType: { } underlyingType })
+        {
+            elementType = underlyingType;
+        }
+
+        if (elementType.TypeKind == TypeKind.Pointer
+            || elementType.SpecialType is SpecialType.System_IntPtr or SpecialType.System_UIntPtr)
+        {
+            elementSize = NativeIntegerSize;
+            return true;
+        }
+
+        elementSize = elementType.SpecialType switch
+        {
+            SpecialType.System_Boolean or SpecialType.System_Byte or SpecialType.System_SByte => 1,
+            SpecialType.System_Char or SpecialType.System_Int16 or SpecialType.System_UInt16 => 2,
+            SpecialType.System_Int32 or SpecialType.System_UInt32 or SpecialType.System_Single => 4,
+            SpecialType.System_Int64 or SpecialType.System_UInt64 or SpecialType.System_Double => 8,
+            SpecialType.System_Decimal => 16,
+
+            // A custom struct has no source-visible size; leave it alone rather than guess.
+            _ => 0
+        };
+
+        return elementSize != 0;
+    }
+
+    private static int GetMaxBytes(SyntaxNodeAnalysisContext context)
+    {
+        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Node.SyntaxTree);
+
+        return options.TryGetValue(MaxBytesOption, out string? value)
+            && int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out int maxBytes)
+            && maxBytes > 0
+                ? maxBytes
+                : DefaultMaxBytes;
+    }
+}

--- a/touki.analyzers/UseIsNullAnalyzer.cs
+++ b/touki.analyzers/UseIsNullAnalyzer.cs
@@ -37,7 +37,7 @@ public sealed class UseIsNullAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
         description: "Comparisons against the null literal should use the 'is null' and 'is not null' patterns.",
-        helpLinkUri: "https://github.com/JeremyKuhne/touki");
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
 
     // Cache the supported-diagnostics array so the property does not allocate a new array on every access.
     private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = ImmutableArray.Create(s_rule);

--- a/touki.testsupport/README.md
+++ b/touki.testsupport/README.md
@@ -11,6 +11,7 @@ extensions used by the touki test suite.
 ## Targets
 
 - `net10.0`
+- `net11.0`
 - `net472`
 
 Like `KlutzyNinja.Touki`, this package ships architecture-neutral


### PR DESCRIPTION
## Changes

Adds two analyzers, documents the whole analyzer set, and cleans up release tracking
that had gone stale.

### TOUKI0011 - Avoid large `stackalloc` allocations

Reliability, Warning. Reports a `stackalloc` whose total size exceeds a configurable
maximum, defaulting to **1024 bytes**. Overrunning the stack raises
`StackOverflowException`, which cannot be caught and terminates the process.

```ini
dotnet_code_quality.TOUKI0011.max_stackalloc_bytes = 512
```

Deliberately silent where the size is not knowable from source - run-time lengths and
custom struct elements, whose layout is a runtime decision Roslyn does not expose. It
does handle constants, enums via their underlying type, pointers and `nint`/`nuint` at
8 bytes, both `stackalloc T[n]` and `stackalloc[] { ... }`, and omitted lengths with an
initializer.

### TOUKI0021 - File name should match the type it declares

Maintainability, Warning. The companion to TOUKI0020: once each file holds one type, the
file name should say which one.

```
Foo.cs            // class Foo
Foo.Windows.cs    // class Foo, platform detail
Foo-Windows.cs    // same, different separator
Foo.Bar.cs        // class Bar nested in Foo
Bar.cs            // also fine for that nested Bar
FooWindows.cs     // TOUKI0021 - no separator, so this is a different name
```

```ini
dotnet_code_quality.TOUKI0021.file_name_detail_separators = .-
```

Comparison is ordinal, so `foo.cs` is reported for type `Foo` even on a case-insensitive
file system. Files declaring no types are not reported.

### Supporting changes

- **`docs/analyzers.md`** - reference for all nine rules: what each flags, why, examples,
  and configuration. Surfaced from the README with a feature bullet, an overview link, and
  a dedicated section, since the analyzers ship inside the package and were not previously
  discoverable.
- **`AnalyzerReleases.Shipped.md`** - had been left empty while seven rules shipped. Now
  records Release 0.4.0 (TOUKI0001-0004, 0010) and Release 0.5.0 (TOUKI0020, 0030).
  Release headings must parse as a numeric version, so the exact `0.4.0-alpha.1` prerelease
  is noted in a comment.
- **`helpLinkUri`** - every rule pointed at the repo root. Now derived from the diagnostic
  id via `HelpLinks.ForRule`, so the IDE's "learn more" lands on the rule's own section and
  cannot drift if a rule is renumbered.
- **Test harness** - gained optional `.editorconfig` values and a file name, both needed by
  the first configurable rules, plus `allowUnsafe` for pointer-element snippets.

## Validation

- 28 new tests; 162 total in the analyzer suite, all passing.
- `dotnet build touki.slnx -c Release` clean at 0 warnings / 0 errors across net472,
  net10.0, and net11.0.
- **Dogfood survey: zero violations for both new rules** across the whole library. Both
  legs were surveyed - `-f net10.0` excludes `touki/Framework/**`, so a net10-only survey
  would have been a false all-clear for the 83 net472-only polyfill files. Neither rule
  needed a polyfill `.editorconfig` exclusion.
- Each rule was verified end-to-end with a throwaway probe rather than trusting the
  in-memory harness: a deliberate violation produced the expected build error, and for
  TOUKI0011 an `.editorconfig` override was confirmed to silence it. Probes reverted.

## Notes for review

- The dotted-path candidates in TOUKI0021 look redundant while `.` is an approved
  separator, because `Foo` alone already matches `Foo.Bar.cs`. They only become
  load-bearing when `.` is removed from the separator set, which a differential test pair
  pins so the branch is not "simplified" away later.
- The first commit is unrelated release aftercare from 0.5.0 - the sample's package pin was
  two releases stale, and the TestSupport README was missing `net11.0`.
- Now that TOUKI0001-0030 are recorded as shipped, changing their id, category, or severity
  requires a `### Changed Rules` entry.
