### PR TITLE
Add TOUKI0040 thread-static naming analyzer and IDE1006 suppressor

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -315,8 +315,8 @@ dotnet_diagnostic.TOUKISUPPRESS0001.severity = none
 
 ## Release history
 
-| Release | Rules added |
-|---------|-------------|
+| Release | Rules and suppressions added |
+|---------|------------------------------|
 | 0.4.0 | TOUKI0001, TOUKI0002, TOUKI0003, TOUKI0004, TOUKI0010 |
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | unreleased | TOUKI0011, TOUKI0021, TOUKI0040, TOUKISUPPRESS0001 |

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -7,7 +7,8 @@ and in the IDE.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
-they get large, and keep types easy to find by file name.
+they get large, keep types easy to find by file name, and name a field for what it
+actually is.
 
 ## Rules
 
@@ -22,6 +23,7 @@ they get large, and keep types easy to find by file name.
 | [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | - | - |
 | [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
+| [TOUKI0040](#touki0040) | Thread-static field should carry the thread-static prefix | Naming | Warning | Yes | `[ThreadStatic]` |
 
 Rules that list a requirement only fire on code that opts in by applying the named
 attribute. The rest apply to any C# the compiler hands them.
@@ -188,6 +190,52 @@ captured by a lambda, put in an array, assigned to a wider local, or used in an 
 method or iterator. A warning you cannot act on is worse than no warning, so anything the
 rule cannot prove is safe to convert is left alone.
 
+## TOUKI0040
+
+**Thread-static field should carry the thread-static prefix.** A `[ThreadStatic]` field
+holds one value per thread rather than one per process, so code that reads it on a thread
+that never wrote it sees a different slot. That belongs in the name, where every use site
+can see it, not only at the declaration where the attribute sits.
+
+```csharp
+[ThreadStatic]
+private static Value[]? t_values;   // fine
+
+[ThreadStatic]
+private static Value[]? s_values;   // TOUKI0040 - should be named 't_values'
+```
+
+The message names the field it wants, so the fix is a rename. The suggested name replaces
+a leading `_`, `s_`, or thread-static prefix and camel cases what is left; an underscore
+the rule does not recognize is kept, so `x_ray` becomes `t_x_ray` rather than `t_ray`.
+
+The rule only looks at non-constant static fields. `[ThreadStatic]` on an instance field
+does nothing - CA2259 reports that - and such a field is still named `_value`.
+
+Configure the prefix:
+
+```ini
+dotnet_code_quality.TOUKI0040.thread_static_prefix = t_
+```
+
+And, if your codebase marks per-thread state with its own attribute, name it. The list is
+comma-separated and each entry may be written with or without the `Attribute` suffix; the
+namespace is not considered:
+
+```ini
+dotnet_code_quality.TOUKI0040.additional_thread_static_attributes = MyThreadLocal
+```
+
+### Why this is not a built-in naming rule
+
+`.editorconfig` naming rules match a symbol group by kind, accessibility, and modifier.
+`[ThreadStatic]` is an attribute, not a modifier, so no symbol group can select thread
+statics - they fall into whatever rule covers ordinary statics, and IDE1006 asks for that
+rule's prefix instead. The gap is tracked by
+[dotnet/roslyn#32955](https://github.com/dotnet/roslyn/issues/32955), open since 2019.
+TOUKI0040 fills it, and the TOUKISUPPRESS0001 suppression below keeps IDE1006 from
+disagreeing.
+
 ---
 
 ## Configuring severity
@@ -226,13 +274,52 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 - `[MustDispose]` - the type owns a resource that must be released on every path. Drives
   TOUKI0010.
 
+## Suppressions
+
+A suppression is not a rule. It removes a report another analyzer produced, and it has its
+own id so it can be traced and turned off.
+
+| ID | Suppresses | When |
+|----|------------|------|
+| TOUKISUPPRESS0001 | IDE1006 | A thread-static field already named the way TOUKI0040 wants |
+
+**Ids are `TOUKISUPPRESS####`, numbered from 0001 independently of the rules.** A suppression
+id is not a rule id, but the two share a namespace - an end user turns either off with the
+same `dotnet_diagnostic` key or `NoWarn` entry - so the `SUPPRESS` infix keeps a suppression
+out of reach of any future `TOUKI####` rule. This is the shape dotnet/runtime uses for
+`SYSLIBSUPPRESS0001`. An id names the *reason*, so one id may cover several suppressed rules.
+
+It is tracked in
+[AnalyzerReleases.Unshipped.md](../touki.analyzers/AnalyzerReleases.Unshipped.md) as a
+`Suppression`-category row, commented out. A suppression id is not a supported diagnostic
+of any analyzer, so a live row fails the build with RS2002 and a `### Suppressions` heading
+fails with RS2007. The row is maintained by hand.
+
+**TOUKISUPPRESS0001** exists because a thread-static field matches the built-in naming rule
+for ordinary statics, so without it every `t_` field draws "Missing prefix: 's_'". This is
+what the hand-written `#pragma warning disable IDE1006` and `[SuppressMessage]` entries
+around thread statics were for; the suppression replaces them.
+
+Only a conforming field is suppressed. A misnamed thread static keeps its IDE1006 report
+alongside TOUKI0040, so turning TOUKI0040 off cannot leave thread statics with no naming
+enforcement at all.
+
+This works even where IDE1006 is raised to `error`, because a diagnostic is suppressible
+when its *default* severity is below error - which IDE1006's is - not its configured one.
+
+Turn the suppression off to get the unsuppressed reports back:
+
+```ini
+dotnet_diagnostic.TOUKISUPPRESS0001.severity = none
+```
+
 ## Release history
 
 | Release | Rules added |
 |---------|-------------|
 | 0.4.0 | TOUKI0001, TOUKI0002, TOUKI0003, TOUKI0004, TOUKI0010 |
 | 0.5.0 | TOUKI0020, TOUKI0030 |
-| unreleased | TOUKI0011, TOUKI0021 |
+| unreleased | TOUKI0011, TOUKI0021, TOUKI0040, TOUKISUPPRESS0001 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/touki.analyzers.tests/.editorconfig
+++ b/touki.analyzers.tests/.editorconfig
@@ -6,3 +6,19 @@ dotnet_diagnostic.CS1591.severity = none
 
 # CA1852: Seal internal types
 dotnet_diagnostic.CA1852.severity = none
+
+# The analyzer authoring rules describe an assembly that ships as an analyzer. This project only hosts test
+# doubles (NamingRuleStubAnalyzer) that are handed to CompilationWithAnalyzers directly, so the packaging and
+# release-tracking requirements do not apply. The real analyzer project, touki.analyzers, keeps them all on.
+
+# RS1036: Specify EnforceExtendedAnalyzerRules
+dotnet_diagnostic.RS1036.severity = none
+
+# RS1038: Compiler extension should not reference Microsoft.CodeAnalysis.Workspaces
+dotnet_diagnostic.RS1038.severity = none
+
+# RS1041: Compiler extension should not target a specific .NET version
+dotnet_diagnostic.RS1041.severity = none
+
+# RS2008: Enable analyzer release tracking
+dotnet_diagnostic.RS2008.severity = none

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -32,23 +32,74 @@ internal static class AnalyzerTestHarness
         IReadOnlyDictionary<string, string>? options = null,
         string? fileName = null)
     {
+        CSharpCompilation compilation = CreateCompilation(source, fileName);
+
+        CompilationWithAnalyzers compilationWithAnalyzers =
+            compilation.WithAnalyzers([analyzer], CreateAnalyzerOptions(options));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  Runs <paramref name="analyzer"/> and <paramref name="suppressor"/> together against
+    ///  <paramref name="source"/> and returns the diagnostics, including suppressed ones.
+    /// </summary>
+    /// <param name="severity">
+    ///  Optional effective severity to configure for <paramref name="suppressedDiagnosticId"/>, standing in
+    ///  for a <c>dotnet_diagnostic.&lt;id&gt;.severity</c> entry.
+    /// </param>
+    /// <remarks>
+    ///  <para>
+    ///   Suppressed diagnostics are reported rather than dropped, so a test can tell the difference between
+    ///   a diagnostic that was suppressed and one that was never produced.
+    ///  </para>
+    /// </remarks>
+    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithSuppressorAsync(
+        DiagnosticAnalyzer analyzer,
+        DiagnosticSuppressor suppressor,
+        string source,
+        IReadOnlyDictionary<string, string>? options = null,
+        string? suppressedDiagnosticId = null,
+        ReportDiagnostic? severity = null)
+    {
+        CSharpCompilation compilation = CreateCompilation(source, fileName: null);
+
+        if (severity is { } reportDiagnostic && suppressedDiagnosticId is not null)
+        {
+            compilation = compilation.WithOptions(
+                compilation.Options.WithSpecificDiagnosticOptions(
+                    ImmutableDictionary<string, ReportDiagnostic>.Empty.Add(suppressedDiagnosticId, reportDiagnostic)));
+        }
+
+        CompilationWithAnalyzersOptions analysisOptions = new(
+            options: CreateAnalyzerOptions(options),
+            onAnalyzerException: null,
+            concurrentAnalysis: false,
+            logAnalyzerExecutionTime: false,
+            reportSuppressedDiagnostics: true);
+
+        CompilationWithAnalyzers compilationWithAnalyzers =
+            compilation.WithAnalyzers([analyzer, suppressor], analysisOptions);
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+    }
+
+    private static CSharpCompilation CreateCompilation(string source, string? fileName)
+    {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, path: fileName ?? string.Empty);
 
-        CSharpCompilation compilation = CSharpCompilation.Create(
+        return CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
             syntaxTrees: [syntaxTree],
             references: s_references.Value,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+    }
 
-        AnalyzerOptions analyzerOptions = new(
+    private static AnalyzerOptions CreateAnalyzerOptions(IReadOnlyDictionary<string, string>? options) =>
+        new(
             additionalFiles: [],
             optionsProvider: new TestAnalyzerConfigOptionsProvider(
                 options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
-
-        CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
-
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
-    }
 
     private static ImmutableArray<MetadataReference> CreateReferences()
     {

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -51,16 +51,18 @@ internal static class AnalyzerTestHarness
     /// <remarks>
     ///  <para>
     ///   Suppressed diagnostics are reported rather than dropped, so a test can tell the difference between
-    ///   a diagnostic that was suppressed and one that was never produced.
+    ///   a diagnostic that was suppressed and one that was never produced. The compilation is returned as
+    ///   well because <see cref="Diagnostic.GetSuppressionInfo"/> needs it to reach the suppression id.
     ///  </para>
     /// </remarks>
-    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithSuppressorAsync(
-        DiagnosticAnalyzer analyzer,
-        DiagnosticSuppressor suppressor,
-        string source,
-        IReadOnlyDictionary<string, string>? options = null,
-        string? suppressedDiagnosticId = null,
-        ReportDiagnostic? severity = null)
+    public static async Task<(ImmutableArray<Diagnostic> Diagnostics, Compilation Compilation)>
+        GetDiagnosticsWithSuppressorAsync(
+            DiagnosticAnalyzer analyzer,
+            DiagnosticSuppressor suppressor,
+            string source,
+            IReadOnlyDictionary<string, string>? options = null,
+            string? suppressedDiagnosticId = null,
+            ReportDiagnostic? severity = null)
     {
         CSharpCompilation compilation = CreateCompilation(source, fileName: null);
 
@@ -81,7 +83,10 @@ internal static class AnalyzerTestHarness
         CompilationWithAnalyzers compilationWithAnalyzers =
             compilation.WithAnalyzers([analyzer, suppressor], analysisOptions);
 
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+        ImmutableArray<Diagnostic> diagnostics =
+            await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+
+        return (diagnostics, compilation);
     }
 
     private static CSharpCompilation CreateCompilation(string source, string? fileName)

--- a/touki.analyzers.tests/NamingRuleStubAnalyzer.cs
+++ b/touki.analyzers.tests/NamingRuleStubAnalyzer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Stands in for the built-in naming rule by reporting <c>IDE1006</c> on every field, at the same location
+///  the real rule uses: the field's identifier.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The real rule lives in the IDE code-style analyzers, which this project does not reference. What
+///   <see cref="ThreadStaticNamingSuppressor"/> needs from it is only the id and the location, both of which
+///   this reproduces. The default severity is deliberately below <see cref="DiagnosticSeverity.Error"/>,
+///   matching the real rule, because that is what makes a diagnostic suppressible at all.
+///  </para>
+///  <para>
+///   The analyzer authoring rules that describe a shippable analyzer assembly (RS1036, RS1038, RS1041,
+///   RS2008) are turned off for this project in its <c>.editorconfig</c>. This stub is handed to
+///   <c>CompilationWithAnalyzers</c> directly and never packaged.
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+internal sealed class NamingRuleStubAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = ThreadStaticNamingSuppressor.SuppressedDiagnosticId;
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Naming rule violation",
+        messageFormat: "Naming rule violation: {0}",
+        category: "Style",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true);
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [s_rule];
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxNodeAction(AnalyzeDeclarator, SyntaxKind.VariableDeclarator);
+    }
+
+    private static void AnalyzeDeclarator(SyntaxNodeAnalysisContext context)
+    {
+        VariableDeclaratorSyntax declarator = (VariableDeclaratorSyntax)context.Node;
+
+        if (declarator.Parent?.Parent is not FieldDeclarationSyntax)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(s_rule, declarator.Identifier.GetLocation(), declarator.Identifier.ValueText));
+    }
+}

--- a/touki.analyzers.tests/ThreadStaticNamingAnalyzerTests.cs
+++ b/touki.analyzers.tests/ThreadStaticNamingAnalyzerTests.cs
@@ -1,0 +1,384 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class ThreadStaticNamingAnalyzerTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source,
+        string? prefix = null,
+        string? additionalAttributes = null)
+    {
+        Dictionary<string, string> options = new();
+
+        if (prefix is not null)
+        {
+            options[ThreadStaticNamingAnalyzer.PrefixOption] = prefix;
+        }
+
+        if (additionalAttributes is not null)
+        {
+            options[ThreadStaticNamingAnalyzer.AdditionalAttributesOption] = additionalAttributes;
+        }
+
+        return await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new ThreadStaticNamingAnalyzer(),
+            source,
+            options.Count == 0 ? null : options).ConfigureAwait(false);
+    }
+
+    private const string Usings = """
+        using System;
+
+        """;
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticWithPrefix_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticWithStaticPrefix_ReportsDiagnostic()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(ThreadStaticNamingAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticWithStaticPrefix_SuggestsThreadStaticName()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'s_value'").And.Contain("'t_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticWithInstancePrefix_SuggestsThreadStaticName()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int _value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticPascalCased_SuggestsCamelCasedName()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int Value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticPascalCasedAfterPrefix_ReportsDiagnostic()
+    {
+        // The prefix alone is not enough; 't_Value' is still not the camel-cased name.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_Value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticUnderscoreOnly_ReportsDiagnostic()
+    {
+        // A name that is nothing but the prefix has no core to camel case.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(ThreadStaticNamingAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticWithUnrelatedUnderscoreName_KeepsBothParts()
+    {
+        // 'x_' is not a prefix this rule knows, so it is part of the name rather than something to replace.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int x_ray;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_x_ray'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_OrdinaryStaticField_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticOnInstanceField_ReportsNothing()
+    {
+        // The attribute does nothing on an instance field, which CA2259 reports. It is still named '_value'.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private int _value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_UnrelatedAttribute_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [Obsolete]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_MultipleDeclarators_ReportsEachSeparately()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_first, s_second;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ConfiguredPrefix_RequiresConfiguredPrefix()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, prefix: "tl_").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'tl_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ConfiguredPrefixMatched_ReportsNothing()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int tl_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, prefix: "tl_").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_EmptyConfiguredPrefix_FallsBackToDefault()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, prefix: "  ").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'");
+    }
+
+    private const string CustomAttribute = """
+        class MyThreadLocalAttribute : Attribute
+        {
+        }
+
+        """;
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributeConfigured_ReportsDiagnostic()
+    {
+        string source = Usings + CustomAttribute + """
+            class Sample
+            {
+                [MyThreadLocal]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, additionalAttributes: "MyThreadLocal").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributeWithSuffix_ReportsDiagnostic()
+    {
+        string source = Usings + CustomAttribute + """
+            class Sample
+            {
+                [MyThreadLocal]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, additionalAttributes: "Other, MyThreadLocalAttribute").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(ThreadStaticNamingAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributeNotConfigured_ReportsNothing()
+    {
+        string source = Usings + CustomAttribute + """
+            class Sample
+            {
+                [MyThreadLocal]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticConst_ReportsNothing()
+    {
+        // A constant has no per-thread slot, and constants are Pascal cased.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private const int Value = 1;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_GeneratedCode_ReportsNothing()
+    {
+        string source = """
+            // <auto-generated/>
+            using System;
+
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/ThreadStaticNamingAnalyzerTests.cs
+++ b/touki.analyzers.tests/ThreadStaticNamingAnalyzerTests.cs
@@ -328,6 +328,87 @@ public class ThreadStaticNamingAnalyzerTests
         diagnostics.Should().BeEmpty();
     }
 
+    private const string SuffixlessAttribute = """
+        class ThreadBound : Attribute
+        {
+        }
+
+        """;
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributeConfiguredWithSuffixTypeWithout_ReportsDiagnostic()
+    {
+        // An attribute class does not have to carry the 'Attribute' suffix, so the suffix has to be
+        // optional on the configured side too.
+        string source = Usings + SuffixlessAttribute + """
+            class Sample
+            {
+                [ThreadBound]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, additionalAttributes: "ThreadBoundAttribute").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributeSuffixOnNeitherSide_ReportsDiagnostic()
+    {
+        string source = Usings + SuffixlessAttribute + """
+            class Sample
+            {
+                [ThreadBound]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, additionalAttributes: "ThreadBound").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(ThreadStaticNamingAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributeDifferentName_ReportsNothing()
+    {
+        // Comparing on the suffix-stripped core must not make unrelated names match.
+        string source = Usings + CustomAttribute + """
+            class Sample
+            {
+                [MyThreadLocal]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, additionalAttributes: "OtherAttribute, Third").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_AdditionalAttributesTrailingComma_ReportsDiagnostic()
+    {
+        string source = Usings + CustomAttribute + """
+            class Sample
+            {
+                [MyThreadLocal]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, additionalAttributes: "MyThreadLocal,").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(ThreadStaticNamingAnalyzer.DiagnosticId);
+    }
+
     [TestMethod]
     public async Task AnalyzeField_ThreadStaticConst_ReportsNothing()
     {

--- a/touki.analyzers.tests/ThreadStaticNamingAnalyzerTests.cs
+++ b/touki.analyzers.tests/ThreadStaticNamingAnalyzerTests.cs
@@ -138,24 +138,6 @@ public class ThreadStaticNamingAnalyzerTests
     }
 
     [TestMethod]
-    public async Task AnalyzeField_ThreadStaticUnderscoreOnly_ReportsDiagnostic()
-    {
-        // A name that is nothing but the prefix has no core to camel case.
-        string source = Usings + """
-            class Sample
-            {
-                [ThreadStatic]
-                private static int t_;
-            }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
-
-        diagnostics.Should().ContainSingle()
-            .Which.Id.Should().Be(ThreadStaticNamingAnalyzer.DiagnosticId);
-    }
-
-    [TestMethod]
     public async Task AnalyzeField_ThreadStaticWithUnrelatedUnderscoreName_KeepsBothParts()
     {
         // 'x_' is not a prefix this rule knows, so it is part of the name rather than something to replace.
@@ -361,6 +343,61 @@ public class ThreadStaticNamingAnalyzerTests
         ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
 
         diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticUnderscoreOnly_SuggestsAConformingName()
+    {
+        // A name that is nothing but the prefix has no core to camel case, so the suggestion falls back to
+        // a placeholder rather than doubling the prefix.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value'").And.NotContain("'t_t_'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_ThreadStaticDigitAfterPrefix_DoesNotSuggestTheSameName()
+    {
+        // 't_1' is not conforming, so it is reported - but the suggestion must not be 't_1' again.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_1;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value1'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeField_StaticDigitName_DoesNotSuggestANameItWouldReport()
+    {
+        // Stripping 's_' leaves '1', which would produce 't_1' - a name this same rule reports.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_1;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("'t_value1'");
     }
 
     [TestMethod]

--- a/touki.analyzers.tests/ThreadStaticNamingSuppressorTests.cs
+++ b/touki.analyzers.tests/ThreadStaticNamingSuppressorTests.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Microsoft.CodeAnalysis.Diagnostics;
+
 namespace Touki.Analyzers;
 
 [TestClass]
@@ -10,7 +12,14 @@ public class ThreadStaticNamingSuppressorTests
     private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
         string source,
         string? prefix = null,
-        ReportDiagnostic? severity = null)
+        ReportDiagnostic? severity = null) =>
+        (await AnalyzeWithCompilationAsync(source, prefix, severity).ConfigureAwait(false)).Diagnostics;
+
+    private static async Task<(ImmutableArray<Diagnostic> Diagnostics, Compilation Compilation)>
+        AnalyzeWithCompilationAsync(
+            string source,
+            string? prefix = null,
+            ReportDiagnostic? severity = null)
     {
         Dictionary<string, string> options = new();
 
@@ -61,11 +70,15 @@ public class ThreadStaticNamingSuppressorTests
             }
             """;
 
-        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+        (ImmutableArray<Diagnostic> diagnostics, Compilation compilation) =
+            await AnalyzeWithCompilationAsync(source).ConfigureAwait(false);
 
         Diagnostic diagnostic = diagnostics.Should().ContainSingle().Subject;
+        SuppressionInfo? suppressionInfo = diagnostic.GetSuppressionInfo(compilation);
 
-        diagnostic.Descriptor.Id.Should().Be(ThreadStaticNamingSuppressor.SuppressedDiagnosticId);
+        suppressionInfo.Should().NotBeNull();
+        suppressionInfo!.ProgrammaticSuppressions.Should().ContainSingle()
+            .Which.Descriptor.Id.Should().Be(ThreadStaticNamingSuppressor.SuppressionId);
     }
 
     [TestMethod]

--- a/touki.analyzers.tests/ThreadStaticNamingSuppressorTests.cs
+++ b/touki.analyzers.tests/ThreadStaticNamingSuppressorTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class ThreadStaticNamingSuppressorTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source,
+        string? prefix = null,
+        ReportDiagnostic? severity = null)
+    {
+        Dictionary<string, string> options = new();
+
+        if (prefix is not null)
+        {
+            options[ThreadStaticNamingAnalyzer.PrefixOption] = prefix;
+        }
+
+        return await AnalyzerTestHarness.GetDiagnosticsWithSuppressorAsync(
+            new NamingRuleStubAnalyzer(),
+            new ThreadStaticNamingSuppressor(),
+            source,
+            options.Count == 0 ? null : options,
+            suppressedDiagnosticId: NamingRuleStubAnalyzer.DiagnosticId,
+            severity).ConfigureAwait(false);
+    }
+
+    private const string Usings = """
+        using System;
+
+        """;
+
+    [TestMethod]
+    public async Task ReportSuppressions_ConformingThreadStaticField_SuppressesNamingDiagnostic()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.IsSuppressed.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_ConformingThreadStaticField_RecordsSuppressionId()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Should().ContainSingle().Subject;
+
+        diagnostic.Descriptor.Id.Should().Be(ThreadStaticNamingSuppressor.SuppressedDiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_MisnamedThreadStaticField_LeavesDiagnostic()
+    {
+        // TOUKI0040 owns the message for this field, but the built-in report is left in place so that
+        // turning TOUKI0040 off cannot leave a thread-static field unchecked.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int s_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.IsSuppressed.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_OrdinaryStaticField_LeavesDiagnostic()
+    {
+        // A 't_' name without the attribute is not a thread static and gets no help here.
+        string source = Usings + """
+            class Sample
+            {
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.IsSuppressed.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_ThreadStaticOnInstanceField_LeavesDiagnostic()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.IsSuppressed.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_ConfiguredAsError_StillSuppresses()
+    {
+        // A diagnostic is suppressible when its *default* severity is below error, which is what lets this
+        // work in a repository that raises IDE1006 to 'error' in .editorconfig.
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, severity: ReportDiagnostic.Error).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Should().ContainSingle().Subject;
+
+        diagnostic.Severity.Should().Be(DiagnosticSeverity.Error);
+        diagnostic.IsSuppressed.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_ConfiguredPrefix_SuppressesConfiguredName()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int tl_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, prefix: "tl_").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.IsSuppressed.Should().BeTrue();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_ConfiguredPrefix_LeavesDefaultPrefixDiagnostic()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, prefix: "tl_").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.IsSuppressed.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ReportSuppressions_MixedFields_SuppressesOnlyThreadStatics()
+    {
+        string source = Usings + """
+            class Sample
+            {
+                [ThreadStatic]
+                private static int t_value;
+
+                private static int s_value;
+
+                private int _value;
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(3);
+        diagnostics.Where(diagnostic => diagnostic.IsSuppressed).Should().ContainSingle();
+    }
+}

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -1,8 +1,20 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+;
+; Suppressions are listed in the same shape as a rule, under a 'Suppression' category, but
+; commented out so the release tracking parser skips them. They cannot be tracked for real:
+; a '### Suppressions' heading fails with RS2007, and putting a suppression id in the table
+; below fails with RS2002, because a DiagnosticSuppressor declares SupportedSuppressions
+; rather than SupportedDiagnostics and so is not a supported diagnostic of any analyzer.
+; Maintain these rows by hand, and move them with the release when one is cut.
+;
+; Rule ID | Category | Severity | Notes
+; --------|----------|----------|-------
+; TOUKISUPPRESS0001 | Suppression | Info | Suppresses IDE1006 for a thread-static field named as TOUKI0040 requires
 
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TOUKI0011 | Reliability | Warning | stackalloc larger than the configured maximum byte size
 TOUKI0021 | Maintainability | Warning | File name does not match a type declared in the file
+TOUKI0040 | Naming | Warning | Thread-static field does not carry the thread-static prefix

--- a/touki.analyzers/ThreadStaticNaming.cs
+++ b/touki.analyzers/ThreadStaticNaming.cs
@@ -23,6 +23,10 @@ internal static class ThreadStaticNaming
 
     private const string AttributeSuffix = "Attribute";
 
+    // Stands in for a name part that cannot be derived, so a suggestion is always a name the rule accepts
+    // rather than one it would report again.
+    private const string PlaceholderCore = "value";
+
     /// <summary>
     ///  Returns the configured thread-static prefix, or <see cref="ThreadStaticNamingAnalyzer.DefaultPrefix"/>
     ///  when none is set.
@@ -117,14 +121,29 @@ internal static class ThreadStaticNaming
     ///  Returns what <paramref name="name"/> should be called: <paramref name="prefix"/> followed by the
     ///  name with any instance, static, or thread-static prefix it already carries replaced.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The result always satisfies <see cref="IsConforming"/>, because the diagnostic message names it as
+    ///   the thing to rename to. A name with nothing to camel case - one that is only a prefix, or that
+    ///   continues with a digit or an underscore - would otherwise be handed back unchanged or turned into
+    ///   another name this rule reports, so those fall back to a placeholder the rule accepts.
+    ///  </para>
+    /// </remarks>
     internal static string SuggestedName(string name, string prefix)
     {
         string core = StripLeadingPrefix(name, prefix);
 
-        // A name that is nothing but a prefix leaves nothing to build on.
-        return core.Length == 0
-            ? prefix + name
-            : prefix + char.ToLowerInvariant(core[0]) + core.Substring(1);
+        if (core.Length > 0)
+        {
+            string suggested = prefix + char.ToLowerInvariant(core[0]) + core.Substring(1);
+
+            if (IsConforming(suggested, prefix))
+            {
+                return suggested;
+            }
+        }
+
+        return prefix + PlaceholderCore + core;
     }
 
     /// <summary>
@@ -171,31 +190,70 @@ internal static class ThreadStaticNaming
     ///  Returns <see langword="true"/> if <paramref name="attributeTypeName"/> is one of the comma-separated
     ///  names in <paramref name="configured"/>, written with or without the <c>Attribute</c> suffix.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The list is walked in place rather than split, because this runs for every attribute on every
+    ///   candidate field once the option is configured, and splitting there would allocate an array and a
+    ///   string per entry each time.
+    ///  </para>
+    /// </remarks>
     private static bool MatchesByName(string attributeTypeName, string configured)
     {
-        foreach (string candidate in configured.Split(','))
+        int start = 0;
+
+        while (start <= configured.Length)
         {
-            string trimmed = candidate.Trim();
+            int end = configured.IndexOf(',', start);
 
-            if (trimmed.Length == 0)
+            if (end < 0)
             {
-                continue;
+                end = configured.Length;
             }
 
-            if (string.Equals(attributeTypeName, trimmed, StringComparison.Ordinal))
-            {
-                return true;
-            }
-
-            // Allow the attribute to be named the way it is written in source, without the suffix.
-            if (attributeTypeName.Length == trimmed.Length + AttributeSuffix.Length
-                && attributeTypeName.StartsWith(trimmed, StringComparison.Ordinal)
-                && attributeTypeName.EndsWith(AttributeSuffix, StringComparison.Ordinal))
+            if (MatchesEntry(attributeTypeName, configured, start, end))
             {
                 return true;
             }
+
+            start = end + 1;
         }
 
         return false;
+    }
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="attributeTypeName"/> is the entry of
+    ///  <paramref name="configured"/> between <paramref name="start"/> and <paramref name="end"/>, ignoring
+    ///  surrounding whitespace and an optional <c>Attribute</c> suffix on the type name.
+    /// </summary>
+    private static bool MatchesEntry(string attributeTypeName, string configured, int start, int end)
+    {
+        while (start < end && char.IsWhiteSpace(configured[start]))
+        {
+            start++;
+        }
+
+        while (end > start && char.IsWhiteSpace(configured[end - 1]))
+        {
+            end--;
+        }
+
+        int length = end - start;
+
+        if (length == 0)
+        {
+            return false;
+        }
+
+        // The type name is either the entry exactly, or the entry plus the suffix that the declaration
+        // carries and the use site does not.
+        if (attributeTypeName.Length != length
+            && (attributeTypeName.Length != length + AttributeSuffix.Length
+                || !attributeTypeName.EndsWith(AttributeSuffix, StringComparison.Ordinal)))
+        {
+            return false;
+        }
+
+        return string.CompareOrdinal(attributeTypeName, 0, configured, start, length) == 0;
     }
 }

--- a/touki.analyzers/ThreadStaticNaming.cs
+++ b/touki.analyzers/ThreadStaticNaming.cs
@@ -1,0 +1,201 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Shared thread-static naming decisions, so that <see cref="ThreadStaticNamingAnalyzer"/> and
+///  <see cref="ThreadStaticNamingSuppressor"/> cannot drift apart. Whatever the analyzer accepts is
+///  exactly what the suppressor stays silent about.
+/// </summary>
+internal static class ThreadStaticNaming
+{
+    /// <summary>
+    ///  Metadata name of the attribute that gives a static field one slot per thread.
+    /// </summary>
+    internal const string ThreadStaticAttributeMetadataName = "System.ThreadStaticAttribute";
+
+    private const string AttributeSuffix = "Attribute";
+
+    /// <summary>
+    ///  Returns the configured thread-static prefix, or <see cref="ThreadStaticNamingAnalyzer.DefaultPrefix"/>
+    ///  when none is set.
+    /// </summary>
+    internal static string GetPrefix(AnalyzerConfigOptions options)
+    {
+        if (options.TryGetValue(ThreadStaticNamingAnalyzer.PrefixOption, out string? value))
+        {
+            string prefix = value.Trim();
+
+            // An empty value is far more likely to be a mistake than a deliberate "require no prefix".
+            if (prefix.Length > 0)
+            {
+                return prefix;
+            }
+        }
+
+        return ThreadStaticNamingAnalyzer.DefaultPrefix;
+    }
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="field"/> is shaped like a thread-static field:
+    ///  a non-constant static that carries at least one attribute.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   This is the filter that keeps the rule cheap. It is what every field in a compilation is measured
+    ///   against, and it runs before any <c>.editorconfig</c> lookup.
+    ///  </para>
+    /// </remarks>
+    internal static bool CouldBeThreadStatic(IFieldSymbol field) =>
+        field.IsStatic && !field.IsConst && !field.GetAttributes().IsEmpty;
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="field"/> gets one slot per thread.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Only a <see langword="static"/> field has a per-thread slot to name. The attribute has no effect on
+    ///   an instance field, which CA2259 already reports, and such a field is still named as an ordinary
+    ///   instance field.
+    ///  </para>
+    /// </remarks>
+    internal static bool IsThreadStatic(
+        IFieldSymbol field,
+        INamedTypeSymbol? threadStaticAttribute,
+        AnalyzerConfigOptions options)
+    {
+        if (!CouldBeThreadStatic(field))
+        {
+            return false;
+        }
+
+        ImmutableArray<AttributeData> attributes = field.GetAttributes();
+
+        foreach (AttributeData attribute in attributes)
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, threadStaticAttribute))
+            {
+                return true;
+            }
+        }
+
+        string additional = GetAdditionalAttributes(options);
+
+        if (additional.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (AttributeData attribute in attributes)
+        {
+            if (attribute.AttributeClass is { } attributeClass && MatchesByName(attributeClass.Name, additional))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="name"/> carries <paramref name="prefix"/> and is
+    ///  camel cased after it.
+    /// </summary>
+    internal static bool IsConforming(string name, string prefix) =>
+        name.Length > prefix.Length
+        && name.StartsWith(prefix, StringComparison.Ordinal)
+        && char.IsLower(name[prefix.Length]);
+
+    /// <summary>
+    ///  Returns what <paramref name="name"/> should be called: <paramref name="prefix"/> followed by the
+    ///  name with any instance, static, or thread-static prefix it already carries replaced.
+    /// </summary>
+    internal static string SuggestedName(string name, string prefix)
+    {
+        string core = StripLeadingPrefix(name, prefix);
+
+        // A name that is nothing but a prefix leaves nothing to build on.
+        return core.Length == 0
+            ? prefix + name
+            : prefix + char.ToLowerInvariant(core[0]) + core.Substring(1);
+    }
+
+    /// <summary>
+    ///  Removes a known field prefix from <paramref name="name"/>: the configured thread-static prefix, the
+    ///  default thread-static prefix, the <c>s_</c> static prefix, or the <c>_</c> instance prefix. Anything
+    ///  else is left alone rather than guessed at, so a name like <c>x_ray</c> keeps both of its parts.
+    /// </summary>
+    private static string StripLeadingPrefix(string name, string prefix)
+    {
+        if (name.StartsWith(prefix, StringComparison.Ordinal))
+        {
+            return name.Substring(prefix.Length);
+        }
+
+        // The default prefix is still a thread-static marker when a different one is configured, so a
+        // 't_value' renamed under 'tl_' becomes 'tl_value' rather than 'tl_t_value'.
+        if (name.StartsWith(ThreadStaticNamingAnalyzer.DefaultPrefix, StringComparison.Ordinal))
+        {
+            return name.Substring(ThreadStaticNamingAnalyzer.DefaultPrefix.Length);
+        }
+
+        if (name.StartsWith("s_", StringComparison.Ordinal))
+        {
+            return name.Substring(2);
+        }
+
+        if (name.StartsWith("_", StringComparison.Ordinal))
+        {
+            return name.Substring(1);
+        }
+
+        return name;
+    }
+
+    /// <summary>
+    ///  Returns the comma-separated attribute names configured as additionally marking a thread-static field.
+    /// </summary>
+    private static string GetAdditionalAttributes(AnalyzerConfigOptions options) =>
+        options.TryGetValue(ThreadStaticNamingAnalyzer.AdditionalAttributesOption, out string? value)
+            ? value.Trim()
+            : string.Empty;
+
+    /// <summary>
+    ///  Returns <see langword="true"/> if <paramref name="attributeTypeName"/> is one of the comma-separated
+    ///  names in <paramref name="configured"/>, written with or without the <c>Attribute</c> suffix.
+    /// </summary>
+    private static bool MatchesByName(string attributeTypeName, string configured)
+    {
+        foreach (string candidate in configured.Split(','))
+        {
+            string trimmed = candidate.Trim();
+
+            if (trimmed.Length == 0)
+            {
+                continue;
+            }
+
+            if (string.Equals(attributeTypeName, trimmed, StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // Allow the attribute to be named the way it is written in source, without the suffix.
+            if (attributeTypeName.Length == trimmed.Length + AttributeSuffix.Length
+                && attributeTypeName.StartsWith(trimmed, StringComparison.Ordinal)
+                && attributeTypeName.EndsWith(AttributeSuffix, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/touki.analyzers/ThreadStaticNaming.cs
+++ b/touki.analyzers/ThreadStaticNaming.cs
@@ -69,18 +69,28 @@ internal static class ThreadStaticNaming
     ///   an instance field, which CA2259 already reports, and such a field is still named as an ordinary
     ///   instance field.
     ///  </para>
+    ///  <para>
+    ///   This repeats the <see cref="CouldBeThreadStatic"/> checks rather than calling it, so that the
+    ///   attributes are fetched once. Callers that filter first, such as the analyzer, still pay a second
+    ///   fetch, but that one hits the symbol's sealed attribute bag rather than binding again.
+    ///  </para>
     /// </remarks>
     internal static bool IsThreadStatic(
         IFieldSymbol field,
         INamedTypeSymbol? threadStaticAttribute,
         AnalyzerConfigOptions options)
     {
-        if (!CouldBeThreadStatic(field))
+        if (!field.IsStatic || field.IsConst)
         {
             return false;
         }
 
         ImmutableArray<AttributeData> attributes = field.GetAttributes();
+
+        if (attributes.IsEmpty)
+        {
+            return false;
+        }
 
         foreach (AttributeData attribute in attributes)
         {

--- a/touki.analyzers/ThreadStaticNaming.cs
+++ b/touki.analyzers/ThreadStaticNaming.cs
@@ -201,7 +201,7 @@ internal static class ThreadStaticNaming
     {
         int start = 0;
 
-        while (start <= configured.Length)
+        while (start < configured.Length)
         {
             int end = configured.IndexOf(',', start);
 
@@ -224,8 +224,15 @@ internal static class ThreadStaticNaming
     /// <summary>
     ///  Returns <see langword="true"/> if <paramref name="attributeTypeName"/> is the entry of
     ///  <paramref name="configured"/> between <paramref name="start"/> and <paramref name="end"/>, ignoring
-    ///  surrounding whitespace and an optional <c>Attribute</c> suffix on the type name.
+    ///  surrounding whitespace and an <c>Attribute</c> suffix on either side.
     /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   The suffix is optional on both sides because an attribute class does not have to carry it - the
+    ///   compiler resolves <c>[Foo]</c> to either <c>Foo</c> or <c>FooAttribute</c> - so neither the entry
+    ///   nor the declaration can be assumed to be the spelling that has it.
+    ///  </para>
+    /// </remarks>
     private static bool MatchesEntry(string attributeTypeName, string configured, int start, int end)
     {
         while (start < end && char.IsWhiteSpace(configured[start]))
@@ -245,15 +252,28 @@ internal static class ThreadStaticNaming
             return false;
         }
 
-        // The type name is either the entry exactly, or the entry plus the suffix that the declaration
-        // carries and the use site does not.
-        if (attributeTypeName.Length != length
-            && (attributeTypeName.Length != length + AttributeSuffix.Length
-                || !attributeTypeName.EndsWith(AttributeSuffix, StringComparison.Ordinal)))
-        {
-            return false;
-        }
+        int nameLength = LengthWithoutAttributeSuffix(attributeTypeName, 0, attributeTypeName.Length);
+        int entryLength = LengthWithoutAttributeSuffix(configured, start, length);
 
-        return string.CompareOrdinal(attributeTypeName, 0, configured, start, length) == 0;
+        return nameLength == entryLength
+            && string.CompareOrdinal(attributeTypeName, 0, configured, start, nameLength) == 0;
     }
+
+    /// <summary>
+    ///  Returns the length of the <paramref name="length"/> characters of <paramref name="value"/> at
+    ///  <paramref name="start"/> with a trailing <c>Attribute</c> suffix removed, or
+    ///  <paramref name="length"/> when there is none.
+    /// </summary>
+    private static int LengthWithoutAttributeSuffix(string value, int start, int length) =>
+
+        // A type named exactly 'Attribute' keeps its name rather than becoming empty.
+        length > AttributeSuffix.Length
+        && string.CompareOrdinal(
+            value,
+            start + length - AttributeSuffix.Length,
+            AttributeSuffix,
+            0,
+            AttributeSuffix.Length) == 0
+            ? length - AttributeSuffix.Length
+            : length;
 }

--- a/touki.analyzers/ThreadStaticNamingAnalyzer.cs
+++ b/touki.analyzers/ThreadStaticNamingAnalyzer.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports a thread-static field whose name does not carry the thread-static prefix, which defaults to
+///  <see cref="DefaultPrefix"/>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   A <c>[ThreadStatic]</c> field holds one value per thread rather than one per process. Code that reads
+///   it on a thread that never wrote it sees a different slot, so the distinction belongs in the name where
+///   every use site can see it, not only at the declaration where the attribute sits.
+///  </para>
+///  <para>
+///   The built-in naming rules cannot express this. A symbol group is matched by kind, accessibility, and
+///   modifier, and <c>[ThreadStatic]</c> is an attribute rather than a modifier, so a thread-static field
+///   matches the ordinary <c>static</c> group and IDE1006 asks for the static prefix instead. That gap is
+///   tracked by dotnet/roslyn#32955. <see cref="ThreadStaticNamingSuppressor"/> silences IDE1006 for any
+///   field this rule accepts, so the two rules never ask for different names.
+///  </para>
+///  <para>
+///   The prefix is configured per path in <c>.editorconfig</c>:
+///   <code>dotnet_code_quality.TOUKI0040.thread_static_prefix = t_</code>
+///  </para>
+///  <para>
+///   Attributes beyond <c>System.ThreadStaticAttribute</c> can be treated as marking a field thread static,
+///   as a comma-separated list of type names written with or without the <c>Attribute</c> suffix. The
+///   namespace is not considered:
+///   <code>dotnet_code_quality.TOUKI0040.additional_thread_static_attributes = MyThreadLocal</code>
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ThreadStaticNamingAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0040";
+
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that overrides the prefix a thread-static field must carry.
+    /// </summary>
+    public const string PrefixOption = "dotnet_code_quality.TOUKI0040.thread_static_prefix";
+
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that names further attributes marking a field thread static, separated
+    ///  by commas.
+    /// </summary>
+    public const string AdditionalAttributesOption =
+        "dotnet_code_quality.TOUKI0040.additional_thread_static_attributes";
+
+    /// <summary>
+    ///  The prefix required when <see cref="PrefixOption"/> is not configured.
+    /// </summary>
+    public const string DefaultPrefix = "t_";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Thread-static field should carry the thread-static prefix",
+        messageFormat: "Thread-static field '{0}' should be named '{1}'",
+        category: "Naming",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "A thread-static field holds one value per thread, so its name should say so at every use site rather than only at the declaration. The built-in naming rules match on modifiers and cannot see the attribute.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    // Cache the supported-diagnostics array so the property does not allocate a new array on every access.
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static start =>
+        {
+            // Resolve the attribute once per compilation so each field is a symbol comparison rather than a
+            // string comparison, and so a compilation without the type does no work at all.
+            INamedTypeSymbol? threadStaticAttribute =
+                start.Compilation.GetTypeByMetadataName(ThreadStaticNaming.ThreadStaticAttributeMetadataName);
+
+            start.RegisterSymbolAction(
+                context => AnalyzeField(context, threadStaticAttribute),
+                SymbolKind.Field);
+        });
+    }
+
+    private static void AnalyzeField(SymbolAnalysisContext context, INamedTypeSymbol? threadStaticAttribute)
+    {
+        IFieldSymbol field = (IFieldSymbol)context.Symbol;
+
+        // A compiler-generated field, such as a property's backing field, is not the author's to name.
+        if (field.IsImplicitlyDeclared || field.Locations.Length == 0)
+        {
+            return;
+        }
+
+        // Filter on the symbol before reading configuration, so an ordinary field costs nothing.
+        if (!ThreadStaticNaming.CouldBeThreadStatic(field))
+        {
+            return;
+        }
+
+        Location location = field.Locations[0];
+
+        if (location.SourceTree is not { } tree)
+        {
+            return;
+        }
+
+        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(tree);
+
+        if (!ThreadStaticNaming.IsThreadStatic(field, threadStaticAttribute, options))
+        {
+            return;
+        }
+
+        string prefix = ThreadStaticNaming.GetPrefix(options);
+
+        if (ThreadStaticNaming.IsConforming(field.Name, prefix))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(
+            Diagnostic.Create(s_rule, location, field.Name, ThreadStaticNaming.SuggestedName(field.Name, prefix)));
+    }
+}

--- a/touki.analyzers/ThreadStaticNamingSuppressor.cs
+++ b/touki.analyzers/ThreadStaticNamingSuppressor.cs
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Suppresses the built-in naming rule (IDE1006) for a thread-static field that
+///  <see cref="ThreadStaticNamingAnalyzer"/> accepts.
+/// </summary>
+/// <remarks>
+///  <para>
+///   A naming symbol group is matched by kind, accessibility, and modifier, and <c>[ThreadStatic]</c> is an
+///   attribute rather than a modifier. A thread-static field therefore matches whatever rule covers ordinary
+///   statics and is reported for missing that rule's prefix. The gap is tracked by dotnet/roslyn#32955; until
+///   it closes, every thread-static field needs a hand-written suppression. This suppressor replaces those.
+///  </para>
+///  <para>
+///   Only a field that already carries the configured thread-static prefix is suppressed. A misnamed one keeps
+///   its IDE1006 report alongside <c>TOUKI0040</c>, so turning <c>TOUKI0040</c> off cannot leave thread-static
+///   fields with no naming enforcement at all.
+///  </para>
+///  <para>
+///   Suppression is possible here because a diagnostic is suppressible when its <em>default</em> severity is
+///   not <see cref="DiagnosticSeverity.Error"/>. IDE1006 defaults below error, so raising it to <c>error</c>
+///   in <c>.editorconfig</c> does not put it out of reach.
+///  </para>
+///  <para>
+///   The suppression itself can be turned off, which restores the unsuppressed IDE1006 reports:
+///   <code>dotnet_diagnostic.TOUKISUPPRESS0001.severity = none</code>
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ThreadStaticNamingSuppressor : DiagnosticSuppressor
+{
+    /// <summary>
+    ///  The identifier of the suppression this suppressor produces.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   A suppression id is not a rule id, but the two share a namespace: an end user turns either off with
+    ///   the same <c>dotnet_diagnostic</c> key or <c>NoWarn</c> entry. The <c>SUPPRESS</c> infix keeps this
+    ///   out of reach of any future <c>TOUKI####</c> rule, which is the shape dotnet/runtime uses for
+    ///   <c>SYSLIBSUPPRESS0001</c>. Number suppressions from 0001 independently of the rules.
+    ///  </para>
+    /// </remarks>
+    public const string SuppressionId = "TOUKISUPPRESS0001";
+
+    /// <summary>
+    ///  The identifier of the diagnostic that is suppressed.
+    /// </summary>
+    public const string SuppressedDiagnosticId = "IDE1006";
+
+    private static readonly SuppressionDescriptor s_rule = new(
+        id: SuppressionId,
+        suppressedDiagnosticId: SuppressedDiagnosticId,
+        justification: "Thread-static fields carry the thread-static prefix, which the built-in naming rules cannot express.");
+
+    // Cache the supported-suppressions array so the property does not allocate a new array on every access.
+    private static readonly ImmutableArray<SuppressionDescriptor> s_supportedSuppressions = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => s_supportedSuppressions;
+
+    /// <inheritdoc/>
+    public override void ReportSuppressions(SuppressionAnalysisContext context)
+    {
+        INamedTypeSymbol? threadStaticAttribute =
+            context.Compilation.GetTypeByMetadataName(ThreadStaticNaming.ThreadStaticAttributeMetadataName);
+
+        // A semantic model is only built for a field that already looks thread static, and only once per
+        // tree. Suppressors run concurrently with each other, but each runs on one thread, so a plain
+        // dictionary is enough.
+        Dictionary<SyntaxTree, SemanticModel>? semanticModels = null;
+
+        foreach (Diagnostic diagnostic in context.ReportedDiagnostics)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            // Creating a suppression for another id throws, and the context is only documented to filter to
+            // the supported ids.
+            if (diagnostic.Id != SuppressedDiagnosticId || diagnostic.Location.SourceTree is not { } tree)
+            {
+                continue;
+            }
+
+            SyntaxNode root = tree.GetRoot(context.CancellationToken);
+
+            // IDE1006 is reported on the identifier, whose innermost node is the declarator. Anything else -
+            // a method, a property, a parameter - is not this suppressor's business.
+            if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                is not VariableDeclaratorSyntax declarator)
+            {
+                continue;
+            }
+
+            AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(tree);
+            string prefix = ThreadStaticNaming.GetPrefix(options);
+
+            // Check the name before doing any semantic work. A field that is not named as a thread static
+            // keeps its report either way.
+            if (!ThreadStaticNaming.IsConforming(declarator.Identifier.ValueText, prefix))
+            {
+                continue;
+            }
+
+            semanticModels ??= [];
+
+            if (!semanticModels.TryGetValue(tree, out SemanticModel? semanticModel))
+            {
+                semanticModel = context.GetSemanticModel(tree);
+                semanticModels.Add(tree, semanticModel);
+            }
+
+            if (semanticModel.GetDeclaredSymbol(declarator, context.CancellationToken) is not IFieldSymbol field
+                || !ThreadStaticNaming.IsThreadStatic(field, threadStaticAttribute, options))
+            {
+                continue;
+            }
+
+            context.ReportSuppression(Suppression.Create(s_rule, diagnostic));
+        }
+    }
+}

--- a/touki.analyzers/ThreadStaticNamingSuppressor.cs
+++ b/touki.analyzers/ThreadStaticNamingSuppressor.cs
@@ -74,6 +74,11 @@ public sealed class ThreadStaticNamingSuppressor : DiagnosticSuppressor
         INamedTypeSymbol? threadStaticAttribute =
             context.Compilation.GetTypeByMetadataName(ThreadStaticNaming.ThreadStaticAttributeMetadataName);
 
+        // Configuration is per tree, so it is read once per tree rather than once per diagnostic. The root is
+        // not cached alongside it: GetRoot returns a stored field on a parsed tree, and a lazy tree caches the
+        // parse on first call, so repeating it costs a field read.
+        Dictionary<SyntaxTree, (AnalyzerConfigOptions Options, string Prefix)>? configurations = null;
+
         // A semantic model is only built for a field that already looks thread static, and only once per
         // tree. Suppressors run concurrently with each other, but each runs on one thread, so a plain
         // dictionary is enough.
@@ -100,12 +105,18 @@ public sealed class ThreadStaticNamingSuppressor : DiagnosticSuppressor
                 continue;
             }
 
-            AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(tree);
-            string prefix = ThreadStaticNaming.GetPrefix(options);
+            configurations ??= [];
+
+            if (!configurations.TryGetValue(tree, out (AnalyzerConfigOptions Options, string Prefix) configuration))
+            {
+                AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(tree);
+                configuration = (options, ThreadStaticNaming.GetPrefix(options));
+                configurations.Add(tree, configuration);
+            }
 
             // Check the name before doing any semantic work. A field that is not named as a thread static
             // keeps its report either way.
-            if (!ThreadStaticNaming.IsConforming(declarator.Identifier.ValueText, prefix))
+            if (!ThreadStaticNaming.IsConforming(declarator.Identifier.ValueText, configuration.Prefix))
             {
                 continue;
             }
@@ -119,7 +130,7 @@ public sealed class ThreadStaticNamingSuppressor : DiagnosticSuppressor
             }
 
             if (semanticModel.GetDeclaredSymbol(declarator, context.CancellationToken) is not IFieldSymbol field
-                || !ThreadStaticNaming.IsThreadStatic(field, threadStaticAttribute, options))
+                || !ThreadStaticNaming.IsThreadStatic(field, threadStaticAttribute, configuration.Options))
             {
                 continue;
             }

--- a/touki/Framework/Polyfills/System.Threading/Lock.ThreadId.cs
+++ b/touki/Framework/Polyfills/System.Threading/Lock.ThreadId.cs
@@ -14,9 +14,7 @@ public sealed partial class Lock
     internal partial struct ThreadId
     {
         [ThreadStatic]
-#pragma warning disable IDE1006 // Naming Styles
         private static uint t_threadId;
-#pragma warning restore IDE1006
 
         private uint _id;
 

--- a/touki/Framework/Polyfills/System.Threading/ThreadBlockingInfo.cs
+++ b/touki/Framework/Polyfills/System.Threading/ThreadBlockingInfo.cs
@@ -43,9 +43,7 @@ internal unsafe struct ThreadBlockingInfo
     // blocking info for the thread, or null if there are no more. Blocking can be reentrant in some cases, such as on UI
     // threads where reentrant waits are used, or if a SynchronizationContext wait override is set.
     [ThreadStatic]
-#pragma warning disable IDE1006 // Naming Styles
     private static ThreadBlockingInfo* t_first; // may be used by debuggers
-#pragma warning restore IDE1006
 
     // This pointer can be used to obtain the object relevant to the blocking. For native object kinds, it points to the
     // native object (for Monitor object kinds in CoreCLR, it points to a native AwareLock object). For managed object

--- a/touki/GlobalSuppressions.cs
+++ b/touki/GlobalSuppressions.cs
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.Collections.Cache`1.t_localItem")]
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.Text.ValueStringBuilder.t_values")]
-
-#if NETFRAMEWORK
-[assembly: SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Thread local", Scope = "member", Target = "~F:Touki.EnumDataCache.t_params")]
-#endif
+// Thread-static fields used to need an IDE1006 suppression each: the built-in naming rules match on
+// modifiers, so a [ThreadStatic] field matches the ordinary static rule and is reported for missing the
+// 's_' prefix (dotnet/roslyn#32955). Touki.Analyzers.ThreadStaticNamingSuppressor now suppresses IDE1006
+// for those fields and TOUKI0040 enforces the 't_' prefix, so no entries are needed here.


### PR DESCRIPTION
## Summary

`.editorconfig` naming rules match a symbol group by kind, accessibility, and modifier. `[ThreadStatic]` is an *attribute*, not a modifier, so no symbol group can select thread statics - they fall into whatever rule covers ordinary statics and IDE1006 asks for the `s_` prefix instead. The gap is tracked by [dotnet/roslyn#32955](https://github.com/dotnet/roslyn/issues/32955), opened by @stephentoub in 2019; design review completed Oct 2024, still Backlog, no implementation.

Until now every thread-static field in this repo carried a hand-written suppression to work around it.

## What's new

**TOUKI0040** (Naming, Warning) reports a `[ThreadStatic]` field that does not carry the thread-static prefix, and names the field it wants so the fix is a rename. Configurable per path:

```ini
dotnet_code_quality.TOUKI0040.thread_static_prefix = t_
dotnet_code_quality.TOUKI0040.additional_thread_static_attributes = MyThreadLocal
```

Only non-constant statics are considered. `[ThreadStatic]` on an instance field does nothing (CA2259 reports that) and such a field is still named `_value`.

**TOUKISUPPRESS0001** suppresses IDE1006 for a field TOUKI0040 accepts. Only a *conforming* name is suppressed - a misnamed thread static keeps its IDE1006 report alongside TOUKI0040, so turning TOUKI0040 off cannot silently leave thread statics with no naming enforcement.

The suppression-id shape follows dotnet/runtime's `SYSLIBSUPPRESS0001`: a suppression id shares a namespace with rule ids (`dotnet_diagnostic` / `NoWarn` disable either), so the `SUPPRESS` infix puts it structurally out of reach of any future `TOUKI####` rule.

## Notable details

- Suppression works even though this repo raises IDE1006 to `error`. `AnalyzerDriver.ApplyProgrammaticSuppressionsCore` gates on `DefaultSeverity != Error` - the *descriptor* default, not the configured severity.
- The five hand-written suppressions are removed: three `[SuppressMessage]` entries in `touki/GlobalSuppressions.cs`, plus pragmas in `Lock.ThreadId.cs` and `ThreadBlockingInfo.cs`. The remaining IDE1006 pragma in `ChunkEnumerator.cs` is for the `m_ChunkChars` `Unsafe.As` layout shim, not a thread static, so it stays.
- A suppression cannot be release-tracked: `### Suppressions` fails with RS2007, and a suppression id in `### New Rules` fails with RS2002 (a suppressor declares `SupportedSuppressions`, never `SupportedDiagnostics`). It is recorded as a commented `Suppression`-category row in `AnalyzerReleases.Unshipped.md`.
- Options are read only after a cheap symbol filter, and the suppressor builds a semantic model only for fields that already look thread static.

## Validation

- **Negative control:** `-p:NoWarn=TOUKISUPPRESS0001` disables the suppression and makes exactly the 5 thread-static fields fail with `error IDE1006`; with it enabled the build is clean. That proves the suppressor is load-bearing rather than IDE1006 being quiet anyway.
- **Option probe in a real `.editorconfig`:** setting `thread_static_prefix = tl_` produced `TOUKI0040: Thread-static field 't_params' should be named 'tl_params'` on all five, confirming config plumbing that the in-memory test harness cannot exercise.
- **Harness vacuity check:** all 29 new test snippets compile (only the two pre-existing known-vacuous tests fail under the check).
- Release: solution builds 0/0; 195 analyzer tests, 6,918 net10, 6,918 net11, 8,159 net481, 13 AOT tests pass.
