### PR TITLE
Re-pin roslyn-analyzers to commons v0.12.0

### DIFF
--- a/.agents/skills/roslyn-analyzers/SKILL.md
+++ b/.agents/skills/roslyn-analyzers/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: dotnet-project-gated
     binding: optional-overlay
     github-path: skills/roslyn-analyzers
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.12.0
+    github-ref: refs/tags/v0.12.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 0456189352ca224c2a9323e44eb883da455027dd
+    github-tree-sha: 7e531df787947535823396d4faada24713a834c9
     maturity: canary
     portability: portable
     related: performance-testing, security-review, pre-pr-self-review, il-copy-inspection
@@ -50,6 +50,10 @@ The short version, in priority order:
 3. **A third-party suite already in the graph or worth adding** - Roslynator,
    StyleCop, Meziantou, SonarAnalyzer.
 4. **Only if none fit** - author a custom analyzer. Continue below.
+
+If the answer is "an existing rule is right except in one context", you may be
+looking at a `DiagnosticSuppressor` rather than an analyzer - but read Rule 0 of
+[suppressors.md](suppressors.md) first, because most suppressors should not exist.
 
 ## Where analyzers live (the project layout)
 
@@ -110,6 +114,9 @@ library it guards (`<root>` is the library project name):
 - [performance.md](performance.md) - the in-IDE performance budget, the cheap-first
   rule, per-compilation symbol caching, concurrency, allocation hygiene, and how to
   measure with `ReportAnalyzer`.
+- [suppressors.md](suppressors.md) - `DiagnosticSuppressor`: when owning the domain
+  beats suppressing, what is suppressible at all, the id convention, why suppressions
+  cannot be release-tracked, and how to prove one is load-bearing.
 
 ## Cross-skill
 

--- a/.agents/skills/roslyn-analyzers/overlay.md
+++ b/.agents/skills/roslyn-analyzers/overlay.md
@@ -1,20 +1,19 @@
 ---
 core: roslyn-analyzers
-core-pin: v0.10.0
+core-pin: v0.12.0
 ---
 
 # Touki overlay - roslyn-analyzers
 
 Repo-specific companion to the vendored [roslyn-analyzers](SKILL.md) skill. The
-`SKILL.md` and its four sibling pages (`design.md`, `validation.md`,
-`existing-analyzers.md`, `performance.md`) are a **pinned copy of the portable
-core** from
+`SKILL.md` and its five sibling pages (`design.md`, `validation.md`,
+`existing-analyzers.md`, `performance.md`, `suppressors.md`) are a **pinned copy of
+the portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core -
-`gh skill update` would flag the drift. Everything touki-specific lives here, plus
-the overlay siblings listed below.
+`gh skill update` would flag the drift. Everything touki-specific lives here.
 
-> **Pinned to a release.** The core is pinned to the commons **v0.10.0** tag. Pull
+> **Pinned to a release.** The core is pinned to the commons **v0.12.0** tag. Pull
 > later upstream changes with `gh skill update roslyn-analyzers` (review the diff,
 > re-pin to the new tag).
 
@@ -111,20 +110,6 @@ Two consequences to document wherever the rule is configured:
   `Diagnostic.Create(..., effectiveSeverity, ...)`. If sub-rules need their own
   strictness, the only level that still works is "off", which the analyzer must honor
   itself by not reporting.
-
-## Overlay siblings
-
-Files in this directory that are **not** part of the vendored core, so an inventory
-check after `gh skill update` classifies them rather than flagging them:
-
-- [suppressors.md](suppressors.md) - authoring `DiagnosticSuppressor`s. The core
-  covers `DiagnosticAnalyzer` and `CodeFixProvider` only.
-
-> **Pending-upstream divergence.** `suppressors.md` is portable, not touki-specific,
-> so by the `manage-skills` golden rule it belongs in the commons core rather than an
-> overlay. It is recorded here as an intentional divergence until someone decides
-> whether to upstream it; do not treat it as a local deviation and do not open a
-> commons PR for it unprompted.
 
 ## Release tracking (`AnalyzerReleases.*.md`)
 

--- a/.agents/skills/roslyn-analyzers/suppressors.md
+++ b/.agents/skills/roslyn-analyzers/suppressors.md
@@ -1,43 +1,44 @@
 # Diagnostic suppressors
 
-Overlay sibling of the vendored [roslyn-analyzers](SKILL.md) core, which covers
-`DiagnosticAnalyzer` and `CodeFixProvider` but not `DiagnosticSuppressor`. Everything
-here is portable and is a **candidate for upstreaming** into the commons core; see
-[overlay.md](overlay.md) for its divergence status.
+Detail for the [roslyn-analyzers](SKILL.md) skill. A `DiagnosticSuppressor` removes a
+diagnostic another analyzer produced. It is the tool for "that rule is right in general
+but wrong in this context", not for "we want a different rule".
 
-A suppressor removes a diagnostic another analyzer produced. It is the tool for "that
-rule is right in general but wrong in this context", not for "we want a different rule".
+Read Rule 0 before writing any of the rest. Most suppressors should not exist.
 
 ## Rule 0: prefer owning the domain over suppressing
 
 Before writing a suppressor, ask **who should own this category of diagnostic**. A
-suppressor is only justified when the other analyzer's rule is right in general and
-you are carving out a genuine exception. If you find yourself suppressing a rule so
-your own rule can say something different about the *same* symbols, you have two
-analyzers competing for one domain, and the cheaper fix is to stop configuring the
-other one for that domain.
+suppressor is only justified when the other analyzer's rule is right in general and you
+are carving out a genuine exception. If you find yourself suppressing a rule so your own
+rule can say something different about the *same* symbols, you have two analyzers
+competing for one domain, and the cheaper fix is to stop configuring the other one for
+that domain.
 
-Concretely: `.editorconfig` naming rules have no built-in defaults for **fields**
-(the defaults cover types, properties, methods, events, and interfaces only). A repo
-that wants custom field naming can define zero field rules, leaving IDE1006 silent on
-fields, and own field naming entirely in its own analyzer - no suppressor, no
-coupling. Verify the equivalent for whatever rule you are about to suppress.
+Concretely, for the case that most often prompts a suppressor - the built-in naming rule
+IDE1006 - the built-in conventions cover types, properties, methods, events and
+interfaces, and have **no defaults for fields**. A repo that wants custom field naming can
+define zero field naming rules, leaving IDE1006 silent on fields, and own field naming
+entirely in its own analyzer. No suppressor, no coupling. Establish the equivalent fact
+for whatever rule you are about to suppress before you write any code.
 
-The cost you avoid is not just the suppressor's own code. It is the coupling in
-Rule 4 and the permanent obligation to keep two rules agreeing.
+The cost you avoid is not just the suppressor's own code. It is the coupling in Rule 4 and
+the permanent obligation to keep two rules agreeing.
 
-**Outcome in this repo.** `ThreadStaticNamingSuppressor` (TOUKISUPPRESS0001) shipped,
-then was deleted a week later when the naming engine was ported and IDE1006 was turned
-off wholesale. Everything below still applies if you need a suppressor, but the
-strongest evidence in this file is that the one suppressor written here should never
-have existed. Signals it was the wrong tool, all visible before it was written:
+**A worked case against.** One suppressor written to this guidance shipped and was deleted
+a week later, once the suppressed rule was replaced outright rather than argued with.
+Everything below still applies when you genuinely need a suppressor, but the strongest
+evidence here is that this one should never have existed. All three signals were visible
+before it was written:
 
-- The suppressed rule and the replacement rule disagreed about the *same* symbols,
-  rather than the replacement carving out an exception.
-- The suppressor had to reimplement the other rule's naming decision to know when to
-  fire (Rule 4), so a change to either side silently desynchronized them.
-- The id could not be tracked in `AnalyzerReleases.*.md` (Rule 5), which is a hint
-  that the ecosystem does not consider suppressions first-class artifacts.
+- The suppressed rule and the replacement rule disagreed about the *same* symbols, rather
+  than the replacement carving out an exception to a rule it otherwise agreed with.
+- The suppressor had to reimplement the other rule's decision in order to know when to
+  fire (Rule 4), so a change on either side would silently desynchronize them.
+- The id could not be release-tracked at all (Rule 5) - a hint that the ecosystem does not
+  treat suppressions as first-class shipped artifacts.
+
+If you cannot answer "why is the other rule right in general?", stop.
 
 ## Rule 1: know what is suppressible
 
@@ -57,50 +58,50 @@ var suppressableDiagnostics = reportedDiagnostics.Where(d => !d.IsSuppressed &&
                                                              !_diagnosticsProcessedForProgrammaticSuppressions.Contains(d));
 ```
 
-So an `IDE####` or `CA####` rule that a repo raised to `error` in `.editorconfig` is
-still suppressible - its descriptor default is below error. A rule whose *descriptor*
-is `Error` never is. Do not assume from the build output which case you are in.
+So an `IDE####` or `CA####` rule that a repo raised to `error` in `.editorconfig` is still
+suppressible - its descriptor default is below error. A rule whose *descriptor* is `Error`
+never is. Do not infer which case you are in from the build output.
 
 ## Rule 2: API mechanics that bite
 
 - `DiagnosticSuppressor.Initialize` is **sealed** and already calls
   `ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)`. Do not try to
   override it; there is nowhere to register actions.
-- `SupportedDiagnostics` is sealed to empty. Suppressors expose
-  `SupportedSuppressions` instead. Cache that array in a `static readonly` field for
-  the same reason analyzers cache `SupportedDiagnostics`.
+- `SupportedDiagnostics` is sealed to empty. Suppressors expose `SupportedSuppressions`
+  instead. Cache that array in a `static readonly` field for the same reason analyzers
+  cache `SupportedDiagnostics`.
 - `Suppression.Create(descriptor, diagnostic)` **throws** `ArgumentException` when
-  `descriptor.SuppressedDiagnosticId != diagnostic.Id`. `context.ReportedDiagnostics`
-  is documented as pre-filtered to your supported ids, but guard on `diagnostic.Id`
-  anyway - the throw is a crash, not a diagnostic.
-- Suppressors run concurrently with **each other**, but each `ReportSuppressions` call
-  is single-threaded, so plain (non-concurrent) local caches inside it are safe.
-- Suppression is additive across suppressors: several may suppress the same
-  diagnostic, and the driver unions them.
+  `descriptor.SuppressedDiagnosticId != diagnostic.Id`. `context.ReportedDiagnostics` is
+  documented as pre-filtered to your supported ids, but guard on `diagnostic.Id` anyway -
+  the throw is a crash, not a diagnostic.
+- Suppressors run concurrently with **each other**, but each `ReportSuppressions` call is
+  single-threaded, so plain (non-concurrent) local caches inside it are safe.
+- Suppression is additive across suppressors: several may suppress the same diagnostic,
+  and the driver unions them.
 
 ## Rule 3: suppress only what the replacement rule accepts
 
-If your suppressor exists because your own analyzer owns the naming/shape decision,
+If your suppressor exists because your own analyzer owns the naming or shape decision,
 suppress **only the cases your analyzer accepts**. Suppressing unconditionally means
 turning your rule off (`severity = none`) silently disables enforcement altogether,
-because the original rule is suppressed too. Conditional suppression keeps the
-original diagnostic as the backstop.
+because the original rule is suppressed too. Conditional suppression keeps the original
+diagnostic as the backstop.
 
 ## Rule 4: you are coupling to another analyzer's report shape
 
 Locating the symbol behind a suppressed diagnostic usually means
-`root.FindNode(diagnostic.Location.SourceSpan)` and then pattern-matching a syntax
-node. That encodes an **undocumented assumption about where the other analyzer
-reports**. If it moves the location, your suppressor silently stops suppressing and
-the build breaks with the original diagnostic.
+`root.FindNode(diagnostic.Location.SourceSpan)` and then pattern-matching a syntax node.
+That encodes an **undocumented assumption about where the other analyzer reports**. If it
+moves the location, your suppressor silently stops suppressing and the build breaks with
+the original diagnostic.
 
-Mitigate by matching defensively (a node shape that is wrong should `continue`, not
-throw) and by keeping the negative control in Rule 7 so the coupling is exercised.
+Mitigate by matching defensively - a node shape that is wrong should `continue`, not throw
+- and by keeping the negative control in Rule 7 so the coupling is exercised.
 
 ## Rule 5: suppressions cannot be release-tracked
 
-The analyzer release files have no section for suppressions, and both workarounds
-fail the build:
+The analyzer release files have no section for suppressions, and both workarounds fail the
+build:
 
 | Attempt | Result |
 | --- | --- |
@@ -111,11 +112,11 @@ RS2002 fires because a suppressor declares `SupportedSuppressions`, never
 `SupportedDiagnostics`, so the tracker cannot match the id to any analyzer.
 
 Do **not** reach for `dotnet_diagnostic.RS2002.severity = none` - that disables
-stale-entry detection for every id in the file, which is the check that catches a
-leftover row after a rule is renamed or deleted.
+stale-entry detection for every id in the file, which is the check that catches a leftover
+row after a rule is renamed or deleted.
 
-Record suppressions as a `;`-commented row in the same shape as a rule, in the
-unshipped file's header block, and move it with the release by hand:
+Record suppressions as a `;`-commented row in the same shape as a rule, in the unshipped
+file's header block, and move it with the release by hand:
 
 ```md
 ; Rule ID | Category | Severity | Notes
@@ -125,10 +126,10 @@ unshipped file's header block, and move it with the release by hand:
 
 ## Rule 6: id convention
 
-A suppression id shares a namespace with rule ids - an end user disables either with
-the same `dotnet_diagnostic.<id>.severity` key or `NoWarn` entry - so an id that
-looks like a rule id can collide with a future rule. Roslyn's design doc requires
-only "a unique suppression ID" and prescribes no shape. What shipping packages do:
+A suppression id shares a namespace with rule ids - an end user disables either with the
+same `dotnet_diagnostic.<id>.severity` key or `NoWarn` entry - so an id that looks like a
+rule id can collide with a future rule. Roslyn's design doc requires only "a unique
+suppression ID" and prescribes no shape. What shipping packages do:
 
 | Package | Rule ids | Suppression ids | Strategy |
 | --- | --- | --- | --- |
@@ -137,63 +138,63 @@ only "a unique suppression ID" and prescribes no shape. What shipping packages d
 | xunit.analyzers | `xUnit####` | `xUnitSuppress-CA1515` | Derived from the suppressed id |
 | nunit.analyzers | `NUnit1xxx/2xxx` | `NUnit3001`-`3004` | Reserved numeric band |
 
-Prefer an **infix token** (`<PREFIX>SUPPRESS####`, numbered from 0001 independently
-of the rules). It makes collision with a future `<PREFIX>####` rule structurally
-impossible, which a numeric band does not - a band is enforced only by memory, and
-RS2002 cannot police it. Derive-from-the-suppressed-id also works and needs no
-counter, but cannot give one reason two suppressed ids.
+Prefer an **infix token** (`<PREFIX>SUPPRESS####`, numbered from 0001 independently of the
+rules). It makes collision with a future `<PREFIX>####` rule structurally impossible,
+which a numeric band does not - a band is enforced only by memory, and RS2002 cannot
+police it. Derive-from-the-suppressed-id also works and needs no counter, but cannot give
+one reason two suppressed ids.
 
-An id names the **reason**, so one id may legitimately cover several suppressed
-rules - CommunityToolkit uses `MVVMTKSPR0001` for both CS0657 and CS0658.
+An id names the **reason**, so one id may legitimately cover several suppressed rules -
+CommunityToolkit uses `MVVMTKSPR0001` for both CS0657 and CS0658.
 
 ## Rule 7: prove the suppressor is load-bearing
 
-A suppressor that does nothing looks exactly like a suppressor that works: the build
-is clean either way. Disable it and confirm the diagnostics come back:
+A suppressor that does nothing looks exactly like a suppressor that works: the build is
+clean either way. Disable it and confirm the diagnostics come back:
 
 ```pwsh
 dotnet build <project> --no-incremental -p:NoWarn=<SuppressionId>
 ```
 
 `SuppressionDescriptor.IsDisabled` reads `SpecificDiagnosticOptions`, which MSBuild's
-`NoWarn` feeds, so this turns the suppression off without editing anything. The
-expected result is the exact set of diagnostics you believe are being suppressed - if
-it is a different set, or empty, the suppressor is not doing what you think.
+`NoWarn` feeds, so this turns the suppression off without editing anything. The expected
+result is the exact set of diagnostics you believe are being suppressed - if it is a
+different set, or empty, the suppressor is not doing what you think.
 
 Do this once per suppressor and record the expected count.
 
 ## Rule 8: order the per-diagnostic work cheapest-first
 
-`ReportSuppressions` runs over every reported diagnostic with your ids. Put the
-cheapest discriminator first and defer anything expensive:
+`ReportSuppressions` runs over every reported diagnostic with your ids. Put the cheapest
+discriminator first and defer anything expensive:
 
-- Configuration (`AnalyzerConfigOptionsProvider.GetOptions(tree)`) is **per tree**;
-  cache it per tree rather than reading it per diagnostic.
+- Configuration (`AnalyzerConfigOptionsProvider.GetOptions(tree)`) is **per tree**; cache
+  it per tree rather than reading it per diagnostic.
 - `context.GetSemanticModel(tree)` is expensive; build it only for diagnostics that
   already passed the syntactic checks, and cache per tree.
 - `SyntaxTree.GetRoot()` does **not** need caching - `ParsedSyntaxTree.GetRoot` is
   `return _root;` and `LazySyntaxTree` caches the parse via `Interlocked.CompareExchange`.
   A reviewer will suggest caching it; the honest answer is that it is a field read.
-- `ISymbol.GetAttributes()` is likewise cached per symbol (`GetAttributesBag()`
-  returns early on a sealed bag), so repeat calls are cheap - but do not *write*
-  redundant calls, since they read as oversights.
+- `ISymbol.GetAttributes()` is likewise cached per symbol (`GetAttributesBag()` returns
+  early on a sealed bag), so repeat calls are cheap - but do not *write* redundant calls,
+  since they read as oversights.
 
 ## Testing a suppressor
 
 The rule you are suppressing usually lives in an assembly the test project does not
-reference (the IDE code-style analyzers, for example). Stand it in with a stub
-analyzer that reports the same id at the same location:
+reference (the IDE code-style analyzers, for example). Stand it in with a stub analyzer
+that reports the same id at the same location:
 
-- Give the stub a **default severity below `Error`**, matching the real rule, or
-  Rule 1 makes it unsuppressible and every test fails for the wrong reason.
+- Give the stub a **default severity below `Error`**, matching the real rule, or Rule 1
+  makes it unsuppressible and every test fails for the wrong reason.
 - Run analyzer and suppressor together with
-  `CompilationWithAnalyzersOptions(..., reportSuppressedDiagnostics: true)` so a test
-  can distinguish *suppressed* from *never produced*. Without it, suppressed
-  diagnostics are dropped and both cases look identical.
+  `CompilationWithAnalyzersOptions(..., reportSuppressedDiagnostics: true)` so a test can
+  distinguish *suppressed* from *never produced*. Without it, suppressed diagnostics are
+  dropped and both cases look identical.
 - Assert the **suppression id**, not the suppressed id.
   `Diagnostic.ProgrammaticSuppressionInfo` is internal; go through the public
-  `Diagnostic.GetSuppressionInfo(Compilation)`, which means the harness has to return
-  the compilation alongside the diagnostics:
+  `Diagnostic.GetSuppressionInfo(Compilation)`, which means the harness has to return the
+  compilation alongside the diagnostics:
 
   ```csharp
   SuppressionInfo? suppressionInfo = diagnostic.GetSuppressionInfo(compilation);
@@ -208,14 +209,14 @@ analyzer that reports the same id at the same location:
 
 ### The stub analyzer trips the analyzer authoring rules
 
-Adding any `[DiagnosticAnalyzer]`-attributed type to a **test** project pulls that
-project into the rules meant for shippable analyzer assemblies:
+Adding any `[DiagnosticAnalyzer]`-attributed type to a **test** project pulls that project
+into the rules meant for shippable analyzer assemblies:
 
 - With the attribute: RS1036 (`EnforceExtendedAnalyzerRules`), RS1038 (Workspaces
   reference), RS1041 (target framework), RS2008 (release tracking).
 - Without the attribute: RS1001 (missing attribute).
 
-There is no shape that satisfies both. Keep the attribute and turn those four off in
-the **test project's** `.editorconfig`, with a comment saying the project only hosts
-test doubles handed to `CompilationWithAnalyzers` directly. Leave them on in the real
-analyzer project.
+There is no shape that satisfies both. Keep the attribute and turn those four off in the
+**test project's** `.editorconfig`, with a comment saying the project only hosts test
+doubles handed to `CompilationWithAnalyzers` directly. Leave them on in the real analyzer
+project.


### PR DESCRIPTION
Resolves the pending-upstream divergence left by #244.

## Why

`suppressors.md` was written in #244 as a **recorded pending-upstream divergence**: portable guidance sitting beside a pinned vendored core, where the `manage-skills` golden rule says it does not belong. It has since been accepted into the commons core as [JeremyKuhne/agent-skills#34](https://github.com/JeremyKuhne/agent-skills/pull/34) and released in [v0.12.0](https://github.com/JeremyKuhne/agent-skills/releases/tag/v0.12.0), so the divergence is resolved the way the rule asks - upstreamed, then re-pinned - rather than left as a permanent local fork.

## What changed

Re-vendored with `gh skill install JeremyKuhne/agent-skills roslyn-analyzers --pin v0.12.0 --force`. Three files:

- **`SKILL.md`** - pin `v0.10.0` → `v0.12.0`, new tree SHA, and the two upstream links to `suppressors.md` (Step 0 and Deep dives).
- **`suppressors.md`** - the local copy replaced by the portable core version. The repo-specific case study was genericized for upstreaming (type names and the `overlay.md` link stripped per the commons `FORMAT.md` portable-core rules); the argument it carries is unchanged.
- **`overlay.md`** - `core-pin` bumped, and the "Overlay siblings" section plus its divergence note **deleted** rather than left stale, since the file is now part of the core. The intro counts five sibling pages instead of four.

## Notes

**Less drift than expected.** v0.11.0 did not touch this skill at all, so despite crossing two releases the entire core diff is the `suppressors.md` addition and its two links. Nothing else in `design.md`, `validation.md`, `existing-analyzers.md` or `performance.md` moved - they appear in `git status` only because the installer wrote LF and git normalized them back out of the commit.

**Pin follows the repo convention** - `github-pinned` carries the tag name, not the underlying commit SHA. That is the mistake a reviewer caught on #222.

## Validation

- Body identity verified against a checkout of the commons at `v0.12.0` for all six core files - all identical.
- `tools/Validate-AgentFiles.ps1`, `tools/Test-AgentFileLinks.ps1`, `tools/Validate-AgentSkills.ps1` all pass (91 files scanned, 18 skills, 14 strict commons cores).
- The release itself was verified with a disposable `gh skill install --pin v0.12.0` into a temp directory, confirming `suppressors.md` is in the published artifact.

Documentation only - no source or build changes.
