### PR TITLE
Ship TOUKI0011, TOUKI0021, and TOUKI0041 in release 0.6.0

### DIFF
--- a/.agents/skills/publish-release/SKILL.md
+++ b/.agents/skills/publish-release/SKILL.md
@@ -65,8 +65,10 @@ Read-only checks:
 Ask the user **which package** if not already obvious from the request:
 
 - `KlutzyNinja.Touki` - the main library.
-- `KlutzyNinja.Touki.TestSupport` - test helpers (rarely shipped; see
-  [docs/release-strategy](../../../touki.testsupport/README.md)).
+- `KlutzyNinja.Touki.TestSupport` - test helpers. Released only when
+  `touki.testsupport/` code changed or the Touki release is a binary break;
+  see [versioning.md](versioning.md) "TestSupport releases: when and what
+  version".
 
 Use `vscode_askQuestions` only if ambiguous; if the user said "publish
 TestSupport" or similar, skip the prompt.
@@ -97,7 +99,8 @@ watch the workflow, and create the GitHub release.
 
 - [versioning.md](versioning.md) - establishing the prior version, the
   prerelease channel decision, the `Major.Minor.Patch` bump table, the
-  `AssemblyVersion` gotcha, and the exact tag format with its regex guard.
+  `AssemblyVersion` gotcha, the exact tag format with its regex guard, and
+  when TestSupport warrants a release of its own.
 - [release-steps.md](release-steps.md) - creating and pushing the annotated
   tag, `workflow_dispatch` recovery, the GitHub release notes template, and
   aftercare.

--- a/.agents/skills/publish-release/release-steps.md
+++ b/.agents/skills/publish-release/release-steps.md
@@ -113,8 +113,11 @@ Notes on the template:
   should advance. The sample dog-foods the released package; leaving it
   stale defeats the purpose. (Open as a follow-up PR - not part of the
   release commit/tag.)
-- If you bumped `Major` (binary break), also bump `Major` of TestSupport
-  on its next release. They don't have to march in lockstep but TestSupport
-  cannot consume an incompatible Touki.
+- If you bumped `Major` (binary break), TestSupport needs a release too -
+  it cannot consume an incompatible Touki. Otherwise check whether
+  `touki.testsupport/` code changed at all; if it did not, skip it. The
+  criteria and the version-matching rule are in
+  [versioning.md](versioning.md) "TestSupport releases: when and what
+  version".
 - Update [touki.testsupport/README.md](../../../touki.testsupport/README.md)
   if the supported targets or AOT story changed.

--- a/.agents/skills/publish-release/versioning.md
+++ b/.agents/skills/publish-release/versioning.md
@@ -26,10 +26,9 @@ but choosing a duplicate is almost always a mistake):
 
 Record the prior version (e.g. `0.1.0-alpha.12` for the main package).
 
-If TestSupport has **no** `ts-v*` tags yet, the next published version becomes
-the bootstrap of that stream. The previously-published version on nuget.org
-under the old scheme was `0.1.0-alpha.8.11`; pick a `ts-v` tag that sorts
-strictly higher (e.g. `ts-v0.1.0-alpha.9` or higher).
+For TestSupport, stop and read "TestSupport releases: when and what version"
+at the end of this page **before** picking a version - most Touki releases
+need no TestSupport release at all.
 
 ## 2. Decide the prerelease channel (alpha / beta / rc / stable)
 
@@ -145,3 +144,40 @@ The regex used by the workflow guards (must match):
 ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
 ^ts-v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?$
 ```
+
+## TestSupport releases: when and what version
+
+`KlutzyNinja.Touki.TestSupport` is **not** released in lockstep with
+`KlutzyNinja.Touki`. Cut a `ts-v*` tag only when at least one of these is
+true:
+
+- **Code in `touki.testsupport/` changed** since the last `ts-v*` tag.
+  Markdown, README, and comment-only edits do not qualify.
+- **The Touki release carries a binary breaking change** - it bumped
+  `Major`, so `AssemblyVersion` moved and every consumer has to rebind.
+
+An additive or bug-fix Touki release needs no TestSupport release:
+`AssemblyVersion` is unchanged, so the already-published TestSupport keeps
+binding to the new Touki without a rebuild. Check with:
+
+```pwsh
+git diff --stat ts-v<prior>..HEAD -- touki.testsupport/
+```
+
+If every hit is markdown, skip it and say so in the release notes rather
+than shipping a no-op package.
+
+### Which version TestSupport gets
+
+When TestSupport does ship, **match the `KlutzyNinja.Touki` version it
+depends on**, prerelease label included: Touki `v0.6.0` -> `ts-v0.6.0`,
+Touki `v0.7.0-alpha.1` -> `ts-v0.7.0-alpha.1`. The pair then reads as a
+matched set on nuget.org.
+
+When TestSupport needs another iteration against a Touki version whose
+number is already taken on the `ts-v` stream, the iteration goes in the
+**build component** - the third position (`Patch` in SemVer terms, the
+*Build* field of .NET's four-part `Version`). A second TestSupport release
+still targeting Touki `0.6.0` is `ts-v0.6.1`. The tag guard above accepts
+only `Major.Minor.Patch[-prerelease]`, so there is no fourth component to
+put an iteration in.

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -403,7 +403,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 |---------|-------------|
 | 0.4.0 | TOUKI0001, TOUKI0002, TOUKI0003, TOUKI0004, TOUKI0010 |
 | 0.5.0 | TOUKI0020, TOUKI0030 |
-| unreleased | TOUKI0011, TOUKI0021, TOUKI0041 |
+| 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/touki.analyzers/AnalyzerReleases.Shipped.md
+++ b/touki.analyzers/AnalyzerReleases.Shipped.md
@@ -24,3 +24,12 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TOUKI0020 | Maintainability | Warning | More than one type declared in a file, nested types included
 TOUKI0030 | Performance | Warning | StringBuilder allocated to build a string that ValueStringBuilder could build
+
+## Release 0.6.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TOUKI0011 | Reliability | Warning | stackalloc larger than the configured maximum byte size
+TOUKI0021 | Maintainability | Warning | File name does not match a type declared in the file
+TOUKI0041 | Naming | Disabled | Name does not follow the configured naming rules

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -1,9 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-TOUKI0011 | Reliability | Warning | stackalloc larger than the configured maximum byte size
-TOUKI0021 | Maintainability | Warning | File name does not match a type declared in the file
-TOUKI0041 | Naming | Disabled | Name does not follow the configured naming rules


### PR DESCRIPTION
Prepares the `v0.6.0` release of `KlutzyNinja.Touki` by moving the three
unshipped analyzer rules into the shipped release tracking file.

## Analyzer release tracking

`AnalyzerReleases.Unshipped.md` -> `AnalyzerReleases.Shipped.md` under a new
`## Release 0.6.0` heading:

| Rule ID | Category | Severity | Notes |
| --- | --- | --- | --- |
| TOUKI0011 | Reliability | Warning | stackalloc larger than the configured maximum byte size |
| TOUKI0021 | Maintainability | Warning | File name does not match a type declared in the file |
| TOUKI0041 | Naming | Disabled | Name does not follow the configured naming rules |

`TOUKI0040` and `TOUKISUPPRESS0001` were added and then removed while still
unshipped (#243, #244), so no `### Changed Rules` entry is required. Once this
merges those three IDs, categories, and default severities are frozen.

`docs/analyzers.md` release-history table gains the matching `0.6.0` row.

## publish-release skill: TestSupport criteria

Captures when `KlutzyNinja.Touki.TestSupport` warrants a release of its own,
and what version it gets:

- Release it only when `touki.testsupport/` **code** changed since the last
  `ts-v*` tag, or when the Touki release is a **binary break** (`Major` bump,
  so `AssemblyVersion` moved). Markdown-only changes do not qualify.
- When it does ship, its version **matches the `KlutzyNinja.Touki` version it
  depends on**, prerelease label included (`v0.6.0` -> `ts-v0.6.0`).
- Iterations against an already-matched Touki version go in the **build
  (third) component** (`ts-v0.6.1`). The workflow tag guard accepts only
  `Major.Minor.Patch[-prerelease]`, so there is no fourth component.

By that rule `0.6.0` needs **no** TestSupport release: nothing but the README
changed under `touki.testsupport/` since `ts-v0.5.0`, and `AssemblyVersion`
stays `0.0.0.0`.

## Validation

- `dotnet build touki.slnx -c Release` - 0 warnings, 0 errors (the RS200x
  release-tracking rules validate both markdown files at build time).
- `touki.analyzers.tests` - 203/203 pass.
- `Validate-AgentFiles.ps1`, `Validate-AgentSkills.ps1`, `Test-AgentFileLinks.ps1` - all pass.

## Follow-ups (not in this PR)

- Tag `v0.6.0` after merge to publish the package.
- Bump the sample's `KlutzyNinja.Touki` pin in `Directory.Packages.props`
  from `0.5.0` to `0.6.0`.
