### PR TITLE
Point the sample at 0.6.0 and trim the README analyzer section

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.16.0-preview.1" />
     <PackageVersion Include="FluentAssertions" Version="6.12.2" />
     <!-- Referencing our own package for the sample project to document consumption. -->
-    <PackageVersion Include="KlutzyNinja.Touki" Version="0.5.0" />
+    <PackageVersion Include="KlutzyNinja.Touki" Version="0.6.0" />
     <PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
     <PackageVersion Include="Microsoft.Build" Version="18.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />

--- a/README.md
+++ b/README.md
@@ -71,38 +71,21 @@ PM> Install-Package KlutzyNinja.Touki
 
 The package includes Roslyn analyzers. They are delivered inside
 `KlutzyNinja.Touki` itself, so referencing the package is all it takes - there
-is nothing extra to install and nothing to switch on.
+is nothing extra to install.
 
-They encode the conventions the library is built on: avoid hidden struct
-copies, release resources deterministically, keep large scratch buffers off the
-stack, and keep types easy to find by file name.
+They encode the conventions the library is built on, across a few areas:
 
-| ID | Rule | Default severity |
-|----|------|------------------|
-| TOUKI0001 | Use pattern matching for null checks | Warning |
-| TOUKI0002 | Defensive copy of a struct | Hidden |
-| TOUKI0003 | Defensive copy of a non-copyable struct | Warning |
-| TOUKI0004 | By-value copy of a non-copyable struct | Warning |
-| TOUKI0010 | Dispose a `[MustDispose]` value deterministically | Warning |
-| TOUKI0011 | Avoid large `stackalloc` allocations | Warning |
-| TOUKI0020 | Declare one type per file | Warning |
-| TOUKI0021 | File name should match the type it declares | Warning |
-| TOUKI0030 | Use `ValueStringBuilder` to build strings | Warning |
+- **Reliability** - hidden struct copies, values that must be disposed
+  deterministically, and `stackalloc` requests large enough to threaten the
+  stack.
+- **Maintainability** - one type per file, and file names that say which type
+  a file holds.
+- **Performance** - building strings without the `StringBuilder` allocation.
+- **Usage and naming** - pattern matching for null checks, and an opt-in
+  naming engine that replaces IDE1006.
 
-Every rule can be re-scoped or turned off per directory through
-`.editorconfig`, and TOUKI0011 and TOUKI0021 take options of their own:
-
-```ini
-# Severity, available on every rule
-dotnet_diagnostic.TOUKI0030.severity = none
-
-# Rule-specific options
-dotnet_code_quality.TOUKI0011.max_stackalloc_bytes = 512
-dotnet_code_quality.TOUKI0021.file_name_detail_separators = .-
-```
-
-See [Analyzers Shipped in the Package](docs/analyzers.md) for what each rule
-flags, why, and how to configure it.
+See [Analyzers Shipped in the Package](docs/analyzers.md) for the full rule
+list, what each one flags, and how to configure it.
 
 ## Requirements
 

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -1,9 +1,9 @@
 # Touki Analyzers
 
 `KlutzyNinja.Touki` ships a set of Roslyn analyzers **inside the package**. There is no
-separate analyzer package to install and no configuration required to turn them on -
-adding the package reference is enough, and the rules start running on the next build
-and in the IDE.
+separate analyzer package to install - adding the package reference is enough, and the
+rules start running on the next build and in the IDE. One rule, [TOUKI0041](#touki0041),
+ships disabled and is opted into per project.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
@@ -23,7 +23,7 @@ actually is.
 | [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | - | - |
 | [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
-| [TOUKI0041](#touki0041) | Name does not follow the configured naming rules | Naming | **Disabled** | Yes | - |
+| [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
 Rules that list a requirement only fire on code that opts in by applying the named
 attribute. The rest apply to any C# the compiler hands them.
@@ -192,9 +192,9 @@ rule cannot prove is safe to convert is left alone.
 
 ## TOUKI0041
 
-**Name does not follow the configured naming rules.** A replacement for the built-in
-IDE1006, configured with `touki_naming_*` keys instead of `dotnet_naming_*` so the two do
-not read each other's configuration.
+**Naming rule violation** - a name does not follow the configured naming rules. A
+replacement for the built-in IDE1006, configured with `touki_naming_*` keys instead of
+`dotnet_naming_*` so the two do not read each other's configuration.
 
 The rule ships **disabled**. Naming is a house style, so a project asks for it:
 


### PR DESCRIPTION
Post-release aftercare for `v0.6.0`, plus a documentation cleanup.

## Sample pin

`Directory.Packages.props` moves the central `KlutzyNinja.Touki` pin from
`0.5.0` to `0.6.0`. The sample references the published package to document
consumption, so leaving it stale defeats the purpose.

Verified against the real package rather than a local build:

- `0.6.0` is live on nuget.org.
- The restored package carries `analyzers/dotnet/cs/touki.analyzers.dll`,
  `analyzers/dotnet/cs/touki.analyzers.codefixes.dll`, and
  `lib/{net10.0,net11.0,net472}/touki.dll`.
- `dotnet build sample/sample.csproj -c Release` is clean on both TFMs, so the
  newly shipped TOUKI0011 and TOUKI0021 do not fire on the sample.

## README

The analyzer section listed all nine enabled rules in a table and then showed
severity and rule-option `.editorconfig` snippets. That duplicated
`docs/analyzers.md` and went stale on every release. It now describes the kinds
of rules - reliability, maintainability, performance, usage and naming - and
links to the doc for the list and the configuration.

Also drops "nothing to switch on", which was never true of TOUKI0041.

## docs/analyzers.md accuracy pass

Checked every table cell against the descriptors in `touki.analyzers/`. IDs,
categories, default severities, `Configurable`, and `Requires` all match;
`ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None)` is present on
all nine analyzers, so "Generated code is excluded from every rule" holds; both
code-fix providers match their documented fixable ids and Fix All behavior; the
TOUKI0041 defaults paragraph matches `DefaultNamingRules`.

Two corrections:

- The intro said no configuration is required to turn the rules on. TOUKI0041
  ships `isEnabledByDefault: false`. The intro now says so and links to it.
- TOUKI0041's table row and section lead paraphrased the rule. Its descriptor
  title is `Naming rule violation`, which is also what the `SuppressMessage`
  example later in the same document uses. Both now use the real title, with
  the description following it.

## Validation

- `dotnet build touki.slnx -c Release` - 0 warnings, 0 errors.
- `dotnet build sample/sample.csproj -c Release` - 0 warnings, 0 errors, both TFMs.
