### PR TITLE
Grant standing approval to resolve addressed review threads

### DIFF
--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -34,11 +34,13 @@ overlay narrows it:
 
 - `git commit` requires an explicit commit instruction in the user's most recent
   message.
-- `push`, `ship it`, or `send it` authorizes only pushing existing commits.
+- `push`, `ship it`, or `send it` authorizes only pushing existing commits, plus
+  the reply-and-resolve follow-through described below.
 - `update the PR` authorizes only the named remote PR action; it does not
   authorize a prerequisite commit or push.
 - Commit, push, and PR-operation approval do not imply one another. Every action
-  performed must be explicit in the same most recent message.
+  performed must be explicit in the same most recent message, with one exception:
+  replying to and resolving an addressed review thread, which is standing.
 
 The latest [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes)
 always wins over examples in the vendored core.

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -35,13 +35,37 @@ overlay narrows it:
 - `git commit` requires an explicit commit instruction in the user's most recent
   message.
 - `push`, `ship it`, or `send it` authorizes only pushing existing commits.
-- `update the PR` or resolving review threads authorizes only the named remote PR
-  actions; it does not authorize a prerequisite commit or push.
+- `update the PR` authorizes only the named remote PR action; it does not
+  authorize a prerequisite commit or push.
 - Commit, push, and PR-operation approval do not imply one another. Every action
   performed must be explicit in the same most recent message.
 
 The latest [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes)
 always wins over examples in the vendored core.
+
+## Standing approval: always resolve an addressed thread
+
+Resolving review threads needs no per-message approval. `push` on a review round
+infers reply-and-resolve; the push itself still needs its own verb.
+
+Reply in the thread, not on the main conversation, and check that it threaded:
+
+```pwsh
+gh api repos/JeremyKuhne/touki/pulls/<n>/comments/<COMMENT_ID>/replies -f body="..."
+gh api repos/JeremyKuhne/touki/pulls/<n>/comments --jq '.[] | {id, in_reply_to_id}'
+```
+
+Replying is not resolving. The thread node id is GraphQL-only:
+
+```pwsh
+gh api graphql -f query='query { repository(owner: "JeremyKuhne", name: "touki") {
+  pullRequest(number: <n>) { reviewThreads(first: 20) { nodes {
+    id isResolved comments(first: 1) { nodes { databaseId } } } } } } }'
+```
+
+Resolve with the PR tool's resolve action, then confirm `isResolved` is `true`.
+
+A declined comment gets an in-thread reply and stays open.
 
 ## Updating
 


### PR DESCRIPTION
Records a standing instruction in the `address-pr-feedback` overlay: once a
review comment is addressed, reply and resolve the thread without asking, and
treat `push` on a review round as implying that follow-through. The push itself
still needs its own verb.

This corrects a bullet in the approval-boundary section that previously listed
resolving as a separately-approved remote action.

Also records the two mechanics that are easy to get wrong:

- A reply must go to the thread's `replies` endpoint. `gh pr comment` posts to
  the main conversation and does not thread; `in_reply_to_id` is the check.
- Replying is not resolving. Resolving needs the GraphQL thread node id
  (`PRRT_...`), which the REST comment endpoints never return, and should be
  confirmed with a follow-up read of `isResolved`.

Overlay only - the vendored core `SKILL.md` is untouched, so `gh skill update`
will not flag drift.

`Validate-AgentFiles.ps1`, `Validate-AgentSkills.ps1`, and
`Test-AgentFileLinks.ps1` all pass.
