### PR TITLE
Document that TOUKI0030 requires 'using Touki.Text;'

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -255,6 +255,25 @@ captured by a lambda, put in an array, assigned to a wider local, or used in an 
 method or iterator. A warning you cannot act on is worse than no warning, so anything the
 rule cannot prove is safe to convert is left alone.
 
+### The type needs `using Touki.Text;`
+
+The snippet above assumes that directive is in scope. Adding it is the whole fix, and it
+coexists with `using System.Text;` - the two do not collide, so no alias is needed.
+
+Leaving it out produces different errors on the two targets, and the .NET Framework one
+is misleading:
+
+- .NET: `CS0246: The type or namespace name 'ValueStringBuilder' could not be found`,
+  which points straight at the missing using.
+- .NET Framework: `CS0122: 'ValueStringBuilder' is inaccessible due to its protection
+  level`. `Microsoft.IO.Redist` carries an internal `System.Text.ValueStringBuilder`, and
+  Touki references that package on .NET Framework, so it reaches consumers. A file that
+  imports `System.Text` finds that type, and "inaccessible" reads like a broken package
+  reference rather than a missing using.
+
+Once `Touki.Text` is imported the accessible type wins and the internal one is ignored,
+including when `using System.Text;` sits in an inner scope.
+
 ## TOUKI0041
 
 **Naming rule violation** - a name does not follow the configured naming rules. A


### PR DESCRIPTION
Documents that `TOUKI0030` requires `using Touki.Text;`, and why forgetting it looks like a broken package reference on .NET Framework.

The snippet under `## TOUKI0030` in `docs/analyzers.md` starts at `using ValueStringBuilder builder = new(...)`, with no indication of which namespace supplies the type. Leaving the directive out fails differently per TFM:

| TFM | Error |
| --- | --- |
| `net10.0` | `CS0246: The type or namespace name 'ValueStringBuilder' could not be found` |
| `net472` | `CS0122: 'ValueStringBuilder' is inaccessible due to its protection level` |

The `CS0122` is ours. `Microsoft.IO.Redist` declares an internal `System.Text.ValueStringBuilder` - confirmed in metadata as `System.Text.ValueStringBuilder [SequentialLayout, Sealed, BeforeFieldInit]`, no `Public` flag. It ships as a real implementation assembly, so internals survive into the compile reference, and touki takes it as a non-private `PackageReference` on the Framework TFM, so it reaches every consumer. A file importing `System.Text` finds that type, and "inaccessible" sends you hunting for a missing package.

Verified on both TFMs that there is **no collision and no alias is needed**: `using System.Text;` alongside `using Touki.Text;` compiles clean on `net10.0` and `net472`, including with `using System.Text;` nested in an inner scope so it is searched first. Lookup skips the inaccessible candidate. The docs note says "add the using", not "alias", so the workaround does not get baked in.

Not doing, per the discussion on the issue:

- Changing the diagnostic message. `messageFormat` already names `'Touki.Text.ValueStringBuilder'` fully qualified.
- A code fix for the rule.
- Hiding `Microsoft.IO.Redist` behind `PrivateAssets`. The Framework public surface exposes `FileSystemEntry`, `FileSystemEnumerator<T>`, `EnumerationOptions`, `MatchType` and `MatchCasing` from `Microsoft.IO.*`, so consumers need its compile assets.

Docs only; no code or build changes.

Fixes #252
