### PR TITLE
Make TOUKI0020 and TOUKI0021 practical to adopt

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -20,7 +20,7 @@ name a field for what it actually is.
 | [TOUKI0004](#touki0004) | By-value copy of a non-copyable struct | Reliability | Warning | - | `[NonCopyable]` |
 | [TOUKI0010](#touki0010) | Dispose a `[MustDispose]` value deterministically | Reliability | Warning | - | `[MustDispose]` |
 | [TOUKI0011](#touki0011) | Avoid large `stackalloc` allocations | Reliability | Warning | Yes | - |
-| [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | - | - |
+| [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | Yes | - |
 | [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
 | [TOUKI0022](#touki0022) | Avoid tab characters | Maintainability | **Disabled** | Yes | - |
 | [TOUKI0023](#touki0023) | Remove trailing whitespace | Maintainability | Warning | - | - |
@@ -142,9 +142,24 @@ Value.cs                 // partial struct Value - its own members
 Value.TypeFlagOfT.cs     // partial struct Value { class TypeFlag<T> }
 ```
 
-There is no code fix, because Roslyn's built-in **Move type to `<Name>.cs`** refactoring
-already does the job. The diagnostic is reported on the type identifier, which is exactly
-where that refactoring is offered.
+The code fix moves the declaration to a new file and supports IDE solution Fix All. Nested
+types remain nested inside `partial` shells that preserve the containing types' modifiers and
+type parameters. Delegates are supported too. If `Type.cs` already exists, the fix tries the
+qualified nested name (`Container.Type.cs`) and then an approved detail separator; it never
+overwrites an existing document or file.
+
+The fix is deliberately withheld for source files containing preprocessor directives,
+file-local types, declarations that reference file-local types, and linked source files. Those
+shapes cannot be moved independently without changing preprocessing or identity, editing
+several projects at once, or breaking symbol binding.
+
+To enforce top-level types now and defer nested types, set:
+
+```ini
+dotnet_code_quality.TOUKI0020.exclude_nested_types = true
+```
+
+The default is `false`.
 
 ## TOUKI0021
 
@@ -172,7 +187,44 @@ dotnet_code_quality.TOUKI0021.file_name_detail_separators = .-
 
 Comparison is ordinal, so `foo.cs` is reported for type `Foo` even on a case-insensitive
 file system. Files that declare no types - global usings, assembly-level attributes - are
-not reported.
+not reported. An empty partial shell containing conditional directives is also omitted, so a
+file for a conditionally compiled nested type does not disagree between build configurations.
+
+The diagnostic suggests an accepted name that is unoccupied in the current compilation. The
+code fix revalidates that name against the complete solution and filesystem before applying it.
+Nested types prefer `Container.Type.cs`. When a partial type has declarations in several files,
+the current stem is retained as detail, for example `Parser.SecurityTests.cs`, instead of
+colliding on `Parser.cs`. IDE solution Fix All allocates names across the complete solution
+before applying each rename. Linked source files are left unchanged because one physical rename
+would have to update every project that includes the file.
+
+### Adopting TOUKI0020 and TOUKI0021
+
+Adopt TOUKI0020 first with IDE solution Fix All. Splitting declarations is what makes most
+file names satisfy TOUKI0021, so renaming first creates throwaway work. Both severities can be
+scoped by path in `.editorconfig`; keep unconverted directories at `none` and raise completed
+directories to `warning` when staging a large repository.
+
+After splitting, clean up imports through the built-in style lane, then use IDE solution Fix
+All for TOUKI0021:
+
+```powershell
+dotnet format style <project> --diagnostics IDE0005 --severity warn
+```
+
+`dotnet format analyzers` cannot safely apply either structural fix. Its `MSBuildWorkspace`
+persists added source documents as explicit `Compile` items that collide with SDK default
+globs, and it does not support document-info renames. The providers therefore decline Fix All
+and individual actions in that host instead of leaving a broken project. Rerun the IDE0005
+command until it produces no changes. When moving a nested type by hand, repeat the container's
+exact modifiers and type parameters on every `partial` shell; the TOUKI0020 fix does this
+automatically.
+
+For a large migration, compare the author-written metadata type names before and after in
+addition to building and testing. `PEReader` and `MetadataReader.TypeDefinitions` can produce
+the list; walk `GetDeclaringType()` for nested names and exclude compiler-generated names
+containing `<` or `>`. This catches a missing declaration even when the remaining assembly
+still builds and its tests pass.
 
 ## TOUKI0022
 

--- a/touki.analyzers.codefixes/MoveTypeToFileCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MoveTypeToFileCodeFixProvider.cs
@@ -342,7 +342,9 @@ public sealed class MoveTypeToFileCodeFixProvider : CodeFixProvider
         }
 
         string currentStem = Path.GetFileNameWithoutExtension(document.FilePath!);
-        string detailStem = $"{qualifiedStem}{detailSeparator}{currentStem}";
+        string detailStem = string.Equals(qualifiedStem, currentStem, StringComparison.OrdinalIgnoreCase)
+            ? qualifiedStem
+            : $"{qualifiedStem}{detailSeparator}{currentStem}";
         string detailCandidate = detailStem + extension;
         if (IsDestinationAvailable(solution, document, detailCandidate))
         {

--- a/touki.analyzers.codefixes/MoveTypeToFileCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MoveTypeToFileCodeFixProvider.cs
@@ -1,0 +1,1009 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Offers a move-to-file fix for extra declarations reported by <c>TOUKI0020</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Nested types remain nested. Their containing types are repeated as partial shells with the original
+///   modifiers and type parameters, while attributes, inheritance, constraints, and primary constructors stay
+///   on the original declaration.
+///  </para>
+///  <para>
+///   Solution-wide Fix All is not offered in <c>MSBuildWorkspace</c>, used by <c>dotnet format</c>, because that
+///   workspace persists added source documents as explicit compile items that collide with SDK default globs.
+///  </para>
+///  <para>
+///   No fix is offered for a source file containing directives, a file-local declaration, or a declaration that
+///   references a file-local type. Moving any of those independently can change preprocessing or symbol binding.
+///  </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(MoveTypeToFileCodeFixProvider))]
+[Shared]
+public sealed class MoveTypeToFileCodeFixProvider : CodeFixProvider
+{
+    private const string OneTypePerFileId = "TOUKI0020";
+    private const string DetailSeparatorsOption = "dotnet_code_quality.TOUKI0021.file_name_detail_separators";
+    private const string DefaultDetailSeparators = ".-_";
+    private const string EquivalenceKey = nameof(MoveTypeToFileCodeFixProvider);
+
+    private static readonly ImmutableArray<string> s_fixableDiagnosticIds = [OneTypePerFileId];
+    private static readonly FixAllProvider s_fixAllProvider = new MoveTypeFixAllProvider();
+    private static readonly SyntaxAnnotation s_madePartialByMove = new(nameof(s_madePartialByMove));
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => s_fixableDiagnosticIds;
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => s_fixAllProvider;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        if (await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false)
+            is not CompilationUnitSyntax root)
+        {
+            return;
+        }
+
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            MemberDeclarationSyntax? declaration = FindDeclaration(root, diagnostic.Location.SourceSpan.Start);
+            if (declaration is null
+                || !await CanMoveAsync(
+                    context.Document,
+                    root,
+                    declaration,
+                    context.CancellationToken).ConfigureAwait(false))
+            {
+                continue;
+            }
+
+            char detailSeparator = GetDetailSeparator(context.Document, root.SyntaxTree);
+            string fileName = GetAvailableFileName(
+                context.Document.Project.Solution,
+                context.Document,
+                declaration,
+                detailSeparator);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Move type to '{fileName}'",
+                    cancellationToken => MoveAsync(
+                        context.Document,
+                        declaration,
+                        fileName,
+                        cancellationToken),
+                    EquivalenceKey),
+                diagnostic);
+        }
+    }
+
+    private static MemberDeclarationSyntax? FindDeclaration(CompilationUnitSyntax root, int position)
+    {
+        for (SyntaxNode? node = root.FindToken(position).Parent; node is not null; node = node.Parent)
+        {
+            if (node is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax)
+            {
+                return (MemberDeclarationSyntax)node;
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<bool> CanMoveAsync(
+        Document document,
+        CompilationUnitSyntax root,
+        MemberDeclarationSyntax declaration,
+        CancellationToken cancellationToken)
+    {
+        if (document.FilePath is null
+            || document.Project.Solution.Workspace.Kind == WorkspaceKind.MSBuild
+            || !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.AddDocument)
+            || !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument)
+            || HasSharedFilePath(document.Project.Solution, document)
+            || ContainsDirective(root)
+            || ContainsFileLocalDeclaration(root))
+        {
+            return false;
+        }
+
+        for (SyntaxNode? node = declaration; node is not null; node = node.Parent)
+        {
+            if (node is MemberDeclarationSyntax memberDeclaration
+                && HasFileModifier(memberDeclaration))
+            {
+                return false;
+            }
+
+            if (node is CompilationUnitSyntax)
+            {
+                break;
+            }
+        }
+
+        SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null
+            || ContainsFileLocalType(semanticModel.GetDeclaredSymbol(declaration, cancellationToken)))
+        {
+            return false;
+        }
+
+        foreach (SyntaxNode node in declaration.DescendantNodes())
+        {
+            if (node is not SimpleNameSyntax name)
+            {
+                continue;
+            }
+
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(name, cancellationToken);
+            if (ContainsFileLocalType(symbolInfo.Symbol))
+            {
+                return false;
+            }
+
+            foreach (ISymbol candidate in symbolInfo.CandidateSymbols)
+            {
+                if (ContainsFileLocalType(candidate))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsDirective(CompilationUnitSyntax root)
+    {
+        foreach (SyntaxTrivia trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (trivia.IsDirective)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsFileLocalDeclaration(CompilationUnitSyntax root)
+    {
+        foreach (SyntaxNode node in root.DescendantNodes())
+        {
+            if (node is MemberDeclarationSyntax declaration && HasFileModifier(declaration))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasFileModifier(MemberDeclarationSyntax declaration) => declaration switch
+    {
+        BaseTypeDeclarationSyntax typeDeclaration => typeDeclaration.Modifiers.Any(SyntaxKind.FileKeyword),
+        DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.Modifiers.Any(SyntaxKind.FileKeyword),
+        _ => false
+    };
+
+    private static bool ContainsFileLocalType(ISymbol? symbol)
+    {
+        if (symbol is null)
+        {
+            return false;
+        }
+
+        if (symbol is IAliasSymbol alias)
+        {
+            return ContainsFileLocalType(alias.Target);
+        }
+
+        if (ContainsFileLocalType(symbol.ContainingType))
+        {
+            return true;
+        }
+
+        return symbol switch
+        {
+            IEventSymbol eventSymbol => ContainsFileLocalType(eventSymbol.Type),
+            IFieldSymbol fieldSymbol => ContainsFileLocalType(fieldSymbol.Type),
+            ILocalSymbol localSymbol => ContainsFileLocalType(localSymbol.Type),
+            IMethodSymbol methodSymbol => ContainsFileLocalType(methodSymbol.ReturnType)
+                || ContainsFileLocalType(methodSymbol.Parameters),
+            INamedTypeSymbol namedType => ContainsFileLocalType((ITypeSymbol)namedType),
+            IParameterSymbol parameterSymbol => ContainsFileLocalType(parameterSymbol.Type),
+            IPropertySymbol propertySymbol => ContainsFileLocalType(propertySymbol.Type),
+            _ => false
+        };
+    }
+
+    private static bool ContainsFileLocalType(ImmutableArray<IParameterSymbol> parameters)
+    {
+        foreach (IParameterSymbol parameter in parameters)
+        {
+            if (ContainsFileLocalType(parameter.Type))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsFileLocalType(ITypeSymbol? type)
+    {
+        switch (type)
+        {
+            case null:
+                return false;
+            case IArrayTypeSymbol arrayType:
+                return ContainsFileLocalType(arrayType.ElementType);
+            case INamedTypeSymbol namedType:
+                if (namedType.IsFileLocal)
+                {
+                    return true;
+                }
+
+                foreach (ITypeSymbol typeArgument in namedType.TypeArguments)
+                {
+                    if (ContainsFileLocalType(typeArgument))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            case IPointerTypeSymbol pointerType:
+                return ContainsFileLocalType(pointerType.PointedAtType);
+            default:
+                return false;
+        }
+    }
+
+    private static bool HasSharedFilePath(Solution solution, Document document)
+    {
+        string filePath = document.FilePath!;
+
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document candidate in project.Documents)
+            {
+                if (candidate.Id != document.Id
+                    && string.Equals(candidate.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static char GetDetailSeparator(Document document, SyntaxTree syntaxTree)
+    {
+        AnalyzerConfigOptions options = document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
+        string separators = options.TryGetValue(DetailSeparatorsOption, out string? configuredSeparators)
+            && !string.IsNullOrWhiteSpace(configuredSeparators)
+                ? configuredSeparators!.Trim()
+                : DefaultDetailSeparators;
+
+        foreach (char separator in separators)
+        {
+            if (Array.IndexOf(Path.GetInvalidFileNameChars(), separator) < 0)
+            {
+                return separator;
+            }
+        }
+
+        return '.';
+    }
+
+    private static string GetAvailableFileName(
+        Solution solution,
+        Document document,
+        MemberDeclarationSyntax declaration,
+        char detailSeparator)
+    {
+        string extension = Path.GetExtension(document.FilePath!);
+        string typeName = GetIdentifier(declaration).ValueText;
+        string simpleCandidate = typeName + extension;
+        if (IsDestinationAvailable(solution, document, simpleCandidate))
+        {
+            return simpleCandidate;
+        }
+
+        string qualifiedStem = GetQualifiedTypeStem(declaration);
+        string qualifiedCandidate = qualifiedStem + extension;
+        if (!string.Equals(simpleCandidate, qualifiedCandidate, StringComparison.OrdinalIgnoreCase)
+            && IsDestinationAvailable(solution, document, qualifiedCandidate))
+        {
+            return qualifiedCandidate;
+        }
+
+        string currentStem = Path.GetFileNameWithoutExtension(document.FilePath!);
+        string detailStem = $"{qualifiedStem}{detailSeparator}{currentStem}";
+        string detailCandidate = detailStem + extension;
+        if (IsDestinationAvailable(solution, document, detailCandidate))
+        {
+            return detailCandidate;
+        }
+
+        for (int suffix = 2; ; suffix++)
+        {
+            string candidate = $"{detailStem}{detailSeparator}{suffix}{extension}";
+            if (IsDestinationAvailable(solution, document, candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private static string GetQualifiedTypeStem(MemberDeclarationSyntax declaration)
+    {
+        Stack<string> names = new();
+        names.Push(GetIdentifier(declaration).ValueText);
+
+        foreach (SyntaxNode ancestor in declaration.Ancestors())
+        {
+            if (ancestor is TypeDeclarationSyntax typeDeclaration)
+            {
+                names.Push(typeDeclaration.Identifier.ValueText);
+            }
+        }
+
+        return string.Join(".", names);
+    }
+
+    private static bool IsDestinationAvailable(Solution solution, Document document, string fileName)
+    {
+        string targetFilePath = GetTargetFilePath(document, fileName)!;
+
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document candidate in project.Documents)
+            {
+                if (string.Equals(candidate.FilePath, targetFilePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return IsFileSystemDestinationAvailable(document.FilePath!, targetFilePath);
+    }
+
+    private static bool IsFileSystemDestinationAvailable(string currentFilePath, string targetFilePath)
+    {
+        string fullCurrentPath = Path.GetFullPath(currentFilePath);
+        string fullTargetPath = Path.GetFullPath(targetFilePath);
+        if (string.Equals(fullCurrentPath, fullTargetPath, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        string? directory = Path.GetDirectoryName(fullTargetPath);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            return true;
+        }
+
+        string targetName = Path.GetFileName(fullTargetPath);
+
+        try
+        {
+            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
+            {
+                string fullEntryPath = Path.GetFullPath(entry);
+                if (string.Equals(fullEntryPath, fullCurrentPath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (string.Equals(Path.GetFileName(fullEntryPath), targetName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string? GetTargetFilePath(Document document, string fileName)
+    {
+        if (document.FilePath is null)
+        {
+            return null;
+        }
+
+        string? directory = Path.GetDirectoryName(document.FilePath);
+        return string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+    }
+
+    private static async Task<Solution> MoveAsync(
+        Document document,
+        MemberDeclarationSyntax declaration,
+        string fileName,
+        CancellationToken cancellationToken)
+    {
+        if (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)
+            is not CompilationUnitSyntax root)
+        {
+            return document.Project.Solution;
+        }
+
+        SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
+        ImmutableArray<MemberDeclarationSyntax> declarations =
+            await GetDeclarationsToMoveAsync(document, root, declaration, cancellationToken).ConfigureAwait(false);
+        CompilationUnitSyntax destinationRoot = CreateDestinationRoot(root, declarations, generator);
+        CompilationUnitSyntax sourceRoot = CreateSourceRoot(root, declarations, generator);
+        string? targetFilePath = GetTargetFilePath(document, fileName);
+        if (targetFilePath is null)
+        {
+            return document.Project.Solution;
+        }
+
+        Document destinationDocument = document.Project.AddDocument(
+            fileName,
+            destinationRoot,
+            document.Folders,
+            targetFilePath);
+        return destinationDocument.Project.Solution.WithDocumentSyntaxRoot(document.Id, sourceRoot);
+    }
+
+    private static async Task<ImmutableArray<MemberDeclarationSyntax>> GetDeclarationsToMoveAsync(
+        Document document,
+        CompilationUnitSyntax root,
+        MemberDeclarationSyntax declaration,
+        CancellationToken cancellationToken)
+    {
+        if (declaration is not TypeDeclarationSyntax typeDeclaration
+            || !typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            return [declaration];
+        }
+
+        SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        ISymbol? symbol = semanticModel?.GetDeclaredSymbol(typeDeclaration, cancellationToken);
+        if (symbol is null)
+        {
+            return [declaration];
+        }
+
+        List<MemberDeclarationSyntax> declarations = [];
+        foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (reference.SyntaxTree == root.SyntaxTree
+                && await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false)
+                    is MemberDeclarationSyntax matchingDeclaration)
+            {
+                declarations.Add(matchingDeclaration);
+            }
+        }
+
+        declarations.Sort(static (left, right) => left.SpanStart.CompareTo(right.SpanStart));
+        return declarations.Count == 0 ? [declaration] : [.. declarations];
+    }
+
+    private static CompilationUnitSyntax CreateDestinationRoot(
+        CompilationUnitSyntax root,
+        ImmutableArray<MemberDeclarationSyntax> declarations,
+        SyntaxGenerator generator)
+    {
+        HashSet<MemberDeclarationSyntax> declarationsToMove = new(declarations);
+        SyntaxList<MemberDeclarationSyntax> movedMembers = GetMovedMembers(
+            root.Members,
+            declarationsToMove,
+            generator);
+
+        List<UsingDirectiveSyntax> usings = [];
+        foreach (UsingDirectiveSyntax usingDirective in root.Usings)
+        {
+            if (usingDirective.GlobalKeyword.IsKind(SyntaxKind.None))
+            {
+                usings.Add(usingDirective);
+            }
+        }
+
+        CompilationUnitSyntax destinationRoot = root
+            .WithAttributeLists([])
+            .WithUsings(SyntaxFactory.List(usings))
+            .WithMembers(movedMembers);
+        return CopyFileBanner(root, destinationRoot);
+    }
+
+    private static SyntaxList<MemberDeclarationSyntax> GetMovedMembers(
+        SyntaxList<MemberDeclarationSyntax> members,
+        HashSet<MemberDeclarationSyntax> declarationsToMove,
+        SyntaxGenerator generator)
+    {
+        List<MemberDeclarationSyntax> movedMembers = [];
+
+        foreach (MemberDeclarationSyntax member in members)
+        {
+            if (declarationsToMove.Contains(member))
+            {
+                movedMembers.Add(member);
+                continue;
+            }
+
+            switch (member)
+            {
+                case BaseNamespaceDeclarationSyntax namespaceDeclaration:
+                    SyntaxList<MemberDeclarationSyntax> namespaceMembers = GetMovedMembers(
+                        namespaceDeclaration.Members,
+                        declarationsToMove,
+                        generator);
+                    if (namespaceMembers.Count > 0)
+                    {
+                        movedMembers.Add(namespaceDeclaration.WithMembers(namespaceMembers));
+                    }
+
+                    break;
+                case TypeDeclarationSyntax typeDeclaration:
+                    SyntaxList<MemberDeclarationSyntax> nestedMembers = GetMovedMembers(
+                        typeDeclaration.Members,
+                        declarationsToMove,
+                        generator);
+                    if (nestedMembers.Count > 0)
+                    {
+                        movedMembers.Add(CreatePartialShell(typeDeclaration, nestedMembers, generator));
+                    }
+
+                    break;
+            }
+        }
+
+        return SyntaxFactory.List(movedMembers);
+    }
+
+    private static TypeDeclarationSyntax CreatePartialShell(
+        TypeDeclarationSyntax container,
+        SyntaxList<MemberDeclarationSyntax> members,
+        SyntaxGenerator generator)
+    {
+        TypeDeclarationSyntax shell = container
+            .WithAttributeLists([])
+            .WithBaseList(null)
+            .WithConstraintClauses([])
+            .WithParameterList(null)
+            .WithMembers(members);
+        if (shell.TypeParameterList is { } typeParameterList)
+        {
+            TypeParameterListSyntax sanitizedTypeParameters = typeParameterList.ReplaceNodes(
+                typeParameterList.Parameters,
+                static (_, rewritten) => rewritten.WithAttributeLists([]));
+            shell = shell.WithTypeParameterList(sanitizedTypeParameters);
+        }
+
+        shell = MakePartial(shell, generator);
+
+        SyntaxTriviaList leadingTrivia = shell.GetLeadingTrivia();
+        List<SyntaxTrivia> whitespace = [];
+        foreach (SyntaxTrivia trivia in leadingTrivia)
+        {
+            if (trivia.IsKind(SyntaxKind.WhitespaceTrivia) || trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                whitespace.Add(trivia);
+            }
+        }
+
+        return shell.WithLeadingTrivia(whitespace);
+    }
+
+    private static CompilationUnitSyntax CreateSourceRoot(
+        CompilationUnitSyntax root,
+        ImmutableArray<MemberDeclarationSyntax> declarations,
+        SyntaxGenerator generator)
+    {
+        SyntaxAnnotation declarationAnnotation = new();
+        SyntaxAnnotation prunableContainerAnnotation = new();
+        CompilationUnitSyntax annotatedRoot = root.ReplaceNodes(
+            declarations,
+            (_, rewritten) => rewritten.WithAdditionalAnnotations(declarationAnnotation));
+        List<TypeDeclarationSyntax> containers = [];
+        HashSet<TypeDeclarationSyntax> prunableContainers = [];
+
+        foreach (SyntaxNode annotatedDeclaration in annotatedRoot.GetAnnotatedNodes(declarationAnnotation))
+        {
+            foreach (SyntaxNode ancestor in annotatedDeclaration.Ancestors())
+            {
+                if (ancestor is TypeDeclarationSyntax typeDeclaration && !containers.Contains(typeDeclaration))
+                {
+                    containers.Add(typeDeclaration);
+                    if (IsContributionFreePartialContainer(typeDeclaration))
+                    {
+                        prunableContainers.Add(typeDeclaration);
+                    }
+                }
+            }
+        }
+
+        SyntaxNode updatedRoot = annotatedRoot.ReplaceNodes(
+            containers,
+            (original, rewritten) =>
+            {
+                TypeDeclarationSyntax updatedContainer = MakePartial(
+                    (TypeDeclarationSyntax)rewritten,
+                    generator);
+                if (!((TypeDeclarationSyntax)original).Modifiers.Any(SyntaxKind.PartialKeyword))
+                {
+                    updatedContainer = updatedContainer.WithAdditionalAnnotations(s_madePartialByMove);
+                }
+
+                return prunableContainers.Contains((TypeDeclarationSyntax)original)
+                    ? updatedContainer.WithAdditionalAnnotations(prunableContainerAnnotation)
+                    : updatedContainer;
+            });
+        List<SyntaxNode> declarationsToRemove = [.. updatedRoot.GetAnnotatedNodes(declarationAnnotation)];
+        updatedRoot = updatedRoot.RemoveNodes(declarationsToRemove, SyntaxRemoveOptions.KeepNoTrivia)!;
+
+        while (true)
+        {
+            TypeDeclarationSyntax? emptyShell = null;
+            foreach (SyntaxNode node in updatedRoot.GetAnnotatedNodes(prunableContainerAnnotation))
+            {
+                if (node is TypeDeclarationSyntax typeDeclaration && IsContributionFreeEmptyShell(typeDeclaration))
+                {
+                    emptyShell = typeDeclaration;
+                    break;
+                }
+            }
+
+            if (emptyShell is null)
+            {
+                return (CompilationUnitSyntax)updatedRoot;
+            }
+
+            updatedRoot = updatedRoot.RemoveNode(emptyShell, SyntaxRemoveOptions.KeepExteriorTrivia)!;
+        }
+    }
+
+    private static bool IsContributionFreePartialContainer(TypeDeclarationSyntax declaration)
+    {
+        if (declaration.AttributeLists.Count > 0
+            || declaration.BaseList is not null
+            || declaration.ConstraintClauses.Count > 0
+            || declaration.ParameterList is not null
+            || !declaration.Modifiers.Any(SyntaxKind.PartialKeyword)
+            || declaration.HasAnnotation(s_madePartialByMove)
+            || HasDocumentationComment(declaration.GetLeadingTrivia()))
+        {
+            return false;
+        }
+
+        if (declaration.TypeParameterList is not { } typeParameterList)
+        {
+            return true;
+        }
+
+        foreach (TypeParameterSyntax parameter in typeParameterList.Parameters)
+        {
+            if (parameter.AttributeLists.Count > 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasDocumentationComment(SyntaxTriviaList triviaList)
+    {
+        foreach (SyntaxTrivia trivia in triviaList)
+        {
+            if (trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+                || trivia.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsContributionFreeEmptyShell(TypeDeclarationSyntax declaration)
+    {
+        return declaration.Members.Count == 0 && IsContributionFreePartialContainer(declaration);
+    }
+
+    private static TypeDeclarationSyntax MakePartial(TypeDeclarationSyntax declaration, SyntaxGenerator generator)
+    {
+        DeclarationModifiers modifiers = generator.GetModifiers(declaration);
+        return modifiers.IsPartial
+            ? declaration
+            : (TypeDeclarationSyntax)generator.WithModifiers(declaration, modifiers.WithPartial(true));
+    }
+
+    private static MemberDeclarationSyntax? GetAnnotatedDeclaration(SyntaxNode root, SyntaxAnnotation annotation)
+    {
+        foreach (SyntaxNode node in root.GetAnnotatedNodes(annotation))
+        {
+            if (node is MemberDeclarationSyntax declaration)
+            {
+                return declaration;
+            }
+        }
+
+        return null;
+    }
+
+    private static CompilationUnitSyntax CopyFileBanner(
+        CompilationUnitSyntax sourceRoot,
+        CompilationUnitSyntax destinationRoot)
+    {
+        SyntaxTriviaList banner = GetFileBanner(sourceRoot);
+        if (banner.Count == 0
+            || destinationRoot.GetLeadingTrivia().ToFullString().StartsWith(
+                banner.ToFullString(),
+                StringComparison.Ordinal))
+        {
+            return destinationRoot;
+        }
+
+        return destinationRoot.WithLeadingTrivia(banner.AddRange(destinationRoot.GetLeadingTrivia()));
+    }
+
+    private static SyntaxTriviaList GetFileBanner(CompilationUnitSyntax root)
+    {
+        SyntaxTriviaList leadingTrivia = root.GetLeadingTrivia();
+        List<SyntaxTrivia> banner = [];
+        bool sawComment = false;
+        int consecutiveLineBreaks = 0;
+
+        foreach (SyntaxTrivia trivia in leadingTrivia)
+        {
+            banner.Add(trivia);
+
+            if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
+                || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia))
+            {
+                sawComment = true;
+                consecutiveLineBreaks = 0;
+                continue;
+            }
+
+            if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                consecutiveLineBreaks++;
+                if (sawComment && consecutiveLineBreaks >= 2)
+                {
+                    return SyntaxFactory.TriviaList(banner);
+                }
+
+                continue;
+            }
+
+            if (!trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                return [];
+            }
+        }
+
+        return [];
+    }
+
+    private static SyntaxToken GetIdentifier(MemberDeclarationSyntax declaration) => declaration switch
+    {
+        BaseTypeDeclarationSyntax typeDeclaration => typeDeclaration.Identifier,
+        DelegateDeclarationSyntax delegateDeclaration => delegateDeclaration.Identifier,
+        _ => default
+    };
+
+    private sealed class MoveTypeFixAllProvider : FixAllProvider
+    {
+        public override Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+        {
+            if (fixAllContext.Solution.Workspace.Kind == WorkspaceKind.MSBuild)
+            {
+                return Task.FromResult<CodeAction?>(null);
+            }
+
+            CodeAction action = CodeAction.Create(
+                "Move types to separate files",
+                cancellationToken => MoveAllAsync(fixAllContext, cancellationToken),
+                EquivalenceKey);
+            return Task.FromResult<CodeAction?>(action);
+        }
+
+        private static async Task<Solution> MoveAllAsync(
+            FixAllContext context,
+            CancellationToken cancellationToken)
+        {
+            ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+            switch (context.Scope)
+            {
+                case FixAllScope.Document when context.Document is not null:
+                    diagnostics.AddRange(await context.GetDocumentDiagnosticsAsync(context.Document).ConfigureAwait(false));
+                    break;
+                case FixAllScope.Project:
+                    diagnostics.AddRange(await context.GetAllDiagnosticsAsync(context.Project).ConfigureAwait(false));
+                    break;
+                case FixAllScope.Solution:
+                    foreach (Project project in context.Solution.Projects)
+                    {
+                        diagnostics.AddRange(await context.GetAllDiagnosticsAsync(project).ConfigureAwait(false));
+                    }
+
+                    break;
+            }
+
+            Dictionary<DocumentId, CompilationUnitSyntax> annotatedRoots = [];
+            List<MoveRequest> requests = [];
+
+            foreach (Diagnostic diagnostic in diagnostics)
+            {
+                if (diagnostic.Location.SourceTree is null)
+                {
+                    continue;
+                }
+
+                Document? document = context.Solution.GetDocument(diagnostic.Location.SourceTree);
+                if (document?.FilePath is null)
+                {
+                    continue;
+                }
+
+                if (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)
+                    is not CompilationUnitSyntax documentRoot)
+                {
+                    continue;
+                }
+
+                MemberDeclarationSyntax? originalDeclaration =
+                    FindDeclaration(documentRoot, diagnostic.Location.SourceSpan.Start);
+                if (originalDeclaration is null
+                    || !await CanMoveAsync(
+                        document,
+                        documentRoot,
+                        originalDeclaration,
+                        cancellationToken).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
+                CompilationUnitSyntax root = annotatedRoots.TryGetValue(document.Id, out CompilationUnitSyntax? annotatedRoot)
+                    ? annotatedRoot
+                    : documentRoot;
+                MemberDeclarationSyntax? declaration = FindDeclaration(root, diagnostic.Location.SourceSpan.Start);
+                if (declaration is null)
+                {
+                    continue;
+                }
+
+                SyntaxAnnotation annotation = new();
+                root = root.ReplaceNode(declaration, declaration.WithAdditionalAnnotations(annotation));
+                annotatedRoots[document.Id] = root;
+                requests.Add(new(
+                    document.Id,
+                    document.FilePath,
+                    annotation,
+                    GetNestingDepth(originalDeclaration),
+                    diagnostic.Location.SourceSpan.Start));
+            }
+
+            requests.Sort(static (left, right) =>
+            {
+                int pathComparison = StringComparer.OrdinalIgnoreCase.Compare(
+                    left.OriginalFilePath,
+                    right.OriginalFilePath);
+                if (pathComparison != 0)
+                {
+                    return pathComparison;
+                }
+
+                int depthComparison = right.NestingDepth.CompareTo(left.NestingDepth);
+                return depthComparison != 0
+                    ? depthComparison
+                    : left.SourcePosition.CompareTo(right.SourcePosition);
+            });
+
+            Solution solution = context.Solution;
+            foreach (KeyValuePair<DocumentId, CompilationUnitSyntax> annotatedRoot in annotatedRoots)
+            {
+                solution = solution.WithDocumentSyntaxRoot(annotatedRoot.Key, annotatedRoot.Value);
+            }
+
+            foreach (MoveRequest request in requests)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Document? document = solution.GetDocument(request.DocumentId);
+                if (document is null
+                    || await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)
+                        is not CompilationUnitSyntax root)
+                {
+                    continue;
+                }
+
+                MemberDeclarationSyntax? declaration = GetAnnotatedDeclaration(root, request.Annotation);
+                if (declaration is null
+                    || !await CanMoveAsync(
+                        document,
+                        root,
+                        declaration,
+                        cancellationToken).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
+                char detailSeparator = GetDetailSeparator(document, root.SyntaxTree);
+                string fileName = GetAvailableFileName(solution, document, declaration, detailSeparator);
+                solution = await MoveAsync(document, declaration, fileName, cancellationToken).ConfigureAwait(false);
+            }
+
+            return solution;
+        }
+
+        private static int GetNestingDepth(MemberDeclarationSyntax declaration)
+        {
+            int depth = 0;
+
+            foreach (SyntaxNode ancestor in declaration.Ancestors())
+            {
+                if (ancestor is TypeDeclarationSyntax)
+                {
+                    depth++;
+                }
+            }
+
+            return depth;
+        }
+    }
+
+    private readonly struct MoveRequest
+    {
+        public MoveRequest(
+            DocumentId documentId,
+            string originalFilePath,
+            SyntaxAnnotation annotation,
+            int nestingDepth,
+            int sourcePosition)
+        {
+            DocumentId = documentId;
+            OriginalFilePath = originalFilePath;
+            Annotation = annotation;
+            NestingDepth = nestingDepth;
+            SourcePosition = sourcePosition;
+        }
+
+        public DocumentId DocumentId { get; }
+
+        public string OriginalFilePath { get; }
+
+        public SyntaxAnnotation Annotation { get; }
+
+        public int NestingDepth { get; }
+
+        public int SourcePosition { get; }
+    }
+}

--- a/touki.analyzers.codefixes/RenameFileToMatchTypeCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/RenameFileToMatchTypeCodeFixProvider.cs
@@ -1,0 +1,354 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Offers a collision-aware file rename for <c>TOUKI0021</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   Workspaces that support document-info changes receive a normal rename. Structural actions are not offered in
+///   <c>MSBuildWorkspace</c>, used by <c>dotnet format</c>: that workspace cannot rename document info, and a
+///   remove/add replacement writes explicit compile items that collide with SDK default globs.
+///  </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RenameFileToMatchTypeCodeFixProvider))]
+[Shared]
+public sealed class RenameFileToMatchTypeCodeFixProvider : CodeFixProvider
+{
+    private const string FileNameMatchesTypeId = "TOUKI0021";
+    private const string SuggestedFileNameProperty = "SuggestedFileName";
+    private const string SuggestedDetailSeparatorProperty = "SuggestedDetailSeparator";
+    private const string EquivalenceKey = nameof(RenameFileToMatchTypeCodeFixProvider);
+
+    private static readonly ImmutableArray<string> s_fixableDiagnosticIds = [FileNameMatchesTypeId];
+    private static readonly FixAllProvider s_fixAllProvider = new RenameFileFixAllProvider();
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => s_fixableDiagnosticIds;
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => s_fixAllProvider;
+
+    /// <inheritdoc/>
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            if (!TryGetSuggestion(diagnostic, out string suggestedFileName, out char detailSeparator)
+                || !CanRename(context.Document))
+            {
+                continue;
+            }
+
+            string availableFileName = GetAvailableFileName(
+                context.Document.Project.Solution,
+                context.Document,
+                suggestedFileName,
+                detailSeparator);
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    $"Rename file to '{availableFileName}'",
+                    cancellationToken => RenameDocumentAsync(
+                        context.Document.Project.Solution,
+                        context.Document,
+                        availableFileName,
+                        cancellationToken),
+                    EquivalenceKey),
+                diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static bool TryGetSuggestion(
+        Diagnostic diagnostic,
+        out string suggestedFileName,
+        out char detailSeparator)
+    {
+        if (diagnostic.Properties.TryGetValue(SuggestedFileNameProperty, out string? value)
+            && !string.IsNullOrWhiteSpace(value)
+            && string.Equals(Path.GetFileName(value), value, StringComparison.Ordinal)
+            && diagnostic.Properties.TryGetValue(SuggestedDetailSeparatorProperty, out string? separatorValue)
+            && separatorValue is { Length: 1 })
+        {
+            suggestedFileName = value!;
+            detailSeparator = separatorValue[0];
+            return true;
+        }
+
+        suggestedFileName = string.Empty;
+        detailSeparator = default;
+        return false;
+    }
+
+    private static bool CanRename(Document document) =>
+        document.FilePath is not null
+        && document.Project.Solution.Workspace.Kind != WorkspaceKind.MSBuild
+        && document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocumentInfo)
+        && !HasSharedFilePath(document.Project.Solution, document);
+
+    private static bool HasSharedFilePath(Solution solution, Document document)
+    {
+        string filePath = document.FilePath!;
+
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document candidate in project.Documents)
+            {
+                if (candidate.Id != document.Id
+                    && string.Equals(candidate.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetAvailableFileName(
+        Solution solution,
+        Document document,
+        string suggestedFileName,
+        char detailSeparator)
+    {
+        if (IsDestinationAvailable(solution, document, suggestedFileName))
+        {
+            return suggestedFileName;
+        }
+
+        string extension = Path.GetExtension(suggestedFileName);
+        string stem = Path.GetFileNameWithoutExtension(suggestedFileName);
+
+        for (int suffix = 2; ; suffix++)
+        {
+            string candidate = $"{stem}{detailSeparator}{suffix}{extension}";
+            if (IsDestinationAvailable(solution, document, candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private static bool IsDestinationAvailable(Solution solution, Document document, string fileName)
+    {
+        string targetFilePath = GetTargetFilePath(document, fileName)!;
+        string currentFilePath = document.FilePath!;
+
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document candidate in project.Documents)
+            {
+                if (candidate.Id != document.Id
+                    && string.Equals(candidate.FilePath, targetFilePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return IsFileSystemDestinationAvailable(currentFilePath, targetFilePath);
+    }
+
+    private static bool IsFileSystemDestinationAvailable(string currentFilePath, string targetFilePath)
+    {
+        string fullCurrentPath = Path.GetFullPath(currentFilePath);
+        string fullTargetPath = Path.GetFullPath(targetFilePath);
+        if (string.Equals(fullCurrentPath, fullTargetPath, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        string? directory = Path.GetDirectoryName(fullTargetPath);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            return true;
+        }
+
+        string targetName = Path.GetFileName(fullTargetPath);
+
+        try
+        {
+            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
+            {
+                string fullEntryPath = Path.GetFullPath(entry);
+                if (string.Equals(fullEntryPath, fullCurrentPath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (string.Equals(Path.GetFileName(fullEntryPath), targetName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string? GetTargetFilePath(Document document, string fileName)
+    {
+        if (document.FilePath is null)
+        {
+            return null;
+        }
+
+        string? directory = Path.GetDirectoryName(document.FilePath);
+        return string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+    }
+
+    private static Task<Solution> RenameDocumentAsync(
+        Solution solution,
+        Document document,
+        string fileName,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        string? targetFilePath = GetTargetFilePath(document, fileName);
+        if (targetFilePath is null)
+        {
+            return Task.FromResult(solution);
+        }
+
+        Solution renamedSolution = solution
+                .WithDocumentName(document.Id, fileName)
+                .WithDocumentFilePath(document.Id, targetFilePath);
+        return Task.FromResult(renamedSolution);
+    }
+
+    private sealed class RenameFileFixAllProvider : FixAllProvider
+    {
+        public override Task<CodeAction?> GetFixAsync(FixAllContext fixAllContext)
+        {
+            if (fixAllContext.Solution.Workspace.Kind == WorkspaceKind.MSBuild)
+            {
+                return Task.FromResult<CodeAction?>(null);
+            }
+
+            CodeAction action = CodeAction.Create(
+                "Rename files to match their types",
+                cancellationToken => RenameAllAsync(fixAllContext, cancellationToken),
+                EquivalenceKey);
+            return Task.FromResult<CodeAction?>(action);
+        }
+
+        private static async Task<Solution> RenameAllAsync(
+            FixAllContext context,
+            CancellationToken cancellationToken)
+        {
+            ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+            switch (context.Scope)
+            {
+                case FixAllScope.Document when context.Document is not null:
+                    diagnostics.AddRange(await context.GetDocumentDiagnosticsAsync(context.Document).ConfigureAwait(false));
+                    break;
+                case FixAllScope.Project:
+                    diagnostics.AddRange(await context.GetAllDiagnosticsAsync(context.Project).ConfigureAwait(false));
+                    break;
+                case FixAllScope.Solution:
+                    foreach (Project project in context.Solution.Projects)
+                    {
+                        diagnostics.AddRange(await context.GetAllDiagnosticsAsync(project).ConfigureAwait(false));
+                    }
+
+                    break;
+            }
+
+            List<RenameRequest> requests = [];
+            foreach (Diagnostic diagnostic in diagnostics)
+            {
+                if (diagnostic.Location.SourceTree is null
+                    || !TryGetSuggestion(
+                        diagnostic,
+                        out string suggestedFileName,
+                        out char detailSeparator))
+                {
+                    continue;
+                }
+
+                Document? document = context.Solution.GetDocument(diagnostic.Location.SourceTree);
+                if (document?.FilePath is null)
+                {
+                    continue;
+                }
+
+                requests.Add(new(document.Id, document.FilePath, suggestedFileName, detailSeparator));
+            }
+
+            requests.Sort(static (left, right) =>
+                StringComparer.OrdinalIgnoreCase.Compare(left.OriginalFilePath, right.OriginalFilePath));
+
+            Solution solution = context.Solution;
+            foreach (RenameRequest request in requests)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Document? document = solution.GetDocument(request.DocumentId);
+                if (document is null || !CanRename(document))
+                {
+                    continue;
+                }
+
+                string availableFileName = GetAvailableFileName(
+                    solution,
+                    document,
+                    request.SuggestedFileName,
+                    request.DetailSeparator);
+                solution = await RenameDocumentAsync(
+                    solution,
+                    document,
+                    availableFileName,
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return solution;
+        }
+    }
+
+    private readonly struct RenameRequest
+    {
+        public RenameRequest(
+            DocumentId documentId,
+            string originalFilePath,
+            string suggestedFileName,
+            char detailSeparator)
+        {
+            DocumentId = documentId;
+            OriginalFilePath = originalFilePath;
+            SuggestedFileName = suggestedFileName;
+            DetailSeparator = detailSeparator;
+        }
+
+        public DocumentId DocumentId { get; }
+
+        public string OriginalFilePath { get; }
+
+        public string SuggestedFileName { get; }
+
+        public char DetailSeparator { get; }
+    }
+}

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -39,6 +39,31 @@ internal static class AnalyzerTestHarness
     {
         CSharpCompilation compilation = CreateCompilation(source, fileName);
 
+        return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  Runs <paramref name="analyzer"/> against several named source files in one compilation and returns the
+    ///  analyzer-produced diagnostics.
+    /// </summary>
+    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        DiagnosticAnalyzer analyzer,
+        IReadOnlyList<(string Source, string FileName)> sources,
+        IReadOnlyDictionary<string, string>? options = null,
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
+    {
+        CSharpCompilation compilation = CreateCompilation(sources);
+
+        return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        DiagnosticAnalyzer analyzer,
+        CSharpCompilation compilation,
+        IReadOnlyDictionary<string, string>? options,
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions)
+    {
+
         if (diagnosticOptions is not null)
         {
             compilation = compilation.WithOptions(
@@ -52,12 +77,20 @@ internal static class AnalyzerTestHarness
     }
 
     private static CSharpCompilation CreateCompilation(string source, string? fileName)
+        => CreateCompilation([(source, fileName ?? string.Empty)]);
+
+    private static CSharpCompilation CreateCompilation(IReadOnlyList<(string Source, string FileName)> sources)
     {
-        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source, path: fileName ?? string.Empty);
+        SyntaxTree[] syntaxTrees = new SyntaxTree[sources.Count];
+
+        for (int i = 0; i < sources.Count; i++)
+        {
+            syntaxTrees[i] = CSharpSyntaxTree.ParseText(sources[i].Source, path: sources[i].FileName);
+        }
 
         return CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
-            syntaxTrees: [syntaxTree],
+            syntaxTrees: syntaxTrees,
             references: s_references.Value,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
     }

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Touki.Analyzers;
@@ -88,6 +89,206 @@ internal static class CodeFixTestHarness
         return text.ToString();
     }
 
+    /// <summary>
+    ///  Runs a code fix against a named multi-document project and returns all documents from the changed solution.
+    /// </summary>
+    public static async Task<CodeFixTestResult> ApplyFixToSolutionAsync(
+        DiagnosticAnalyzer analyzer,
+        CodeFixProvider codeFix,
+        IReadOnlyList<(string Name, string FilePath, string Source)> sources,
+        string diagnosticId,
+        bool fixAll,
+        IReadOnlyDictionary<string, string>? options = null,
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
+        string? workspaceKind = null)
+    {
+        using AdhocWorkspace workspace = workspaceKind is null
+            ? new AdhocWorkspace()
+            : new AdhocWorkspace(MefHostServices.DefaultHost, workspaceKind);
+        Project project = workspace
+            .AddProject("TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(s_references.Value)
+            .WithCompilationOptions(new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                allowUnsafe: true));
+
+        foreach ((string name, string filePath, string source) in sources)
+        {
+            Document document = project.AddDocument(name, source, filePath: filePath);
+            project = document.Project;
+        }
+
+        Compilation compilation = (await project.GetCompilationAsync().ConfigureAwait(false))!;
+
+        if (diagnosticOptions is not null)
+        {
+            compilation = compilation.WithOptions(
+                compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
+        }
+
+        AnalyzerOptions analyzerOptions = new(
+            additionalFiles: [],
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(
+                options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
+
+        CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
+        ImmutableArray<Diagnostic> diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
+        Diagnostic? target = diagnostics.FirstOrDefault(diagnostic => diagnostic.Id == diagnosticId);
+        if (target is null || target.Location.SourceTree is null)
+        {
+            return await CreateResultAsync(
+                project.Solution,
+                analyzer,
+                analyzerOptions,
+                diagnosticOptions).ConfigureAwait(false);
+        }
+
+        Document? triggerDocument = project.Solution.GetDocument(target.Location.SourceTree);
+        if (triggerDocument is null)
+        {
+            return await CreateResultAsync(
+                project.Solution,
+                analyzer,
+                analyzerOptions,
+                diagnosticOptions).ConfigureAwait(false);
+        }
+
+        List<CodeAction> actions = [];
+        CodeFixContext fixContext = new(
+            triggerDocument,
+            target,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+        await codeFix.RegisterCodeFixesAsync(fixContext).ConfigureAwait(false);
+
+        if (actions.Count == 0 && !fixAll)
+        {
+            return await CreateResultAsync(
+                project.Solution,
+                analyzer,
+                analyzerOptions,
+                diagnosticOptions).ConfigureAwait(false);
+        }
+
+        CodeAction? actionToApply = actions.FirstOrDefault();
+        if (fixAll)
+        {
+            FixAllProvider? fixAllProvider = codeFix.GetFixAllProvider();
+            if (fixAllProvider is null)
+            {
+                return await CreateResultAsync(
+                    project.Solution,
+                    analyzer,
+                    analyzerOptions,
+                    diagnosticOptions,
+                    fixAllActionOffered: false).ConfigureAwait(false);
+            }
+
+            FixAllContext fixAllContext = new(
+                triggerDocument,
+                codeFix,
+                FixAllScope.Solution,
+                actionToApply?.EquivalenceKey,
+                [diagnosticId],
+                new TestDiagnosticProvider(diagnostics),
+                CancellationToken.None);
+            CodeAction? fixAllAction = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
+            if (fixAllAction is null)
+            {
+                return await CreateResultAsync(
+                    project.Solution,
+                    analyzer,
+                    analyzerOptions,
+                    diagnosticOptions,
+                    fixAllActionOffered: false).ConfigureAwait(false);
+            }
+
+            actionToApply = fixAllAction;
+        }
+
+        if (actionToApply is null)
+        {
+            return await CreateResultAsync(
+                project.Solution,
+                analyzer,
+                analyzerOptions,
+                diagnosticOptions).ConfigureAwait(false);
+        }
+
+        ImmutableArray<CodeActionOperation> operations =
+            await actionToApply.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+        ApplyChangesOperation? applyChanges = operations.OfType<ApplyChangesOperation>().SingleOrDefault();
+        Solution changedSolution = applyChanges?.ChangedSolution ?? project.Solution;
+        return await CreateResultAsync(
+            changedSolution,
+            analyzer,
+            analyzerOptions,
+            diagnosticOptions,
+            fixAllActionOffered: fixAll ? true : null).ConfigureAwait(false);
+    }
+
+    private static async Task<CodeFixTestResult> CreateResultAsync(
+        Solution solution,
+        DiagnosticAnalyzer analyzer,
+        AnalyzerOptions analyzerOptions,
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions,
+        bool? fixAllActionOffered = null)
+    {
+        ImmutableArray<CodeFixTestDocument>.Builder documents = ImmutableArray.CreateBuilder<CodeFixTestDocument>();
+        ImmutableArray<Diagnostic>.Builder compilerErrors = ImmutableArray.CreateBuilder<Diagnostic>();
+        ImmutableArray<Diagnostic>.Builder analyzerDiagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document document in project.Documents)
+            {
+                SourceText text = await document.GetTextAsync().ConfigureAwait(false);
+                documents.Add(new(document.Name, document.FilePath, text.ToString()));
+            }
+
+            Compilation compilation = (await project.GetCompilationAsync().ConfigureAwait(false))!;
+            if (diagnosticOptions is not null)
+            {
+                compilation = compilation.WithOptions(
+                    compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
+            }
+
+            compilerErrors.AddRange(
+                compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
+            CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
+            analyzerDiagnostics.AddRange(
+                await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false));
+        }
+
+        return new(
+            documents.ToImmutable(),
+            compilerErrors.ToImmutable(),
+            analyzerDiagnostics.ToImmutable(),
+            fixAllActionOffered);
+    }
+
+    private sealed class TestDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        : FixAllContext.DiagnosticProvider
+    {
+        public override async Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(
+            Document document,
+            CancellationToken cancellationToken)
+        {
+            SyntaxTree? syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+            return diagnostics.Where(diagnostic => diagnostic.Location.SourceTree == syntaxTree);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(
+            Project project,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(diagnostics.Where(diagnostic => diagnostic.Location == Location.None));
+
+        public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(
+            Project project,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IEnumerable<Diagnostic>>(diagnostics);
+    }
+
     private static ImmutableArray<MetadataReference> CreateReferences()
     {
         string trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
@@ -101,3 +302,11 @@ internal static class CodeFixTestHarness
         ];
     }
 }
+
+internal sealed record CodeFixTestResult(
+    ImmutableArray<CodeFixTestDocument> Documents,
+    ImmutableArray<Diagnostic> CompilerErrors,
+    ImmutableArray<Diagnostic> AnalyzerDiagnostics,
+    bool? FixAllActionOffered);
+
+internal sealed record CodeFixTestDocument(string Name, string? FilePath, string Source);

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -111,10 +111,14 @@ internal static class CodeFixTestHarness
             .WithCompilationOptions(new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 allowUnsafe: true));
+        string temporaryRoot = Path.Combine(Path.GetTempPath(), $"touki-code-fix-{Guid.NewGuid():N}");
 
         foreach ((string name, string filePath, string source) in sources)
         {
-            Document document = project.AddDocument(name, source, filePath: filePath);
+            Document document = project.AddDocument(
+                name,
+                source,
+                filePath: GetAbsoluteTestPath(filePath, temporaryRoot));
             project = document.Project;
         }
 
@@ -265,6 +269,20 @@ internal static class CodeFixTestHarness
             compilerErrors.ToImmutable(),
             analyzerDiagnostics.ToImmutable(),
             fixAllActionOffered);
+    }
+
+    private static string GetAbsoluteTestPath(string filePath, string temporaryRoot)
+    {
+        if (Path.IsPathFullyQualified(filePath))
+        {
+            return filePath;
+        }
+
+        string relativePath = filePath
+            .Replace('\\', Path.DirectorySeparatorChar)
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace(':', '_');
+        return Path.GetFullPath(Path.Combine(temporaryRoot, relativePath));
     }
 
     private sealed class TestDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)

--- a/touki.analyzers.tests/FileNameMatchesTypeAnalyzerTests.cs
+++ b/touki.analyzers.tests/FileNameMatchesTypeAnalyzerTests.cs
@@ -59,7 +59,80 @@ public class FileNameMatchesTypeAnalyzerTests
         ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "Other.cs").ConfigureAwait(false);
 
         diagnostics.Should().ContainSingle()
-            .Which.GetMessage().Should().Contain("Other").And.Contain("Foo");
+            .Which.GetMessage().Should().Be("Rename file 'Other' to 'Foo.cs' to match type 'Foo'");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NameDiffers_ProvidesSuggestedFileName()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(SimpleType, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Properties[FileNameMatchesTypeAnalyzer.SuggestedFileNameProperty].Should().Be("Foo.cs");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NestedNameDiffers_SuggestsQualifiedFileName()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(NestedType, "Unrelated.cs").ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Should().ContainSingle().Subject;
+        diagnostic.GetMessage().Should().Be("Rename file 'Unrelated' to 'Foo.Bar.cs' to match type 'Bar'");
+        diagnostic.Properties[FileNameMatchesTypeAnalyzer.SuggestedFileNameProperty].Should().Be("Foo.Bar.cs");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSemanticModel_SplitPartialType_SuggestsCurrentStemAsDetail()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new FileNameMatchesTypeAnalyzer(),
+            [
+                ("partial class Foo { int First; }", "/src/FirstPart.cs"),
+                ("partial class Foo { int Second; }", "/src/SecondPart.cs")
+            ]).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Single(
+            candidate => candidate.Location.SourceTree!.FilePath == "/src/FirstPart.cs");
+        diagnostic.Properties[FileNameMatchesTypeAnalyzer.SuggestedFileNameProperty]
+            .Should().Be("Foo.FirstPart.cs");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSemanticModel_SplitPartialType_UsesConfiguredDetailSeparator()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new FileNameMatchesTypeAnalyzer(),
+            [
+                ("partial class Foo { int First; }", "/src/FirstPart.cs"),
+                ("partial class Foo { int Second; }", "/src/SecondPart.cs")
+            ],
+            new Dictionary<string, string>
+            {
+                [FileNameMatchesTypeAnalyzer.DetailSeparatorsOption] = "-"
+            }).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Single(
+            candidate => candidate.Location.SourceTree!.FilePath == "/src/FirstPart.cs");
+        diagnostic.Properties[FileNameMatchesTypeAnalyzer.SuggestedFileNameProperty]
+            .Should().Be("Foo-FirstPart.cs");
+        diagnostic.Properties[FileNameMatchesTypeAnalyzer.SuggestedDetailSeparatorProperty]
+            .Should().Be("-");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSemanticModel_PreferredFileNameOccupied_SuggestsCurrentStemAsDetail()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new FileNameMatchesTypeAnalyzer(),
+            [
+                ("class Foo { }", "/src/Unrelated.cs"),
+                ("class Occupant { }", "/src/Foo.cs")
+            ]).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Single(
+            candidate => candidate.Location.SourceTree!.FilePath == "/src/Unrelated.cs");
+        diagnostic.Properties[FileNameMatchesTypeAnalyzer.SuggestedFileNameProperty]
+            .Should().Be("Foo.Unrelated.cs");
     }
 
     [TestMethod]
@@ -254,6 +327,78 @@ public class FileNameMatchesTypeAnalyzerTests
     }
 
     [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConditionallyEmptyPartialShell_ReportsNothing()
+    {
+        string source = """
+            public sealed partial class ETWTraceEventSource
+            {
+            #if TARGET_WINDOWS
+                private readonly record struct ClassicTemplateCacheEntry;
+            #endif
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(source, "ClassicTemplateCacheEntry.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_UnconditionallyEmptyPartialType_ReportsDiagnostic()
+    {
+        string source = """
+            partial class Foo
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConditionallyEmptyContributingPartialType_ReportsNothing()
+    {
+        string source = """
+            [System.Obsolete]
+            public partial class Foo
+            {
+            #if TARGET_WINDOWS
+                private class Nested
+                {
+                }
+            #endif
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConditionallyEmptyDocumentedPartialType_ReportsNothing()
+    {
+        string source = """
+            /// <summary>Owns nested types.</summary>
+            public partial class Foo
+            {
+            #if TARGET_WINDOWS
+                private class Nested
+                {
+                }
+            #endif
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Other.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
     public async Task AnalyzeSyntaxTree_NoFilePath_ReportsNothing()
     {
         // An in-memory tree has no name to match against.
@@ -308,6 +453,15 @@ public class FileNameMatchesTypeAnalyzerTests
     {
         ImmutableArray<Diagnostic> diagnostics =
             await AnalyzeAsync(SimpleType, "Foo.Windows.cs", separators).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_ConfiguredInvalidSeparators_FallsBackToDefault()
+    {
+        ImmutableArray<Diagnostic> diagnostics =
+            await AnalyzeAsync(SimpleType, "Foo.Windows.cs", separators: "/").ConfigureAwait(false);
 
         diagnostics.Should().BeEmpty();
     }

--- a/touki.analyzers.tests/FileNameMatchesTypeCodeFixTests.cs
+++ b/touki.analyzers.tests/FileNameMatchesTypeCodeFixTests.cs
@@ -1,0 +1,227 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class FileNameMatchesTypeCodeFixTests
+{
+    private static async Task<CodeFixTestResult> ApplyFixAsync(
+        IReadOnlyList<(string Name, string FilePath, string Source)> sources,
+        bool fixAll = false,
+        IReadOnlyDictionary<string, string>? options = null)
+    {
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new FileNameMatchesTypeAnalyzer(),
+            new RenameFileToMatchTypeCodeFixProvider(),
+            sources,
+            FileNameMatchesTypeAnalyzer.DiagnosticId,
+            fixAll,
+            options).ConfigureAwait(false);
+
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().NotContain(
+            diagnostic => diagnostic.Id == FileNameMatchesTypeAnalyzer.DiagnosticId);
+        return result;
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_NameDiffers_RenamesFileAndPreservesSource()
+    {
+        const string Source = "class Foo { }";
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Other.cs", "C:\\src\\Other.cs", Source)]).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("Foo.cs");
+        document.FilePath.Should().Be("C:\\src\\Foo.cs");
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_CaseDiffers_PerformsCaseOnlyRename()
+    {
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("foo.cs", "C:\\src\\foo.cs", "class Foo { }")]).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("Foo.cs");
+        document.FilePath.Should().Be("C:\\src\\Foo.cs");
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_DirectoryOccupiesDestination_UsesSuffix()
+    {
+        const string Source = "class Foo { }";
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-file-fix-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            string currentPath = Path.Combine(directory, "Other.cs");
+            File.WriteAllText(currentPath, Source);
+            Directory.CreateDirectory(Path.Combine(directory, "Foo.cs"));
+
+            CodeFixTestResult result = await ApplyFixAsync(
+                [("Other.cs", currentPath, Source)]).ConfigureAwait(false);
+
+            result.Documents.Should().ContainSingle().Which.Name.Should().Be("Foo.2.cs");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_CaseSensitiveTwinOccupiesDestination_UsesSuffix()
+    {
+        const string Source = "class Foo { }";
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-case-fix-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            string currentPath = Path.Combine(directory, "foo.cs");
+            string targetPath = Path.Combine(directory, "Foo.cs");
+            File.WriteAllText(currentPath, Source);
+            File.WriteAllText(targetPath, "excluded");
+
+            int caseVariants = Directory.EnumerateFileSystemEntries(directory)
+                .Count(path => string.Equals(Path.GetFileName(path), "foo.cs", StringComparison.Ordinal)
+                    || string.Equals(Path.GetFileName(path), "Foo.cs", StringComparison.Ordinal));
+            if (caseVariants < 2)
+            {
+                return;
+            }
+
+            CodeFixTestResult result = await ApplyFixAsync(
+                [("foo.cs", currentPath, Source)]).ConfigureAwait(false);
+
+            result.Documents.Should().ContainSingle().Which.Name.Should().Be("Foo.2.cs");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_SplitPartialType_UsesCurrentStemsAsDetail()
+    {
+        CodeFixTestResult result = await ApplyFixAsync(
+            [
+                ("FirstPart.cs", "C:\\src\\FirstPart.cs", "partial class Foo { int First; }"),
+                ("SecondPart.cs", "C:\\src\\SecondPart.cs", "partial class Foo { int Second; }")
+            ],
+            fixAll: true).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["Foo.FirstPart.cs", "Foo.SecondPart.cs"]);
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_SplitPartialType_UsesConfiguredDetailSeparator()
+    {
+        CodeFixTestResult result = await ApplyFixAsync(
+            [
+                ("FirstPart.cs", "C:\\src\\FirstPart.cs", "partial class Foo { int First; }"),
+                ("SecondPart.cs", "C:\\src\\SecondPart.cs", "partial class Foo { int Second; }")
+            ],
+            fixAll: true,
+            new Dictionary<string, string>
+            {
+                [FileNameMatchesTypeAnalyzer.DetailSeparatorsOption] = "-"
+            }).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["Foo-FirstPart.cs", "Foo-SecondPart.cs"]);
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_SplitPartialType_InvalidConfiguredSeparatorFallsBackToDefault()
+    {
+        CodeFixTestResult result = await ApplyFixAsync(
+            [
+                ("FirstPart.cs", "C:\\src\\FirstPart.cs", "partial class Foo { int First; }"),
+                ("SecondPart.cs", "C:\\src\\SecondPart.cs", "partial class Foo { int Second; }")
+            ],
+            fixAll: true,
+            new Dictionary<string, string>
+            {
+                [FileNameMatchesTypeAnalyzer.DetailSeparatorsOption] = "/"
+            }).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["Foo.FirstPart.cs", "Foo.SecondPart.cs"]);
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_PreferredNameOccupied_UsesDetailAndRenamesOccupant()
+    {
+        CodeFixTestResult result = await ApplyFixAsync(
+            [
+                ("Unrelated.cs", "C:\\src\\Unrelated.cs", "class Foo { }"),
+                ("Foo.cs", "C:\\src\\Foo.cs", "class Occupant { }")
+            ],
+            fixAll: true).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["Foo.Unrelated.cs", "Occupant.cs"]);
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_MsBuildWorkspace_LeavesSolutionUnchanged()
+    {
+        const string Source = "class Foo { }";
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new FileNameMatchesTypeAnalyzer(),
+            new RenameFileToMatchTypeCodeFixProvider(),
+            [("Other.cs", "C:\\src\\Other.cs", Source)],
+            FileNameMatchesTypeAnalyzer.DiagnosticId,
+            fixAll: true,
+            workspaceKind: WorkspaceKind.MSBuild).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("Other.cs");
+        document.Source.Should().Be(Source);
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().Contain(
+            diagnostic => diagnostic.Id == FileNameMatchesTypeAnalyzer.DiagnosticId);
+        result.FixAllActionOffered.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_MsBuildWorkspace_LeavesSolutionUnchanged()
+    {
+        const string Source = "class Foo { }";
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new FileNameMatchesTypeAnalyzer(),
+            new RenameFileToMatchTypeCodeFixProvider(),
+            [("Other.cs", "C:\\src\\Other.cs", Source)],
+            FileNameMatchesTypeAnalyzer.DiagnosticId,
+            fixAll: false,
+            workspaceKind: WorkspaceKind.MSBuild).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("Other.cs");
+        document.Source.Should().Be(Source);
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().Contain(
+            diagnostic => diagnostic.Id == FileNameMatchesTypeAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public void GetFixAllProvider_DefaultScopes_ContainsSolution()
+    {
+        FixAllProvider provider = new RenameFileToMatchTypeCodeFixProvider().GetFixAllProvider();
+
+        provider.GetSupportedFixAllScopes().Should().Contain(FixAllScope.Solution);
+    }
+}

--- a/touki.analyzers.tests/FileNameMatchesTypeCodeFixTests.cs
+++ b/touki.analyzers.tests/FileNameMatchesTypeCodeFixTests.cs
@@ -32,25 +32,47 @@ public class FileNameMatchesTypeCodeFixTests
     public async Task ApplyFix_NameDiffers_RenamesFileAndPreservesSource()
     {
         const string Source = "class Foo { }";
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-rename-{Guid.NewGuid():N}");
+        string sourcePath = Path.Combine(directory, "Other.cs");
 
         CodeFixTestResult result = await ApplyFixAsync(
-            [("Other.cs", "C:\\src\\Other.cs", Source)]).ConfigureAwait(false);
+            [("Other.cs", sourcePath, Source)]).ConfigureAwait(false);
 
         CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
         document.Name.Should().Be("Foo.cs");
-        document.FilePath.Should().Be("C:\\src\\Foo.cs");
+        document.FilePath.Should().Be(Path.Combine(directory, "Foo.cs"));
         document.Source.Should().Be(Source);
     }
 
     [TestMethod]
     public async Task ApplyFix_CaseDiffers_PerformsCaseOnlyRename()
     {
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-case-rename-{Guid.NewGuid():N}");
+        string sourcePath = Path.Combine(directory, "foo.cs");
+
         CodeFixTestResult result = await ApplyFixAsync(
-            [("foo.cs", "C:\\src\\foo.cs", "class Foo { }")]).ConfigureAwait(false);
+            [("foo.cs", sourcePath, "class Foo { }")]).ConfigureAwait(false);
 
         CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
         document.Name.Should().Be("Foo.cs");
-        document.FilePath.Should().Be("C:\\src\\Foo.cs");
+        document.FilePath.Should().Be(Path.Combine(directory, "Foo.cs"));
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_UnrootedPath_NormalizesToIsolatedAbsolutePath()
+    {
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Other.cs", Path.Combine("relative", "Other.cs"), "class Foo { }")]).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.FilePath.Should().NotBeNull();
+        Path.IsPathFullyQualified(document.FilePath!).Should().BeTrue();
+        document.FilePath!.EndsWith(
+            Path.Combine("relative", "Foo.cs"),
+            StringComparison.Ordinal).Should().BeTrue();
+        document.FilePath.StartsWith(
+            Path.GetTempPath(),
+            StringComparison.OrdinalIgnoreCase).Should().BeTrue();
     }
 
     [TestMethod]

--- a/touki.analyzers.tests/OneTypePerFileAnalyzerTests.cs
+++ b/touki.analyzers.tests/OneTypePerFileAnalyzerTests.cs
@@ -7,8 +7,21 @@ namespace Touki.Analyzers;
 [TestClass]
 public class OneTypePerFileAnalyzerTests
 {
-    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source) =>
-        await AnalyzerTestHarness.GetDiagnosticsAsync(new OneTypePerFileAnalyzer(), source).ConfigureAwait(false);
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source,
+        string? excludeNestedTypes = null)
+    {
+        Dictionary<string, string>? options = excludeNestedTypes is null
+            ? null
+            : new Dictionary<string, string>
+            {
+                [OneTypePerFileAnalyzer.ExcludeNestedTypesOption] = excludeNestedTypes
+            };
+
+        return await AnalyzerTestHarness
+            .GetDiagnosticsAsync(new OneTypePerFileAnalyzer(), source, options)
+            .ConfigureAwait(false);
+    }
 
     [TestMethod]
     public async Task AnalyzeSyntaxTree_SingleType_ReportsNothing()
@@ -140,6 +153,56 @@ public class OneTypePerFileAnalyzerTests
 
         diagnostics.Should().HaveCount(3);
         diagnostics.Should().OnlyContain(diagnostic => diagnostic.Id == OneTypePerFileAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NestedTypesExcluded_ReportsNothing()
+    {
+        const string source = """
+            namespace Sample;
+
+            public class Outer
+            {
+                private struct Nested
+                {
+                }
+
+                public enum Kind
+                {
+                    None
+                }
+
+                public delegate void Handler();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "true").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeSyntaxTree_NestedTypesExcluded_StillReportsSecondTopLevelType()
+    {
+        const string source = """
+            namespace Sample;
+
+            public class First
+            {
+                private struct Nested
+                {
+                }
+            }
+
+            public class Second
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "true").ConfigureAwait(false);
+
+        Location location = diagnostics.Should().ContainSingle().Subject.Location;
+        location.SourceTree!.GetText().ToString(location.SourceSpan).Should().Be("Second");
     }
 
     [TestMethod]

--- a/touki.analyzers.tests/OneTypePerFileCodeFixTests.cs
+++ b/touki.analyzers.tests/OneTypePerFileCodeFixTests.cs
@@ -63,6 +63,19 @@ public class OneTypePerFileCodeFixTests
     }
 
     [TestMethod]
+    public async Task ApplyFix_TypeNameMatchesCurrentStem_UsesNumericSuffix()
+    {
+        const string Source = "class First { } class Bar { }";
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-duplicate-stem-{Guid.NewGuid():N}");
+        string sourcePath = Path.Combine(directory, "Bar.cs");
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Bar.cs", sourcePath, Source)]).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().Contain("Bar.2.cs");
+    }
+
+    [TestMethod]
     public async Task ApplyFix_DirectoryOccupiesDestination_UsesDetailName()
     {
         const string Source = "class First { } class Second { }";

--- a/touki.analyzers.tests/OneTypePerFileCodeFixTests.cs
+++ b/touki.analyzers.tests/OneTypePerFileCodeFixTests.cs
@@ -1,0 +1,509 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class OneTypePerFileCodeFixTests
+{
+    private static async Task<CodeFixTestResult> ApplyFixAsync(
+        IReadOnlyList<(string Name, string FilePath, string Source)> sources,
+        bool fixAll = false,
+        bool expectFix = true)
+    {
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new OneTypePerFileAnalyzer(),
+            new MoveTypeToFileCodeFixProvider(),
+            sources,
+            OneTypePerFileAnalyzer.DiagnosticId,
+            fixAll).ConfigureAwait(false);
+
+        result.CompilerErrors.Should().BeEmpty();
+        if (expectFix)
+        {
+            result.AnalyzerDiagnostics.Should().NotContain(
+                diagnostic => diagnostic.Id == OneTypePerFileAnalyzer.DiagnosticId);
+        }
+        else
+        {
+            result.AnalyzerDiagnostics.Should().Contain(
+                diagnostic => diagnostic.Id == OneTypePerFileAnalyzer.DiagnosticId);
+        }
+
+        return result;
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_TopLevelDelegate_MovesDeclarationAndCopiesHeader()
+    {
+        const string Source = """
+            // Copyright header
+
+            namespace Sample;
+
+            class Owner
+            {
+            }
+
+            delegate void Handler();
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)]).ConfigureAwait(false);
+
+        result.Documents.Should().HaveCount(2);
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "Owner.cs");
+        CodeFixTestDocument destination = result.Documents.Single(document => document.Name == "Handler.cs");
+        source.Source.Should().NotContain("delegate void Handler");
+        destination.Source.Should().Contain("delegate void Handler();");
+        destination.Source.Should().StartWith("// Copyright header");
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_DirectoryOccupiesDestination_UsesDetailName()
+    {
+        const string Source = "class First { } class Second { }";
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-move-fix-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            string currentPath = Path.Combine(directory, "First.cs");
+            File.WriteAllText(currentPath, Source);
+            Directory.CreateDirectory(Path.Combine(directory, "Second.cs"));
+
+            CodeFixTestResult result = await ApplyFixAsync(
+                [("First.cs", currentPath, Source)]).ConfigureAwait(false);
+
+            result.Documents.Select(document => document.Name).Should().Contain("Second.First.cs");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_CaseVariantOccupiesDestination_UsesDetailName()
+    {
+        const string Source = "class First { } class Second { }";
+        string directory = Path.Combine(Path.GetTempPath(), $"touki-move-case-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+
+        try
+        {
+            string currentPath = Path.Combine(directory, "First.cs");
+            File.WriteAllText(currentPath, Source);
+            File.WriteAllText(Path.Combine(directory, "second.cs"), "excluded");
+
+            CodeFixTestResult result = await ApplyFixAsync(
+                [("First.cs", currentPath, Source)]).ConfigureAwait(false);
+
+            result.Documents.Select(document => document.Name).Should().Contain("Second.First.cs");
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_NestedType_PreservesModifiersAndRemovesShellOnlySyntax()
+    {
+        const string Source = """
+            [System.Obsolete]
+            internal sealed unsafe class Outer<T>(int value) : Base where T : class
+            {
+                private int _value = value;
+
+                private readonly record struct Nested;
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [
+                ("Base.cs", "C:\\src\\Base.cs", "class Base { }"),
+                ("Outer.cs", "C:\\src\\Outer.cs", Source)
+            ]).ConfigureAwait(false);
+
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "Outer.cs");
+        CodeFixTestDocument destination = result.Documents.Single(document => document.Name == "Nested.cs");
+        source.Source.Should().Contain("internal sealed unsafe partial class Outer<T>(int value) : Base where T : class");
+        destination.Source.Should().Contain("internal sealed unsafe partial class Outer<T>");
+        destination.Source.Should().Contain("private readonly record struct Nested;");
+        destination.Source.Should().NotContain("System.Obsolete");
+        destination.Source.Should().NotContain("(int value)");
+        destination.Source.Should().NotContain(": Base");
+        destination.Source.Should().NotContain("where T : class");
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_TypeWrappedInConditionalDirective_LeavesSolutionUnchanged()
+    {
+        const string Source = """
+            class Owner
+            {
+            }
+
+            #if true
+            class WindowsOnly
+            {
+            }
+            #endif
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)],
+            expectFix: false).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("Owner.cs");
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_FileContainsConditionalUsing_LeavesSolutionUnchanged()
+    {
+        const string Source = """
+            #if TARGET_WINDOWS
+            using System;
+            #endif
+
+            class Owner
+            {
+            }
+
+            class Other
+            {
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)],
+            expectFix: false).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_FileLocalEnum_LeavesSolutionUnchanged()
+    {
+        const string Source = "class Owner { } file enum Hidden { None }";
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)],
+            expectFix: false).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_FileLocalDelegate_LeavesSolutionUnchanged()
+    {
+        const string Source = "class Owner { } file delegate void Hidden();";
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)],
+            expectFix: false).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_TypeReferencesFileLocalType_LeavesSolutionUnchanged()
+    {
+        const string Source = """
+            class Owner
+            {
+            }
+
+            class Consumer
+            {
+                public void UseHidden()
+                {
+                    Hidden hidden = new();
+                    _ = hidden;
+                }
+            }
+
+            file class Hidden
+            {
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)],
+            expectFix: false).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_FileContainsUnrelatedFileLocalType_LeavesSolutionUnchanged()
+    {
+        const string Source = """
+            class Owner
+            {
+            }
+
+            class Other
+            {
+            }
+
+            file class Hidden
+            {
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Owner.cs", "C:\\src\\Owner.cs", Source)],
+            expectFix: false).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Source.Should().Be(Source);
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_AttributedTypeParameter_StripsAttributeFromPartialShell()
+    {
+        const string Source = """
+            partial class Outer<[Marker] T>
+            {
+                private int _value;
+
+                class Nested
+                {
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [
+                ("Marker.cs", "C:\\src\\Marker.cs", "class MarkerAttribute : System.Attribute { }"),
+                ("Outer.cs", "C:\\src\\Outer.cs", Source)
+            ]).ConfigureAwait(false);
+
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "Outer.cs");
+        CodeFixTestDocument destination = result.Documents.Single(document => document.Name == "Nested.cs");
+        source.Source.Should().Contain("Outer<[Marker] T>");
+        destination.Source.Should().Contain("partial class Outer<T>");
+        destination.Source.Should().NotContain("[Marker]");
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_RepeatedPartialDeclarations_MovesAllDeclarations()
+    {
+        const string Source = """
+            class First
+            {
+            }
+
+            partial class Second
+            {
+                private int _first;
+            }
+
+            partial class Second
+            {
+                private int _second;
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("First.cs", "C:\\src\\First.cs", Source)]).ConfigureAwait(false);
+
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "First.cs");
+        CodeFixTestDocument destination = result.Documents.Single(document => document.Name == "Second.cs");
+        source.Source.Should().NotContain("class Second");
+        destination.Source.Should().Contain("private int _first;");
+        destination.Source.Should().Contain("private int _second;");
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_SoleNestedType_RemovesEmptyHostingShell()
+    {
+        const string Source = """
+            class First
+            {
+            }
+
+            partial class Outer
+            {
+                class Nested
+                {
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("First.cs", "C:\\src\\First.cs", Source)]).ConfigureAwait(false);
+
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "First.cs");
+        CodeFixTestDocument destination = result.Documents.Single(document => document.Name == "Nested.cs");
+        source.Source.Should().NotContain("class Outer");
+        destination.Source.Should().Contain("partial class Outer");
+        destination.Source.Should().Contain("class Nested");
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_ThreeTopLevelTypes_MovesAllButFirst()
+    {
+        const string Source = """
+            class First
+            {
+            }
+
+            class Second
+            {
+            }
+
+            delegate void Third();
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("First.cs", "C:\\src\\First.cs", Source)],
+            fixAll: true).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["First.cs", "Second.cs", "Third.cs"]);
+        result.Documents.Single(document => document.Name == "First.cs").Source
+            .Should().NotContain("class Second").And.NotContain("delegate void Third");
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_NestedHierarchy_MovesDeepestTypeFirst()
+    {
+        const string Source = """
+            class Outer
+            {
+                class Middle
+                {
+                    class Leaf
+                    {
+                    }
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Outer.cs", "C:\\src\\Outer.cs", Source)],
+            fixAll: true).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["Outer.cs", "Middle.cs", "Leaf.cs"]);
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "Outer.cs");
+        source.Source.Should().Contain("partial class Outer");
+        CodeFixTestDocument leaf = result.Documents.Single(document => document.Name == "Leaf.cs");
+        leaf.Source.Should().Contain("partial class Outer");
+        leaf.Source.Should().Contain("partial class Middle");
+        leaf.Source.Should().Contain("class Leaf");
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_DocumentedPartialHost_PreservesHostAndDocumentation()
+    {
+        const string Source = """
+            /// <summary>Owns nested types.</summary>
+            partial class Outer
+            {
+                private int _value;
+
+                class Nested
+                {
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("Outer.cs", "C:\\src\\Outer.cs", Source)]).ConfigureAwait(false);
+
+        CodeFixTestDocument source = result.Documents.Single(document => document.Name == "Outer.cs");
+        source.Source.Should().Contain("/// <summary>Owns nested types.</summary>");
+        source.Source.Should().Contain("partial class Outer");
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_SameNestedName_UsesQualifiedFallback()
+    {
+        const string Source = """
+            class First
+            {
+                class BitReader
+                {
+                }
+            }
+
+            class Second
+            {
+                class BitReader
+                {
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await ApplyFixAsync(
+            [("First.cs", "C:\\src\\First.cs", Source)],
+            fixAll: true).ConfigureAwait(false);
+
+        result.Documents.Select(document => document.Name).Should().BeEquivalentTo(
+            ["First.cs", "BitReader.cs", "Second.cs", "Second.BitReader.cs"]);
+    }
+
+    [TestMethod]
+    public async Task ApplyFixAll_MsBuildWorkspace_LeavesSolutionUnchanged()
+    {
+        const string Source = "class First { } class Second { }";
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new OneTypePerFileAnalyzer(),
+            new MoveTypeToFileCodeFixProvider(),
+            [("First.cs", "C:\\src\\First.cs", Source)],
+            OneTypePerFileAnalyzer.DiagnosticId,
+            fixAll: true,
+            workspaceKind: WorkspaceKind.MSBuild).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("First.cs");
+        document.Source.Should().Be(Source);
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().Contain(
+            diagnostic => diagnostic.Id == OneTypePerFileAnalyzer.DiagnosticId);
+        result.FixAllActionOffered.Should().BeFalse();
+    }
+
+    [TestMethod]
+    public async Task ApplyFix_MsBuildWorkspace_LeavesSolutionUnchanged()
+    {
+        const string Source = "class First { } class Second { }";
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new OneTypePerFileAnalyzer(),
+            new MoveTypeToFileCodeFixProvider(),
+            [("First.cs", "C:\\src\\First.cs", Source)],
+            OneTypePerFileAnalyzer.DiagnosticId,
+            fixAll: false,
+            workspaceKind: WorkspaceKind.MSBuild).ConfigureAwait(false);
+
+        CodeFixTestDocument document = result.Documents.Should().ContainSingle().Subject;
+        document.Name.Should().Be("First.cs");
+        document.Source.Should().Be(Source);
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().Contain(
+            diagnostic => diagnostic.Id == OneTypePerFileAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public void GetFixAllProvider_DefaultScopes_ContainsSolution()
+    {
+        FixAllProvider provider = new MoveTypeToFileCodeFixProvider().GetFixAllProvider();
+
+        provider.GetSupportedFixAllScopes().Should().Contain(FixAllScope.Solution);
+    }
+}

--- a/touki.analyzers/FileNameMatchesTypeAnalyzer.cs
+++ b/touki.analyzers/FileNameMatchesTypeAnalyzer.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -31,7 +32,13 @@ namespace Touki.Analyzers;
 ///  </para>
 ///  <para>
 ///   Comparison is ordinal, so casing must match even on a case-insensitive file system. A file that
-///   declares no types is not reported, and neither is a tree with no path.
+///   declares no types is not reported, and neither is a tree with no path. An empty partial declaration whose
+///   body contains conditional directives is also omitted: after preprocessing it is only a shell for a type
+///   declared in another build configuration.
+///  </para>
+///  <para>
+///   Diagnostics include a collision-aware suggested file name. A nested declaration prefers its containing
+///   type path, and one part of a type split across files keeps the current stem as detail.
 ///  </para>
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -41,6 +48,16 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
     ///  The diagnostic identifier reported by this analyzer.
     /// </summary>
     public const string DiagnosticId = "TOUKI0021";
+
+    /// <summary>
+    ///  The diagnostic property containing the suggested destination file name.
+    /// </summary>
+    public const string SuggestedFileNameProperty = "SuggestedFileName";
+
+    /// <summary>
+    ///  The diagnostic property containing the separator used to add distinguishing detail.
+    /// </summary>
+    public const string SuggestedDetailSeparatorProperty = "SuggestedDetailSeparator";
 
     /// <summary>
     ///  The <c>.editorconfig</c> key that overrides the characters allowed to introduce trailing detail in a
@@ -57,7 +74,7 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor s_rule = new(
         id: DiagnosticId,
         title: "File name should match the type it declares",
-        messageFormat: "File name '{0}' does not match type '{1}'",
+        messageFormat: "Rename file '{0}' to '{2}' to match type '{1}'",
         category: "Maintainability",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
@@ -76,23 +93,31 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
-        // The rule is about the file as a whole. Only member lists are walked, which keeps the walk
-        // proportional to the number of declarations rather than to the size of the file.
-        context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+        // The rule is about the file as a whole. Only member lists are walked. A symbol is bound only after a
+        // mismatch, when deciding whether a partial type needs the current file stem as distinguishing detail.
+        context.RegisterSemanticModelAction(AnalyzeSemanticModel);
     }
 
-    private static void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
+    private static void AnalyzeSemanticModel(SemanticModelAnalysisContext context)
     {
+        SyntaxTree tree = context.SemanticModel.SyntaxTree;
+
         // An in-memory tree has no path to match against.
-        if (string.IsNullOrEmpty(context.Tree.FilePath)
-            || context.Tree.GetRoot(context.CancellationToken) is not CompilationUnitSyntax compilationUnit)
+        if (string.IsNullOrEmpty(tree.FilePath)
+            || tree.GetRoot(context.CancellationToken) is not CompilationUnitSyntax compilationUnit)
         {
             return;
         }
 
         List<string> candidates = [];
-        SyntaxToken firstIdentifier = default;
-        CollectNames(compilationUnit.Members, prefix: null, candidates, ref firstIdentifier);
+        MemberDeclarationSyntax? preferredDeclaration = null;
+        string? preferredStem = null;
+        CollectNames(
+            compilationUnit.Members,
+            prefix: null,
+            candidates,
+            ref preferredDeclaration,
+            ref preferredStem);
 
         if (candidates.Count == 0)
         {
@@ -100,7 +125,7 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        string fileName = Path.GetFileNameWithoutExtension(context.Tree.FilePath);
+        string fileName = Path.GetFileNameWithoutExtension(tree.FilePath);
         string separators = GetDetailSeparators(context);
 
         foreach (string candidate in candidates)
@@ -111,26 +136,55 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
             }
         }
 
+        if (preferredDeclaration is null || preferredStem is null)
+        {
+            return;
+        }
+
+        SyntaxToken preferredIdentifier = GetIdentifier(preferredDeclaration);
+        char detailSeparator = GetPreferredDetailSeparator(separators);
+        string suggestedFileName = GetSuggestedFileName(
+            context,
+            preferredDeclaration,
+            preferredStem,
+            detailSeparator);
+        ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+            .Add(SuggestedFileNameProperty, suggestedFileName)
+            .Add(SuggestedDetailSeparatorProperty, detailSeparator.ToString());
+
         context.ReportDiagnostic(
-            Diagnostic.Create(s_rule, firstIdentifier.GetLocation(), fileName, firstIdentifier.ValueText));
+            Diagnostic.Create(
+                s_rule,
+                preferredIdentifier.GetLocation(),
+                properties,
+                fileName,
+                preferredIdentifier.ValueText,
+                suggestedFileName));
     }
 
     /// <summary>
     ///  Adds every name a file declaring <paramref name="members"/> may be called to
-    ///  <paramref name="candidates"/>, and records the first type's identifier in
-    ///  <paramref name="firstIdentifier"/>. A nested type contributes both its own name and its dotted path.
+    ///  <paramref name="candidates"/>, and records the first non-hosting declaration and qualified stem in
+    ///  <paramref name="preferredDeclaration"/> and <paramref name="preferredStem"/>. A nested type contributes
+    ///  both its own name and its dotted path.
     /// </summary>
     private static void CollectNames(
         SyntaxList<MemberDeclarationSyntax> members,
         string? prefix,
         List<string> candidates,
-        ref SyntaxToken firstIdentifier)
+        ref MemberDeclarationSyntax? preferredDeclaration,
+        ref string? preferredStem)
     {
         foreach (MemberDeclarationSyntax member in members)
         {
             if (member is BaseNamespaceDeclarationSyntax namespaceDeclaration)
             {
-                CollectNames(namespaceDeclaration.Members, prefix, candidates, ref firstIdentifier);
+                CollectNames(
+                    namespaceDeclaration.Members,
+                    prefix,
+                    candidates,
+                    ref preferredDeclaration,
+                    ref preferredStem);
                 continue;
             }
 
@@ -143,13 +197,21 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
                 continue;
             }
 
-            if (firstIdentifier.IsKind(SyntaxKind.None))
+            if (member is TypeDeclarationSyntax conditionalShell
+                && IsConditionallyEmptyPartial(conditionalShell))
             {
-                firstIdentifier = identifier;
+                continue;
             }
 
             string name = identifier.ValueText;
             string qualified = prefix is null ? name : $"{prefix}.{name}";
+
+            if (preferredDeclaration is null
+                && (member is not TypeDeclarationSyntax candidate || !IsHostingShell(candidate)))
+            {
+                preferredDeclaration = member;
+                preferredStem = qualified;
+            }
 
             candidates.Add(name);
 
@@ -173,9 +235,154 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
             // Only class, struct, interface, and record bodies can hold a nested type.
             if (member is TypeDeclarationSyntax typeDeclaration)
             {
-                CollectNames(typeDeclaration.Members, qualified, candidates, ref firstIdentifier);
+                CollectNames(
+                    typeDeclaration.Members,
+                    qualified,
+                    candidates,
+                    ref preferredDeclaration,
+                    ref preferredStem);
             }
         }
+    }
+
+    private static bool IsHostingShell(TypeDeclarationSyntax typeDeclaration)
+    {
+        if (typeDeclaration.Members.Count == 0
+            || !typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+        {
+            return false;
+        }
+
+        foreach (MemberDeclarationSyntax member in typeDeclaration.Members)
+        {
+            if (GetIdentifier(member).IsKind(SyntaxKind.None))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsConditionallyEmptyPartial(TypeDeclarationSyntax typeDeclaration)
+    {
+        if (typeDeclaration.Members.Count != 0
+            || !typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword)
+            || typeDeclaration.OpenBraceToken.IsKind(SyntaxKind.None)
+            || typeDeclaration.CloseBraceToken.IsKind(SyntaxKind.None))
+        {
+            return false;
+        }
+
+        int bodyStart = typeDeclaration.OpenBraceToken.Span.End;
+        int bodyEnd = typeDeclaration.CloseBraceToken.SpanStart;
+
+        foreach (SyntaxTrivia trivia in typeDeclaration.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (trivia.SpanStart < bodyStart || trivia.Span.End > bodyEnd)
+            {
+                continue;
+            }
+
+            if (trivia.IsKind(SyntaxKind.IfDirectiveTrivia)
+                || trivia.IsKind(SyntaxKind.ElifDirectiveTrivia)
+                || trivia.IsKind(SyntaxKind.ElseDirectiveTrivia)
+                || trivia.IsKind(SyntaxKind.EndIfDirectiveTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string GetSuggestedFileName(
+        SemanticModelAnalysisContext context,
+        MemberDeclarationSyntax preferredDeclaration,
+        string preferredStem,
+        char detailSeparator)
+    {
+        SyntaxTree tree = context.SemanticModel.SyntaxTree;
+        Compilation compilation = context.SemanticModel.Compilation;
+        string extension = Path.GetExtension(tree.FilePath);
+        string currentStem = Path.GetFileNameWithoutExtension(tree.FilePath);
+        bool isSplitPartial = preferredDeclaration is TypeDeclarationSyntax typeDeclaration
+            && typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword)
+            && IsDeclaredInAnotherTree(context.SemanticModel, tree, typeDeclaration, context.CancellationToken);
+
+        string firstStem = isSplitPartial ? $"{preferredStem}{detailSeparator}{currentStem}" : preferredStem;
+        string firstCandidate = firstStem + extension;
+        if (IsAvailableFileName(compilation, tree, firstCandidate))
+        {
+            return firstCandidate;
+        }
+
+        string detailStem = $"{preferredStem}{detailSeparator}{currentStem}";
+        string detailCandidate = detailStem + extension;
+        if (!string.Equals(firstCandidate, detailCandidate, StringComparison.OrdinalIgnoreCase)
+            && IsAvailableFileName(compilation, tree, detailCandidate))
+        {
+            return detailCandidate;
+        }
+
+        for (int suffix = 2; ; suffix++)
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+            string candidate = $"{detailStem}{detailSeparator}{suffix}{extension}";
+            if (IsAvailableFileName(compilation, tree, candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    private static char GetPreferredDetailSeparator(string separators)
+        => separators[0];
+
+    private static bool IsDeclaredInAnotherTree(
+        SemanticModel semanticModel,
+        SyntaxTree currentTree,
+        TypeDeclarationSyntax declaration,
+        CancellationToken cancellationToken)
+    {
+        ISymbol? symbol = semanticModel.GetDeclaredSymbol(declaration, cancellationToken);
+
+        if (symbol is null)
+        {
+            return false;
+        }
+
+        foreach (SyntaxReference reference in symbol.DeclaringSyntaxReferences)
+        {
+            if (reference.SyntaxTree != currentTree)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsAvailableFileName(Compilation compilation, SyntaxTree currentTree, string candidate)
+    {
+        string currentDirectory = Path.GetDirectoryName(currentTree.FilePath) ?? string.Empty;
+
+        foreach (SyntaxTree tree in compilation.SyntaxTrees)
+        {
+            if (tree == currentTree || string.IsNullOrEmpty(tree.FilePath))
+            {
+                continue;
+            }
+
+            string directory = Path.GetDirectoryName(tree.FilePath) ?? string.Empty;
+            if (string.Equals(directory, currentDirectory, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(Path.GetFileName(tree.FilePath), candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>
@@ -233,13 +440,14 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
         return separators.IndexOf(fileName[candidate.Length]) >= 0;
     }
 
-    private static string GetDetailSeparators(SyntaxTreeAnalysisContext context)
+    private static string GetDetailSeparators(SemanticModelAnalysisContext context)
     {
-        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree);
+        AnalyzerConfigOptions options =
+            context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.SemanticModel.SyntaxTree);
 
         if (options.TryGetValue(DetailSeparatorsOption, out string? value))
         {
-            string separators = value.Trim();
+            string separators = GetValidDetailSeparators(value.Trim());
 
             // An empty value is far more likely to be a mistake than a deliberate "allow no detail".
             if (separators.Length > 0)
@@ -249,5 +457,21 @@ public sealed class FileNameMatchesTypeAnalyzer : DiagnosticAnalyzer
         }
 
         return DefaultDetailSeparators;
+    }
+
+    private static string GetValidDetailSeparators(string separators)
+    {
+        char[] validSeparators = new char[separators.Length];
+        int count = 0;
+
+        foreach (char separator in separators)
+        {
+            if (Array.IndexOf(Path.GetInvalidFileNameChars(), separator) < 0)
+            {
+                validSeparators[count++] = separator;
+            }
+        }
+
+        return count == 0 ? string.Empty : new string(validSeparators, 0, count);
     }
 }

--- a/touki.analyzers/OneTypePerFileAnalyzer.cs
+++ b/touki.analyzers/OneTypePerFileAnalyzer.cs
@@ -23,8 +23,12 @@ namespace Touki.Analyzers;
 ///   so it is not counted.
 ///  </para>
 ///  <para>
-///   The diagnostic is reported on the identifier of the extra type, which is where the built-in
-///   "Move type to <c>&lt;TypeName&gt;.cs</c>" refactoring is offered - accept it to split the file.
+///   The diagnostic is reported on the identifier of the extra type. The companion code fix moves the
+///   declaration to a new file and supports solution-wide Fix All, including delegates and nested types.
+///  </para>
+///  <para>
+///   Set <c>dotnet_code_quality.TOUKI0020.exclude_nested_types = true</c> to enforce top-level types while
+///   deferring nested-type adoption.
 ///  </para>
 ///  <para>
 ///   <b>Constraints and limitations.</b> The rule is purely syntactic; it never binds a symbol.
@@ -62,6 +66,11 @@ public sealed class OneTypePerFileAnalyzer : DiagnosticAnalyzer
     /// </summary>
     public const string DiagnosticId = "TOUKI0020";
 
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that excludes nested types while retaining top-level type enforcement.
+    /// </summary>
+    public const string ExcludeNestedTypesOption = "dotnet_code_quality.TOUKI0020.exclude_nested_types";
+
     private static readonly DiagnosticDescriptor s_rule = new(
         id: DiagnosticId,
         title: "Declare one type per file",
@@ -96,8 +105,13 @@ public sealed class OneTypePerFileAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree);
+        bool excludeNestedTypes = options.TryGetValue(ExcludeNestedTypesOption, out string? configuredValue)
+            && bool.TryParse(configuredValue.Trim(), out bool configuredExcludeNestedTypes)
+            && configuredExcludeNestedTypes;
+
         List<MemberDeclarationSyntax> types = [];
-        CollectTypes(compilationUnit.Members, types);
+        CollectTypes(compilationUnit.Members, types, includeNestedTypes: !excludeNestedTypes);
 
         if (types.Count < 2)
         {
@@ -119,14 +133,17 @@ public sealed class OneTypePerFileAnalyzer : DiagnosticAnalyzer
     ///  Adds every type declared in <paramref name="members"/> to <paramref name="types"/> in source order,
     ///  descending through namespace declarations and type bodies alike.
     /// </summary>
-    private static void CollectTypes(SyntaxList<MemberDeclarationSyntax> members, List<MemberDeclarationSyntax> types)
+    private static void CollectTypes(
+        SyntaxList<MemberDeclarationSyntax> members,
+        List<MemberDeclarationSyntax> types,
+        bool includeNestedTypes)
     {
         foreach (MemberDeclarationSyntax member in members)
         {
             switch (member)
             {
                 case BaseNamespaceDeclarationSyntax namespaceDeclaration:
-                    CollectTypes(namespaceDeclaration.Members, types);
+                    CollectTypes(namespaceDeclaration.Members, types, includeNestedTypes);
                     break;
                 case TypeDeclarationSyntax typeDeclaration:
                     if (IsNamedType(typeDeclaration)
@@ -136,7 +153,11 @@ public sealed class OneTypePerFileAnalyzer : DiagnosticAnalyzer
                         types.Add(typeDeclaration);
                     }
 
-                    CollectTypes(typeDeclaration.Members, types);
+                    if (includeNestedTypes)
+                    {
+                        CollectTypes(typeDeclaration.Members, types, includeNestedTypes);
+                    }
+
                     break;
                 case EnumDeclarationSyntax or DelegateDeclarationSyntax:
                     // Neither can be partial or contain a nested type, so they are always a plain leaf.


### PR DESCRIPTION
## Summary

- add collision-aware IDE solution Fix All providers for moving TOUKI0020 declarations and renaming TOUKI0021 files
- preserve nested type identity, repeated partial declarations, containing type shells, file headers, and configured filename detail separators
- add `TOUKI0020.exclude_nested_types` for staged adoption and improve TOUKI0021 filename suggestions for split partial types
- withhold structural fixes for directive-bearing, linked, or file-local-sensitive sources and for `MSBuildWorkspace`, whose project mutation model cannot safely persist these changes
- document the recommended adoption workflow and formatter limitations

## Validation

- `dotnet test touki.analyzers.tests/touki.analyzers.tests.csproj -c Debug --no-restore` - 300 passed
- `dotnet test touki.analyzers.tests/touki.analyzers.tests.csproj -c Release --no-build --no-restore` - 300 passed
- `dotnet test touki.tests/touki.tests.csproj -c Release --no-build --no-restore` - all target frameworks passed with expected platform skips
- `dotnet test touki.aot.tests/touki.aot.tests.csproj -c Release --no-build --no-restore` - 13 passed

Fixes #254