### PR TITLE
Re-vendor agent-skills commons at v0.13.0

### DIFF
--- a/.agents/skills/FORMAT.md
+++ b/.agents/skills/FORMAT.md
@@ -49,7 +49,10 @@ This repo also uses:
 - Portfolio metadata - string-valued `portability`, `applicability`, `binding`,
   `risk`, `maturity`, `requires`, and `related`. The vocabularies are enforced by
   the bundled strict validator; relationship values are `none` or comma-separated
-  skill names.
+  skill names. A `requires` target must be present in this repo. A `related`
+  target must be too, except on a vendored core, whose metadata is owned upstream
+  and may name a portfolio sibling this repo deliberately does not vendor; record
+  that decision in the core's overlay and in the catalog.
 
 Touki uses the ASCII skill-name subset `^[a-z0-9-]{1,64}$`, matching current
 VS Code discovery. Exact vendored payloads can retain upstream punctuation and
@@ -80,7 +83,7 @@ sentence. The overlay starts with:
 ```yaml
 ---
 core: skill-name
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 ```
 

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -30,6 +30,8 @@ The "Disambiguation" section below records every known overlap.
 | [roslyn-analyzers](./roslyn-analyzers/SKILL.md) | "write an analyzer", "create a Roslyn/diagnostic analyzer", "add an analyzer rule", "add a code fix", "enforce a convention at build time", "flag a pattern in code"; find-first check of existing `CA`/`IDE` rules, `BannedApiAnalyzers`, EditorConfig, Roslynator/StyleCop/Meziantou before authoring; `touki.analyzers` layout, packing into `KlutzyNinja.Touki`, statelessness/`IOperation` design, the `Microsoft.CodeAnalysis.Testing` harness, in-IDE perf budget | vendored (portable core) + overlay | `performance-testing`, `security-review`, `pre-pr-self-review`, `il-copy-inspection`, `create-pr` (via [overlay](./roslyn-analyzers/overlay.md)) |
 | [il-copy-inspection](./il-copy-inspection/SKILL.md) | "find struct copies", "where does the compiler copy this struct", "is this a defensive copy", "check for boxing in IL", "did the compiler emit a copy", "confirm the analyzer's defensive-copy warning", "audit a `[NonCopyable]` type's copies after build"; reading emitted IL (`ildasm`/`ilspycmd`/Cecil/`MetadataReader`) for the `ldobj`/`stloc`/`ldloca` defensive-copy signature, `box`, by-value field/arg/return copies, and PDB offset-to-source mapping | vendored (portable core) + overlay | `roslyn-analyzers`, `framework-jit-optimization`, `performance-testing`, `scratch-buffer-strategy` (via [overlay](./il-copy-inspection/overlay.md)) |
 | [code-comprehension](./code-comprehension/SKILL.md) | "review this for readability", "is this too complex", "reduce nesting / cognitive load", "reasonable method length / parameter count / nesting depth", judging whether code will be hard to understand | vendored (portable core) + overlay | `pre-pr-self-review` (via [overlay](./code-comprehension/overlay.md)) |
+| [cswin32-interop](./cswin32-interop/SKILL.md) | replacing `[DllImport]` with generated `PInvoke.*` calls, working with `Windows.Win32` projections (`HANDLE`/`HRESULT`/`BOOL`, typed enums and constants), editing `NativeMethods.txt` / `NativeMethods.json`, blittable signatures under `allowMarshaling: false`, native allocator ownership and byte-versus-element lengths, platform guards for Windows-only code, CsWin32 vs `[LibraryImport]` | vendored (portable core) + overlay | `cswin32-com`, `dotnet-polyfills`, `scratch-buffer-strategy`, `security-review` (via [overlay](./cswin32-interop/overlay.md)) |
+| [github-actions-cost-optimization](./github-actions-cost-optimization/SKILL.md) | "reduce CI cost / spend / minutes / job count", optimizing workflow triggers, matrices, runner selection, caches, artifact retention, eliminating duplicate Actions runs, deciding which checks are automatic versus scheduled or manual | vendored (portable core) + overlay | `engineering-baseline`, `security-review` (via [overlay](./github-actions-cost-optimization/overlay.md)) |
 
 **Portability** (mirrored from each skill's `metadata.portability`) marks how much
 a skill would need to change to be reused in another repo: `portable` (generic),
@@ -178,6 +180,24 @@ being read:
 `il-copy-inspection` never runs the code and never measures time; if a request needs
 a number, it belongs to `performance-testing`. The natural chain is analyzer
 prediction -> IL confirmation -> asm/runtime cost.
+
+### `github-actions-cost-optimization` vs `performance-testing`
+
+Both match "reduce cost" and "optimize". They split by **what is being measured**:
+
+- **CI runner usage** - workflow triggers, matrices, runner labels, caches,
+  artifact retention, duplicate Actions runs -> `github-actions-cost-optimization`.
+  The unit is runner minutes.
+- **Shipped code at execution time** - `Mean`, `Allocated`, both TFMs ->
+  `performance-testing`. The unit is nanoseconds and bytes.
+
+"Make CI cheaper" is never `performance-testing`, and "make this method faster"
+is never `github-actions-cost-optimization`.
+
+Two commons skills that these two name are intentionally **not vendored here**:
+`cswin32-com` (touki has no struct-based COM surface) and `engineering-baseline`
+(touki is already an established repository). Their names appear only as
+upstream-owned cross-references.
 
 ## Maintenance
 

--- a/.agents/skills/address-pr-feedback/SKILL.md
+++ b/.agents/skills/address-pr-feedback/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/address-pr-feedback
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: ceb544da854ef7ba911679b8af8bca2631150ef9
+    github-tree-sha: 7db8903886f6ce4509f97eae6f72fca6c883abe0
     maturity: canary
     portability: portable
     related: create-pr, pre-pr-self-review, agent-files-review
@@ -33,10 +33,9 @@ authorizes you to *edit*:
 - This skill authorizes editing files in response to review feedback or
   CI failures on an existing PR. Same approval gate before commit/push.
 
-Your repo's agent guidance (the "Working with the user on changes" rules in
-`AGENTS.md`) is the source of truth for the commit/push approval rule. Re-read it
-at the start of every invocation; this skill is the decision-point reminder, not
-a replacement.
+Repository guidance is the source of truth for commit/push approval. Re-read it
+at the start of every invocation when present; this skill is a reminder, not a
+replacement.
 
 ## Recognizing approval
 
@@ -65,11 +64,15 @@ Stop and ask one short yes/no question.
 
 ## Workflow
 
-1. **Fetch the feedback.** Read review comments, PR conversation, and check-run
-   logs via the GitHub PR tools (or `Invoke-RestMethod` against
-   `api.github.com/repos/<owner>/<repo>/pulls/<N>/comments`). With multiple
-   review passes, fetch the **latest** review's comments (filter by the newest
-   review id) so you act on the current round.
+1. **Confirm the PR is open, then fetch feedback.** If it was merged, stop and
+    propose a user-approved follow-up such as a revert or new PR. If it was closed
+    without merging, stop and propose reopening it or creating a new PR. Do not
+    mutate the old branch in either case. Read every unresolved review thread
+    across all review passes, including replies, plus the PR conversation and
+    compact check statuses. Fetch logs only for failed checks being investigated.
+    Do not filter by newest review id - older unresolved threads remain
+    actionable. Prefer a PR tool; use
+    [thread-workflow.md](thread-workflow.md) for the `gh` fallback.
 
    Automated reviewers (e.g. Copilot) post asynchronously - on open, on push, or
    when requested - a minute or two after the trigger. If one was requested but
@@ -92,27 +95,33 @@ Stop and ask one short yes/no question.
    commit`, or `git push`.
 5. **Wait** for an explicit publishing verb (see "Recognizing approval"
    above).
-6. **Only then** stage by path, commit with a message that summarizes the
-   round of changes, and push. The staging/commit/push mechanics are the
-   same as in the `create-pr` skill (its "Commit changes" and "Push the
-   branch" steps).
-7. **Resolve the threads, with explanations.** Replying and resolving are remote
-   actions, so they ride in the same approved publish step as the push; honor
-   explicit scoping ("push and resolve only", "don't re-request") and report
-   what you did. For each comment, reply then resolve:
-   - **Fixed** - one line on what changed (reference the commit or behavior).
-   - **False positive / won't-fix** - the rationale or the evidence. Leave a
-     thread open only to invite a human onto a contested point, and say so.
-   With the PR tool, use its resolve action; with `gh`, resolve via the GraphQL
-   `resolveReviewThread` mutation on the thread node id (not the comment id).
-8. **Re-request review when non-trivial.** After real code changes, request a
-   fresh pass from the same reviewer - also a remote action in the publish step.
-   Skip it for trivial rounds (typo, reword, one-line nit) to avoid an endless
-   trickle, and say which you did.
+6. **Only then** recheck that the PR is open before staging or committing. Commit
+    the round, then confirm the PR is still open immediately before each remote
+    write in steps 6-8; abort and report if it is not. Push using the mechanics in
+    the `create-pr` skill.
+7. **Reply in-thread, then resolve.** These are PR write actions. Follow repository
+    guidance; when it does not bundle them with push/update approval, get explicit
+    approval. Refresh each targeted thread before writing: skip one already
+    resolved, and reclassify one with new replies. Write one scoped reply per
+    thread: state what changed for a fix, or give the evidence for a false positive
+    or won't-fix. Do not combine answers across threads or post the review summary
+    to the PR conversation. Leave a thread open only to invite a human onto a
+    contested point, and say so.
+    Verify both operations; a reply does not resolve a thread. Report what you did.
+8. **Get the next review when non-trivial.** If the repository automatically
+    reviews pushes, never request or re-request review; let the automatic pass run
+    without polling. Otherwise, after real code changes, request a fresh pass from
+    the same reviewer using the repository's PR-write approval policy. Skip a
+    manual request for trivial rounds (typo, reword, one-line nit), and say which
+    path applies.
 
 **When to stop.** Later auto-review passes drift toward nits and false positives.
-Once comments stop being substantive, stop re-requesting, say so, and let the
-user merge.
+Before calling the PR ready, confirm it is open, non-draft, mergeable, required
+checks and reviews are satisfied, no review threads remain unresolved, and the
+latest requested or automatic review has completed. Account for every actionable
+PR-conversation comment with a response or recorded disposition as well.
+Otherwise report what is pending. Once comments stop being substantive, stop
+requesting additional manual reviews and let the user merge.
 
 ## When you've already violated the rule
 
@@ -123,7 +132,7 @@ force-push, or leave the commit in place.
 
 ## Related
 
-- Your repo's agent guidance (`AGENTS.md`) - the rule itself.
+- Repository agent guidance, when present - the local approval rule.
 - The `create-pr` skill - opening the initial PR (same publish gate,
   different edit scope).
 - The `pre-pr-self-review` skill - the validation checklist that applies

--- a/.agents/skills/address-pr-feedback/overlay.md
+++ b/.agents/skills/address-pr-feedback/overlay.md
@@ -1,15 +1,20 @@
 ---
 core: address-pr-feedback
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - address-pr-feedback
 
 Repo-specific companion to the vendored [address-pr-feedback](SKILL.md) skill. The
-`SKILL.md` is a **pinned copy of the portable core** from
+`SKILL.md` and its sibling page [thread-workflow.md](thread-workflow.md) are a
+**pinned copy of the portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in its frontmatter). Do not hand-edit the core -
 `gh skill update` would flag the drift. Everything touki-specific lives here.
+
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag. Pull
+> later upstream changes with `gh skill update address-pr-feedback` (review the
+> diff, re-pin to the new tag).
 
 ## Cross-references (the core names these skills generically)
 
@@ -47,27 +52,31 @@ always wins over examples in the vendored core.
 
 ## Standing approval: always resolve an addressed thread
 
-Resolving review threads needs no per-message approval. `push` on a review round
-infers reply-and-resolve; the push itself still needs its own verb.
-
-Reply in the thread, not on the main conversation, and check that it threaded:
-
-```pwsh
-gh api repos/JeremyKuhne/touki/pulls/<n>/comments/<COMMENT_ID>/replies -f body="..."
-gh api repos/JeremyKuhne/touki/pulls/<n>/comments --jq '.[] | {id, in_reply_to_id}'
-```
-
-Replying is not resolving. The thread node id is GraphQL-only:
-
-```pwsh
-gh api graphql -f query='query { repository(owner: "JeremyKuhne", name: "touki") {
-  pullRequest(number: <n>) { reviewThreads(first: 20) { nodes {
-    id isResolved comments(first: 1) { nodes { databaseId } } } } } } }'
-```
-
-Resolve with the PR tool's resolve action, then confirm `isResolved` is `true`.
+The core's step 7 defers reply-and-resolve approval to repository guidance. In
+touki that approval is **standing**: resolving review threads needs no
+per-message approval, and `push` on a review round infers reply-and-resolve. The
+push itself still needs its own verb.
 
 A declined comment gets an in-thread reply and stays open.
+
+## Getting the next review (the core's step 8)
+
+**Copilot auto-review is always on for this repo.** A review posts automatically
+a minute or two after the PR opens and after every subsequent push, so the core's
+"repository automatically reviews pushes" branch is the one that applies: never
+request or re-request a review, and do not poll for the automatic one. Say that a
+review will land on its own, and expect a fresh round of comments on each new
+commit.
+
+Later rounds drift toward nits and false positives. Verify every claim against
+the code before acting.
+
+## Thread mechanics
+
+The core's [thread-workflow.md](thread-workflow.md) is the `gh` fallback for
+listing, replying to, and resolving threads when the PR tool cannot. The only
+touki bindings it needs are the repository coordinates: owner `JeremyKuhne`, name
+`touki`. There is no `upstream` remote, so the PR always lives on `origin`.
 
 ## Updating
 

--- a/.agents/skills/address-pr-feedback/thread-workflow.md
+++ b/.agents/skills/address-pr-feedback/thread-workflow.md
@@ -1,0 +1,103 @@
+# GitHub review-thread fallback
+
+Use this only when the PR tool cannot list, reply to, or resolve review threads.
+Target the repository that owns the PR explicitly; the checkout may be a fork.
+
+Create each query and reply file below with a unique name in the OS temporary
+directory, never in the repository. Delete it immediately after use.
+
+## Fetch all unresolved feedback
+
+Save the thread query:
+
+```graphql
+query(
+  $owner: String!
+  $repo: String!
+  $number: Int!
+  $endCursor: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $endCursor) {
+        nodes { id isResolved }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+Replace the uppercase tokens below with actual values and temporary-file paths.
+Run the query with pagination and keep unresolved thread node IDs:
+
+```text
+gh api graphql --paginate -F owner=BASE_OWNER -F repo=BASE_REPO -F number=PULL_NUMBER -F query=@THREADS_QUERY_FILE --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | .id'
+```
+
+For each unresolved thread, save and run this paginated comments query:
+
+```graphql
+query($threadId: ID!, $endCursor: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 100, after: $endCursor) {
+        nodes {
+          id
+          body
+          url
+          path
+          line
+          author { login }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+```
+
+```text
+gh api graphql --paginate -F threadId=THREAD_NODE_ID -F query=@COMMENTS_QUERY_FILE --jq '.data.node.comments.nodes[]'
+```
+
+Classify every unresolved thread after reading all its replies.
+
+## Reply in-thread
+
+Write the response to a unique temporary Markdown file, then use the thread node
+ID to reply. This cannot create a top-level PR comment:
+
+```graphql
+mutation($threadId: ID!, $body: String!) {
+  addPullRequestReviewThreadReply(
+    input: { pullRequestReviewThreadId: $threadId, body: $body }
+  ) {
+    comment { id url body }
+  }
+}
+```
+
+```text
+gh api graphql -F threadId=THREAD_NODE_ID -F body=@REPLY_FILE -F query=@REPLY_QUERY_FILE --jq '.data.addPullRequestReviewThreadReply.comment'
+```
+
+Require a non-null comment `id` before reporting that the reply was posted.
+
+## Resolve separately
+
+Save and run the resolve mutation:
+
+```graphql
+mutation($threadId: ID!) {
+  resolveReviewThread(input: { threadId: $threadId }) {
+    thread { id isResolved }
+  }
+}
+```
+
+```text
+gh api graphql -F threadId=THREAD_NODE_ID -F query=@RESOLVE_QUERY_FILE --jq '.data.resolveReviewThread.thread'
+```
+
+Require `isResolved: true` before reporting success.

--- a/.agents/skills/agent-files-review/SKILL.md
+++ b/.agents/skills/agent-files-review/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: agent-customization
     binding: optional-overlay
     github-path: skills/agent-files-review
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 64a00d548909d8f84fb8ac6f6e3db77deceab270
     maturity: canary

--- a/.agents/skills/agent-files-review/overlay.md
+++ b/.agents/skills/agent-files-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: agent-files-review
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - agent-files-review

--- a/.agents/skills/code-comprehension/SKILL.md
+++ b/.agents/skills/code-comprehension/SKILL.md
@@ -5,8 +5,8 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/code-comprehension
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: d2e1be7b63a31345f054a1d0785a67d5ba2aa604
     maturity: canary

--- a/.agents/skills/code-comprehension/overlay.md
+++ b/.agents/skills/code-comprehension/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: code-comprehension
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - code-comprehension

--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: git-github
     binding: optional-overlay
     github-path: skills/create-pr
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: dcdd58e7cad32b4907ce6a8bf0fe6bf01cb14f59
+    github-tree-sha: 6fef038602c67d66b0c8278e8f7681b56803a95f
     maturity: canary
     portability: portable
     related: pre-pr-self-review, address-pr-feedback
@@ -34,6 +34,12 @@ once the user supplies an explicit publishing verb - `commit`, `push`,
 `ship it`, or equivalent. See your repo's agent guidance (the "Working with
 the user on changes" rules in `AGENTS.md`) for the canonical rule and the
 recurring not-approval phrasings.
+
+Branch-name confirmation is a separate prerequisite, not part of publish
+approval. If the current branch is `main`, do not choose or create a branch
+until the user confirms its name. In a non-interactive run where confirmation
+cannot be requested, stop and report the proposed name; never infer confirmation
+from the request to open a PR.
 
 Before running this workflow, walk through the `pre-pr-self-review` checklist -
 it catches the test, allocation, overflow-arithmetic, and TFM-phrasing mistakes
@@ -67,6 +73,9 @@ Decide the PR base:
   before creating it. Offer the suggested kebab-case name and a way to enter a
   different name. If the host has no structured question tool, ask in chat.
   Known client adapters are in [host-adapters.md](host-adapters.md).
+- **Do not run `git switch -c`, `git checkout -b`, or `git branch <name>` until
+  that confirmation is received.** If the host cannot ask in the current mode,
+  stop with the proposed branch name.
 - Use `git switch -c <branch>` to move uncommitted changes onto the new
   branch.
 - If already on a non-`main` branch, keep using it.

--- a/.agents/skills/create-pr/overlay.md
+++ b/.agents/skills/create-pr/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: create-pr
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - create-pr
@@ -44,6 +44,14 @@ overlay narrows it:
 
 The latest [AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes)
 always wins over examples in the vendored core.
+
+## Automated review (the core's step 7)
+
+**Copilot auto-review is always on for this repo.** A review posts automatically
+a minute or two after the PR opens and after every push, so the core's "if
+nothing auto-reviews, offer to request a reviewer" branch never applies here: do
+not offer to request a reviewer, and do not poll. Say a review will land on its
+own, then hand off to [`address-pr-feedback`](../address-pr-feedback/SKILL.md).
 
 ## Updating
 

--- a/.agents/skills/cswin32-interop/SKILL.md
+++ b/.agents/skills/cswin32-interop/SKILL.md
@@ -1,0 +1,127 @@
+---
+compatibility: Requires the .NET SDK and the Microsoft.Windows.CsWin32 source generator; projects Windows APIs across .NET 10 and .NET Framework. Owner/extender composition requires C# 14.
+description: Guides CsWin32 P/Invoke interop in a multi-targeted .NET 10 and .NET Framework library. Consult when replacing [DllImport] with source-generated PInvoke.* calls, working with generated Windows.Win32 projections (HANDLE / HMODULE / HRESULT / BOOL and typed enum/constant types), configuring NativeMethods.txt / NativeMethods.json, composing a public PInvoke across foundation/owner/extender packages with extensionReceiver, deciding which support library owns a helper, auditing native allocation and byte/element lengths, selecting compile-time / runtime / analyzer guards for Windows-only code, or choosing between CsWin32 and [LibraryImport]. Not for managed-only changes with no native boundary. Paired with the cswin32-com skill for the struct-based COM layer.
+license: MIT
+metadata:
+    applicability: dotnet
+    binding: optional-overlay
+    github-path: skills/cswin32-interop
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 14960bec081ff29eaa9bf5593b7a6ca9d5201ae8
+    maturity: canary
+    portability: portable
+    related: cswin32-com, dotnet-polyfills, scratch-buffer-strategy, security-review
+    requires: none
+    risk: local-write
+name: cswin32-interop
+---
+# CsWin32 P/Invoke interop
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+[CsWin32](https://github.com/microsoft/CsWin32) is a source generator that
+replaces hand-written `[DllImport]` declarations with generated `PInvoke.*`
+calls and strongly-typed projections of Win32 handles, structs, enums, and
+constants. You list the API, type, or constant names you need in
+`NativeMethods.txt`; the generator emits them and pulls in their dependencies.
+
+This skill is the general P/Invoke layer. The struct-based COM layer builds on
+it - see the paired **cswin32-com** skill, whose vtable methods follow the same
+[blittable-signatures](blittable-signatures.md) rules.
+
+## Rules
+
+1. **Replace a hand-written `[DllImport]` with `PInvoke.*` when CsWin32 can
+  project the API.** After verifying the generated declaration and supporting
+  types, delete their hand-written equivalents. Keep a source-generated
+  `[LibraryImport]` on .NET 10 and `[DllImport]` on .NET Framework for an
+  export absent from the available Win32 metadata. See
+  [types-and-constants.md](types-and-constants.md).
+2. **Use the generated types directly** (`HANDLE`, `HMODULE`, `HRESULT.S_OK`,
+   `FILE_FLAGS_AND_ATTRIBUTES`, ...). Never keep a parallel local copy of a
+   Win32 enum or struct CsWin32 already projects.
+3. **Call the generated method directly** - no thin wrapper. Within one
+   ownership layer, generate once and share internal types with friend
+   assemblies. When a downstream package intentionally extends a public owner,
+   use the [owner/extender composition](composition.md) model instead.
+4. **Prefer CsWin32 for Windows APIs present in its metadata.** Use
+  `[LibraryImport]` (or `[DllImport]` on .NET Framework) for private, custom,
+  or otherwise unprojectable Windows exports and for non-Windows native calls
+  such as `libc`. Keep those signatures blittable under the same rules.
+5. **Preserve the original error-handling contract when migrating.** Check the
+   old declaration for `PreserveSig` / `SetLastError` / `BOOL` / `HRESULT`
+   semantics and reproduce them: `PreserveSig=false` becomes
+   `.ThrowOnFailure()`; `SetLastError=true` plus a failed `BOOL` becomes
+   `throw new Win32Exception()`. Silently returning where the old code threw is
+   a behavior change. The paired cswin32-com skill has the COM-side parity
+   table.
+6. **Keep signatures blittable.** CsWin32 is configured `allowMarshaling: false`,
+   so every `[DllImport]` and every COM vtable method must be blittable. The
+   full rule set is in [blittable-signatures.md](blittable-signatures.md).
+7. **Audit ownership and size units.** Generated wrappers do not decide which
+   allocator frees an output, whether a COM reference remains caller-owned, or
+   whether a length is bytes or elements. Record and test those contracts using
+   [ownership-and-units.md](ownership-and-units.md).
+
+## Platform and target-framework guards
+
+CsWin32 projects Windows APIs, but compile inclusion, runtime reachability, and
+the public platform contract are separate decisions. Generated declarations can
+live in a cross-platform assembly; reachable calls still need a recognized
+Windows runtime guard or a Windows-only API context. Exclude source at compile
+time only when a target intentionally omits that interop surface or one of its
+dependencies. In the .NET 10 / .NET Framework target model, use `NET` for the
+.NET 10 leg and `NETFRAMEWORK` for the Framework leg. See
+[gating.md](gating.md) for the decision table, `CA1416`, and guarded-build
+verification. An overlay records the concrete TFMs and any repository-specific
+compile symbol or source-item condition.
+
+## Configuration
+
+- **`NativeMethods.txt`** - one API / type / constant name per line; the
+  generator projects each and pulls in its dependencies.
+- **`NativeMethods.json`** - generator options. `allowMarshaling: false` (raw
+  blittable signatures, no marshaller) and `useSafeHandles: false` are the
+  interop-friendly defaults these skills assume.
+- Run the generator in a single project within an ownership layer and share via
+  `InternalsVisibleTo` rather than adding CsWin32 to every implementation
+  project. A package that extends another package's public projection is a
+  separate layer: configure `className` / `extensionReceiver` as described in
+  [composition.md](composition.md).
+
+### Source generator versus build task
+
+The Roslyn source generator is the default. Setting
+`CsWin32RunAsBuildTask=true` replaces it with an MSBuild task that writes `.cs`
+files under the intermediate output directory and adds them to `Compile`; the
+source generator stands down. Treat this as an opt-in for a specific build
+ordering, generated-file, or tooling requirement, not as a general upgrade.
+
+Before keeping build-task mode, clean and build all .NET 10 and .NET Framework
+TFMs, compare the emitted public API, and measure clean-build time. It can be
+materially slower. It also does not make an `allowMarshaling: false` project
+more AOT-safe by itself, so do not enable `DisableRuntimeMarshalling` merely
+because generation moved to the task.
+
+## Sibling pages
+
+- [blittable-signatures.md](blittable-signatures.md) - the signature rules
+  shared by `[DllImport]` and COM vtables (`HRESULT`, `T**` vs `out T*`,
+  `void*`, `nint`, `PCWSTR` / `PWSTR`, typed enum parameters).
+- [types-and-constants.md](types-and-constants.md) - using the generated
+  handle / enum / constant projections, "grep the metadata before redefining",
+  type conversions, FILETIME, and native integers.
+- [composition.md](composition.md) - composing one public `PInvoke` across an
+  owner package and downstream extender, including constants, XML docs, and
+  package verification.
+- [library-layering.md](library-layering.md) - placing generic utilities,
+  shared Win32 support, domain extensions, and applications in a directed
+  package stack, with migration and release ordering.
+- [ownership-and-units.md](ownership-and-units.md) - matching native allocators
+  and deallocators, caller-owned COM references, failure cleanup, and
+  byte-versus-element conversions.
+- [gating.md](gating.md) - source inclusion, runtime and TFM guards, `CA1416`, a
+  stack-first scratch-buffer strategy, and guarded-build verification.

--- a/.agents/skills/cswin32-interop/blittable-signatures.md
+++ b/.agents/skills/cswin32-interop/blittable-signatures.md
@@ -1,0 +1,47 @@
+# Blittable signatures
+
+Detail for [cswin32-interop](SKILL.md). CsWin32 is configured
+`allowMarshaling: false`, so every `[DllImport]` and every manual COM vtable
+method must be **blittable** - the runtime does no marshalling at the boundary.
+These rules apply to both surfaces.
+
+- **Return `HRESULT`, not `int`,** from HRESULT-returning APIs. `HRESULT` is
+  blittable (a single `int` field) and exposes `.Succeeded` / `.Failed` /
+  `.Value` / `.ThrowOnFailure()`. Use `HRESULT.S_OK` instead of `0`; cast
+  `e.HResult` to `(HRESULT)` when wrapping. `AddRef` / `Release` return `uint`
+  (the `IUnknown` contract).
+- **Throw with `hr.ThrowOnFailure()`** rather than
+  `if (hr.Failed) Marshal.ThrowExceptionForHR(hr)`. It is the idiomatic helper,
+  produces the same `IErrorInfo`-enriched exception, and reads cleanly at the
+  call site: `iface->Method(...).ThrowOnFailure();`. Branch on the raw `hr` only
+  when you handle a specific code (e.g. `ERROR_INSUFFICIENT_BUFFER`) before
+  throwing.
+- **Prefer `T**` for raw pointer outputs and vtable signatures.** `out T*` is
+  also blittable and represents the same native indirection, but it introduces
+  managed by-reference syntax and cannot bind to helpers that expose `T**` or
+  `void**`. Keep `out T*` only when the hand-written declaration intentionally
+  wants C# definite-assignment semantics; match the raw ABI with `T**` by
+  default.
+- **Use `void*` for opaque / reserved parameters** and pass `null` literally -
+  never round-trip through `IntPtr.Zero` inside `unsafe`.
+- **Prefer `nint` / `nuint` for new native-sized values.** Keep
+  `IntPtr` / `UIntPtr` only where an existing public contract or managed API
+  requires those names (`Marshal.*`, `SafeHandle.DangerousGetHandle`, or a
+  compatibility-sensitive public API), and convert once at that boundary.
+- **Use the generated `PCWSTR` / `PWSTR` for wide strings,** never a managed
+  `string`. The caller pins with `fixed (char* p = managedString)` (implicit on
+  most overloads). Add the type to `NativeMethods.txt` if not yet generated.
+- **No managed reference types** (`string`, `StringBuilder`, arrays) in a
+  blittable signature.
+- **Do not set `PreserveSig = true` on `[DllImport]`** - it is the default. Use
+  `PreserveSig = false` only to force the marshaller to throw on failure
+  HRESULTs (rare; prefer returning `HRESULT` and calling `.ThrowOnFailure()`).
+  Note `[ComImport]` defaults the opposite way, but struct-based COM uses raw
+  `delegate*` invocation and is unaffected.
+- **Constrain flag / option parameters to a typed `enum`.** When a native
+  `DWORD` / `ULONG` / `int` is documented as a `typedef enum` or a `#define`
+  set, declare a matching C# `[Flags] enum Foo : uint` (same underlying type)
+  and use it in the signature (and in the `delegate*` cast for a COM method).
+  Mirror the constraint even when the native side has no named enum:
+  `OpenScope(path, CorOpenFlags.ofRead, ...)` self-documents where
+  `OpenScope(path, 0, ...)` does not. Co-locate the enum with its consumer.

--- a/.agents/skills/cswin32-interop/composition.md
+++ b/.agents/skills/cswin32-interop/composition.md
@@ -1,0 +1,101 @@
+# Layered owner/extender composition
+
+Detail for [cswin32-interop](SKILL.md). Use this model when one package owns the
+public CsWin32 projection and another package adds APIs to that same callable
+surface. This is different from sharing one internal projection with friend
+assemblies: each layer runs CsWin32, but only one layer owns the receiver type.
+For the broader managed-foundation / Win32-owner / domain-extender package
+stack and release order, see [library-layering.md](library-layering.md).
+
+## Choose the ownership boundary first
+
+| Layer | Responsibility |
+| --- | --- |
+| Owner | Publishes the canonical `Windows.Win32.PInvoke` and shared projected or hand-authored Win32 types. |
+| Extender | References the owner and projects additional APIs as C# 14 extension members on the owner's `PInvoke`. |
+| Consumer | References the extender and calls owner and extender APIs through one `PInvoke` surface. |
+
+The owner configuration names and publishes the receiver:
+
+```json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "PInvoke",
+  "public": true,
+  "allowMarshaling": false,
+  "useSafeHandles": false
+}
+```
+
+The extender uses a different host name and points `extensionReceiver` at the
+owner type:
+
+```json
+{
+  "$schema": "https://aka.ms/CsWin32.schema.json",
+  "className": "Interop",
+  "extensionReceiver": "PInvoke",
+  "public": true,
+  "allowMarshaling": false,
+  "useSafeHandles": false
+}
+```
+
+The extender project must reference the owner assembly at compile time and use a
+C# version that supports extension blocks. Keep the CsWin32 package private in a
+library package unless consumers need it directly; generated source is compiled
+into the extender assembly.
+
+## What composes, and what does not
+
+- Call generated methods and read generated values through `PInvoke` in normal
+  runtime code. The extender's `Interop` type is the generated implementation
+  host, not a second public facade for ordinary calls.
+- A generated constant remains a real `const` on the extender host, while its
+  `PInvoke` projection is an extension property. Extension properties are not
+  compile-time constants. Enum initializers, `case` labels, constant patterns,
+  attributes, and optional-parameter defaults therefore use
+  `Interop.CONSTANT`; runtime expressions use `PInvoke.CONSTANT`.
+- Composition is receiver- and namespace-specific. A second projection root
+  such as `Windows.Wdk.Interop` does not automatically appear on
+  `Windows.Win32.PInvoke`; keep it separate or design another explicit receiver.
+- `partial` does not cross assembly boundaries. Do not try to augment an
+  owner-generated struct or `PInvoke` with a downstream `partial` declaration.
+  Put shared public types in the owner and add downstream behavior with C# 14
+  extension blocks. Give implementation-only provider types unique names so a
+  consumer never sees two public types with the same fully qualified name.
+- Read the generated extender output when overload resolution changes. A
+  friendly generated overload can become ambiguous with a downstream helper;
+  call the raw pointer overload explicitly or rename the helper rather than
+  introducing another facade.
+- Re-audit native ownership whenever a helper or call shape moves between
+  layers. Generated overloads do not preserve allocator, COM reference, or
+  byte/element obligations by themselves; use
+  [ownership-and-units.md](ownership-and-units.md).
+
+## Generated XML documentation diagnostics
+
+Some CsWin32 versions emit cross-assembly XML `cref` values for
+`extensionReceiver` members that Roslyn cannot resolve, producing `CS1574` or
+`CS1580` from generated code. First verify the diagnostics originate only in
+CsWin32 output and that the referenced API compiles. If so, suppress exactly
+those two diagnostics in the extender project and record why. A project-level
+suppression also applies to hand-authored source, so keep normal documentation
+review in the validation path rather than disabling XML warnings broadly.
+
+## Verify the packaged composition
+
+A same-solution build is necessary but not sufficient. Pack both layers, then
+build a scratch consumer that references **only the extender package** and
+compiles at least:
+
+1. one owner-provided `PInvoke` call;
+2. one extender-provided `PInvoke` call;
+3. any public extension member added to an owner-provided generated type.
+
+Restore into a clean package cache when reusing a local version number. This
+catches missing transitive dependencies, stale packages, duplicate generated
+types, inaccessible receivers, and composition that worked only through project
+references. Inspect the packed dependency graph too: an extender that directly
+uses a foundation library should declare it directly, even when the owner also
+depends on it.

--- a/.agents/skills/cswin32-interop/gating.md
+++ b/.agents/skills/cswin32-interop/gating.md
@@ -1,0 +1,93 @@
+# Platform and target-framework guards
+
+Detail for [cswin32-interop](SKILL.md). CsWin32 projects Windows APIs. Decide
+source inclusion, runtime reachability, and the platform contract independently;
+one guard does not automatically satisfy all three.
+
+## Choose the guard from the constraint
+
+| Constraint | Compile-time action | Runtime action |
+| --- | --- | --- |
+| Windows-specific TFM or assembly | Usually none; the assembly already carries the platform context. | None unless the API requires a newer Windows version than the assembly contract. |
+| Cross-platform assembly; declarations compile on both runtime families | None. | Guard every reachable call with a recognized Windows check, or annotate the containing API as Windows-only. |
+| A target intentionally omits the interop source or one of its dependencies | Exclude whole files with conditional `Compile` items, or use a documented project symbol for smaller regions. | Still guard calls on any included target that can run cross-platform. |
+| A member exists only on the .NET 10 leg | Use `#if NET`. | Independent of the platform guard. |
+| A member or polyfill exists only on .NET Framework | Use a Framework-only source folder or `#if NETFRAMEWORK`. | Independent of the platform guard. |
+
+Generated P/Invoke declarations are not themselves a reason to remove source
+from non-Windows builds. Use compile-time exclusion only when the project has a
+real source or dependency constraint. When a whole file is conditional, prefer
+an MSBuild item condition over a whole-file `#if`. Namespace `using` directives
+and private helpers referenced only by a conditional region must use the same
+condition. The overlay names any custom symbol or item condition.
+
+For a cross-platform binary, use a guard recognized by the platform analyzer:
+
+```csharp
+#if NET
+if (OperatingSystem.IsWindows())
+#else
+if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+#endif
+{
+    _ = PInvoke.GetCurrentProcessId();
+}
+else
+{
+    // Cross-platform fallback.
+}
+```
+
+Use `OperatingSystem.IsWindows()` on .NET 10 and
+`RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` on .NET Framework. If the
+interop call is also conditionally compiled, keep the compile condition outside
+the runtime branch so the fallback remains complete when that source is absent.
+
+## CA1416 platform compatibility
+
+For a cross-platform assembly, satisfy the analyzer semantically rather than
+suppressing it:
+
+- Use `OperatingSystem.IsWindows()` or
+  `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`. Annotate a custom
+  boolean field, property, or method with
+  `[SupportedOSPlatformGuard("windows")]` before relying on it as a guard.
+- Apply `[SupportedOSPlatform("windows")]` to an assembly, type, or member when
+  its contract is Windows-only. The attribute is valid on structs. Include a
+  version only when the API has that real minimum, and match the documented
+  version instead of applying one baseline to every CsWin32 call.
+- Use `#pragma warning disable CA1416` only as a narrow, justified last resort
+  when a recognized guard or platform annotation cannot express the contract.
+
+The platform attributes are available on modern .NET but not in .NET Framework
+reference assemblies. In dual-target source, place them under `#if NET` unless
+the Framework target provides a compatible source polyfill.
+
+## A stack-first scratch buffer
+
+Win32 string and buffer APIs often want caller-allocated storage followed by a
+length retry. Check for a CsWin32 `Span<T>` convenience overload before writing
+a `fixed` block. For a bounded common case, start with a small stack span and
+rent from `ArrayPool<T>` when the required length exceeds it. Choose the stack
+size from element size, call depth, measured workloads, and the repository's
+stack budget; there is no universal byte cutoff.
+
+A repository may provide a disposable `ref struct` that combines the stack and
+pool paths. Always dispose that scope so a rented array is returned. The
+`scratch-buffer-strategy` skill covers the choice when installed, and the
+overlay names any concrete helper. On retry, preserve the native API's exact
+length semantics: bytes versus elements, and whether the required count includes
+a terminator or header.
+
+## Verify the guarded build
+
+Anything referenced **only** inside a compile condition must itself be inside
+that condition, or the excluded build can fail under warnings-as-errors. Watch
+for `IDE0005` (unused `using`), `IDE0051` / `IDE0052` (unused private members),
+`CA1823` (an unused private field), and `CS1587` (an XML doc comment left before
+a conditional member).
+
+Build all .NET 10 and .NET Framework TFMs and every custom-symbol state that
+changes source inclusion. For a cross-platform binary, also execute an
+unsupported-OS path and verify it takes the fallback without loading or calling
+the Windows API.

--- a/.agents/skills/cswin32-interop/library-layering.md
+++ b/.agents/skills/cswin32-interop/library-layering.md
@@ -1,0 +1,91 @@
+# Support-library layering
+
+Detail for [cswin32-interop](SKILL.md). A public CsWin32 composition surface works
+best as one layer in a directed package stack, not as the place where every
+shared helper accumulates.
+
+## The four layers
+
+| Layer | Owns | Must not own |
+| --- | --- | --- |
+| Managed foundation | Cross-domain buffers, pooling, collections, enum helpers, compiler/runtime polyfills, and other utilities that remain useful without a public Win32 API. | The canonical public `Windows.Win32.PInvoke` or public Win32 type identity. |
+| Win32 composition owner | The public `PInvoke`, shared generated Win32 types, Windows-specific lifetime/ownership helpers, common COM wrappers, and owner-only generated hooks. | Product- or domain-specific UI and workflow behavior. |
+| Domain extender | Additional generated APIs projected through `extensionReceiver`, domain wrappers, and extension members on owner-provided types. | Duplicate owner types, cross-assembly partial declarations, or a competing public `PInvoke`. |
+| Consumer | Application behavior that calls the composed surface. | Another generated projection unless it is intentionally a separate namespace/ABI domain. |
+
+The conceptual layer order is foundation -> owner -> extender -> consumer;
+package references point back down that stack. An extender may also reference
+the foundation directly when its source uses that surface. Declare that
+dependency explicitly rather than relying on the owner's transitive dependency.
+
+A foundation package may use platform interop internally. The boundary is its
+**public ownership contract**: an internal generated `PInvoke` does not compete
+with the composition owner, while a public `Windows.Win32.PInvoke` does.
+
+## Decide where a helper belongs
+
+Move a helper toward the lowest reusable layer that can own it without importing
+higher-level policy:
+
+- A pooled scratch buffer, allocation-free flag operation, or .NET Framework
+   BCL polyfill belongs in the managed foundation.
+- A `HANDLE` close helper, `HRESULT` mapping, `PWSTR` ownership operation,
+   owned COM-pointer scope, `SAFEARRAY`/`VARIANT` support, or owner-side CCW hook
+   belongs in the Win32 owner when multiple extenders can use it.
+- A windowing framework, accessibility model, dialog abstraction, or
+  domain-specific COM adapter belongs in the extender.
+- An implementation-only vtable provider needed by one extender stays there
+  under a unique name; it does not justify a duplicate imported interface.
+
+Before promoting code, remove dependencies on the higher layer and ask whether
+its public namespace and exception/ownership contract make sense for every
+consumer of the lower layer. "Used by two projects" is not enough if both uses
+carry the same product policy.
+
+## API identity and compatibility
+
+Moving a public type from an extender assembly into the owner is not merely a
+source relocation. Even with the same namespace and type name, its assembly
+identity changes. Treat the move as a binary and often source breaking change
+unless the old assembly provides type forwarding and compatible facade members.
+Also call out removed static facades, renamed nested types, and changed extension
+lookup in release notes.
+
+Do not leave both definitions public during migration. Two assemblies exporting
+the same fully qualified type create ambiguity instead of compatibility.
+
+## Release order and package metadata
+
+Publish from the bottom up:
+
+1. publish the managed foundation when its required surface changed;
+2. publish the Win32 owner against that foundation;
+3. restore the owner from the real feed into the extender, then publish the
+   extender;
+4. validate an application that references only the top-level package.
+
+Keep the owner and extender on compatible CsWin32 versions and language levels.
+If the owner is prerelease, the extender package must also be prerelease; NuGet
+warns when a stable package depends on a prerelease package. Inspect the packed
+extender nuspec to confirm the owner and foundation dependency versions before
+publishing.
+
+## Migration sequence
+
+For an existing library that duplicates owner candidates:
+
+1. inventory generated types, hand-authored partials, helpers, and static
+   facades; classify each into the four layers;
+2. add the shared public surface and generated hooks to the owner, with direct
+   tests, and publish it first;
+3. restore that published owner into an empty package root using normal feeds;
+4. configure `extensionReceiver`, remove duplicate types, and convert downstream
+   augmentation to extension blocks or uniquely named provider types;
+5. audit every raw pointer and native buffer while changing call shapes; moving
+   ownership does not preserve caller obligations automatically;
+6. pack the extender and build a clean-cache consumer that references only the
+   extender package.
+
+For the final restore, use `--no-cache` and a fresh `--packages` directory. Check
+`project.assets.json`, the package's `.nupkg.metadata` source, and the nuspec so a
+locally cached rehearsal package cannot masquerade as the published dependency.

--- a/.agents/skills/cswin32-interop/overlay.md
+++ b/.agents/skills/cswin32-interop/overlay.md
@@ -1,0 +1,93 @@
+---
+core: cswin32-interop
+core-pin: v0.13.0
+---
+
+# Touki overlay - cswin32-interop
+
+Repo-specific companion to the vendored [cswin32-interop](SKILL.md) skill. The
+`SKILL.md` and its six sibling pages (`blittable-signatures.md`,
+`types-and-constants.md`, `composition.md`, `library-layering.md`,
+`ownership-and-units.md`, `gating.md`) are a **pinned copy of the portable core**
+from [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see
+the `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core -
+`gh skill update` would flag the drift. Everything touki-specific lives here.
+
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag. Pull
+> later upstream changes with `gh skill update cswin32-interop` (review the diff,
+> re-pin to the new tag).
+
+## Concrete bindings for the core's placeholders
+
+- **Generating project**: [touki/touki.csproj](../../../touki/touki.csproj) is the
+  only project that references `Microsoft.Windows.CsWin32`
+  (`PrivateAssets="all"`), on **both** TFMs. Do not add the generator to
+  `touki.tests`, `touki.perf`, or the analyzer projects - they reach the
+  projection through `InternalsVisibleTo`.
+- **Target frameworks**: `net10.0` (`NET`) and `$(DotNetFrameworkVersion)` =
+  `net472` (`NETFRAMEWORK`); tests run the Framework leg as `net481`. Never
+  describe a projection as "net481-only".
+- **Generator version**: `Microsoft.Windows.CsWin32` is pinned centrally in
+  [Directory.Packages.props](../../../Directory.Packages.props). The core's
+  `IComIID` and extension-block guidance assumes a newer generator than the one
+  pinned here; check the pinned version before relying on it.
+- **API list**: [touki/NativeMethods.txt](../../../touki/NativeMethods.txt) - the
+  clipboard surface (`OpenClipboard` ... `GetClipboardData`), the global-memory
+  allocator (`GlobalAlloc`/`GlobalLock`/`GlobalUnlock`/`GlobalSize`/`GlobalFree`),
+  `GetCurrentThreadId`, `WaitForMultipleObjectsEx`, `Sleep`, and the
+  `CLIPBOARD_FORMAT` / `GLOBAL_ALLOC_FLAGS` / `WIN32_ERROR` / `E_HANDLE`
+  projections.
+- **Generator options**:
+  [touki/NativeMethods.json](../../../touki/NativeMethods.json) sets
+  `public: false`, `allowMarshaling: false`, `useSafeHandles: false`,
+  `className: PInvoke`, and `preserveSigMethods: ["*"]`. The generated surface is
+  internal, so it never appears in `KlutzyNinja.Touki`'s public API.
+- **Working example to copy**:
+  [WindowsClipboardProvider.cs](../../../touki/Touki/Io/Providers/WindowsClipboardProvider.cs)
+  calls the generated `Windows.Win32.PInvoke` surface identically on both TFMs;
+  its tests are
+  [WindowsClipboardProviderTests.cs](../../../touki.tests/Touki/Io/Providers/WindowsClipboardProviderTests.cs).
+- **Non-Windows natives stay on `[LibraryImport]` / `[DllImport]`** per the core's
+  rule 4: [LinuxClipboardProvider.cs](../../../touki/Touki/Io/Providers/LinuxClipboardProvider.cs)
+  and [MacClipboardProvider.cs](../../../touki/Touki/Io/Providers/MacClipboardProvider.cs)
+  (libc / Objective-C runtime), and
+  [NativeMemory.cs](../../../touki/Framework/Polyfills/System.Runtime.InteropServices/NativeMemory.cs)
+  (`ucrtbase`, Framework-only). CA1401/SYSLIB1054 wiring for those is recorded in
+  [touki/GlobalSuppressions.cs](../../../touki/GlobalSuppressions.cs).
+- **Coding style**: follow [AGENTS.md](../../../AGENTS.md) (no `var`, target-typed
+  `new()`, C# keyword type names, `nint`/`nuint`, `is null` / `is not null`,
+  indented XML docs).
+
+## Gating in touki
+
+Windows-only providers are selected at runtime, not excluded at compile time, so
+generated declarations compile into the cross-platform assembly on both TFMs. Use
+the platform guards described in [gating.md](gating.md) rather than trimming the
+source item; the Unix oracle suites (see
+[`run-tests-on-wsl`](../run-tests-on-wsl/SKILL.md)) build the same files.
+
+For the scratch buffers the core's `gating.md` mentions, follow
+[`scratch-buffer-strategy`](../scratch-buffer-strategy/SKILL.md) - it carries the
+net481/net10 size crossovers this repo measured.
+
+## Cross-references (the core's "Related skills")
+
+- [`dotnet-polyfills`](../dotnet-polyfills/SKILL.md) and
+  [`polyfill-dotnet-api`](../polyfill-dotnet-api/SKILL.md) - the Framework
+  polyfills that consume parts of this projection.
+- [`scratch-buffer-strategy`](../scratch-buffer-strategy/SKILL.md) - buffers on
+  the native boundary.
+- [`security-review`](../security-review/SKILL.md) - required for any change to
+  the native boundary: allocator ownership, byte-versus-element lengths, and the
+  `Unsafe`/`MemoryMarshal`/`Marshal` audit.
+- [`il-copy-inspection`](../il-copy-inspection/SKILL.md) - confirming struct
+  copies around blittable projections.
+
+The core's paired `cswin32-com` skill is **not vendored here**: touki has no
+struct-based COM surface (no `ComScope`, `IID.Get`, `delegate*` vtables, or CCW
+bridges). Vendor it if an OLE/`IDataObject` clipboard path ever lands.
+
+## Updating
+
+Pull upstream changes to the core with `gh skill update cswin32-interop` (review
+the diff, re-pin). Keep touki-specific additions in this file, not in the core.

--- a/.agents/skills/cswin32-interop/ownership-and-units.md
+++ b/.agents/skills/cswin32-interop/ownership-and-units.md
@@ -1,0 +1,133 @@
+# Native ownership and size units
+
+Detail for [cswin32-interop](SKILL.md). Generated signatures make calls easier to
+write; they do not infer who owns an output or whether a length is bytes,
+characters, or elements. Read the native contract before choosing a wrapper.
+
+## Record the ownership contract before calling
+
+For every pointer or handle output, identify all four facts:
+
+1. who allocates or increments the reference;
+2. whether the result is owned or borrowed;
+3. which operation releases it;
+4. whether failure guarantees the output is initialized.
+
+Common pairs include:
+
+| Acquired value | Release operation |
+| --- | --- |
+| AddRef'd COM interface | `IUnknown::Release` (prefer a repository-provided owned-pointer scope) |
+| COM task allocator memory, including many Shell PIDLs | `CoTaskMemFree` |
+| `LocalAlloc` memory | `LocalFree` |
+| `BSTR` | `SysFreeString` / `Marshal.FreeBSTR` |
+| Owned Win32 handle | The API-specific close function, such as `CloseHandle` |
+| Borrowed pointer/handle | No release; keep the owner alive for the whole use |
+
+Do not infer the deallocator from the projected pointer type. Two `PWSTR` values
+can have different allocators depending on the API that returned them.
+
+## Cleanup must cover failure paths
+
+A native API may leave an output untouched when it fails. If cleanup runs in a
+`finally`, initialize the actual native output storage to null and prefer the raw
+pointer overload so that initialization cannot be hidden by a convenience
+wrapper:
+
+```csharp
+ITEMIDLIST* itemIdList = null;
+HRESULT result;
+fixed (char* pathPointer = path)
+{
+    result = PInvoke.SHParseDisplayName(
+        pathPointer,
+        null,
+        &itemIdList,
+        0,
+        null);
+}
+
+try
+{
+    result.ThrowOnFailure();
+    // Consume itemIdList.
+}
+finally
+{
+    PInvoke.CoTaskMemFree(itemIdList);
+}
+```
+
+Freeing null is safe for the matching Windows allocators. Inspect generated
+convenience-overload source before relying on its failure initialization or
+ownership behavior.
+
+## A retained COM pointer is still caller-owned
+
+A helper that returns an AddRef'd COM pointer gives the caller one reference.
+Passing it to a method such as `Advise`, `SetClientSite`, or another retaining
+API does not transfer that caller reference. The callee adds its own reference
+when its contract retains the pointer; the caller still releases its reference.
+In the example, `AcquireOwnedCcwPointer<T>()` is pseudocode for a repository
+helper that returns one caller-owned CCW interface pointer. Its implementation
+may use classic COM marshalling or `ComWrappers`; only the latter can support a
+NativeAOT path. Use the repository's owned-pointer scope when available;
+otherwise make the release explicit:
+
+```csharp
+IEventSink* sink = AcquireOwnedCcwPointer<IEventSink>(managedSink);
+try
+{
+    source->Advise(sink, &cookie).ThrowOnFailure();
+}
+finally
+{
+    if (sink is not null)
+    {
+        sink->Release();
+    }
+}
+```
+
+Pair every successful cookie-producing `Advise` with `Unadvise(cookie)` before
+releasing the source object. Do not confuse a non-retaining parameter with a
+borrowed pointer: an owned pointer passed to a non-retaining call still needs its
+caller reference released, while a pointer that is itself borrowed must not be
+released. Keep the borrowed pointer's owner alive for the whole call, or call
+`AddRef` first when an owned scope is required.
+
+## Length parameters: bytes are not elements
+
+Read each length parameter's native documentation. A managed buffer abstraction
+usually reports **elements**, while many NT and Win32 APIs accept and return
+**bytes**. Convert explicitly with checked arithmetic:
+
+```csharp
+uint capacityInBytes = checked((uint)buffer.Length * sizeof(char));
+
+// Native call writes requiredBytes.
+int requiredElements = checked(
+    (int)(((ulong)requiredBytes + sizeof(char) - 1) / sizeof(char)));
+buffer.EnsureCapacity(requiredElements);
+```
+
+Use ceiling division for a required **capacity** because an odd byte count still
+needs another element. For a payload length that must contain whole elements,
+validate divisibility when malformed native data is possible, then divide
+exactly. Also distinguish whether a returned byte count includes a header,
+terminator, or only payload; size the whole native buffer but slice only the
+payload field.
+
+## Review and test shapes
+
+When adding or migrating an interop call, cover the branches that expose the
+contract:
+
+- success and native failure, including cleanup after each;
+- null/default output and double-dispose or repeated cleanup when supported;
+- a result large enough to force buffer growth;
+- a malformed or odd-sized payload when the input is not trusted;
+- a retaining COM call followed by explicit disconnect and owner disposal.
+
+A happy-path build cannot detect a leaked reference, the wrong allocator, or a
+byte/element mismatch that only appears beyond the initial buffer.

--- a/.agents/skills/cswin32-interop/types-and-constants.md
+++ b/.agents/skills/cswin32-interop/types-and-constants.md
@@ -1,0 +1,96 @@
+# Types and constants
+
+Detail for [cswin32-interop](SKILL.md). Prefer the CsWin32 projection over any
+hand-written copy, and let the typed value flow as far as possible before
+casting.
+
+## Prefer the generated projection - grep the metadata first
+
+Before defining a `private const int ERROR_*` or a `private enum FooFlags`,
+search the generated metadata; CsWin32 almost certainly already projects it:
+
+- `ERROR_*` (Win32 error codes) -> `WIN32_ERROR.ERROR_*` (a `uint` enum)
+- `HRESULT` codes -> `HRESULT.S_OK`, etc.
+- File flags -> `FILE_FLAGS_AND_ATTRIBUTES`, `FILE_ACCESS_RIGHTS`,
+  `FILE_SHARE_MODE`, `FILE_CREATION_DISPOSITION`
+- Process flags -> `PROCESS_CREATION_FLAGS`, `STARTUPINFOW_FLAGS`,
+  `PROCESS_ACCESS_RIGHTS`
+- Memory mapping -> `PAGE_PROTECTION_FLAGS`, `FILE_MAP`
+- Standard handles / known folders -> `STD_HANDLE`, `KNOWN_FOLDER_FLAG`
+
+Add the name to `NativeMethods.txt` if not yet generated, then read the emitted
+`Windows.Win32.<Name>.g.cs` under the generator's output for the exact shape.
+
+In a layered `extensionReceiver` project, the real `const` remains on the
+extender's generated host (for example, `Interop.VALUE`); the member projected
+onto the owner's `PInvoke` is an extension property. Use the host in enum
+initializers, `case` labels, constant patterns, attributes, and optional defaults,
+because an extension property is not a compile-time constant. Use the unified
+`PInvoke.VALUE` surface in runtime expressions. See
+[composition.md](composition.md).
+
+## Some flags are standalone constants, not enum members
+
+A Win32 `#define` that sits outside a `typedef enum` generates as a `const` on
+the configured generated host, not as an enum member. Its visibility follows
+the CsWin32 `public` setting. Add the **constant name** to `NativeMethods.txt`
+like any API, then OR it onto an enum of matching width and cast back where
+needed. Do not reintroduce a local `const` the generator already emits.
+
+## Match local types to the generated type
+
+Declare the CsWin32 type and let it flow, instead of casting to `int` / `uint`
+at every use:
+
+```csharp
+// Keep the generated type rather than storing the result as int.
+WIN32_ERROR result = PInvoke.RmStartSession(...);
+
+// Cast only at a non-CsWin32 boundary.
+Win32Exception exception = new((int)result, ...);
+```
+
+The same applies to `HRESULT`, `BOOL`, `HANDLE`, and every flag enum. **Delete
+local mirror enums** that exist only to duplicate a Win32 one - the generated
+type is the source of truth.
+
+## Type conversions
+
+- `HANDLE` <-> `nint`: `(HANDLE)ptr` / `(nint)h.Value`. Sentinels:
+  `HANDLE.Null`, `HANDLE.INVALID_HANDLE_VALUE`.
+- `BOOL` is a struct - use its implicit conversion to `bool`, never a raw
+  `int` / `uint`.
+- `HRESULT` - check `.Succeeded` / `.Failed`; cast to `int` only at a boundary
+  with a non-CsWin32 API.
+- Nullable value-type parameters: `(SECURITY_ATTRIBUTES?)null`.
+- **Anonymous unions** surface as nested `Anonymous` members
+  (`info.Anonymous.Anonymous.wProcessorArchitecture`) - read the generated
+  `*.g.cs` for the exact path.
+- **Enum flags:** test with bitwise `&`. `Enum.HasFlag` boxes on .NET Framework;
+  avoid it on hot paths. A repo may ship allocation-free flag extensions - see
+  the overlay.
+
+## FILETIME
+
+`FILETIME` is a split 32/32 value; convert with a helper, never hand-roll
+`DateTime.FromFileTime((long)hi << 32 | lo)`. Note CsWin32 uses
+`ComTypes.FILETIME` (int fields) for COM members and
+`Windows.Win32.Foundation.FILETIME` (uint fields) for kernel ones; a shared
+extension usually targets `ComTypes.FILETIME`. Read the producing API's time
+contract and choose the desired managed result deliberately. `GetFileTime` and
+the creation / exit outputs from `GetProcessTimes` are UTC-based timestamps: use
+`FromFileTimeUtc` to preserve UTC, or `FromFileTime` only when intentionally
+converting the result to local time. The kernel / user outputs from
+`GetProcessTimes` are elapsed 100-nanosecond durations, not dates; combine their
+64-bit values and convert them to `TimeSpan` ticks. Do not infer time-zone or
+duration semantics from the projected struct shape.
+
+## Native integers
+
+Prefer `nint` / `nuint` for new native-sized values. Preserve
+`IntPtr` / `UIntPtr` where an existing public contract or managed API requires
+those names, and convert at that boundary rather than carrying both forms
+through the implementation. Note that `nint` does not implement
+`IEquatable<nint>` on .NET Framework, so a generic method constrained
+`where T : unmanaged, IEquatable<T>` cannot be instantiated with `nint` for a
+cross-target call site - pick a concrete value type or split the path by TFM.

--- a/.agents/skills/dotnet-polyfills/SKILL.md
+++ b/.agents/skills/dotnet-polyfills/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/dotnet-polyfills
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: ae0aa41d3c5c002298172ba4e5f7b24eb615d9db
     maturity: canary

--- a/.agents/skills/dotnet-polyfills/overlay.md
+++ b/.agents/skills/dotnet-polyfills/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: dotnet-polyfills
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - dotnet-polyfills
@@ -11,7 +11,7 @@ portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core.
 
-> **Pinned to a release.** The core is pinned to the commons **v0.10.0** tag.
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag.
 
 ## Touki bindings
 

--- a/.agents/skills/framework-jit-optimization/SKILL.md
+++ b/.agents/skills/framework-jit-optimization/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/framework-jit-optimization
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 1523bdc712c82636a88605ecf3f31b95308a0e39
+    github-tree-sha: 97120f8dc990d4af91d9dbfb1c191a48ecce48f1
     maturity: canary
     portability: portable
     related: performance-testing, scratch-buffer-strategy, pre-pr-self-review
@@ -79,7 +79,7 @@ beats a naive per-element loop for whole-buffer primitives.
 
 **Practical consequence:** do not assume "the BCL is vectorized so my generic code
 is fine." On `net481` a hand-written specialized loop frequently beats the BCL by
-2-3&times; for full-scan workloads.
+2-3× for full-scan workloads.
 
 ## Decision flow for a new framework-only fast path
 
@@ -120,17 +120,17 @@ a PR.
 
 | Decision | Net481 effect (length 4096, full scan) |
 | --- | --- |
-| `typeof(T)` specialization vs generic `IEquatable` loop | 1.42&times; faster |
-| `[AggressiveInlining]` on a tight scalar loop (length 16) | 1.82&times; &rarr; 1.07&times; vs baseline |
-| Unroll-4 indexed (`ptr[0..3]` + `ptr += 4`) | 1.5&times; faster than scalar |
-| Unroll-8 same form | **1.6&times; slower** than scalar at 256+ |
-| Per-iteration `*ptr; ptr++` instead of indexed reads | ~1.4&times; slower than indexed |
+| `typeof(T)` specialization vs generic `IEquatable` loop | 1.42× faster |
+| `[AggressiveInlining]` on a tight scalar loop (length 16) | 1.82× → 1.07× vs baseline |
+| Unroll-4 indexed (`ptr[0..3]` + `ptr += 4`) | 1.5× faster than scalar |
+| Unroll-8 same form | **1.6× slower** than scalar at 256+ |
+| Per-iteration `*ptr; ptr++` instead of indexed reads | ~1.4× slower than indexed |
 | Integer-indexed unroll (`ptr[i+0..3]; i += 4`) | **Worse than the scalar baseline** |
-| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5-3&times; slower** than branchful conditional store |
-| SWAR haszero for char `Replace` (dense matches) | **3&times; slower** than scalar |
-| BCL `IndexOf` for `Replace` (full-scan) | 2.18-3.08&times; slower than specialized scalar |
-| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2-3&times; **faster** than full-scan specialization |
-| Exponential `SequenceEqual` probe for `CommonPrefixLength` (4096, full match) | 3.3&times; faster than per-element scalar |
+| Branchless `*ptr = v == old ? new : v` (sparse matches) | **1.5-3× slower** than branchful conditional store |
+| SWAR haszero for char `Replace` (dense matches) | **3× slower** than scalar |
+| BCL `IndexOf` for `Replace` (full-scan) | 2.18-3.08× slower than specialized scalar |
+| BCL `IndexOf` for `Count` (sparse matches, 1/64 density) | 2-3× **faster** than full-scan specialization |
+| Exponential `SequenceEqual` probe for `CommonPrefixLength` (4096, full match) | 3.3× faster than per-element scalar |
 | Tuple swap `(a, b) = (b, a)` for plain locals | **~23% slower** than `T t = a; a = b; b = t;` |
 | Tuple swap on paired `Span<T>` indexed swap (sort hot path) | **~9% slower** than explicit temps |
 | Tuple swap on a single `Span<T>` indexed swap or two `ref` locals | Equivalent (within noise) |

--- a/.agents/skills/framework-jit-optimization/antipatterns.md
+++ b/.agents/skills/framework-jit-optimization/antipatterns.md
@@ -14,7 +14,7 @@ your specific call pattern.
 The `net481` JIT does not lower the ternary into a `cmov` for `ushort` / `byte`
 stores. You get a guaranteed store every iteration regardless of whether the
 value changed. For a sparse-match `Replace` workload (the realistic case), the
-extra writes cost 1.5-3&times; vs the branchful form below.
+extra writes cost 1.5-3× vs the branchful form below.
 
 ```c#
 // GOOD on net481.
@@ -77,7 +77,7 @@ The bit-trick (`(x - Lo16) & ~x & Hi16`) adds a dependent-chain of 3 arithmetic
 ops per chunk, plus a load and an XOR, plus the broadcast computation. **Whenever
 any lane matches, the code falls through to the four scalar checks** - you
 pay the SWAR overhead **on top of** the mutation cost. On dense matches this
-regresses by 3&times;.
+regresses by 3×.
 
 The classic strchr-style SWAR optimization makes sense in C without true SIMD;
 on `net481` it does not pay back its overhead even for sparse data, because the
@@ -102,7 +102,7 @@ The attribute looks like a non-functional hint, but on `net481` it's load-bearin
 A small specialized loop that doesn't get inlined into its caller becomes a
 JIT-time call, defeating the entire `typeof(T)` specialization (because the
 caller now invokes a generic stub through a virtual dispatch mechanism the
-specialization was meant to elide). Measured: 1.82&times; &rarr; 1.07&times; on
+specialization was meant to elide). Measured: 1.82× → 1.07× on
 a tight scalar loop at length 16 just from adding the attribute back.
 
 If you really must remove it (e.g. method body becomes too large), measure

--- a/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
+++ b/.agents/skills/framework-jit-optimization/bcl-tradeoffs.md
@@ -23,8 +23,8 @@ slightly less aggressive unrolling lose to a hand-written `ushort*` /
 
 | Method | Realistic input | Win factor (length 4096) |
 | --- | --- | --- |
-| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18-3.08&times; faster than `IndexOf`-walking |
-| `IndexOfAnyExcept(T)` | typically scans most of the buffer (e.g. trim, parse) | 0.34&times; vs scalar = 3&times; faster |
+| `Span<T>.Replace(T, T)` | mutate every match in place | 2.18-3.08× faster than `IndexOf`-walking |
+| `IndexOfAnyExcept(T)` | typically scans most of the buffer (e.g. trim, parse) | 0.34× vs scalar = 3× faster |
 
 These are the methods that already have `typeof(T)` specialization in the
 Framework-only tree.
@@ -56,9 +56,9 @@ Measured ratios vs a full-scan `ushort*` unroll-4 specialization on `net481`:
 
 | Match density (1 in N) | BCL `IndexOf`-walk vs specialized |
 | ---: | --- |
-| 1   | **9&times; slower** (specialization wins) |
-| 7   | 1.85&times; slower (specialization still wins) |
-| 64  | **0.45&times; slower** (BCL wins) |
+| 1   | **9× slower** (specialization wins) |
+| 7   | 1.85× slower (specialization still wins) |
+| 64  | **0.45× slower** (BCL wins) |
 
 Realistic `Count` calls are sparse (counting newlines in source, separators in a
 path, error markers in a log line). The BCL form is correct.
@@ -84,10 +84,10 @@ return length;
 ```
 
 `O(log n)` BCL calls instead of `O(n)` element compares. At length 4096 with a
-full match this beats any scalar loop by **3.3&times;** even on `net481`.
+full match this beats any scalar loop by **3.3×** even on `net481`.
 
 The early-divergence case (mismatch at index 8) is roughly tied with a scalar
-specialization - absolute saving is ~8 ns - not worth a 3.3&times;
+specialization - absolute saving is ~8 ns - not worth a 3.3×
 regression on the long-prefix case (path normalization, string interning,
 sorted-key compression are the realistic callers).
 

--- a/.agents/skills/framework-jit-optimization/overlay.md
+++ b/.agents/skills/framework-jit-optimization/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: framework-jit-optimization
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - framework-jit-optimization
@@ -107,4 +107,4 @@ The [modern-net.md](modern-net.md) and [cross-tfm-codegen.md](cross-tfm-codegen.
 sibling pages originated here and were upstreamed to the
 [agent-skills commons](https://github.com/JeremyKuhne/agent-skills) in
 [PR #1](https://github.com/JeremyKuhne/agent-skills/pull/1); the vendored core is
-pinned to `v0.10.0`, which includes them. No pending divergence remains.
+pinned to `v0.13.0`, which includes them. No pending divergence remains.

--- a/.agents/skills/framework-jit-optimization/specialization.md
+++ b/.agents/skills/framework-jit-optimization/specialization.md
@@ -75,7 +75,7 @@ Always put this on the generic entry method when you specialize:
 - The `net481` JIT's default heuristics are conservative. Without the attribute,
   the wrapper method itself is a JIT-time call, defeating the whole point.
 - Measured impact on a tight scalar `ref T` loop at length 16:
-  `1.82&times; &rarr; 1.07&times;` vs the dedicated-overload baseline. The
+  `1.82× → 1.07×` vs the dedicated-overload baseline. The
   attribute is doing real work, not just hinting.
 
 The inlining attribute is also why we don't need separate `extension(Span<char>)`
@@ -109,7 +109,7 @@ ushort oldShort = (ushort)(Unsafe.As<T, ushort>(ref oldValue) & 0xFFFF);
 Without the mask, `[AggressiveInlining]` plus a literal signed argument
 (`(sbyte)-1`, `(short)-1`) on net481 RyuJIT produces wrong results in
 **Release** (Debug passes). The caller's int-promoted constant
-(`-1` &rarr; `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
+(`-1` → `0xFFFFFFFF`) propagates through `Unsafe.As<T, byte>` into the
 loop's `cmp` immediate as a 32-bit value. The `movzx`-loaded byte is in
 `[0, 0xFF]`, so `cmp ecx, 0FFFFFFFF` is unconditionally false - the loop
 runs, finds nothing, returns silently.

--- a/.agents/skills/framework-jit-optimization/unrolling.md
+++ b/.agents/skills/framework-jit-optimization/unrolling.md
@@ -56,7 +56,7 @@ if (*ptr == oldShort) *ptr = newShort; ptr++;
 ```
 
 Every load now depends on the previous `ptr++`. The JIT does not recover the
-parallelism by recognizing the pattern. Measured: 0.84&times; vs 1.12&times;
+parallelism by recognizing the pattern. Measured: 0.84× vs 1.12×
 ratio at length 256 on `net481` - the `ptr++` form is actually slower
 than the un-unrolled scalar baseline.
 
@@ -75,7 +75,7 @@ for (int i = 0; i < unrollEnd; i += 4)
 
 The `net481` JIT does not hoist the `ptr + i` calculation. Each `ptr[i + k]`
 becomes `lea` + `mov`. **Worse than the scalar baseline at length 4096
-(1.22&times;).** Always advance the pointer instead.
+(1.22×).** Always advance the pointer instead.
 
 ### Unroll-by-8
 
@@ -89,7 +89,7 @@ while (ptr < unrollEnd)
 }
 ```
 
-Wins at length 16 (small loop, fewer iterations). **Regresses 1.3-1.6&times;
+Wins at length 16 (small loop, fewer iterations). **Regresses 1.3-1.6×
 at length 256+** on `net481`. Most likely the larger method body trips a
 register-allocation or loop-alignment threshold. The .NET 10 JIT recovers but
 `net481` does not.

--- a/.agents/skills/fuzz-testing/SKILL.md
+++ b/.agents/skills/fuzz-testing/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-project-gated
     binding: optional-overlay
     github-path: skills/fuzz-testing
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: fe13e0ef1efd66ebe32d7b37ef15669429591e39
     maturity: canary

--- a/.agents/skills/fuzz-testing/overlay.md
+++ b/.agents/skills/fuzz-testing/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: fuzz-testing
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - fuzz-testing
@@ -12,7 +12,7 @@ portable core** from
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core -
 `gh skill update` would flag the drift. Everything touki-specific lives here.
 
-> **Pinned to a release.** The core is pinned to the commons **v0.10.0** tag. Pull
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag. Pull
 > later upstream changes with `gh skill update fuzz-testing`.
 
 **Authoritative mechanics.** The core's

--- a/.agents/skills/github-actions-cost-optimization/SKILL.md
+++ b/.agents/skills/github-actions-cost-optimization/SKILL.md
@@ -1,0 +1,104 @@
+---
+compatibility: Requires access to the repository's GitHub Actions workflows; precise estimates require current GitHub billing rates and representative job durations.
+description: Audit and reduce GitHub Actions runner usage and normalized cost without weakening required validation. Use when asked to reduce CI cost, spend, minutes, or job count; optimize workflow triggers, matrices, runner selection, caches, or artifact retention; eliminate duplicate Actions runs; or decide which checks should be automatic versus scheduled or manual. Not for application runtime performance, which belongs in a performance-testing workflow.
+license: MIT
+metadata:
+    applicability: git-github
+    binding: optional-overlay
+    github-path: skills/github-actions-cost-optimization
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
+    github-repo: https://github.com/JeremyKuhne/agent-skills
+    github-tree-sha: 1fac6778d86ec0879641e2b593e881f49b43c648
+    maturity: canary
+    portability: portable
+    related: engineering-baseline, security-review
+    requires: none
+    risk: local-write
+name: github-actions-cost-optimization
+---
+# GitHub Actions cost optimization
+
+If `overlay.md` exists beside this file, read it before acting; it contains
+repository-specific bindings. This core remains usable without it.
+
+Reduce the cost and latency of GitHub Actions while preserving the checks that
+make a change safe to merge and release. Optimize the repository's full change
+lifecycle, not one conspicuous job: duplicate triggers, repeated setup, matrix
+fan-out, retries, and retained storage can outweigh the longest individual step.
+
+This skill applies to requests such as "reduce our CI spend", "why does this
+workflow use so many minutes?", "move expensive checks out of every PR", and
+"choose cheaper runners without losing coverage". It should not trigger for
+"make this parser faster" or "reduce allocations in this method"; those are
+application performance questions.
+
+## Non-negotiable rule
+
+State the validation invariants before proposing savings. A cheaper workflow
+that no longer tests the merge candidate, a supported platform, a release
+configuration, or a security boundary is not an optimization. Treat changes to
+CodeQL frequency, untrusted-code permissions, branch protection, and merge
+bypass paths as security or governance decisions, not accounting details.
+
+For public repositories, standard GitHub-hosted runners may have no invoiced
+minute charge. Still report normalized list-price cost and runner usage so
+alternatives remain comparable and the workflow stays economical if repository
+visibility or billing policy changes. Keep actual invoiced cost distinct from
+that normalized comparison. Public and private repositories can receive
+different hardware for the same runner label; when they do, label the normalized
+number as a synthetic rate-weighted comparison, not a visibility-change forecast.
+
+## Workflow
+
+1. Read [audit.md](audit.md). Inventory workflows, triggers, required checks,
+   merge paths, runner types, matrices, setup duplication, storage, and recent
+   durations. Identify every automatic run caused by one logical change.
+2. Write down the load-bearing invariants and classify each check as automatic
+   blocking, scheduled/manual breadth, or release-only. Do not reclassify a check
+   merely because its runner is expensive.
+3. Read [cost-model.md](cost-model.md). Calculate the current per-PR, per-merge,
+   and periodic cost from current official rates and observed job durations.
+   State assumptions and show both actual and normalized cost where they differ.
+4. Read [optimizations.md](optimizations.md). Rank changes by savings,
+   confidence, and validation risk. Prefer removing work over making redundant
+   work slightly faster.
+5. Implement the smallest coherent set of workflow changes. Keep repository-
+   specific commands, required status names, platform obligations, and ruleset
+   details in the consuming repository's overlay.
+6. Validate workflow syntax, local build/test equivalents, required-context
+   behavior, and at least one hosted run for every retained native platform.
+   Compare observed durations with the estimate and record any gap.
+
+## Required output
+
+Report:
+
+- the current and proposed job/trigger topology;
+- observed durations, runner hardware, invocation assumptions, and the rate
+  source/date;
+- actual and normalized cost per PR, merged change, and periodic run;
+- validation invariants preserved automatically and breadth moved elsewhere;
+- expected savings, residual risks, and the hosted checks still required;
+- workflow files changed and deterministic validation performed.
+
+Do not present a precise percentage without exposing its inputs. Do not claim
+that a manual or scheduled workflow preserves coverage unless it has a named
+owner, trigger, and occasion or cadence.
+
+## Remote boundary
+
+Workflow edits are local and reversible. Changing repository rulesets, required
+status checks, budgets, merge-queue settings, or Actions retention settings is a
+remote operation: propose the exact change and wait for explicit approval.
+Committing, pushing, and opening a pull request remain separate approval
+boundaries defined by the consuming repository.
+
+## Sub-pages
+
+- [audit.md](audit.md) - inventory, validation invariants, and evidence
+  collection.
+- [cost-model.md](cost-model.md) - actual versus normalized cost calculations
+  and the reporting table.
+- [optimizations.md](optimizations.md) - ordered savings levers, guardrails, and
+  validation traps.

--- a/.agents/skills/github-actions-cost-optimization/audit.md
+++ b/.agents/skills/github-actions-cost-optimization/audit.md
@@ -1,0 +1,139 @@
+# Audit GitHub Actions usage
+
+Build an evidence-backed picture before editing a workflow. The audit has two
+outputs: the current job topology and the validation invariants that topology is
+supposed to enforce.
+
+## 1. Inventory local workflow topology
+
+Read every workflow under `.github/workflows/`, including reusable and release
+workflows. Record one row per job, after expanding matrix legs conceptually:
+
+| Field | What to record |
+| ----- | -------------- |
+| Workflow and job | Display name, job id, and matrix leg names |
+| Trigger | `pull_request`, `push`, `merge_group`, tag, schedule, dispatch, or caller |
+| Filters | Branch, tag, and path filters plus job-level `if` expressions |
+| Runner | Exact label, architecture, operating system, and standard/larger/self-hosted class |
+| Dependencies | `needs`, reusable workflow calls, and aggregate status jobs |
+| Work | Restore, build, tests, coverage, analysis, perf, AOT, pack, publish, or scripts |
+| Repetition | Checkout, SDK setup, restore, cache, and artifact transfer repeated in sibling jobs |
+| Storage | Cache keys/paths and uploaded artifact size and retention |
+| Controls | Concurrency group, cancellation policy, permissions, and timeout |
+
+Check for trigger overlap. A pull request that runs once before merge and again
+on the resulting default-branch push consumes two workflow lifecycles. Tag
+pushes can match both branch and release workflows. A reusable workflow is billed
+to its caller, so include it in the caller's topology rather than treating it as
+free shared infrastructure.
+
+Do not infer behavior from names. Confirm what each command compiles or runs,
+whether `--no-build` actually reuses prior output, and whether a cache path
+matches the tool's configured package/cache directory.
+
+## 2. Inventory remote merge and governance paths
+
+Read the repository rulesets or branch protection when access permits. Otherwise
+mark each item unverified and ask for the missing facts:
+
+- required status-check names and whether they are tied to a GitHub App;
+- pull-request and review requirements;
+- merge queue use and whether workflows handle `merge_group`;
+- administrator, team, automation, or deploy-key bypass paths;
+- whether direct pushes, merge commits, or branch updates can reach the default
+  branch without testing the exact merge candidate;
+- release environments, protected tags, and publishing approvals;
+- Actions budgets, artifact/log retention, and cache limits.
+
+This determines whether a default-branch `push` run is duplicate confirmation or
+the only validation for a bypass path. Do not remove it based only on the presence
+of a `pull_request` trigger.
+
+Required checks and path filters need special care. If an entire required
+workflow is skipped because no filtered path matched, GitHub can leave its check
+pending and block the merge. Prefer an always-created aggregate check, job-level
+conditional work, or a ruleset design that does not require a path-filtered
+workflow.
+
+## 3. State validation invariants
+
+List what must remain true before merge and release. Derive this from supported
+platforms, packaging promises, security posture, and repository guidance, not
+from the current matrix alone. Common invariants include:
+
+- Release configuration builds and tests the merge candidate;
+- legacy target frameworks compile or execute on a compatible host;
+- platform-specific source and native interop execute on each supported native
+  operating system or architecture that cannot be represented elsewhere;
+- coverage, API compatibility, formatting, generated-file, and lock-file gates
+  continue to fail the required aggregate check;
+- performance gates run in a stable environment and cannot reuse stale output;
+- trim and Native AOT paths publish and execute for the support contract they
+  protect;
+- package creation and release authentication are tested before publishing;
+- untrusted pull-request code never receives write tokens or secrets;
+- code scanning runs at the cadence and merge boundary required by the security
+  model.
+
+Classify each invariant:
+
+| Class | Meaning |
+| ----- | ------- |
+| Automatic blocking | Every merge candidate must pass it |
+| Scheduled/manual breadth | Important regression coverage with a named cadence or operator |
+| Release-only | Must pass before a release, but not every change |
+
+Record the owner and trigger for every non-automatic invariant. "Available
+manually" without an owner or occasion is deferred indefinitely, not preserved
+coverage.
+
+## 4. Collect representative execution evidence
+
+Use Actions usage/performance metrics when available. They expose workflow and
+job minutes, runner type, average runtime, queue time, and failure rate. The
+displayed usage metrics do not apply billing multipliers, so join them to current
+runner rates in the cost model.
+
+Without organization metrics, inspect recent runs with GitHub CLI:
+
+```shell
+gh run list --workflow WORKFLOW --limit 20
+gh run view RUN_ID --json event,startedAt,updatedAt,jobs
+```
+
+For each material job, collect successful, failed, and canceled samples over a
+representative period. Prefer at least 10 recent ordinary runs when the history
+exists. Report the median for a typical estimate and a high percentile (for
+example p75) for a conservative estimate. Keep queue time separate from runner
+execution time.
+
+Include:
+
+- reruns after flaky or infrastructure failures;
+- time consumed before superseded runs are canceled;
+- cache-hit and cache-miss samples;
+- pull-request updates per merged change;
+- scheduled, bot, merge-queue, and post-merge invocations;
+- jobs created only to emit required status contexts.
+
+Do not substitute workflow wall-clock duration for runner usage. Parallel jobs
+reduce elapsed feedback time while still consuming and billing each runner.
+
+## 5. Produce the baseline topology
+
+End the audit with:
+
+1. A diagram or table showing which logical change causes each workflow and job.
+2. The automatic, periodic, and release validation invariants.
+3. Unverified remote assumptions that could make an optimization unsafe.
+4. The duration samples and invocation frequencies used by the cost model.
+5. Obvious waste hypotheses, each paired with a check that could disprove it.
+
+Examples of falsifiable hypotheses:
+
+- "The default-branch run duplicates PR validation" is disproved by an allowed
+  direct-push or bypass path.
+- "This Linux job can move to ARM64" is disproved by an unavailable toolchain,
+  native dependency, or architecture-sensitive test.
+- "The cache saves restore time" is disproved when cache-hit and no-cache
+  durations are equivalent or the configured path is never populated.

--- a/.agents/skills/github-actions-cost-optimization/cost-model.md
+++ b/.agents/skills/github-actions-cost-optimization/cost-model.md
@@ -1,0 +1,160 @@
+# Model GitHub Actions cost
+
+Use current official billing rules and observed job durations. Do not preserve a
+copied price table as timeless policy: runner SKUs and rates change.
+
+## Sources
+
+Record the access date and use GitHub's current documentation:
+
+- [Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)
+  for standard and larger runner rates and billing granularity;
+- [GitHub Actions billing](https://docs.github.com/en/billing/concepts/product-billing/github-actions)
+  for plan allowances, public-repository treatment, and artifact/cache storage;
+- [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+  for visibility-specific CPU, memory, architecture, and image specifications;
+- [Actions usage metrics](https://docs.github.com/en/enterprise-cloud@latest/organizations/collaborating-with-groups-in-organizations/viewing-usage-metrics-for-github-actions)
+  for organization-level job and workflow evidence.
+
+At the time of analysis, verify rather than assume these rules:
+
+- whether each job's partial minute is rounded up independently;
+- whether the runner is standard, larger, or self-hosted;
+- whether repository visibility makes standard hosted minutes free;
+- whether plan allowances make the next minute non-billable but still consume a
+  finite quota;
+- current artifact, cache, and custom-image storage treatment.
+
+## Two cost views
+
+Always distinguish:
+
+1. **Actual invoiced cost.** What the owner is expected to pay under current
+   visibility, plan allowance, budgets, runner class, and storage usage.
+2. **Normalized list-price cost.** A synthetic rate-weighted measure: observed
+  job duration multiplied by current published runner rates before
+  public-repository or plan allowances.
+
+For a public repository on standard hosted runners, actual minute cost may be
+zero while normalized cost is nonzero. Report both. Normalized cost makes runner
+choices comparable, exposes resource use, and remains useful if visibility or
+billing policy changes.
+
+Runner labels do not always identify equivalent hardware across visibility. For
+example, GitHub can assign more CPU and memory to a standard public
+`ubuntu-latest` or `windows-latest` job than to the same label in a private
+repository. In that case:
+
+- call the normalized result a **synthetic rate-only comparison**;
+- record both hardware specifications beside the rate;
+- do not present the number as what making the repository private would cost;
+- forecast a visibility change only from durations measured on equivalent paid
+  hardware, or report a runtime range that accounts for the hardware change.
+
+Comparing alternatives measured on the same public runner remains useful, but
+the rate-weighted result ranks their observed usage rather than predicting a
+different runner's elapsed time.
+
+Do not label a self-hosted runner free. GitHub may not charge hosted-runner
+minutes, but infrastructure, maintenance, scaling, and incident response still
+have a cost. Model those separately when they matter.
+
+## Job-level calculation
+
+When current GitHub policy rounds each job up to a whole minute:
+
+```text
+billedMinutesPerJob = ceiling(observedRunnerSeconds / 60)
+normalizedJobCost = invocations * billedMinutesPerJob * currentRunnerRate
+```
+
+Apply the rounding to every matrix leg and aggregate job independently. Do not
+round the sum of raw seconds once at workflow level. This is why six 15-second
+jobs can cost six billed minutes while one sequential 90-second job costs two.
+
+Use runtime after a runner starts; queue time affects feedback latency but is not
+runner execution. Setup, checkout, restore, and cleanup run on the runner and do
+count. Canceled and failed jobs consume the time used before they stop.
+
+If GitHub changes billing granularity, replace the `ceiling` function with the
+current rule and cite it in the report.
+
+## Lifecycle calculation
+
+Calculate at least three scopes:
+
+```text
+perPullRequest = sum(PR update and rerun job costs)
+perMergedChange = perPullRequest + merge-queue + default-branch + deployment jobs
+monthlyPeriodic = scheduled frequency * cost per scheduled run
+```
+
+State invocation assumptions explicitly. Useful variables include:
+
+- average pull-request updates before merge;
+- percentage of pull requests merged;
+- bot/dependency pull-request volume;
+- flaky rerun rate;
+- cancellation delay for superseded runs;
+- releases and manual full-matrix runs per month.
+
+Report both a typical estimate (median durations and ordinary update count) and a
+conservative estimate (high-percentile durations plus observed reruns). Do not
+claim precision beyond the quality of the history.
+
+## Storage calculation
+
+Runner minutes and retained storage are separate. Inventory:
+
+- uploaded artifacts and their `retention-days`;
+- repository-level log/artifact retention;
+- cache size, key cardinality, churn, and eviction;
+- custom images used by larger runners;
+- package storage if the workflow publishes artifacts externally.
+
+GitHub bills applicable storage over time, commonly in GB-hours converted to
+GB-months. Deleting an artifact stops future accrual but does not erase storage
+already accrued. Use the current billing page for allowances and rates.
+
+Caching is an optimization only when its time savings exceed restore/upload
+overhead and storage pressure. Compare cache-hit, cache-miss, and no-cache runs.
+Key caches on dependency inputs and runner compatibility; a cache pointed at a
+different directory than the tool uses has zero benefit.
+
+## Reporting table
+
+Use one row per expanded job:
+
+| Workflow / job | Trigger | Runner / hardware / SKU | Runs per scope | p50 / p75 | Billed min | Rate | Normalized cost |
+| -------------- | ------- | ----------------------- | -------------- | --------- | ---------- | ---- | --------------- |
+| Example | PR | current label and specs | measured | measured | calculated | dated source | calculated |
+
+Then summarize:
+
+| Scope | Current actual | Current normalized | Proposed actual | Proposed normalized | Change |
+| ----- | -------------- | ------------------ | --------------- | ------------------- | ------ |
+| Pull request | | | | | |
+| Merged change | | | | | |
+| Monthly periodic | | | | | |
+
+Calculate reduction as:
+
+```text
+reductionPercent = (currentNormalized - proposedNormalized) / currentNormalized * 100
+```
+
+If current normalized cost is zero, report the absolute duration/job reduction
+instead of an undefined percentage.
+
+## Sanity checks
+
+- The sum includes every matrix leg and every tiny aggregate job.
+- PR and default-branch triggers are modeled separately.
+- Public-repository free usage is not presented as zero resource consumption.
+- Visibility-specific runner hardware is recorded; a synthetic public-duration
+  by private-rate number is not presented as a private-repository forecast.
+- Larger runners are not assumed free for public repositories.
+- Canceled, failed, scheduled, release, and manual runs are either modeled or
+  explicitly excluded.
+- Rates have a source and access date.
+- The proposed estimate uses the same assumptions as the baseline.

--- a/.agents/skills/github-actions-cost-optimization/optimizations.md
+++ b/.agents/skills/github-actions-cost-optimization/optimizations.md
@@ -1,0 +1,153 @@
+# Optimize GitHub Actions safely
+
+Apply changes in this order. Earlier steps remove unnecessary work and usually
+carry less validation risk than deleting matrix dimensions.
+
+## 1. Stop runs that should not start
+
+- Cancel superseded pull-request runs with a concurrency key stable for that
+  pull request. A run id is unique and therefore cannot cancel anything.
+- Remove the default-branch `push` trigger only when rulesets prove every path to
+  the branch validates an equivalent merge candidate. Keep it when direct or
+  bypass pushes remain possible.
+- Avoid overlapping branch, tag, and release workflows.
+- Use path filters for optional workflows whose absence cannot block a required
+  status. For required checks, ensure the context is always emitted.
+- Group dependency updates when repository policy permits so one compatible
+  batch pays one CI lifecycle instead of many.
+- Add `merge_group` when a merge queue requires testing the synthetic merge
+  candidate; do not count a PR-head test as equivalent.
+
+## 2. Remove repeated setup and rounding overhead
+
+Every job pays for runner startup, checkout, SDK/tool setup, restore, and current
+job-level billing granularity. Consolidate sequential work that needs the same
+runner and artifacts when the saved setup and rounded minutes outweigh the lost
+parallelism.
+
+Good consolidation candidates include build plus tests, multiple target
+framework test invocations on one compatible host, and performance gates that
+can reuse a verified Release build. Preserve separate jobs when they provide
+material wall-clock savings, isolation, permissions boundaries, or genuinely
+different runners.
+
+Do not split tiny script checks into many jobs merely for presentation. A cheap
+aggregate required check should be one job when one stable context is enough.
+
+## 3. Choose the cheapest compatible runner
+
+- Use a slim one-core Linux runner for short scripts and aggregate status jobs
+  when its toolset and speed are sufficient.
+- Prefer standard Linux for portable build/test work.
+- Consider Linux ARM64 only after restore, toolchain, native dependency, and test
+  compatibility are demonstrated. Architecture substitution is a test-coverage
+  decision as well as a price decision.
+- Keep Windows or macOS where native APIs, legacy frameworks, packaging, signing,
+  filesystem semantics, or supported-platform behavior requires them.
+- Compare larger runners by total job cost, not minute rate alone. A faster,
+  more expensive runner can be cheaper if measured runtime falls enough.
+
+Cross-compiling proves compilation for a target; it does not replace executing
+native behavior on that target.
+
+## 4. Make the automatic matrix load-bearing
+
+Run Release tests automatically because Release code generation is what ships.
+Keep Debug automatic only when it detects a distinct class of regressions that
+the project has chosen to gate.
+
+For operating-system, architecture, target-framework, runtime-identifier, AOT,
+and SDK matrices:
+
+1. Map every leg to a stated invariant.
+2. Keep merge-blocking legs for common or high-risk behavior.
+3. Move expensive breadth to a named scheduled/manual workflow or a release gate
+   only when delayed detection is acceptable.
+4. Give periodic breadth a cadence and owner so it cannot silently rot.
+
+Do not call a reduced automatic matrix "equivalent" to the full matrix. Report
+what remains automatic and what becomes delayed.
+
+## 5. Fix restore and cache behavior
+
+- Restore once per job and use `--no-restore` or the tool's equivalent only when
+  the following command truly supports it.
+- Point the cache at the actual configured package directory. If an environment
+  variable redirects that directory, cache the redirected path.
+- Include operating system, architecture, lock files, SDK/tool versions, and
+  other compatibility inputs in the key when they affect cache validity.
+- Use restore keys only when a partial match is safe.
+- Remove caches whose hit-rate or measured savings do not justify upload,
+  download, and storage churn.
+
+Never share build output across jobs without proving it cannot become stale or
+mix configurations. Rebuilding is cheaper than trusting the wrong binary.
+
+## 6. Control artifacts and logs
+
+- Upload only outputs needed by downstream jobs, diagnostics, or release.
+- Set the shortest practical `retention-days` on large transient artifacts.
+- Avoid uploading duplicate binaries from every matrix leg.
+- Keep test logs and failure diagnostics long enough to debug ordinary failures.
+- Review repository retention and cache limits as remote settings; changing them
+  requires approval.
+
+## 7. Treat security scans as security decisions
+
+Moving CodeQL or another scanner from every pull request to a schedule lowers
+runner cost but delays detection. Before doing so, record:
+
+- whether the repository handles untrusted input or sensitive data;
+- whether language/compiler analyzers cover part of the same risk;
+- whether branch protection currently requires the scan;
+- scheduled cadence, alert ownership, and response expectations;
+- whether release gates need a fresh scan.
+
+Use a security-review workflow when this decision is material. Never run
+untrusted pull-request code with write permissions or repository secrets to save
+the setup cost of a separate trusted job.
+
+## 8. Preserve required-check behavior
+
+When branch protection depends on historical check names, a temporary aggregate
+job can preserve them while the underlying topology changes. The aggregate must:
+
+- use `if: always()` so it runs after failed, canceled, or skipped dependencies;
+- inspect every dependency result;
+- succeed only when all required dependencies succeeded;
+- use a cheap compatible runner and a short timeout.
+
+An aggregate that runs only after success can be skipped on failure and leave an
+ambiguous required context. An aggregate that accepts `skipped` without a
+deliberate policy can turn missing validation green.
+
+Update or remove legacy contexts only with explicit approval to change the
+remote ruleset. Required-check changes and workflow changes should be sequenced
+so merges are never accidentally unguarded.
+
+## 9. Validate in layers
+
+After each coherent edit:
+
+1. Run an Actions-aware linter and YAML/editor diagnostics.
+2. Run whitespace and repository policy checks.
+3. Execute the local build, Release tests, and any perf/AOT/package commands the
+   changed automatic jobs will use.
+4. Confirm cache paths and generated artifact locations statically.
+5. Push only with approval and observe one hosted run on every retained native
+   platform and architecture.
+6. Confirm required contexts appear and fail closed for a deliberately failed or
+   canceled dependency when practical.
+7. Replace estimated durations with hosted measurements and recalculate cost.
+
+## Common traps
+
+- A path-filtered required workflow never starts and leaves the PR pending.
+- A concurrency group includes a unique run id, so no prior run is canceled.
+- A cache saves the default directory while the build uses a redirected one.
+- A shallow checkout changes git-derived versioning such as MinVer.
+- `--no-build` reuses output from a different configuration or target.
+- A manual full matrix has no cadence or owner and quietly stops being useful.
+- Removing post-merge CI ignores an administrator or automation bypass path.
+- Replacing native execution with cross-compilation drops behavior coverage.
+- Many tiny jobs look parallel but multiply setup and rounded billing minutes.

--- a/.agents/skills/github-actions-cost-optimization/overlay.md
+++ b/.agents/skills/github-actions-cost-optimization/overlay.md
@@ -1,0 +1,88 @@
+---
+core: github-actions-cost-optimization
+core-pin: v0.13.0
+---
+
+# Touki overlay - github-actions-cost-optimization
+
+Repo-specific companion to the vendored
+[github-actions-cost-optimization](SKILL.md) skill. The `SKILL.md` and its three
+sibling pages (`audit.md`, `cost-model.md`, `optimizations.md`) are a **pinned
+copy of the portable core** from
+[JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
+`metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core -
+`gh skill update` would flag the drift. Everything touki-specific lives here.
+
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag. Pull
+> later upstream changes with `gh skill update github-actions-cost-optimization`
+> (review the diff, re-pin to the new tag).
+
+## Workflow inventory (the core's step 1)
+
+Everything lives under [.github/workflows/](../../../.github/workflows/):
+
+| Workflow | Trigger | Runners |
+| --- | --- | --- |
+| [dotnet.yml](../../../.github/workflows/dotnet.yml) | PR and push to `main` | `ubuntu-24.04-arm` matrix, one `windows-latest` and one `windows-11-arm` smoke leg, `ubuntu-slim` aggregator |
+| [agent-files.yml](../../../.github/workflows/agent-files.yml) | PR and push to `main` | `ubuntu-latest`, gated in-job by `dorny/paths-filter` |
+| [platform-tests.yml](../../../.github/workflows/platform-tests.yml) | `workflow_call` only | caller-supplied `inputs.runner` |
+| [manual-linux.yml](../../../.github/workflows/manual-linux.yml), [manual-macos.yml](../../../.github/workflows/manual-macos.yml), [manual-windows.yml](../../../.github/workflows/manual-windows.yml) | `workflow_dispatch` | the full per-platform matrices moved off the automatic path |
+| [publish.yml](../../../.github/workflows/publish.yml) (`v*.*.*`), [publishtestsupport.yml](../../../.github/workflows/publishtestsupport.yml) (`ts-v*.*.*`) | tag push, `workflow_dispatch` | `windows-latest` |
+
+`platform-tests.yml` is the single reusable body; measure a change there, not in
+each caller. Its `full-validation`, `collect-coverage`, `pack`, `anycpu`,
+`linux-desktop`, and `native-aot-rid` inputs are the existing cost levers.
+
+## Validation invariants (the core's step 2)
+
+State these before proposing any saving:
+
+- **`.NET / build` is the required status check name.** It is a deliberately
+  cheap `ubuntu-slim` aggregation job that fails when any upstream leg fails.
+  Renaming it or changing its `needs` breaks branch protection on `main` -
+  a governance change, not an accounting one.
+- **Both target frameworks must stay covered on the automatic path.** `net481`
+  is validated by the `windows-latest` leg; the Linux ARM64 matrix covers
+  `net10.0`/`net11.0` in Debug and Release. A cross-TFM library cannot drop
+  either leg.
+- **Windows-only behavior needs a real Windows runner** (clipboard providers,
+  the CsWin32 projection - see
+  [`cswin32-interop`](../cswin32-interop/SKILL.md)), and the Unix path oracles
+  need a real Linux runner (see
+  [`run-tests-on-wsl`](../run-tests-on-wsl/SKILL.md)).
+- Coverage upload, packaging checks, and Native AOT publish already run on
+  exactly one leg each. Do not fan them out to save wall-clock.
+
+The existing topology is already the result of one cost pass: Linux ARM64 owns
+the full matrix because it is the cheapest runner, Windows is reduced to smoke
+legs, the full per-platform matrices are `workflow_dispatch`-only, and
+`concurrency` cancels superseded PR runs. Re-measure before assuming further
+savings remain.
+
+## Remote boundary
+
+The core's remote boundary binds to touki's stricter rule: branch protection,
+required checks, and Actions settings are remote changes that need explicit
+approval, and committing, pushing, and opening a PR are three separate approval
+boundaries - see
+[AGENTS.md](../../../AGENTS.md#working-with-the-user-on-changes) and
+[`create-pr`](../create-pr/SKILL.md).
+
+## Cross-references (the core's "Related skills")
+
+- [`security-review`](../security-review/SKILL.md) - before changing CodeQL
+  cadence, workflow permissions, or anything that runs untrusted PR code.
+- [`publish-release`](../publish-release/SKILL.md) - owns the two tag-triggered
+  publish workflows; do not re-time them for cost.
+- [`agent-files-review`](../agent-files-review/SKILL.md) - owns `agent-files.yml`
+  and its path filters.
+
+The core's related `engineering-baseline` skill is **not vendored here**: touki
+is an established repository already wired for build, test, publish, and
+governance, so the scaffold/audit workflow has no binding to make.
+
+## Updating
+
+Pull upstream changes to the core with
+`gh skill update github-actions-cost-optimization` (review the diff, re-pin).
+Keep touki-specific additions in this file, not in the core.

--- a/.agents/skills/il-copy-inspection/SKILL.md
+++ b/.agents/skills/il-copy-inspection/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet
     binding: optional-overlay
     github-path: skills/il-copy-inspection
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 07bce64dc12f798aeeec01aab716d26bbde5c0ed
     maturity: canary

--- a/.agents/skills/il-copy-inspection/overlay.md
+++ b/.agents/skills/il-copy-inspection/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: il-copy-inspection
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - il-copy-inspection
@@ -11,7 +11,7 @@ portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core.
 
-> **Pinned to a release.** The core is pinned to the commons **v0.10.0** tag.
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag.
 
 ## Touki bindings
 

--- a/.agents/skills/manage-skills/SKILL.md
+++ b/.agents/skills/manage-skills/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/manage-skills
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: bb78d07296156a84ee9f54023145532a5275607a
+    github-tree-sha: 5b881e8d4c0a1d5e9bdf3d48cb91d515088e44d2
     maturity: canary
     portability: portable
     related: agent-files-review

--- a/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
+++ b/.agents/skills/manage-skills/scripts/Validate-Skills.ps1
@@ -18,6 +18,8 @@
       - compatibility: if present, a string <= 500 chars.
       - yaml: inline scalar values carry no unquoted ':' (a mapping indicator that
         a strict parser, like the strictyaml skills-ref uses, would reject).
+      - readability: Markdown files contain no HTML entities; direct Unicode and
+        plain words remain valid.
       - length: SKILL.md is at most 500 lines (the spec's progressive-disclosure
         recommendation, "Keep your main SKILL.md under 500 lines").
 
@@ -450,6 +452,18 @@ function Test-SkillDir ([string] $dir) {
     $metadata = if ($fm.Contains('metadata')) { $fm['metadata'] } else { $null }
     Test-PortfolioMetadata $metadata $raw $dir $RequirePortfolioMetadata.IsPresent |
         ForEach-Object { $errors.Add($_) }
+
+    $htmlEntityRegex = [regex]::new('&(?:#[0-9]+|#[xX][0-9A-Fa-f]+|[A-Za-z][A-Za-z0-9]+);', [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    foreach ($markdownFile in Get-ChildItem -LiteralPath $dir -Recurse -File -Filter '*.md') {
+        [int] $lineNumber = 0
+        foreach ($line in Get-Content -LiteralPath $markdownFile.FullName) {
+            $lineNumber++
+            foreach ($match in $htmlEntityRegex.Matches($line)) {
+                [string] $relativePath = [System.IO.Path]::GetRelativePath($dir, $markdownFile.FullName)
+                $errors.Add("$relativePath`:$lineNumber contains HTML entity '$($match.Value)'; write the character directly or use plain words.")
+            }
+        }
+    }
 
     $lineCount = Measure-SkillLineCount $raw
     if ($lineCount -gt $MaxSkillLines) {

--- a/.agents/skills/performance-testing/SKILL.md
+++ b/.agents/skills/performance-testing/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: dotnet-project-gated
     binding: optional-overlay
     github-path: skills/performance-testing
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 5a20e5995ee9e6d6d6a24131e1522f0084761e79
+    github-tree-sha: 9cdddfa386a045ddc14a9799126929da23341e89
     maturity: canary
     portability: portable
     related: framework-jit-optimization, scratch-buffer-strategy, pre-pr-self-review
@@ -141,6 +141,9 @@ inspection.
   method, the interactive picker, and useful switches.
 - [interpreting-results.md](interpreting-results.md) - before/after discipline on
   both TFMs and reading the memory columns.
+- [investigation-workflow.md](investigation-workflow.md) - fresh-state phase
+   measurement versus profiling, experiment ledgers, exact-source oracles, and
+   reconstructable run provenance for multi-step investigations.
 - [reading-codegen.md](reading-codegen.md) - seeing the C# lowering, IL, and JIT
   asm behind a number: sharplab, `[DisassemblyDiagnoser]`, `[HardwareCounters]`,
   the `DOTNET_JitDisasm*` knobs, and the tiering/PGO inspection traps.

--- a/.agents/skills/performance-testing/investigation-workflow.md
+++ b/.agents/skills/performance-testing/investigation-workflow.md
@@ -1,0 +1,191 @@
+# Reproducible performance investigations
+
+Detail for the [performance-testing](SKILL.md) skill. Use this workflow when a
+performance question spans multiple phases, compares an external implementation,
+iterates through several candidate optimizations, or must remain reproducible from
+a dirty worktree.
+
+For a simple A/B benchmark over one pure operation, use [authoring.md](authoring.md),
+[running.md](running.md), and [interpreting-results.md](interpreting-results.md)
+directly. Do not add phase harnesses or source bundles when the ordinary benchmark
+already answers the question.
+
+The expected outputs are a trustworthy benchmark or profile, a compact experiment
+ledger, and enough source and run provenance to reconstruct any result that is kept.
+Creating those local artifacts does not authorize committing, uploading, or
+publishing them.
+
+## Measure phases with fresh state
+
+A mutable or consumable intermediate representation cannot be reused across
+measurements. Reuse can make a later phase observe already-mutated state, shared
+arrays, warmed caches, or an object graph that no longer represents a fresh
+operation.
+
+For phase latency:
+
+1. Prepare a bounded batch of fresh inputs in `[IterationSetup]`.
+2. Consume every item exactly once in the `[Benchmark]` method.
+3. Set `OperationsPerInvoke` to the number of items consumed so BenchmarkDotNet
+   reports per-operation time and allocation.
+4. Release the batch in `[IterationCleanup]` so one iteration's live set does not
+   leak into the next.
+5. Run separate configurations for one item, an intermediate batch, and a larger
+   batch. Keep `OperationsPerInvoke` accurate for each configuration.
+
+The one-item run exposes timer and harness overhead. The larger run exposes
+retained-live-set and GC distortion. Keep the smallest batch that amortizes the
+harness without changing the workload's allocation or latency shape.
+
+A consumable-state benchmark may need one invocation per iteration. BenchmarkDotNet
+can then warn that the minimum iteration time was not reached. Document why the
+invocation count must remain one; do not silence the warning by consuming the same
+state repeatedly.
+
+### Use a different harness for CPU profiling
+
+The one-shot measurement harness is often too sparse for a useful periodic CPU
+profile. Prefer an adaptive end-to-end benchmark that BenchmarkDotNet can repeat,
+then use the repository's trace analyzer to scope the profile to the phase method.
+Work before that phase call remains outside the selected subtree while the repeated
+end-to-end operation supplies enough observations.
+
+Profile the one-shot harness only when the selected phase query has enough
+contributing records under the analyzer's sample-quality contract. A whole-trace
+sample count does not establish quality for a narrow phase.
+
+Before trusting a decomposition, compare it with an independently measured
+end-to-end operation:
+
+- phase allocations should add to the end-to-end allocation at the report's
+  precision;
+- phase means should approximately add to the end-to-end mean;
+- each phase should receive fresh, semantically equivalent state.
+
+A large gap usually means setup leaked into a measurement, state was reused, or
+the batch changed GC and live-set behavior.
+
+## Keep an experiment ledger
+
+Start the ledger before the first edit and add one row per candidate. Record
+rejected variants as carefully as retained ones.
+
+| Hypothesis | Small edit | Discriminating check | Time | Allocation | Target frame | Decision |
+| --- | --- | --- | ---: | ---: | --- | --- |
+| Example claim | One-variable change | Same filtered benchmark | Result | Result | Before -> after | Keep or reject, with reason |
+
+Change one material variable at a time. Use the same scenario, filter, target
+framework, job, and profiler scope before and after. Preserve both target
+frameworks when the production code serves both. A rejection is useful evidence:
+it prevents a later investigation from retrying an attractive idea that already
+lost on throughput, allocation, another runtime, or the intended target frame.
+
+The final report should explain why the retained implementation beat at least the
+most plausible alternative, not merely state that the retained row was faster than
+the original baseline.
+
+## Compare an exact-source oracle
+
+When the baseline lives in another repository or revision, compare against exact
+source rather than an unpinned package or a mutable checkout:
+
+1. Create a clean detached checkout at an exact commit SHA.
+2. Build it in Release with the subject repository's pinned SDK. Record the SDK
+   version and any compatibility override.
+3. Verify the built assembly's informational version and configuration when that
+   metadata is available, and retain its SHA-256 hash.
+4. Isolate namespace and type collisions with an `extern alias` rather than
+   renaming either implementation.
+5. Make the oracle reference opt-in. Set an environment variable whose name is
+   also an optional MSBuild property before launching BenchmarkDotNet; the
+   generated child build inherits the environment, while an outer `/p:` argument
+   alone may not reach that child build.
+6. Include the oracle reference and benchmark methods only when that property is
+   present. An ordinary build must contain neither.
+7. Validate semantic parity before measuring: equivalent inputs, outputs,
+   exceptions, options, and fresh mutable state for every operation.
+8. Remove the temporary checkout after the retained artifacts record its commit
+   and assembly hash.
+
+Do not assume a parsed model or decoded object graph can be reused safely. Prove
+that repeated materialization is independent, or reconstruct the intermediate
+state per operation. Shared mutable arrays or caches can make an oracle appear
+faster while changing the work being measured.
+
+As a build check, inspect the generated BenchmarkDotNet child project for an
+opt-in run and confirm that it contains the exact oracle reference. Then build
+without the environment property and confirm that no oracle reference or
+oracle-only benchmark method remains.
+
+## Preserve a reconstructable run
+
+Give every retained run a unique directory or output stem, for example:
+
+```text
+<subject>-<phase>-<variant>-<tfm>-<job>-<timestamp>
+```
+
+Retain the compact report and raw result, exact command line, non-secret
+environment settings, runtime and JIT identity, OS and architecture, base commit,
+clean/dirty state, experiment-ledger row, and any trace manifest. Keep separate
+run directories so a later BenchmarkDotNet invocation cannot overwrite the
+baseline used in a claim.
+
+### Dirty-source bundle contract
+
+A commit SHA plus hashes is insufficient when tracked, untracked, binary, or
+ignored inputs affected the run. For a dirty worktree, retain one of these:
+
+- a complete source snapshot; or
+- a base commit plus all of the following reconstruction artifacts.
+
+The reconstruction artifacts are:
+
+1. A binary-capable full-index patch of every tracked difference from the recorded
+   base commit, including staged and unstaged changes. Store that commit in
+   `$baseCommit`, then use `git diff --binary --full-index $baseCommit --` so the
+   patch and restore point cannot disagree.
+2. An archive containing the bytes of every relevant untracked or ignored source,
+   generated input, and benchmark data file, stored at its repository-relative
+   path. Build the archive from an explicit allowlist after reviewing each file
+   for credentials, signing material, personal data, proprietary inputs, and
+   unrelated local configuration. Include required file metadata when it affects
+   the build or run.
+3. A manifest containing the base commit, repository-relative path, tracked /
+   untracked / ignored classification, byte length, and SHA-256 hash for every
+   archived input, plus hashes of the patch and archive themselves. Record who or
+   what performed the allowlist review and list any non-secret external
+   provisioning requirements.
+4. The exact restore procedure: detach the base commit, apply the binary patch,
+   extract the archive at the repository root, and verify the manifest hashes.
+
+Hashes prove integrity; they do not replace missing content. Never archive a file
+merely because it is ignored or untracked. Do not archive credentials, signing
+material, package caches, unrelated build output, or data whose redistribution is
+not authorized. When a secret influences setup, record a non-secret provisioning
+requirement rather than the secret. If the run cannot be reconstructed without
+retaining sensitive bytes, do not publish or share the bundle; keep the result
+local or redesign the input so a safe equivalent can be retained.
+
+For a result that will support a durable claim, test the restore procedure in a
+temporary clean checkout before discarding the original worktree. The restored
+checkout must reproduce the recorded source hashes and include every build or
+benchmark input that was not obtainable from the base commit.
+
+## Acceptance checks
+
+The workflow is complete when all applicable checks pass:
+
+- A consumable parse/materialize split uses fresh-state batches for measurement
+  and an adaptive end-to-end path for profiling unless the one-shot phase has
+  enough query-level evidence.
+- The ledger preserves rejected variants and explains the final decision.
+- An opt-in BenchmarkDotNet child build references the assembly built from the
+   recorded oracle commit and hash, semantic-parity checks pass on fresh state, and
+   an ordinary build has no oracle surface.
+- A clean checkout plus the retained dirty-source bundle reconstructs and verifies
+   every source and input byte needed for the run; its explicit allowlist contains
+   no secret, unauthorized, or unrelated content.
+- The retained command, non-secret environment, runtime/JIT, OS/architecture,
+   target framework, job, and profiler scope identify the execution environment
+   closely enough to rerun the same experiment.

--- a/.agents/skills/performance-testing/overlay.md
+++ b/.agents/skills/performance-testing/overlay.md
@@ -1,21 +1,21 @@
 ---
 core: performance-testing
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - performance-testing
 
 Repo-specific companion to the vendored [performance-testing](SKILL.md) skill.
-The `SKILL.md` and its five sibling pages (`authoring.md`, `running.md`,
-`interpreting-requests.md`, `interpreting-results.md`, `reading-codegen.md`) are
-a **pinned copy of the portable core** from
+The `SKILL.md` and its six sibling pages (`authoring.md`, `running.md`,
+`interpreting-requests.md`, `interpreting-results.md`, `investigation-workflow.md`,
+`reading-codegen.md`) are a **pinned copy of the portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in `SKILL.md`'s frontmatter). Do not hand-edit the
 core - `gh skill update` would flag the drift. Everything touki-specific lives
 here, plus the two profiling pages below, which are a touki overlay (they drive
 the repo's trace analyzer).
 
-> **Pinned to a release.** The core is pinned to the commons **v0.10.0** tag. Pull
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag. Pull
 > later upstream changes with `gh skill update performance-testing` (review the
 > diff, re-pin to the new tag).
 
@@ -70,30 +70,22 @@ The full field manual is [docs/performance-investigation.md](../../../docs/perfo
 
 ## Candidate upstream improvements
 
-The generic parts of [profiling.md](profiling.md) added after the July 2026 NRBF
-investigation are intentionally being validated in Touki before promotion to
-[`JeremyKuhne/agent-skills`](https://github.com/JeremyKuhne/agent-skills).
-
-Implemented locally and candidates for promotion:
-
-- separate harness guidance for one-shot phase measurement versus adaptive phase
-  profiling;
-- an experiment ledger that retains rejected variants and allocation outcomes.
+None pending. The multi-phase investigation guidance that was being validated
+here - one-shot phase measurement versus adaptive phase profiling, the experiment
+ledger that retains rejected variants, exact-source comparison, and
+reconstructable run-artifact provenance - was upstreamed and now ships in the
+core's [investigation-workflow.md](investigation-workflow.md) as of commons
+**v0.13.0**. The touki [profiling.md](profiling.md) page defers to it instead of
+restating it.
 
 Periodic CPU sample-quality, provider-state, source-resolution, BenchmarkDotNet
-scope, and trace-manifest contracts are now owned by the filtrace 0.6 tool-shipped
+scope, and trace-manifest contracts are owned by the filtrace 0.6 tool-shipped
 skill. They remain cross-referenced from Touki's profiling page but are not
 `agent-skills` promotion candidates.
 
-Further portable candidates are specified in
-[performance-investigation-agent-tooling-retrospective.md](../../../docs/performance-investigation-agent-tooling-retrospective.md)
-but are not yet implemented as local skill guidance: exact-source comparison and
-reconstructable run-artifact provenance. Keep that distinction until the workflow
-has been exercised locally or promoted directly upstream.
-
-Do not copy these changes into the pinned core locally. Once the guidance has
-settled, uplevel the portable wording to `agent-skills`, publish a new commons
-version, and re-vendor/re-pin the performance-testing core here. Filtrace release
+Do not copy new guidance into the pinned core locally. Once wording has settled,
+uplevel the portable part to `agent-skills`, publish a new commons version, and
+re-vendor/re-pin the performance-testing core here. Filtrace release
 [0.6.0](https://github.com/JeremyKuhne/filtrace/releases/tag/v0.6.0) completed the
 product, capture-script, and tool-shipped-skill work from
 [filtrace#42](https://github.com/JeremyKuhne/filtrace/issues/42); do not promote

--- a/.agents/skills/performance-testing/profiling.md
+++ b/.agents/skills/performance-testing/profiling.md
@@ -42,27 +42,12 @@ load-and-summarize the other tools do implicitly.
 
 ## Agent protocol for phase investigations
 
-**Use different harnesses for measurement and profiling.** A mutable or
-consumable intermediate representation needs fresh state for every measured
-operation: prepare a bounded batch in `IterationSetup`, consume every item once,
-normalize with `OperationsPerInvoke`, and release the batch in
-`IterationCleanup`. Sweep one item, an intermediate batch, and a larger batch:
-the first exposes timer overhead, while the last exposes retained-live-set
-distortion. Keep the smallest batch that amortizes the harness without changing
-the workload.
-
-That one-shot shape is often a poor CPU-profiling harness. For profiling, prefer
-an adaptive end-to-end benchmark and root-scope filtrace to the phase method.
-Work before that call remains outside the selected subtree, while BenchmarkDotNet
-can execute enough operations to produce a denser profile. Profile the one-shot
-benchmark only when a compatible periodic CPU capture has enough contributing
-samples in the selected query.
-
-Validate a phase split before trusting it: phase allocations should add to the
-independently measured end-to-end allocation at reported precision, and phase
-means should approximately add to the end-to-end mean. A large gap usually means
-setup leaked into one measurement, mutable state was reused, or the batch changed
-GC/live-set behavior.
+The portable half of this protocol - fresh-state phase harnesses, the separate
+adaptive harness for CPU profiling, phase-versus-end-to-end cross-checks, the
+experiment ledger that retains rejected variants, exact-source oracles, and
+reconstructable run provenance - lives in the core's
+[investigation-workflow.md](investigation-workflow.md). Follow it first; what
+follows is only the touki/filtrace-specific part.
 
 **Use the filtrace 0.6.3 evidence contracts:**
 
@@ -99,15 +84,6 @@ GC/live-set behavior.
 - Use `trace_batch`/`batch` for parameter matrices and manifest-aware
   `trace_diff`/`diff` for before/after scope shares. Per-operation values require
   matching operation count and unit metadata in both manifests.
-
-Keep a compact experiment ledger while iterating:
-
-| Hypothesis | Small edit | Check | Time | Allocation | Target frame | Decision |
-| --- | --- | --- | ---: | ---: | --- | --- |
-
-Record rejected variants as well as retained changes. Rejections prevent a later
-agent from repeating attractive experiments that already lost on another TFM or
-on allocation.
 
 Things that bite, kept short - full rationale in
 [docs/performance-investigation.md](../../../docs/performance-investigation.md)

--- a/.agents/skills/pre-pr-self-review/SKILL.md
+++ b/.agents/skills/pre-pr-self-review/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/pre-pr-self-review
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 880e117910c69bb909f59a3dfea81cbbf33ac047
+    github-tree-sha: c172ca7a01a7368bb4fee88b4d0b756442d38976
     maturity: canary
     portability: portable
     related: create-pr, address-pr-feedback, security-review, performance-testing
@@ -109,7 +109,7 @@ patterns in a `polyfill-correctness` overlay companion):
 - Performance claims name the JIT (net481 RyuJIT vs modern .NET RyuJIT)
   and are measured or explicitly marked unmeasured.
 
-If the change is not in the Framework-only tree, skip to &sect;3.
+If the change is not in the Framework-only tree, skip to section 3.
 
 ## 3. PR description matches reality
 

--- a/.agents/skills/pre-pr-self-review/overlay.md
+++ b/.agents/skills/pre-pr-self-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: pre-pr-self-review
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - pre-pr-self-review

--- a/.agents/skills/roslyn-analyzers/SKILL.md
+++ b/.agents/skills/roslyn-analyzers/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: dotnet-project-gated
     binding: optional-overlay
     github-path: skills/roslyn-analyzers
-    github-pinned: v0.12.0
-    github-ref: refs/tags/v0.12.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: 7e531df787947535823396d4faada24713a834c9
+    github-tree-sha: bbaae1b14879e43711ccfe12b09dcc87b29b4d37
     maturity: canary
     portability: portable
     related: performance-testing, security-review, pre-pr-self-review, il-copy-inspection
@@ -86,8 +86,9 @@ library it guards (`<root>` is the library project name):
    severity, `helpLinkUri`. Add the row to `AnalyzerReleases.Unshipped.md` in the
    same change or RS2000 fails.
 3. **Design the analyzer** to the statelessness, registration, and
-   `IOperation`-vs-syntax rules in [design.md](design.md). Copy the shape of a
-   known-good analyzer.
+    `IOperation`-vs-syntax rules in [design.md](design.md). Copy the shape of a
+    known-good analyzer. For declaration-wide rules, also read
+    [symbol-actions.md](symbol-actions.md).
 4. **Validate** with positive, negative, and boundary cases per
    [validation.md](validation.md). Run in Debug *and* Release.
 5. **Check performance** against the in-IDE budget in [performance.md](performance.md):
@@ -108,6 +109,10 @@ library it guards (`<root>` is the library project name):
 - [design.md](design.md) - authoring rules: stateless and thread-safe, narrowest
   registration, `IOperation` over raw syntax, descriptors, release tracking, and a
   note on code-fix providers.
+- [symbol-actions.md](symbol-actions.md) - complete symbol coverage, names that
+  cannot be fixed at the report site, and analyzer-crash diagnosis.
+- [release-tracking.md](release-tracking.md) - shipped/unshipped file format,
+  immutable release history, release promotion, and the `RS20xx` diagnostics.
 - [validation.md](validation.md) - testing: the `Microsoft.CodeAnalysis.Testing`
   markup harness, a lightweight in-memory harness, the coverage checklist, and the
   dogfood probe.

--- a/.agents/skills/roslyn-analyzers/design.md
+++ b/.agents/skills/roslyn-analyzers/design.md
@@ -65,6 +65,10 @@ walking, which is where slow analyzers come from. Never call
 `SyntaxNode.DescendantNodes()` to hunt for nodes a registration filter would have
 delivered directly.
 
+For rules that walk declarations, [symbol-actions.md](symbol-actions.md) covers
+parameters/type parameters, locals, synthetic names, overrides, and explicit
+interface implementations.
+
 ## Rule 3: prefer `IOperation` over raw syntax when semantics matter
 
 Raw syntax is a literal transcription of the source - it cannot tell you what a
@@ -106,6 +110,8 @@ private static readonly DiagnosticDescriptor s_rule = new(
 - `messageFormat` is a format string; pass arguments at `Diagnostic.Create`. Do not
   pre-format with interpolation - it defeats localization and allocates.
 - Set a real `helpLinkUri`.
+- Verify the link for every new diagnostic ID. If its fragment is derived from the
+  ID, the matching documentation anchor must exist before the rule ships.
 - For an analyzer you intend to *ship and localize*, move `title`/`messageFormat`/
   `description` into a `.resx` and use `LocalizableResourceString`. For an
   internal, English-only repo rule the inline strings above are acceptable.
@@ -119,21 +125,23 @@ should land exactly on what the user must change. Pass the precise
 
 ## Rule 6: honor configuration; do not hardcode severity behavior
 
-Report the diagnostic unconditionally and let the host's `.editorconfig` severity
-mapping decide whether it is an error, warning, suggestion, or suppressed. Do not
-read severities yourself or branch on configuration; the descriptor's
-`defaultSeverity` plus user `.editorconfig` lines are the entire mechanism.
+Report the diagnostic unconditionally and let the host's configuration decide
+whether it is an error, warning, suggestion, or suppressed. Do not read severity
+configuration yourself. The descriptor's `defaultSeverity` and
+`isEnabledByDefault` establish the initial state; host configuration determines
+the effective severity.
+
+A rule that enforces house style should usually set `isEnabledByDefault: false`.
+Consumers enable it with `dotnet_diagnostic.<id>.severity`, which also controls
+the effective severity of every report under that ID. Do not rely on per-report
+severity to preserve independent sub-rule levels once the consumer sets the
+ID-wide severity; use analyzer-specific options to turn sub-rules off instead.
 
 ## Rule 7: release tracking is part of the change
 
-Every new or changed rule updates the analyzer release files in the same commit:
-
-- New rule -> add a row under `### New Rules` in
-  `AnalyzerReleases.Unshipped.md`.
-- On release, entries move from `Unshipped` to `Shipped` under a version heading.
-
-RS2000/RS2002 fail the build if the unshipped file and `SupportedDiagnostics`
-disagree, so this cannot be forgotten if you build before committing.
+Every new, removed, or changed rule updates the analyzer release files in the same
+commit. Follow [release-tracking.md](release-tracking.md); `RS20xx` diagnostics
+enforce the file format and agreement with `SupportedDiagnostics`.
 
 ## Code-fix providers (optional)
 

--- a/.agents/skills/roslyn-analyzers/overlay.md
+++ b/.agents/skills/roslyn-analyzers/overlay.md
@@ -1,19 +1,19 @@
 ---
 core: roslyn-analyzers
-core-pin: v0.12.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - roslyn-analyzers
 
 Repo-specific companion to the vendored [roslyn-analyzers](SKILL.md) skill. The
-`SKILL.md` and its five sibling pages (`design.md`, `validation.md`,
-`existing-analyzers.md`, `performance.md`, `suppressors.md`) are a **pinned copy of
-the portable core** from
+`SKILL.md` and its seven sibling pages (`design.md`, `symbol-actions.md`,
+`release-tracking.md`, `validation.md`, `existing-analyzers.md`, `performance.md`,
+`suppressors.md`) are a **pinned copy of the portable core** from
 [JeremyKuhne/agent-skills](https://github.com/JeremyKuhne/agent-skills) (see the
 `metadata.github-*` provenance in `SKILL.md`). Do not hand-edit the core -
 `gh skill update` would flag the drift. Everything touki-specific lives here.
 
-> **Pinned to a release.** The core is pinned to the commons **v0.12.0** tag. Pull
+> **Pinned to a release.** The core is pinned to the commons **v0.13.0** tag. Pull
 > later upstream changes with `gh skill update roslyn-analyzers` (review the diff,
 > re-pin to the new tag).
 
@@ -63,28 +63,14 @@ starting `DEVIATION from dotnet/roslyn:` with the issue number that motivated th
 
 ## Symbol-walking analyzers
 
-Hard-won specifics from writing [NamingStyleAnalyzer](../../../touki.analyzers/NamingStyleAnalyzer.cs),
-which visits every declared symbol in a compilation:
+The portable rules - covering each declaration shape once, reporting only names
+owned at the report site (indexers, overrides, explicit implementations), and
+diagnosing `AD0001` and static-initializer ordering - were upstreamed and now ship
+in the core's [symbol-actions.md](symbol-actions.md) as of commons **v0.13.0**.
 
-- **An indexer's `ISymbol.Name` is the synthetic `this[]`.** Any analyzer that reasons
-  about names has to filter `IPropertySymbol { IsIndexer: true }` or it reports on a
-  name nobody wrote and no code fix can change.
-- **Filter what cannot be fixed at the report site**: `symbol.IsOverride` and non-empty
-  `ExplicitInterfaceImplementations` both mean the name is dictated elsewhere. Report
-  the declaration, not the copy.
-- **`RegisterSymbolAction` does not cover parameters or type parameters.** Visit them
-  from the declaring symbol's action (`INamedTypeSymbol.TypeParameters`,
-  `IMethodSymbol.Parameters`), and reach locals and local functions with
-  `RegisterOperationAction(OperationKind.VariableDeclarator, OperationKind.LocalFunction)`.
-- **An unhandled exception in an analyzer surfaces as `AD0001`, not as a stack trace**,
-  and under `TreatWarningsAsErrors` it fails the build with only the exception type and
-  message. `ArgumentNullException` with `Parameter 'value'` from a symbol-walking
-  analyzer is almost always `string.StartsWith(null)` reached through a `default` struct.
-- **Static initializers run in declaration order.** A `static readonly`/`{ get; } =`
-  member whose initializer reads another static member declared *below* it gets that
-  member's zero value. For a struct with `string` fields that is a fully null instance
-  that only explodes later, inside the analyzer, as `AD0001`. Declare the dependency
-  first.
+Touki's worked example of that page is
+[NamingStyleAnalyzer](../../../touki.analyzers/NamingStyleAnalyzer.cs), which
+visits every declared symbol in a compilation.
 
 ## Test harness gotchas
 
@@ -113,29 +99,13 @@ Two consequences to document wherever the rule is configured:
 
 ## Release tracking (`AnalyzerReleases.*.md`)
 
-The core's design.md Rule 7 covers the happy path. Touki specifics and the traps:
-
-- Release headings must be **numeric** (`## Release 0.4.0`). A prerelease label such
-  as `0.4.0-alpha.1` does not parse, so record the exact shipped version in a `;`
-  comment above the heading instead.
-- Once a rule is listed under a shipped release its id, category, and severity are
-  frozen; changing one needs a `### Changed Rules` entry. Renumbering is free only
-  while the rule is still unshipped.
-- The only valid headings are `### New Rules`, `### Removed Rules`, and
-  `### Changed Rules`. Anything else fails with **RS2007**.
-- A suppression id cannot be a live row - **RS2002**. See
-  [suppressors.md](suppressors.md) Rule 5 for the commented-row convention this repo
-  uses instead.
-
-Which rule fires when:
-
-| Code | Means |
-| --- | --- |
-| RS2000 | A declared diagnostic id is missing from the unshipped file |
-| RS2001 | A listed entry's category/severity disagrees with the descriptor |
-| RS2002 | A listed id is not a supported diagnostic of any analyzer |
-| RS2007 | Invalid or unknown heading in a release file |
-| RS2008 | Release tracking not enabled (files missing from `AdditionalFiles`) |
+The file format, the numeric release heading, the frozen-once-shipped rule, the
+`;`-comment for an exact prerelease package version, and the RS2000-RS2008 guide
+were upstreamed and now ship in the core's
+[release-tracking.md](release-tracking.md) as of commons **v0.13.0**. It binds to
+the two `AnalyzerReleases.*.md` files listed under "Concrete bindings" above; the
+repo's commented-row convention for suppression ids is in
+[suppressors.md](suppressors.md) Rule 5.
 
 ## Documentation and help links
 

--- a/.agents/skills/roslyn-analyzers/release-tracking.md
+++ b/.agents/skills/roslyn-analyzers/release-tracking.md
@@ -1,0 +1,83 @@
+# Analyzer release tracking
+
+Detail for [design.md](design.md) Rule 7. Each analyzer assembly that contributes
+diagnostics to a package needs `AnalyzerReleases.Shipped.md` and
+`AnalyzerReleases.Unshipped.md` as `AdditionalFiles`.
+
+## File format
+
+The unshipped file represents the next release and starts empty. Add only the
+sections needed by the pending change:
+
+- `### New Rules`;
+- `### Removed Rules`;
+- `### Changed Rules`.
+
+New and removed rules use this table shape:
+
+```text
+Rule ID | Category | Severity | Notes
+--------|----------|----------|------
+ABCD0001 | Usage | Warning | Short description or documentation link
+```
+
+Changed rules must record both states:
+
+```text
+Rule ID | New Category | New Severity | Old Category | Old Severity | Notes
+--------|--------------|--------------|--------------|--------------|------
+ABCD0001 | Reliability | Warning | Usage | Info | Reason for the change
+```
+
+Use `Disabled` in a severity column when `isEnabledByDefault` is false; otherwise
+use the `DiagnosticSeverity` name (`Hidden`, `Info`, `Warning`, or `Error`).
+
+The shipped file is append-only release history. Each release uses a numeric
+heading such as `## Release 1.2.0`, followed by the same section/table shapes.
+Prerelease labels are not part of the release-heading grammar; record an exact
+prerelease package version in a `;` comment when needed.
+
+Once a rule ships, its ID and release metadata are history. Record a later
+category, default-severity, or enabled-by-default change under `### Changed
+Rules`; record removal under `### Removed Rules`. Do not rewrite an older release
+section to describe current behavior.
+
+Suppression descriptors are not supported diagnostics and cannot be live table
+rows. Use the commented-row convention in [suppressors.md](suppressors.md) when a
+repository chooses to track them alongside rules.
+
+## During development
+
+- New diagnostic: add it to `### New Rules` in the unshipped file.
+- Removed shipped diagnostic: add it to `### Removed Rules`.
+- Changed category, default severity, or enabled-by-default status of a shipped
+  diagnostic: add it to `### Changed Rules`. For a new unshipped diagnostic,
+  update its `### New Rules` row instead.
+- Build the analyzer project after every edit; the release-tracking analyzer
+  checks the files against `SupportedDiagnostics`.
+
+## At release
+
+1. Append a new numeric release section to the shipped file.
+2. Move every unshipped section and row under it.
+3. Return the unshipped file to its empty header state.
+4. Build and pack with the intended package version so the recorded release and
+  package agree.
+
+## Diagnostic guide
+
+| ID | Meaning |
+| --- | --- |
+| RS2000 | A supported diagnostic is missing from analyzer release tracking. |
+| RS2001 | A tracked diagnostic entry is not up to date. |
+| RS2002 | An unsupported diagnostic appears as New/Changed instead of Removed. |
+| RS2003 | A shipped diagnostic is no longer reported but lacks an unshipped Removed entry. |
+| RS2004 | A diagnostic marked Removed is still reported by an analyzer. |
+| RS2005 | The same diagnostic appears more than once in one release. |
+| RS2006 | A diagnostic has a duplicate entry across releases instead of a valid later Changed/Removed entry. |
+| RS2007 | The release file contains an invalid heading, table, or entry. |
+| RS2008 | Release tracking is not enabled; add both files as `AdditionalFiles`. |
+
+Treat these as contract failures, not warnings to suppress. A stale row can be
+more dangerous than a missing row because it publishes the wrong category or
+default behavior to consumers.

--- a/.agents/skills/roslyn-analyzers/symbol-actions.md
+++ b/.agents/skills/roslyn-analyzers/symbol-actions.md
@@ -1,0 +1,60 @@
+# Symbol-action analyzers
+
+Detail for [design.md](design.md) Rule 2. Use this when a rule inspects declared
+symbols across a compilation, especially naming or declaration-style rules.
+
+## Cover each declaration shape once
+
+`RegisterSymbolAction` is appropriate for namespaces, named types, methods,
+properties, fields, events, and parameters. Register `SymbolKind.Parameter` for
+member, primary-constructor, and indexer parameters.
+
+`SymbolKind.TypeParameter` is not supported for symbol actions (RS1003). Visit
+type parameters from the named type or method that declares them.
+
+Local functions, lambdas, anonymous methods, and their parameters live in
+executable code rather than the declaration symbol walk. Reach ordinary local
+variable declarators with `OperationKind.VariableDeclarator`, local functions with
+`OperationKind.LocalFunction`, and lambdas/anonymous methods with
+`OperationKind.AnonymousFunction`; inspect the operation's method symbol for its
+parameters and type parameters. Test each registration path so a declaration is
+neither missed nor reported twice.
+
+Do not treat `VariableDeclarator` as complete coverage for every local symbol.
+Declaration expressions (`out var`, deconstruction) and declaration patterns use
+different operation shapes. Enumerate the source forms the rule promises to cover
+and add the matching operation/syntax registrations and tests deliberately.
+
+## Report only names owned at the report site
+
+Before reporting or offering a rename, exclude declarations whose source name is
+synthetic or dictated elsewhere:
+
+- `IsImplicitlyDeclared`, no source location, or an empty name;
+- `ISymbol.IsOverride` - the overridden declaration owns the name;
+- non-empty `ExplicitInterfaceImplementations` on methods, properties, or events;
+- method kinds whose names are compiler-defined, such as accessors and operators.
+
+For C# naming rules, also exclude `IPropertySymbol.IsIndexer`: its symbol name is
+the synthetic `this[]`, not source text a rename can change. Do not apply that
+assumption to Visual Basic default properties, whose names are user-defined.
+
+A diagnostic with no valid local remedy teaches users to suppress the rule. Keep
+the candidate filter beside the report path and test every excluded shape.
+
+## Diagnose analyzer crashes and static initialization
+
+An exception thrown by a registered analyzer callback is surfaced as `AD0001`.
+Build output may contain only the exception type and message, so reproduce it in
+the analyzer test harness or under a debugger rather than guessing from the
+diagnostic location. Failures while loading the analyzer assembly or constructing
+the analyzer can instead surface as load diagnostics such as C# `CS8032` or the
+corresponding language diagnostic.
+
+Static field and auto-property backing-field initializers execute in their
+initialization order. An initializer that reads a field/backing field whose
+initializer has not run yet observes its zero value. This is especially deceptive
+when the value is a struct: it can look valid while containing null reference
+fields, then fail much later in unrelated code. Do not rely on textual order across
+partial-type parts. Declare dependencies before consumers within one ordered part,
+avoid initializer dependency chains, and add a test that forces type initialization.

--- a/.agents/skills/roslyn-analyzers/validation.md
+++ b/.agents/skills/roslyn-analyzers/validation.md
@@ -47,6 +47,22 @@ Either way, if your repo treats warnings as errors or enforces XML-doc comments,
 the test project may need a local `.editorconfig` to relax rules that fire on the
 inline test snippets - for example disabling `CS1591` (missing XML docs).
 
+### Lightweight-harness traps
+
+- **Reject accidental compiler errors.** A harness that returns only analyzer
+  diagnostics makes an invalid snippet look like a successful "reports nothing"
+  test. Unless a test intentionally covers erroneous code, fail when
+  `compilation.GetDiagnostics()` contains an error. For intentional errors,
+  assert the expected compiler diagnostic explicitly.
+- **Implement every option member the analyzer uses.** A dictionary-backed
+  `AnalyzerConfigOptions` double must override `Keys` when the analyzer enumerates
+  configuration; the base implementation throws. Its provider must return the
+  intended options for the tested syntax tree.
+- **Enable disabled rules in the compilation.** An analyzer whose descriptor has
+  `isEnabledByDefault: false` produces nothing until the test sets its ID through
+  `CompilationOptions.WithSpecificDiagnosticOptions`, for example to
+  `ReportDiagnostic.Warn`. Otherwise every negative test passes vacuously.
+
 ### Testing a code fix without the official harness
 
 If you skip `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing`, a code fix can still be
@@ -116,6 +132,11 @@ cheapest proof is a temporary violation:
 This is more reliable than reading the analyzer-execution report from build output,
 which is easily buried (see [performance.md](performance.md)). Do not leave the
 probe behind.
+
+For a configurable rule, add a second temporary probe that changes the relevant
+`.editorconfig` option and proves the real build changes behavior. In-memory option
+doubles test analyzer logic; they do not prove the compiler is supplying the
+repository's configuration as intended.
 
 ## When the analyzer should not apply everywhere
 

--- a/.agents/skills/scratch-buffer-strategy/SKILL.md
+++ b/.agents/skills/scratch-buffer-strategy/SKILL.md
@@ -6,8 +6,8 @@ metadata:
     applicability: dotnet-framework
     binding: optional-overlay
     github-path: skills/scratch-buffer-strategy
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
     github-tree-sha: 3ae67f801e33d4b55730633f22e27c0fa941ea99
     maturity: canary

--- a/.agents/skills/scratch-buffer-strategy/overlay.md
+++ b/.agents/skills/scratch-buffer-strategy/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: scratch-buffer-strategy
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - scratch-buffer-strategy

--- a/.agents/skills/security-review/SKILL.md
+++ b/.agents/skills/security-review/SKILL.md
@@ -6,10 +6,10 @@ metadata:
     applicability: universal
     binding: optional-overlay
     github-path: skills/security-review
-    github-pinned: v0.10.0
-    github-ref: refs/tags/v0.10.0
+    github-pinned: v0.13.0
+    github-ref: refs/tags/v0.13.0
     github-repo: https://github.com/JeremyKuhne/agent-skills
-    github-tree-sha: b5f145ccbc662182f38554418b5c8b7057c16baa
+    github-tree-sha: 8f2b820c678065733b6582b6dcb1685bd49854f3
     maturity: canary
     portability: portable
     related: pre-pr-self-review, performance-testing, fuzz-testing

--- a/.agents/skills/security-review/checklist.md
+++ b/.agents/skills/security-review/checklist.md
@@ -6,15 +6,15 @@ or *unchecked precondition* could push the code into the failure mode, not
 whether it currently does.
 
 The largest category - `unsafe` / `Unsafe.*` / `MemoryMarshal.*` and other
-caller-validated APIs (&sect;7) - lives in [unsafe-apis.md](unsafe-apis.md).
+caller-validated APIs (section 7) - lives in [unsafe-apis.md](unsafe-apis.md).
 
 When attention is limited, allocate it by tier:
 
-- **Critical (never skip):** &sect;1, &sect;4, [unsafe-apis.md](unsafe-apis.md).
-- **Standard (every member):** &sect;2, &sect;5, &sect;9.
-- **Conditional (when the code shape matches):** &sect;3 (allocates
-  proportional to input), &sect;6 (encoder uses in-band sentinels),
-  &sect;8 (path-handling API).
+- **Critical (never skip):** sections 1 and 4, [unsafe-apis.md](unsafe-apis.md).
+- **Standard (every member):** sections 2, 5, and 9.
+- **Conditional (when the code shape matches):** section 3 (allocates
+  proportional to input), section 6 (encoder uses in-band sentinels),
+  section 8 (path-handling API).
 
 ## 1. Length / size of inputs
 
@@ -47,13 +47,13 @@ outside. Specialized fast paths often bypass the affected code
 ## 3. Allocation pressure / memory DoS
 
 - Does work allocate proportional to (or worse than) input size?
-- Is the worst case bounded by an explicit cap (&sect;1) or only by
+- Is the worst case bounded by an explicit cap (section 1) or only by
   available memory?
 - Do buffers rent from `ArrayPool<T>.Shared` (good), allocate fresh
   per call (acceptable if bounded), or grow without limit (red flag)?
 
-**Tests:** a "large but legitimate" input completes within a
-`Stopwatch` bound (`Should().BeLessThan(TimeSpan.FromSeconds(2))`).
+**Tests:** a "large but legitimate" input completes within a `Stopwatch`
+bound (`Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(2))`).
 Reach for BenchmarkDotNet's `MemoryDiagnoser` only to pin a specific
 allocation count.
 
@@ -64,7 +64,7 @@ allocation count.
   alternation) that retries every wildcard on mismatch. Safe shape:
   **fixed savepoint slots** (each new wildcard overwrites the
   previous slot of the same kind), bounding the worst case to
-  O(n&middot;m).
+  O(n * m).
 - Hashtable attacks: are user-controlled keys hashed with a
   randomized hash (modern .NET `string.GetHashCode()` and
   `Dictionary<,>` are per-process randomized), or a deterministic one
@@ -73,17 +73,17 @@ allocation count.
 **Tests** (pin the safe property):
 
 ```csharp
-[Fact]
+[TestMethod]
 public void Method_PathologicalInput_TerminatesPromptly()
 {
-    /* construct adversarial pattern + input */
+    /* construct adversarial pattern, input, matcher, and expected result */
 
-    Stopwatch sw = Stopwatch.StartNew();
-    bool result = m.IsMatch(input);
-    sw.Stop();
+    Stopwatch stopwatch = Stopwatch.StartNew();
+    bool result = matcher.IsMatch(input);
+    stopwatch.Stop();
 
-    result.Should().Be(/* expected */);
-    sw.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(2));
+    Assert.AreEqual(expectedResult, result);
+    Assert.IsTrue(stopwatch.Elapsed < TimeSpan.FromSeconds(2));
 }
 ```
 

--- a/.agents/skills/security-review/overlay.md
+++ b/.agents/skills/security-review/overlay.md
@@ -1,6 +1,6 @@
 ---
 core: security-review
-core-pin: v0.10.0
+core-pin: v0.13.0
 ---
 
 # Touki overlay - security-review

--- a/.agents/skills/security-review/unsafe-apis.md
+++ b/.agents/skills/security-review/unsafe-apis.md
@@ -1,6 +1,6 @@
 # Caller-validated APIs (`unsafe`, `Unsafe.*`, `MemoryMarshal.*`)
 
-Detail for &sect;7 of the [security-review](SKILL.md) audit
+Detail for section 7 of the [security-review](SKILL.md) audit
 [checklist.md](checklist.md). Mandatory whenever a PR touches one of these.
 The compiler offloads safety to you; the review *is* the safety check.
 
@@ -23,7 +23,7 @@ Walk every use site against this table; rows are independent.
 | `Unsafe.As<TFrom, TTo>(ref TFrom)` / `Unsafe.As<T>(object)` | `sizeof(TTo) <= sizeof(TFrom)`; GC reference layout matches. | Reads garbage past source; corrupts GC heap if reference layout differs. **Older-JIT pitfall:** on .NET Framework RyuJIT, an `[AggressiveInlining]` method that reinterprets a signed-primitive parameter via `Unsafe.As<T, byte>(ref param)` can propagate the caller's int-promoted negative value into the comparison immediate; mask explicitly. | One test per primitive width including signed/negative values; mask with `& 0xFF` / `& 0xFFFF` if needed. |
 | `Unsafe.SkipInit<T>(out T)` | Caller fully initializes every reachable field before any read. | Stale-pointer foot-gun for ref fields; uninitialized read otherwise. | Test every code path that reads from the skip-init local. |
 | `MemoryMarshal.Cast<TFrom, TTo>` / `AsBytes` | Result length is `source.Length * sizeof(TFrom) / sizeof(TTo)`; partial elements vanish silently. | Caller treats a truncated result as the full payload. | Partial-element case (source length doesn't divide evenly). |
-| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime &le; referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
+| `MemoryMarshal.CreateSpan` / `CreateReadOnlySpan` | Returned span lifetime <= referenced storage lifetime. | Use-after-free when the storage was a stack local or short rental. | Audit every caller for lifetime escape; no automated test catches this. |
 | `fixed (T* p = ...)` | `p` valid only inside the `fixed` block. | Dangling pointer after GC relocates. | Manual review: `p` not stashed in a field, passed to `async`/iterator continuations, or returned. |
 | `stackalloc T[n]` | `n` small and bounded. | Stack-overflow DoS if `n` comes from input. | Max-allowed size succeeds; one element more is rejected before `stackalloc` runs. Use a pooled / growable scratch-buffer helper when the input could exceed the stack budget. |
 | `[DllImport]` / `LibraryImport` | Marshaller attrs (`[MarshalAs]`, `SizeConst`, `string` vs `IntPtr`) silently change buffer sizes / ownership. | Buffer overrun, double-free, type confusion across the managed/native boundary. | Cross-check signature against native docs; re-verify on every TFM. |

--- a/tools/Validate-AgentSkills.ps1
+++ b/tools/Validate-AgentSkills.ps1
@@ -268,9 +268,16 @@ foreach ($skill in $skillData.Values) {
         $value = [string]$skill.$relationship
         if ([string]::IsNullOrWhiteSpace($value) -or $value -eq 'none') { continue }
         foreach ($target in ($value -split ',' | ForEach-Object { $_.Trim() })) {
-            if (-not $skillData.ContainsKey($target)) {
-                Add-Error "$($skill.Name) metadata.$($relationship.ToLowerInvariant()) references missing skill '$target'."
+            if ($skillData.ContainsKey($target)) { continue }
+
+            # A vendored core's metadata is owned upstream and may name a sibling from the
+            # source portfolio that this repository deliberately does not vendor. That is
+            # only tolerable for 'related'; a 'requires' target is a hard dependency.
+            if ($relationship -eq 'Related' -and -not [string]::IsNullOrWhiteSpace([string]$skill.Repo)) {
+                continue
             }
+
+            Add-Error "$($skill.Name) metadata.$($relationship.ToLowerInvariant()) references missing skill '$target'."
         }
     }
 }


### PR DESCRIPTION
Re-vendors the agent-skills commons from **v0.10.0** (roslyn-analyzers v0.12.0) to **v0.13.0**, reconciles the overlays against content that release absorbed, and adds the two newly relevant commons skills.

All 16 vendored payloads (62 files) were verified byte-identical to the `v0.13.0` tag. `github-pinned` is the tag name on every core, and every `core-pin` matches.

## Overlay content v0.13.0 upstreamed

Removed locally so no vendored core is shadowed by a stale copy:

| Overlay | Removed | Now lives in |
| --- | --- | --- |
| `performance-testing/overlay.md` | all four recorded pending-upstream candidates | core `investigation-workflow.md` |
| `performance-testing/profiling.md` | phase-harness and experiment-ledger prose | same |
| `roslyn-analyzers/overlay.md` | symbol-walking rules; release tracking incl. the RS2000-RS2008 table | `symbol-actions.md`, `release-tracking.md` |
| `address-pr-feedback/overlay.md` | the `gh` reply/resolve recipes | `thread-workflow.md` |

The touki-specific residue stays: the standing approval to reply-and-resolve, the `NamingStyleAnalyzer` worked example, the `AnalyzerReleases.*.md` bindings, and the filtrace 0.6.3 evidence contracts.

## New bindings

Both PR overlays now record that **Copilot auto-review is always on here** - that is the branch the v0.13.0 cores added to `create-pr` step 7 and `address-pr-feedback` step 8 ("never request or re-request review").

## Newly vendored

- **`cswin32-interop`** - touki really does use CsWin32 (`touki/NativeMethods.txt` + `.json`, the clipboard and global-memory surface consumed by `WindowsClipboardProvider`).
- **`github-actions-cost-optimization`** - eight workflows over one reusable `platform-tests.yml` body.

`cswin32-com` (no struct-based COM or CCW anywhere in the repo) and `engineering-baseline` (touki is already an established repository) stay unvendored. Both decisions are recorded in the catalog and in the relevant overlays rather than left implicit.

## Validator change this forced

`tools/Validate-AgentSkills.ps1` errored on `related` targets that are not vendored. A **vendored** core's `related` is upstream-owned and may name a portfolio sibling this repo deliberately does not consume; `requires` must still resolve, as must `related` on a repo-owned skill. Documented in `FORMAT.md`.

## Validation

- `tools/Validate-AgentSkills.ps1` - 20 mixed, 16 strict commons cores
- `tools/Validate-AgentFiles.ps1` - passed
- `tools/Test-AgentFileLinks.ps1` - 108 files, all relative links resolve
- `markdownlint-cli2` over CI's glob set - 108 files, 0 issues
- Vendored-payload identity re-verified against the `v0.13.0` tag after every edit

No product code changed, so no build or test run applies to this diff.
