### PR TITLE
Refresh README and feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
 ﻿# Touki (登器): Code for .NET and .NET Framework
 
-[![Build](https://github.com/JeremyKuhne/touki/actions/workflows/dotnet.yml/badge.svg)](https://github.com/JeremyKuhne/touki/actions/workflows/dotnet.yml)
-[![codecov](https://codecov.io/gh/JeremyKuhne/touki/branch/main/graph/badge.svg)](https://codecov.io/gh/JeremyKuhne/touki)
-[![NuGet](https://img.shields.io/nuget/v/KlutzyNinja.Touki.svg)](https://www.nuget.org/packages/KlutzyNinja.Touki/)
+[![Build][build-badge]][build-workflow]
+[![codecov][codecov-badge]][codecov]
+[![NuGet][nuget-badge]][nuget]
+
+[build-badge]: https://github.com/JeremyKuhne/touki/actions/workflows/dotnet.yml/badge.svg
+[build-workflow]: https://github.com/JeremyKuhne/touki/actions/workflows/dotnet.yml
+[codecov-badge]: https://codecov.io/gh/JeremyKuhne/touki/branch/main/graph/badge.svg
+[codecov]: https://codecov.io/gh/JeremyKuhne/touki
+[nuget-badge]: https://img.shields.io/nuget/v/KlutzyNinja.Touki.svg
+[nuget]: https://www.nuget.org/packages/KlutzyNinja.Touki/
 
 Provides useful functionality both for .NET and .NET Framework applications.
 
@@ -18,35 +25,54 @@ Some of the design goals include:
 
 ## Features
 
-- Non allocating interpolated string support on .NET Framework (`$"Age: {age}"`)
-- Formatting directly into `Stream` and `TextWriter` without unnecessary allocations
+- Low-allocation interpolated string support on .NET Framework that avoids
+  boxing and intermediate formatting strings (`$"Age: {age}"`)
+- Handler-backed formatting into `TextWriter`, or raw UTF-16 code-unit output
+  to `Stream`, without materializing a result string
 - Robust and performant `StringSegment` struct for working with substrings without allocations
-- `SpanReader` and `SpanWriter` for efficient reading and writing of data in spans
+- `SpanReader`, `SpanWriter`, and span-based byte run-length encoding
 - `BufferScope<T>` for easy management of temporary `ArrayPool` and stack based buffers
-- `Value` struct for creating strongly typed arbitrary collections of values without boxing most primitives
-- Pooled and single-item-optimized list types (`ArrayPoolList<T>`,
-  `SingleOptimizedList<TItem, TList>`) and ref-counted resource caches
-- `MSBuildEnumerator` for MSBuild-style glob enumeration with no
-  allocations until a match is produced
+- `Value` for carrying primitives, nullables, enums, and object values through
+  one API without boxing supported primitives
+- Pooled, single-item-optimized, and sequence-interning collections
+  (`ArrayPoolList<T>`, `SingleOptimizedList<TItem, TList>`, `SequenceSet<T>`),
+  plus ref-counted resource caches
+- Reusable compiled glob matching for POSIX, Bash/extglob, Git/gitignore,
+  MSBuild, `Microsoft.Extensions.FileSystemGlobbing`, PowerShell, and simple
+  wildcard dialects
+- Lazy file-system glob enumeration with include/exclude patterns,
+  plus a compatibility-focused MSBuild result API with drive-root safety
+- Gitignore parsing with ordered include/exclude rules and best-effort text
+  clipboard access across supported desktop platforms
+- Raw `.resources` inspection, registered-type NRBF deserialization for trusted
+  payloads, and culture side-file string resources
+- Interop ownership helpers that pair native handles with their managed owners
 - Polyfills for many modern .NET BCL APIs on .NET Framework 4.7.2 (see the
-  [polyfill layout doc](.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md) for the full list)
+  [polyfill guide](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md))
 - A `DisposableBase` with double-disposal protection and disposal
   tracking helpers for diagnosing leaks
-- [Roslyn analyzers](docs/analyzers.md) that ship in the package and run
-  automatically - no separate analyzer package to install
+- [Roslyn analyzers](https://github.com/JeremyKuhne/touki/blob/main/docs/analyzers.md)
+  that ship in the package and run automatically - no separate analyzer package
+  to install
 - Much more!
 
 ## Overviews
 
-- [Configuring Your Project for Touki](sample/README.md)
-- [Analyzers Shipped in the Package](docs/analyzers.md)
-- [Reducing String Allocations with Touki](docs/strings.md)
-- [Low-Allocation Collections](docs/collections.md)
-- [Buffers, Span Readers, and Span Writers](docs/buffers.md)
-- [IO Helpers (globs, paths, temp folders, stream formatting)](docs/io.md)
-- [.NET Framework Polyfill Layout & Disambiguation](.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md)
-- [Span Performance on .NET Framework (net472+)](.agents/skills/framework-jit-optimization/references/framework-span-performance.md)
-- [ArrayPool vs Stack Scratch Buffers (net481/net10)](.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md)
+- [Configuring Your Project for Touki](https://github.com/JeremyKuhne/touki/blob/main/sample/README.md)
+- [Analyzers Shipped in the Package](https://github.com/JeremyKuhne/touki/blob/main/docs/analyzers.md)
+- [Reducing String Allocations with Touki](https://github.com/JeremyKuhne/touki/blob/main/docs/strings.md)
+- [Low-Allocation Collections](https://github.com/JeremyKuhne/touki/blob/main/docs/collections.md)
+- [Interning Variable-Length Sequences with `SequenceSet<T>`](https://github.com/JeremyKuhne/touki/blob/main/docs/sequence-set.md)
+- [Buffers, Span Readers, and Span Writers](https://github.com/JeremyKuhne/touki/blob/main/docs/buffers.md)
+- [Compiled Glob Matching and File-System Enumeration](https://github.com/JeremyKuhne/touki/blob/main/docs/globbing.md)
+- [IO Helpers (globs, gitignore, clipboard, paths, temp folders, streams)](https://github.com/JeremyKuhne/touki/blob/main/docs/io.md)
+- [Resources and Legacy Serialization](https://github.com/JeremyKuhne/touki/blob/main/docs/resources.md)
+- .NET Framework polyfill layout and disambiguation:
+  [Polyfill guide](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/polyfill-dotnet-api/references/polyfill-layout.md)
+- Span performance on .NET Framework (net472+):
+  [Reference](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/framework-jit-optimization/references/framework-span-performance.md)
+- Stack and pooled scratch-buffer performance (net481/net10):
+  [Reference](https://github.com/JeremyKuhne/touki/blob/main/.agents/skills/scratch-buffer-strategy/references/arraypool-performance.md)
 
 ## Package Installation
 
@@ -84,7 +110,7 @@ They encode the conventions the library is built on, across a few areas:
 - **Usage and naming** - pattern matching for null checks, and an opt-in
   naming engine that replaces IDE1006.
 
-See [Analyzers Shipped in the Package](docs/analyzers.md) for the full rule
+See [Analyzers Shipped in the Package](https://github.com/JeremyKuhne/touki/blob/main/docs/analyzers.md) for the full rule
 list, what each one flags, and how to configure it.
 
 ## Requirements
@@ -97,4 +123,4 @@ list, what each one flags, and how to configure it.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to contribute to this project.
+See [CONTRIBUTING.md](https://github.com/JeremyKuhne/touki/blob/main/CONTRIBUTING.md) for more information on how to contribute to this project.

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -1,9 +1,11 @@
 # Touki Analyzers
 
 `KlutzyNinja.Touki` ships a set of Roslyn analyzers **inside the package**. There is no
-separate analyzer package to install - adding the package reference is enough, and the
-rules start running on the next build and in the IDE. Two rules, [TOUKI0022](#touki0022)
-and [TOUKI0041](#touki0041), ship disabled and are opted into per project.
+separate analyzer package to install - adding the package reference is enough, and shipped
+rules start running on the next build and in the IDE. This page also documents
+[TOUKI0022](#touki0022) and [TOUKI0023](#touki0023), which are present on the main branch
+but have not been released in the package. TOUKI0041 ships disabled, and the upcoming
+TOUKI0022 is also disabled unless a project opts in.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
@@ -22,8 +24,8 @@ name a field for what it actually is.
 | [TOUKI0011](#touki0011) | Avoid large `stackalloc` allocations | Reliability | Warning | Yes | - |
 | [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | Yes | - |
 | [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
-| [TOUKI0022](#touki0022) | Avoid tab characters | Maintainability | **Disabled** | Yes | - |
-| [TOUKI0023](#touki0023) | Remove trailing whitespace | Maintainability | Warning | - | - |
+| [TOUKI0022](#touki0022) (unreleased) | Avoid tab characters | Maintainability | **Disabled** | Yes | - |
+| [TOUKI0023](#touki0023) (unreleased) | Remove trailing whitespace | Maintainability | Warning | - | - |
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
 | [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
@@ -42,7 +44,14 @@ squiggle lands on exactly the text to change.
 
 ```csharp
 if (value != null)   // TOUKI0001
+{
+  Console.WriteLine(value);
+}
+
 if (value is not null)
+{
+  Console.WriteLine(value);
+}
 ```
 
 ## TOUKI0002
@@ -228,6 +237,8 @@ still builds and its tests pass.
 
 ## TOUKI0022
 
+**Availability: unreleased.**
+
 **Avoid tab characters.** A tab renders at whatever width the reader's editor is set to, so
 a file containing tabs lines up for its author and not for anyone else.
 
@@ -260,6 +271,8 @@ A non-numeric value is skipped rather than treated as an error, so the legal
 `indent_size = tab` falls through to the next source instead of failing the build.
 
 ## TOUKI0023
+
+**Availability: unreleased.**
 
 **Remove trailing whitespace.** Whitespace between the last visible character of a line and
 its line break is invisible in review and becomes diff noise the next time the line is

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -1,7 +1,7 @@
 # Touki Analyzers
 
 `KlutzyNinja.Touki` ships a set of Roslyn analyzers **inside the package**. There is no
-separate analyzer package to install - adding the package reference is enough, and shipped
+separate analyzer package to install - adding the package reference is enough. The shipped
 rules start running on the next build and in the IDE. This page also documents
 [TOUKI0022](#touki0022) and [TOUKI0023](#touki0023), which are present on the main branch
 but have not been released in the package. TOUKI0041 ships disabled, and the upcoming

--- a/docs/buffers.md
+++ b/docs/buffers.md
@@ -1,9 +1,9 @@
 # Buffers, Span Readers, and Span Writers
 
 Touki's buffer-related types in [`touki/Touki/Buffers/`](../touki/Touki/Buffers/)
-are declared in the `Touki` namespace and provide a small set of
-stack-friendly APIs for working with `Span<T>` and `ReadOnlySpan<T>`.
-They're available on .NET 10 and .NET Framework 4.7.2.
+and reader/writer types in [`touki/Touki/Io/`](../touki/Touki/Io/) provide a
+small set of stack-friendly APIs for working with `Span<T>` and
+`ReadOnlySpan<T>`. They're available on .NET 10 and .NET Framework 4.7.2.
 
 ## `BufferScope<T>`
 
@@ -35,48 +35,56 @@ Call `EnsureCapacity(int, bool copy)` to grow the buffer; it switches to
 
 ## `SpanReader<T>`
 
-[`SpanReader<T>`](../touki/Touki/Buffers/SpanReader.cs) is a
+[`SpanReader<T>`](../touki/Touki/Io/SpanReader.cs) is a
 `ref struct` over a `ReadOnlySpan<T>` modeled on `SequenceReader<T>`. It
 constrains `T : unmanaged, IEquatable<T>`, which lets it read primitives,
 chars, bytes, and small structs:
 
 ```csharp
+using Touki.Io;
+
+ReadOnlySpan<byte> payload = [0x01, 0x03, 0x00, 0x00, 0x00, 0xAA, 0xBB, 0xCC];
 SpanReader<byte> reader = new(payload);
 
-if (reader.TryRead(out byte tag) && reader.TryRead<int>(out int length))
+if (reader.TryRead(out byte tag)
+    && reader.TryRead<int>(out int length)
+    && length >= 0)
 {
-    if (reader.TryReadCount(length, out ReadOnlySpan<byte> body))
+    if (reader.TryRead(length, out ReadOnlySpan<byte> body))
     {
-        Process(tag, body);
+        Console.WriteLine($"Tag {tag}: {body.Length} bytes");
     }
 }
 ```
 
 Highlights:
 
-* `TryRead`, `TryReadCount`, `TryReadTo`, `TryPeek`, `Advance`,
+* `TryRead`, `TryReadTo`, `TryPeek`, `Advance`,
   `AdvancePast` - the standard reader surface.
 * `Position`, `Length`, `Unread`, `End` for inspection.
 * `TryRead<TValue>(out TValue)` reads any other unmanaged value type
   out of a `byte` reader via a checked reinterpret.
-* [`SpanReaderExtensions`](../touki/Touki/Buffers/SpanReaderExtensions.cs)
+* [`SpanReaderExtensions`](../touki/Touki/Io/SpanReaderExtensions.cs)
   adds higher-level helpers (e.g. `TryReadPositiveInteger` on a
   `SpanReader<char>`).
 
 ## `SpanWriter<T>`
 
-[`SpanWriter<T>`](../touki/Touki/Buffers/SpanWriter.cs) is the symmetric
+[`SpanWriter<T>`](../touki/Touki/Io/SpanWriter.cs) is the symmetric
 type for writing into a `Span<T>` with `T : unmanaged`:
 
 ```csharp
+using Touki.Io;
+
+ReadOnlySpan<byte> payload = [0x02, 0x03];
 Span<byte> destination = stackalloc byte[64];
 SpanWriter<byte> writer = new(destination);
 
 if (writer.TryWrite((byte)0x01)
-    && writer.TryWrite<int>(payload.Length)
     && writer.TryWrite(payload))
 {
-    Send(destination[..writer.Position]);
+    ReadOnlySpan<byte> written = destination[..writer.Position];
+    Console.WriteLine($"Wrote {written.Length} bytes");
 }
 ```
 
@@ -87,9 +95,21 @@ without exception overhead.
 ## `SpanExtensions`
 
 [`SpanExtensions`](../touki/Touki/Buffers/SpanExtensions.cs) adds
-allocation-free helpers on top of `Span<T>` and `ReadOnlySpan<T>`. For
-downlevel targets, the `Split(...)` / `SpanSplitEnumerator<T>` polyfill
-lives in
+helpers for searching, ordinal comparison, replacement, sorting, line
+enumeration, null-terminated slicing, and other common operations on
+`Span<T>` and `ReadOnlySpan<T>`. For downlevel targets, the `Split(...)` /
+`SpanSplitEnumerator<T>` polyfill lives in
 [`System.SpanExtensions`](../touki/Framework/Polyfills/System/SpanExtensions.SpanSplitEnumerator.cs),
 so the same `foreach (Range range in span.Split(...))` code compiles on
 .NET 10 and .NET Framework 4.7.2.
+
+## `RunLengthEncoder`
+
+[`RunLengthEncoder`](../touki/Touki/Buffers/RunLengthEncoder.cs) provides a
+simple span-based byte run-length codec. The format stores each run as a
+one-byte count followed by the repeated byte; runs longer than 255 bytes are
+split across pairs.
+
+Use `GetEncodedLength` or `GetDecodedLength` to size a destination, then call
+`TryEncode` or `TryDecode`. The `Try` methods return `false` when the destination
+is too small, and `TryDecode` also rejects an odd-length count/value stream.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -2,28 +2,39 @@
 
 Touki ships a small family of collection types under
 [Touki.Collections](../touki/Touki/Collections/) aimed at scenarios where
-the BCL `List<T>`, `LinkedList<T>` or `ConcurrentBag<T>` either allocate
-more than necessary or don't fit the access pattern. They all live on
-.NET 10 and .NET Framework 4.7.2.
+the caller can avoid backing storage, reuse pooled storage, or use a more
+specialized access pattern than the general BCL collections provide. They all
+live on .NET 10 and .NET Framework 4.7.2.
 
 ## Overview
 
-| Type | When to reach for it |
-| --- | --- |
-| [`ListBase<T>`](../touki/Touki/Collections/ListBase.cs) | Abstract base that implements `IList<T>`, `IReadOnlyList<T>`, and non-generic `IList` once so concrete lists only implement the interesting members. |
-| [`ContiguousList<T>`](../touki/Touki/Collections/ContiguousList.cs) | `ListBase<T>` for lists backed by contiguous storage (exposes `AsSpan`-style access for derived types). |
-| [`ArrayBackedList<T>`](../touki/Touki/Collections/ArrayBackedList.cs) | Concrete base for lists backed by a `T[]`; subclasses override how the array is rented and returned. |
-| [`ArrayList<T>`](../touki/Touki/Collections/ArrayList.cs) | Plain `T[]`-backed list (no pooling). |
-| [`ArrayPoolList<T>`](../touki/Touki/Collections/ArrayPoolList.cs) | `T[]`-backed list that rents from `ArrayPool<T>.Shared` and returns the buffer on `Dispose`. |
-| [`SingleOptimizedList<TItem, TList>`](../touki/Touki/Collections/SingleOptimizedList.cs) | Stores a single item inline; promotes to `TList` (e.g. `ArrayPoolList<T>`) only when a second item is added. |
-| [`SinglyLinkedList<T>`](../touki/Touki/Collections/SinglyLinkedList.cs) | Minimal singly-linked list used internally by `RefCountedCache<,,>`; useful when you need cheap front/back inserts without a doubly-linked layout. |
-| [`SequenceSet<T>`](../touki/Touki/Collections/SequenceSet.cs) | Hash set of variable-length `ReadOnlySpan<T>` sequences of unmanaged values, interned into one pooled arena with no per-sequence allocation. For deduplicating or memoizing short value-type sequences. See [sequence-set.md](sequence-set.md). |
-| [`Cache<T>`](../touki/Touki/Collections/Cache.cs) | Fixed-size, thread-safe object pool with a per-thread fast slot. For pooling reusable workers, parsers, builders, etc. |
-| [`RefCountedCache<TValue, TCacheEntryData, TKey>`](../touki/Touki/Collections/RefCountedCache.cs) | Cache that hands out scoped, ref-counted handles to expensive resources (GDI objects, native handles, `Pen`/`Brush`/`Font`-style objects). |
-| [`EmptyList<T>`](../touki/Touki/Collections/EmptyList.cs) | Singleton empty `IList<T>`/`IReadOnlyList<T>`. |
+* [`ListBase<T>`](../touki/Touki/Collections/ListBase.cs) implements `IList<T>`,
+    `IReadOnlyList<T>`, and non-generic `IList` for derived list types.
+* [`ContiguousList<T>`](../touki/Touki/Collections/ContiguousList.cs) adds
+    contiguous, span-style storage access for derived lists.
+* [`ArrayBackedList<T>`](../touki/Touki/Collections/ArrayBackedList.cs) is the
+    base for `T[]`-backed lists whose subclasses control renting and returning.
+* [`ArrayList<T>`](../touki/Touki/Collections/ArrayList.cs) is a non-pooled,
+    array-backed list.
+* [`ArrayPoolList<T>`](../touki/Touki/Collections/ArrayPoolList.cs) rents its
+    backing array from `ArrayPool<T>.Shared` and returns it on `Dispose`.
+* [`SingleOptimizedList<TItem, TList>`](../touki/Touki/Collections/SingleOptimizedList.cs)
+    stores one item inline and promotes to `TList` when a second item is added.
+* [`SinglyLinkedList<T>`](../touki/Touki/Collections/SinglyLinkedList.cs) is a
+    minimal singly linked list with inexpensive front and back insertion.
+* [`SequenceSet<T>`](../touki/Touki/Collections/SequenceSet.cs) interns unmanaged
+    value sequences into one pooled arena. See [sequence-set.md](sequence-set.md).
+* [`Cache<T>`](../touki/Touki/Collections/Cache.cs) is a fixed-size, thread-safe
+    object pool with a per-thread fast slot.
+* [`RefCountedCache<TValue, TCacheEntryData, TKey>`](../touki/Touki/Collections/RefCountedCache.cs)
+    hands out scoped, ref-counted access to expensive or constrained resources.
+* [`EmptyList<T>`](../touki/Touki/Collections/EmptyList.cs) is a singleton empty
+    `IList<T>` / `IReadOnlyList<T>`.
 
-`ListBase<T>` and friends require `T : notnull`; nulls are rejected at the
-boundary. Pooled lists such as `ArrayPoolList<T>` (and
+`ListBase<T>` and friends declare `T : notnull`, so nullable analysis warns when
+callers use nullable item types. Many mutation methods also reject null at run
+time, but the constraint is not a universal runtime check on every mutation
+path. Pooled lists such as `ArrayPoolList<T>` (and
 `SingleOptimizedList<TItem, TList>` once it has promoted to a pooled
 `TList`) return rented buffers to `ArrayPool<T>.Shared` on `Dispose`;
 non-pooled lists such as `ArrayList<T>` simply drop their references and
@@ -31,8 +42,9 @@ let the GC reclaim the backing array.
 
 ## `ArrayPoolList<T>`
 
-A drop-in replacement for `List<T>` whose backing array is rented from
-`ArrayPool<T>.Shared`:
+An `IList<T>`-compatible collection whose backing array is rented from
+`ArrayPool<T>.Shared`. Use it when the caller can own and deterministically
+dispose the list:
 
 ```csharp
 using ArrayPoolList<int> values = new(minimumCapacity: 256);
@@ -73,6 +85,11 @@ if (alsoMatchesSecond)
 }
 ```
 
+On .NET Framework, accessing `Values` or `UnsafeValues` also promotes an inline
+item to the backing `TList`, because the downlevel implementation cannot safely
+expose a span over the inline field. Modern .NET keeps the item inline for those
+accessors.
+
 ## `Cache<T>`
 
 `Cache<T>` is a small, fixed-size pool with a `[ThreadStatic]` fast slot,
@@ -98,8 +115,16 @@ finally
 ```
 
 `cacheSpace: 0` (or any value `< 1`) defaults to
-`Environment.ProcessorCount * 4`. `T` must have a public parameterless
-constructor; `Acquire` falls back to `new T()` when the cache is empty.
+`Environment.ProcessorCount * 4`. `T` must be a reference type with a public
+parameterless constructor; `Acquire` falls back to `new T()` when the cache is
+empty.
+
+When every cache slot is occupied, `Release` disposes the displaced item if it
+implements `IDisposable`. Disposing the cache disposes items in its array-backed
+slots and the calling thread's fast slot, then rejects subsequent releases. Fast
+slots populated on other threads are thread-local and cannot be drained by that
+call. The fast slot is static for each closed `Cache<T>` type, so cache instances
+on the same thread share it rather than having per-instance isolation.
 
 ## `RefCountedCache<TValue, TCacheEntryData, TKey>`
 
@@ -108,29 +133,34 @@ objects, large buffers). Consumers get a `Scope` that ref-counts the
 underlying entry and releases it on `Dispose`:
 
 ```csharp
-public sealed class PenCache : RefCountedCache<Pen, Color, Color>
+using System.IO;
+using Touki.Collections;
+
+using StreamCache streams = new();
+
+RefCountedCache<MemoryStream, int, int>.CacheEntry entry = streams.GetEntry(256);
+using RefCountedCache<MemoryStream, int, int>.Scope scope = entry.CreateScope();
+
+MemoryStream stream = scope;
+stream.WriteByte(0x2A);
+
+public sealed class StreamCache : RefCountedCache<MemoryStream, int, int>
 {
-    protected override CacheEntry CreateEntry(Color key, bool cached)
-        => new PenCacheEntry(key, cached);
+    protected override CacheEntry CreateEntry(int capacity, bool cached)
+        => new StreamCacheEntry(capacity, cached);
 
-    protected override bool IsMatch(Color key, CacheEntry entry)
-        => key == entry.Data;
+    protected override bool IsMatch(int capacity, CacheEntry entry)
+        => capacity == entry.Data;
 
-    private sealed class PenCacheEntry : CacheEntry
+    private sealed class StreamCacheEntry : CacheEntry
     {
-        private readonly Pen _pen;
-        public PenCacheEntry(Color color, bool cached) : base(color, cached)
-            => _pen = new Pen(color);
-        public override Pen Object => _pen;
+        private readonly MemoryStream _stream;
+
+        public StreamCacheEntry(int capacity, bool cached) : base(capacity, cached)
+            => _stream = new MemoryStream(capacity);
+
+        public override MemoryStream Object => _stream;
     }
-}
-
-PenCache pens = new();
-
-using (RefCountedCache<Pen, Color, Color>.Scope scope = pens.GetEntry(Color.Red))
-{
-    Pen pen = scope; // implicit conversion
-    DrawWith(pen);
 }
 ```
 

--- a/docs/extglob.md
+++ b/docs/extglob.md
@@ -2,7 +2,7 @@
 
 Reference for the extended-glob feature surface in
 [`Touki.Io.Globbing`](../touki/Touki/Io/Globbing/). Covers the five extglob
-constructs, how they relate to the &quot;normal&quot; glob metacharacters
+constructs, how they relate to the "normal" glob metacharacters
 (`*`, `?`, `[...]`), how to turn the feature on, and where touki agrees with
 - or deliberately diverges from - bash.
 
@@ -13,18 +13,19 @@ the **gotchas**.
 
 ## Normal glob (the baseline)
 
-Without `AllowExtGlob` set, every dialect that touki ships understands the
-classic three metacharacters, with per-dialect tweaks for path semantics and
-escape characters:
+Without `AllowExtGlob` set, every dialect supports `*` and `?`; the remaining
+syntax varies by dialect:
 
-| Token   | Meaning                                                              |
-| ------- | -------------------------------------------------------------------- |
-| `?`     | match exactly one character (path-aware dialects: not the separator) |
-| `*`     | match zero or more characters (path-aware: not the separator)        |
-| `**`    | globstar: match zero or more path segments - only when `AllowGlobStar` is set or the dialect has implicit globstar (`MSBuild`, `FileSystemGlobbing`, `Git`) |
-| `[...]` | character class - only on dialects with `HasCharacterClasses()` (POSIX family, Bash, Git, FSG) |
-| `[!...]` / `[^...]` | negated character class (same dialects)                    |
-| `\<c>`  | escape `<c>` to its literal form - only on dialects with an escape character (POSIX family, Bash, Git use `\\`; PowerShell uses `` ` ``) |
+* `?` matches exactly one character, excluding the separator in path-aware
+  dialects.
+* `*` matches zero or more characters, excluding the separator in path-aware
+  dialects.
+* `**` matches zero or more path segments when `AllowGlobStar` is set or the
+  dialect enables it implicitly (`MSBuild`, `FileSystemGlobbing`, and `Git`).
+* `[...]` and its `[!...]` / `[^...]` negated forms are character classes in the
+  POSIX-family, Bash, Git, and PowerShell dialects.
+* `\<c>` escapes a character in POSIX-family, Bash, and Git patterns.
+  PowerShell uses backtick instead.
 
 Each `?` consumes exactly one character. `*` is greedy at the matcher's NFA
 level. Neither `*` nor `?` crosses the path separator on path-aware
@@ -36,7 +37,7 @@ described below are silently treated as ordinary text unless you opt in via
 
 ## Extended glob (what `AllowExtGlob` adds)
 
-Extended glob (extglob in bash, `FNM_EXTMATCH` in POSIX, `extendedglob` in
+Extended glob (extglob in bash, GNU/glibc `fnmatch(FNM_EXTMATCH)`, `extendedglob` in
 ksh / zsh) layers five **alternation constructs** over the normal glob
 grammar. Each consists of one of `?`, `*`, `+`, `@`, `!`, followed
 immediately by `(`, a `|`-separated list of inner patterns, and a closing
@@ -77,9 +78,9 @@ falling back to a character class or post-filtering.
 ### The negation form
 
 `!(...)` is the only construct without a direct equivalent in the
-normal-glob grammar. Read it as &quot;the surrounding pattern matches when
+normal-glob grammar. Read it as "the surrounding pattern matches when
 the input slice taken by this construct is **not** one of the listed
-alternatives, taken as a whole consumed slice.&quot;
+alternatives, taken as a whole consumed slice."
 
 For `!(foo)bar`:
 
@@ -98,9 +99,9 @@ multiple constructs joined with explicit separators (e.g., `!(foo)/!(bar)`).
 ### Nesting and recursion
 
 Constructs nest freely up to the
-[`MaxExtGlobDepth`](../touki/Touki/Io/Globbing/GlobSpecification.Factory.cs)
+[`MaxExtGlobDepth`](../touki/Touki/Io/Globbing/GlobSpecification.Limits.cs)
 cap of 8 levels. Example: `*(a|@(b|c))d` matches any sequence built from
-the &quot;literal `a`&quot; and &quot;exactly one of `b` or `c`&quot;
+the "literal `a`" and "exactly one of `b` or `c`"
 alternatives, followed by `d`. So `d`, `ad`, `bd`, `cd`, `abcd`, etc., all
 match; `abxd` doesn't (the inner `@(b|c)` doesn't accept `x`).
 
@@ -113,20 +114,19 @@ The option is opt-in on every dialect:
 ```csharp
 using Touki.Io.Globbing;
 
-GlobSpecification spec = GlobSpecification.Compile(
+using GlobSpecification specification = GlobSpecification.Compile(
     pattern: "@(*.cs|*.txt)",
     dialect: GlobDialect.Bash,
-    options: GlobOptions.AllowGlobStar | GlobOptions.AllowExtGlob);
+    options: GlobOptions.AllowExtGlob);
 
-bool matched = spec.IsMatch("foo.cs");      // true
-bool ignored = spec.IsMatch("foo.json");    // false
+bool matched = specification.IsMatch("foo.cs");      // true
+bool ignored = specification.IsMatch("foo.json");    // false
 ```
 
 When `AllowExtGlob` is omitted, the pattern `@(*.cs|*.txt)` is interpreted
-as the literal characters `@(*.cs|*.txt)` and matches no real-world file
-name - the parser does not warn, so the silent no-match can be
-surprising. If your pattern is user-supplied, prefer to pass the flag
-unconditionally.
+without extglob alternation - the parser does not warn, so the resulting match
+behavior can be surprising. If your pattern language permits extglob, pass the
+flag explicitly.
 
 The same flag lights the feature up regardless of dialect - it is
 honored by every dialect that uses the bytecode interpreter
@@ -136,29 +136,33 @@ in-code equivalent of `shopt -s extglob`.
 
 ## Limits and error cases
 
-To keep the interpreter's recursion bounded and prevent pathological
-backtracking, the compile pipeline enforces a small set of hard limits:
+To bound pattern structure and alternation work, the compile pipeline enforces a
+small set of hard limits:
 
 | Limit                                    | Default | Failure mode                                         |
 | ---------------------------------------- | ------- | ---------------------------------------------------- |
 | Nesting depth                            | 8       | `GlobFormatException(FeatureLimitExceeded)`          |
 | Alternatives per construct               | 32      | `GlobFormatException(FeatureLimitExceeded)`          |
 | Alternation block bytecode length        | 65535   | `GlobFormatException(PatternTooLarge)`               |
-| Total `AltStart` opcodes in one program  | bounded by block length |                                       |
 
-These caps are enforced **at compile time**, so a runtime match never
-spins on a pathological pattern.
+These caps are enforced **at compile time**. The iterative matcher engages a
+failure memo after 1,000 choice visits, records at most $2^{20}$ failed states,
+and bounds native recursion by the compiled nesting limit. Its temporary frame
+and range buffers can still grow through `ArrayPool<T>`. Matching cost and memory
+therefore vary with the pattern and input, so applications accepting both from
+untrusted sources should also pass an application-specific `maxPatternLength`
+and enforce input length and time limits.
 
 Compile-time errors specific to extglob:
 
 | Error code                                       | Triggered by                                  |
 | ------------------------------------------------ | --------------------------------------------- |
-| `GlobCompileErrorCode.UnterminatedExtGlob`       | `?(foo`, `*(a|b`, &hellip;                    |
+| `GlobCompileErrorCode.UnterminatedExtGlob`       | `?(foo`, `*(a|b`, ...                         |
 | `GlobCompileErrorCode.InvalidExtGlobBody`        | Empty body `?()`. Allowed: `?(|)` (explicit empty alternative). |
 | `GlobCompileErrorCode.FeatureLimitExceeded`      | Nesting or alternative count exceeds the cap. |
 
-`DanglingEscape` and `UnterminatedClass` continue to apply when an
-extglob body contains malformed escapes or classes.
+`DanglingEscape` continues to apply when an extglob body contains a malformed
+escape. An unterminated character class is treated as literal text.
 
 ## Path-aware semantics
 
@@ -178,15 +182,14 @@ On path-aware dialects (`PosixPath`, `Bash`, `Git`, `MSBuild`,
 ## Performance notes
 
 - When `AllowExtGlob` is **off** or the pattern contains no extglob
-  construct, the encoder emits byte-identical bytecode and the matcher
-  uses the same iterative two-slot loop as today. There is one extra
-  branch per pattern character (the scanner check for the `kind` chars
-  followed by `(`) in the compile path, and one extra branch in the
-  matcher dispatch.
-- When extglob is in use, the matcher takes a recursive path
+  construct, the encoder emits the ordinary glob bytecode and matching uses the
+  ordinary iterative engine. Extglob detection adds a scanner check during
+  compilation and a dispatch check during matching.
+- When extglob is in use, the iterative extglob engine
   ([`CompiledGlobStrategy.ExtGlob.cs`](../touki/Touki/Io/Globbing/CompiledGlobStrategy.ExtGlob.cs))
-  with a stack-allocated `Span<ProgramRange>` of 32 entries. No heap
-  allocations on the match path.
+  starts with stack-backed work buffers sized from the extglob depth. More
+  complex matches can grow through pooled buffers and engage failure-memo
+  storage.
 - Specialized strategies (`Literal`, `Prefix`, `Suffix`, `Contains`,
   `PrefixSuffix`, `Any`, `GlobStarFileName`) disqualify themselves on
   extglob patterns and route to the general bytecode path. This is
@@ -202,7 +205,7 @@ On path-aware dialects (`PosixPath`, `Bash`, `Git`, `MSBuild`,
 The `Bash` dialect with `AllowGlobStar | AllowExtGlob` set is compared
 row-by-row against `bash -O extglob -O globstar` in
 [`ExtGlobOracleTests.Bash`](../touki.tests/Touki/Io/Globbing/ExtGlobOracleTests.Bash.cs)
-(~552 rows of 24 patterns &times; 23 inputs). The oracle runs on Linux
+(~552 rows of 24 patterns x 23 inputs). The oracle runs on Linux
 and Windows Git Bash; macOS is skipped because Apple ships GNU bash 3.2,
 which predates several of the cases the oracle relies on
 ([`BashInterop.cs`](../touki.tests/Touki/Io/Globbing/BashInterop.cs)
@@ -210,15 +213,26 @@ short-circuits to `null` there).
 
 ### Documented divergence
 
-Bash and touki agree on every oracle row in the suite **except one**:
+Bash and touki have a known negation divergence outside the current oracle row
+set:
 
-| Pattern | Input | bash 5.x | touki | Notes                                                                                                       |
-| ------- | ----- | -------- | ----- | ----------------------------------------------------------------------------------------------------------- |
-| `!(*)`  | `""`  | match    | no match | Touki reads negation as &quot;no alternative matches the slice exactly.&quot; The inner `*` matches the empty slice exactly, so `L = 0` is rejected. Bash short-circuits this case. |
+| Pattern | Input | bash 5.x | touki |
+| ------- | ----- | -------- | ----- |
+| `!(*)`  | `""`  | match    | no match |
 
-The row is skipped in the oracle so any other future drift surfaces as a
-hard failure. If you write a pattern of the form `!(*)X`, prefer
-`?(X)` or `+(X)` to express the intent more directly.
+Touki reads negation as "no alternative matches the slice exactly." The inner
+`*` matches the empty slice exactly, so `L = 0` is rejected. Bash short-circuits
+this case.
+
+The case is tracked separately from the oracle matrix. If you write a pattern
+of the form `!(*)X`, prefer `?(X)` or `+(X)` to express the intent more directly.
+
+There is also a leading-dot limitation in extglob alternations. If any
+alternative starts with a literal dot, a sibling alternative led by `*`, `?`, a
+character class, or globstar can consume a leading dot even when
+`MatchLeadingDot` is not set. Avoid mixing literal-dot and wildcard-led
+alternatives when hidden-name exclusion matters, or set `MatchLeadingDot` when
+leading-dot matching is intentional.
 
 ## When to reach for extglob
 
@@ -228,9 +242,9 @@ hard failure. If you write a pattern of the form `!(*)X`, prefer
 - Useful with `GlobDialect.Bash` to round-trip shell scripts that already
   use extglob.
 - Useful inside `.gitignore`-style rule sets when you want to ignore
-  &quot;everything but `keep.log`&quot; in a single rule: `!(keep).log`.
+  "everything but `keep.log`" in a single rule: `!(keep).log`.
 
-If your only goal is &quot;match either of these literal filenames,&quot;
+If your only goal is "match either of these literal filenames,"
 the un-extended `[abc]` character class is still the cheapest answer:
 `[ab]c` matches `ac` or `bc` without the alternation machinery.
 
@@ -240,7 +254,5 @@ the un-extended `[abc]` character class is still the cheapest answer:
   per-flag reference.
 - [`GlobDialect.cs`](../touki/Touki/Io/Globbing/GlobDialect.cs) -
   per-dialect defaults.
-- [`globbing-feature-plan.md`](globbing-feature-plan.md) - internal
-  planning, including the F1.3 / F1.4 rollout history.
 - [bash Pattern Matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html)
 - [fnmatch(3) FNM_EXTMATCH](https://man7.org/linux/man-pages/man3/fnmatch.3.html)

--- a/docs/extglob.md
+++ b/docs/extglob.md
@@ -3,7 +3,7 @@
 Reference for the extended-glob feature surface in
 [`Touki.Io.Globbing`](../touki/Touki/Io/Globbing/). Covers the five extglob
 constructs, how they relate to the "normal" glob metacharacters
-(`*`, `?`, `[...]`), how to turn the feature on, and where touki agrees with
+(`*`, `?`, `[...]`), how to turn the feature on, and where Touki agrees with
 - or deliberately diverges from - bash.
 
 If you only need the surface-level API contract, the
@@ -213,10 +213,10 @@ short-circuits to `null` there).
 
 ### Documented divergence
 
-Bash and touki have a known negation divergence outside the current oracle row
+Bash and Touki have a known negation divergence outside the current oracle row
 set:
 
-| Pattern | Input | bash 5.x | touki |
+| Pattern | Input | bash 5.x | Touki |
 | ------- | ----- | -------- | ----- |
 | `!(*)`  | `""`  | match    | no match |
 

--- a/docs/globbing.md
+++ b/docs/globbing.md
@@ -1,0 +1,148 @@
+# Compiled Glob Matching and File-System Enumeration
+
+Touki separates glob compilation from file-system enumeration. Use
+[`GlobSpecification`](../touki/Touki/Io/Globbing/GlobSpecification.cs) to
+compile and reuse a pattern, [`GlobEnumerator`](../touki/Touki/Io/GlobEnumerator.cs)
+to apply compiled glob semantics to a directory tree, and
+[`MSBuildEnumerator`](../touki/Touki/Io/MSBuildEnumerator.cs) when compatibility
+with MSBuild item specifications is the primary requirement.
+
+All three APIs are available on .NET 10 and .NET Framework 4.7.2.
+
+## Compile and reuse a pattern
+
+`GlobSpecification` is immutable and can be reused concurrently. Evaluation
+reuses the compiled strategy; path-aware dialects that need to coalesce runs of
+separators may rent a temporary buffer.
+
+```csharp
+using Touki.Io.Globbing;
+
+using GlobSpecification specification = GlobSpecification.Compile(
+    pattern: "**/*.cs",
+    dialect: GlobDialect.PosixPath,
+    options: GlobOptions.AllowGlobStar);
+
+bool matches = specification.IsMatch("src/Program.cs");
+```
+
+Use `TryCompile` when a pattern can be malformed. It returns a
+[`GlobCompileError`](../touki/Touki/Io/Globbing/GlobCompileError.cs) instead of
+throwing `GlobFormatException`. For patterns supplied by untrusted input, pass an
+application-specific `maxPatternLength` to bound compilation work.
+
+## Dialects
+
+[`GlobDialect`](../touki/Touki/Io/Globbing/GlobDialect.cs) selects the behavior
+that the compiler models:
+
+| Dialect | Behavior modeled |
+| --- | --- |
+| `Posix` | POSIX `fnmatch` without path-aware separator handling. |
+| `PosixPath` | POSIX path matching, where ordinary wildcards do not cross separators. |
+| `Bash` | Bash pattern matching, with opt-in globstar and extglob constructs. |
+| `Git` | Git `wildmatch` / `.gitignore`, including negation and path anchors. |
+| `MSBuild` | MSBuild item-wildcard matching. |
+| `FileSystemGlobbing` | `Microsoft.Extensions.FileSystemGlobbing.Matcher` behavior. |
+| `Simple` | `System.IO.Enumeration.FileSystemName` simple `*` and `?` matching. |
+| `PowerShell` | PowerShell `-like` / `WildcardPattern` behavior. |
+
+The dialect controls defaults such as path awareness, separators, case folding,
+leading-dot handling, escaping, and whether `**` is enabled. The names identify
+the behavior being modeled; they do not promise drop-in parity for every default
+or edge case.
+
+### Compatibility notes
+
+* **`Posix` / `PosixPath`** - Touki applies `FNM_PERIOD`-style leading-dot
+    protection by default; POSIX `fnmatch` requires the `FNM_PERIOD` flag. Use
+    `MatchLeadingDot` to model a call without that flag. Path mode currently
+    protects only the start of the complete input, not each segment.
+* **`Git`** - Touki protects a leading dot by default, while Git `wildmatch`
+    normally lets wildcards consume it. Use `MatchLeadingDot` for that behavior.
+* **`Simple`** - Touki defaults to case-sensitive matching and treats backslash
+    literally. `FileSystemName.MatchesSimpleExpression` defaults to
+    `ignoreCase: true` and uses backslash as an escape. `IgnoreCase` aligns
+    casing; there is no Simple-dialect escape mode today.
+* **`FileSystemGlobbing`** - Touki defaults to case-sensitive matching. The
+    parameterless `Matcher` defaults to case-insensitive matching; use
+    `IgnoreCase` to align it.
+* **`PowerShell`** - Touki defaults to case-sensitive matching like a bare
+    `WildcardPattern`; PowerShell `-like` is case-insensitive, so use
+    `IgnoreCase` for that casing. Touki additionally accepts POSIX-style bracket
+    negation and named classes, which PowerShell does not.
+
+See the MSBuild section below and [Extended Glob Patterns](extglob.md) for
+additional result-model, multiple-asterisk, extglob, and leading-dot limits.
+
+## Options
+
+[`GlobOptions`](../touki/Touki/Io/Globbing/GlobOptions.cs) enables behavior that
+is not already provided by a dialect's defaults:
+
+| Option | Effect |
+| --- | --- |
+| `IgnoreCase` | Enables the dialect's case-insensitive comparison mode. |
+| `MatchLeadingDot` | Allows wildcards to consume a leading `.`. |
+| `NoEscape` | Treats the dialect's escape character as a literal. |
+| `AllowGlobStar` | Enables path-aware `**` matching where it is not enabled by default. |
+| `AllowExtGlob` | Enables `?(...)`, `*(...)`, `+(...)`, `@(...)`, and `!(...)`. |
+
+See [Extended Glob Patterns](extglob.md) for extglob syntax, limits, and the
+intentional differences between supported dialects.
+
+## Enumerate a directory tree
+
+`GlobEnumerator` accepts one include and zero or more exclude patterns. Its default
+dialect is `PosixPath`; select another dialect explicitly when the pattern comes
+from another ecosystem.
+
+```csharp
+using Touki.Io;
+using Touki.Io.Globbing;
+
+string projectDirectory = @"C:\repos\my-project";
+
+using GlobEnumerator enumerator = GlobEnumerator.Create(
+    includePattern: "**/*.cs",
+    excludePattern: "**/obj/**",
+    rootDirectory: projectDirectory,
+    dialect: GlobDialect.PosixPath,
+    globOptions: GlobOptions.AllowGlobStar);
+
+while (enumerator.MoveNext())
+{
+    Console.WriteLine(enumerator.Current);
+}
+```
+
+Results are relative to `rootDirectory`. Use `GlobOptions.IgnoreCase` to select
+case-insensitive matching. Pass `EnumerationOptions` to customize recursion,
+inaccessible-directory handling, and other file-system traversal behavior.
+
+## MSBuild item specifications
+
+`MSBuildEnumerator` is a separate compatibility-oriented path for MSBuild include
+and exclude specifications. It handles the common `*`, `?`, and recursive `**`
+forms. When `projectDirectory` is supplied, relative specifications produce
+paths relative to that directory; with a null project directory, results are
+fully qualified.
+
+Use `MSBuildEnumerator.CreateResult` when the distinction between a search, an
+invalid specification returned verbatim, an empty result, and a rejected
+drive-root search matters. Its
+[`MSBuildSearchAction`](../touki/Touki/Io/MSBuildSearchAction.cs) reports that
+disposition without collapsing every outcome into an empty sequence.
+For `RunSearch`, the caller owns `result.Enumerator` and must dispose it after
+enumeration.
+Recursive drive or share enumeration is rejected by default; opt in with
+[`MSBuildEnumerationOptions.AllowDriveEnumeration`](../touki/Touki/Io/MSBuildEnumerationOptions.cs)
+only when the caller deliberately permits that scope.
+
+The drive/share policy check is specific to `CreateResult`. The ordinary
+`Create` overloads do not reject a recursive drive-root specification; prefer
+`CreateResult` when a specification comes from an external source.
+
+The implementation targets MSBuild item semantics, but it is not a drop-in copy of
+every `FileMatcher` shortcut and edge case. Callers that require exact oracle parity
+for unusual literal or trailing-separator inputs should validate those cases.

--- a/docs/io.md
+++ b/docs/io.md
@@ -3,13 +3,28 @@
 [`Touki.Io`](../touki/Touki/Io/) collects file-system, path, and stream
 helpers that are useful on both .NET 10 and .NET Framework 4.7.2.
 
-## `MSBuildEnumerator`: glob-style file matching
+## Glob matching and enumeration
+
+Touki supports reusable compiled matching and file-system enumeration across
+POSIX, Bash/extglob, Git/gitignore, MSBuild,
+`Microsoft.Extensions.FileSystemGlobbing`, PowerShell, and simple wildcard
+dialects.
+
+[`GlobSpecification`](../touki/Touki/Io/Globbing/GlobSpecification.cs) compiles
+an immutable pattern for repeated `IsMatch` calls.
+[`GlobEnumerator`](../touki/Touki/Io/GlobEnumerator.cs) applies one include and
+zero or more exclude patterns to a directory tree. See
+[Compiled Glob Matching and File-System Enumeration](globbing.md) for the
+dialect matrix, options, examples, and the distinction between these APIs and
+MSBuild item enumeration.
+
+## `MSBuildEnumerator`: MSBuild item specifications
 
 [`MSBuildEnumerator`](../touki/Touki/Io/MSBuildEnumerator.cs) walks the
-file system using the same wildcard semantics MSBuild uses for items
-like `<Compile Include="src/**/*.cs" Exclude="**/obj/**"/>`. It builds
-on `Microsoft.IO.Enumeration` (or `System.IO.Enumeration` on .NET) and
-is allocation-free until it produces a match.
+file system using MSBuild-style item include and exclude specifications such as
+`<Compile Include="src/**/*.cs" Exclude="**/obj/**"/>`. It builds on
+`Microsoft.IO.Enumeration` (or `System.IO.Enumeration` on .NET). After setup,
+enumeration is lazy and matched paths are materialized as strings.
 
 Supported wildcards:
 
@@ -24,19 +39,73 @@ using Touki.Io;
 
 string projectDirectory = @"C:\repos\my-project";
 
-foreach (string path in MSBuildEnumerator.Create(
+using MSBuildEnumerator enumerator = MSBuildEnumerator.Create(
     fileSpec: @"src\**\*.cs",
     excludeSpecs: @"**\obj\**;**\bin\**",
-    projectDirectory: projectDirectory))
+  projectDirectory: projectDirectory);
+
+while (enumerator.MoveNext())
 {
-    Console.WriteLine(path);
+  Console.WriteLine(enumerator.Current);
 }
 ```
 
 By default, paths are returned relative to `projectDirectory` when the
-spec is not fully qualified, matching MSBuild's behavior. Casing follows
-the OS (case-insensitive on Windows / macOS / iOS, case-sensitive on
-Linux); pass an `EnumerationOptions` to override.
+spec is not fully qualified. A null project directory produces fully qualified
+results. Casing follows the OS (case-insensitive on Windows / macOS / iOS,
+case-sensitive on Linux); pass an `EnumerationOptions` to override.
+
+Use `MSBuildEnumerator.CreateResult` when the caller needs to distinguish a
+normal search from an invalid specification returned verbatim, an empty result,
+or a recursive drive/share search rejected by the default safety guard.
+[`MSBuildSearchAction`](../touki/Touki/Io/MSBuildSearchAction.cs) reports the
+outcome. Set
+[`MSBuildEnumerationOptions.AllowDriveEnumeration`](../touki/Touki/Io/MSBuildEnumerationOptions.cs)
+only when whole-drive or whole-share recursion is intentional.
+When the action is `RunSearch`, the caller owns and must dispose the result's
+`Enumerator`.
+
+The drive/share policy check is specific to `CreateResult`. The ordinary
+`Create` overloads do not reject a recursive drive-root specification; prefer
+`CreateResult` for externally supplied specifications.
+
+This API targets MSBuild item semantics but intentionally differs from a few
+`FileMatcher` shortcuts and edge cases. It should not be treated as a byte-for-byte
+replacement for every internal MSBuild outcome.
+
+## Gitignore rules and matcher composition
+
+[`GitIgnore`](../touki/Touki/Io/GitIgnore.cs) parses `.gitignore` text with the
+`Git` glob dialect. Blank lines and comments are skipped, `!` re-includes a
+previously excluded path, and rule order is preserved. `Parse` returns an owned
+[`OrderedMatchSet`](../touki/Touki/Io/OrderedMatchSet.cs), so dispose the set when
+matching is complete.
+
+`OrderedMatchSet` uses last-matching-rule-wins semantics. Its
+`includeByDefault: true` mode models gitignore behavior; the default `false` mode
+acts as an ordered allow list. Directory-only excludes claim their subtree during
+file-system traversal, so a later file-level include below a pruned directory is
+not reached.
+
+Touki currently strips all trailing spaces and tabs from rules. Unlike Git, an
+escaped trailing space is not preserved as part of the pattern.
+
+[`MatchSet`](../touki/Touki/Io/MatchSet.cs) provides a different composition
+model: any matching exclude overrides all includes. Both set types implement
+`IEnumerationMatcher` for use with `MatchEnumerator<TResult>` or a custom walker.
+
+## Clipboard
+
+[`Clipboard`](../touki/Touki/Io/Clipboard.cs) is a best-effort plain-text
+clipboard API. Check `IsAvailable`, then use `TryGetText`, `TrySetText`, or
+`TryClear`; transport failures and clipboard contention are reported as `false`
+rather than thrown exceptions.
+
+On .NET, Touki supports the Windows clipboard, macOS AppKit when available, and
+Linux Wayland/X11 when a supported helper (`wl-copy` / `wl-paste`, `xclip`, or
+`xsel`) is present. The .NET Framework build uses the Windows provider. Headless
+or unsupported environments fall back to an unavailable provider whose
+operations return `false`.
 
 ## `Paths`
 
@@ -48,6 +117,13 @@ Linux); pass an `EnumerationOptions` to override.
   and .NET Framework.
 * `MatchesExpression(name, expression, matchCasing, matchType)` for
   one-off glob matching without spinning up an enumerator.
+* `IsSameOrSubdirectory(firstDirectory, secondDirectory, ignoreCase)` for
+  normalized, fully qualified string-path comparisons. It does not resolve
+  symbolic links or junctions.
+* `RemoveRelativeSegments(...)` for collapsing separator runs and `.` / `..`
+  segments without first combining with a root.
+* `ChangeAlternateDirectorySeparators(string)` for normalizing separator
+  characters to the platform primary separator.
 
 ## `TempFolder`
 
@@ -69,7 +145,13 @@ Failures during deletion (e.g. files held open by another process) are
 swallowed so `Dispose` is safe to call from `finally` blocks and test
 teardown.
 
-## `WriteFormatted` on `Stream` and `TextWriter`
+## `Stream` and `TextWriter` extensions
+
+[`StreamExtensions`](../touki/Touki/Io/StreamExtensions.cs) adds synchronous and
+asynchronous `Read` / `Write` overloads for `ArraySegment<byte>`, including
+cancellation-token support for the asynchronous forms.
+
+### `WriteFormatted`
 
 [`TextWriterExtensions`](../touki/Touki/Io/TextWriterExtensions.cs) (and
 its `Stream`-targeted partial in
@@ -80,6 +162,13 @@ target without an intermediate `string` allocation. See
 [strings.md](strings.md) for the full picture.
 
 ```csharp
-using FileStream stream = File.Create("log.txt");
-stream.WriteFormatted($"Started at {DateTime.UtcNow:O} for user {userId}");
+using Touki.Io;
+
+int userId = 42;
+using StreamWriter writer = File.CreateText("log.txt");
+writer.WriteFormatted($"Started at {DateTime.UtcNow:O} for user {userId}");
 ```
+
+`Stream.WriteFormatted` is a lower-level overload that writes the builder's raw
+UTF-16 code-unit bytes without a text encoding or byte-order mark. Use a
+`TextWriter` such as `StreamWriter` for encoded text files and protocols.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -83,6 +83,7 @@ cultures, and falls back to the assembly's embedded neutral resources.
 
 ```csharp
 using System.Globalization;
+using System.IO;
 using Touki.Resources;
 
 SatelliteStringResourceManager resources = new(

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -83,13 +83,11 @@ cultures, and falls back to the assembly's embedded neutral resources.
 
 ```csharp
 using System.Globalization;
-using System.IO;
 using Touki.Resources;
 
 SatelliteStringResourceManager resources = new(
     baseName: "MyApp.Resources.Strings",
-    assembly: typeof(Program).Assembly,
-    probeRoot: Path.Combine(AppContext.BaseDirectory, "resources"));
+    assembly: typeof(Program).Assembly);
 
 string? greeting = resources.GetString("Greeting", new CultureInfo("de-DE"));
 ```

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,100 @@
+# Resources and Legacy Serialization
+
+[`Touki.Resources`](../touki/Touki/Resources/) provides low-level access to
+binary `.resources` files, inspection and opt-in deserialization of .NET
+Remoting Binary Format (NRBF) payloads, and localized string lookup from loose
+culture side files. These APIs are available on .NET 10 and .NET Framework
+4.7.2.
+
+## `RawResourceReader`
+
+[`RawResourceReader`](../touki/Touki/Resources/RawResourceReader.cs) reads the
+default version 2 binary `.resources` format without using `ResourceReader` to
+deserialize stored values. It can locate entries by ordinal, case-sensitive
+name; report their index, type code, and raw byte length; and copy names or
+supported value bytes into caller-provided spans or streams.
+
+```csharp
+using Touki.Resources;
+
+using RawResourceReader reader = RawResourceReader.CreateFromFile("My.resources");
+
+if (reader.TryFindResource("Greeting", out ResourceLocation location))
+{
+    Console.WriteLine($"{location.TypeCode}: {location.ByteLength} bytes");
+}
+```
+
+`CreateFromFile` memory-maps the file and transfers ownership of that mapping to
+the reader, so dispose it. The `ReadOnlyMemory<byte>` constructor reads
+caller-owned memory instead.
+
+The reader exposes raw content for strings, primitives, byte arrays, and stream
+entries. For serialized user types it exposes type metadata but not value bytes,
+and it never instantiates the stored type. A bad `.resources` magic number
+throws `ArgumentException`. A version other than 2 - including input truncated
+before the version field - throws `NotSupportedException`. Other malformed or
+truncated structures generally throw `BadImageFormatException`. The format
+reader supports little-endian systems.
+
+## Inspecting NRBF payloads
+
+[`BinaryFormattedObject`](../touki/Touki/Resources/BinaryFormattedObject.cs)
+parses an NRBF stream into `System.Formats.Nrbf` records. Construction does not
+instantiate payload-defined types, and the supplied stream remains open.
+
+```csharp
+using Touki.Resources;
+
+using FileStream stream = File.OpenRead("payload.bin");
+BinaryFormattedObject payload = new(stream);
+
+Console.WriteLine(payload.RootRecord);
+Console.WriteLine($"{payload.RecordMap.Count} records");
+```
+
+Parsing is inspection-only and does not instantiate payload-defined types, but
+deserialization must remain opt-in: call `Deserialize` only for trusted payloads
+with an allowlisted resolver. Parsing still allocates record state, so callers
+accepting untrusted input should impose an application-specific payload-size
+limit.
+
+Use `RootRecord`, `RecordMap`, and the record-id indexer when structural
+inspection is enough.
+
+### Deserializing trusted payloads
+
+`Deserialize()` instantiates the parsed graph through an
+[`ITypeResolver`](../touki/Touki/ITypeResolver.cs). The default
+[`RegisteredTypeResolver`](../touki/Touki/RegisteredTypeResolver.cs) recognizes
+a fixed framework type set; register each additional trusted type explicitly.
+
+Deserialization can run serialization constructors, `ISerializable` code,
+callbacks, and `IObjectReference` implementations. Register only trusted types
+and call `Deserialize()` only for trusted payloads. It is a one-shot operation:
+a second call throws even when the first call failed.
+
+## `SatelliteStringResourceManager`
+
+[`SatelliteStringResourceManager`](../touki/Touki/Resources/SatelliteStringResourceManager.cs)
+extends `ResourceManager` with loose side-file probing. It looks under
+`<probeRoot>/<culture>/<baseName>.resources`, merges specific and parent
+cultures, and falls back to the assembly's embedded neutral resources.
+
+```csharp
+using System.Globalization;
+using Touki.Resources;
+
+SatelliteStringResourceManager resources = new(
+    baseName: "MyApp.Resources.Strings",
+    assembly: typeof(Program).Assembly,
+    probeRoot: Path.Combine(AppContext.BaseDirectory, "resources"));
+
+string? greeting = resources.GetString("Greeting", new CultureInfo("de-DE"));
+```
+
+Only intrinsic string entries are loaded from side files. Other primitives,
+arrays, streams, and serialized user types are skipped without deserialization.
+Unreadable files, unsupported resource formats, and structurally malformed side
+files are treated as absent. The two-argument constructor uses the `resources`
+directory under `AppContext.BaseDirectory` as its probe root.

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -1,38 +1,79 @@
 # Reducing String Allocations with Touki
 
-String creation is one of the most frequently executed operations in many .NET programs. Every time a string is built or modified a new instance is allocated and old instances eventually need to be reclaimed by the garbage collector.
+String creation is one of the most frequently executed operations in many .NET
+programs. Every time a string is built or modified, a new instance is allocated
+and old instances eventually need to be reclaimed by the garbage collector.
 
-On modern .NET platforms (from .NET 6 onward) the compiler rewrites interpolated strings into a lower‑level representation using **interpolated string handlers** - see *String Interpolation in C# 10 and .NET 6* ([.NET Blog](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/)). Benchmarks published in that post show a ~40 % throughput improvement and about a five‑fold reduction in memory allocation compared with `string.Format`.
+On modern .NET platforms (from .NET 6 onward) the compiler rewrites interpolated
+strings into a lower-level representation using **interpolated string handlers** -
+see *String Interpolation in C# 10 and .NET 6*
+([.NET Blog](https://devblogs.microsoft.com/dotnet/string-interpolation-in-c-10-and-net-6/)).
+Benchmarks published in that post show a ~40% throughput improvement and about a
+five-fold reduction in memory allocation compared with `string.Format`.
 
-For developers who need to target .NET Framework 4.8 or earlier, these improvements are not available because the framework lacks the built‑in interpolated‑string handler and many of the supporting APIs. The **Touki** library bridges that gap by providing a default interpolated string handler and polyfills for .NET Framework 4.7.2 and later.
+For developers who need to target .NET Framework 4.8 or earlier, these
+improvements are not available because the framework lacks the built-in
+interpolated-string handler and many of the supporting APIs. The **Touki** library
+bridges that gap by providing a default interpolated string handler and polyfills
+for .NET Framework 4.7.2 and later.
 
-**Touki** also provides additional high‑performance text utilities on **both** .NET 10 **and** .NET Framework 4.7.2 and later so you can enjoy performant, lower allocation string handling while still supporting older frameworks.
+**Touki** also provides additional high-performance text utilities on **both**
+.NET 10 **and** .NET Framework 4.7.2 and later, so applications can use
+lower-allocation string handling while still supporting older frameworks.
 
 ## Why reducing allocations matters
 
-Strings in .NET are immutable. Every time you use `string.Concat`, `StringBuilder.Append` or `string.Format`, a new string instance is created. Frequent allocations lead to:
+Strings in .NET are immutable. Operations such as `string.Concat` and
+`string.Format` materialize result strings. `StringBuilder` mutates its own
+buffer, but growing that buffer can allocate additional arrays and `ToString()`
+materializes the final string. Frequent allocations lead to:
 
-* **Garbage‑collection pressure** - short‑lived strings can quickly accumulate to dramatic weight on the GC.
-* **Hidden boxing** - `string.Format` boxes value‑type arguments into an `object[]` array and creates the array itself (see the .NET Blog post above), generating unnecessary heap activity.
-* **Parsing costs** - `string.Format` interprets the composite format string at run‑time, so when you don’t know the format string until run‑time you miss out on compile‑time parsing or optimized code paths.
+* **Garbage-collection pressure** - short-lived strings can quickly accumulate to
+  significant weight on the GC.
+* **Hidden boxing** - `string.Format` boxes value-type arguments into an
+  `object[]` array and creates the array itself (see the .NET Blog post above),
+  generating unnecessary heap activity.
+* **Parsing costs** - `string.Format` interprets the composite format string at
+  run time, so when the format is not known until run time, compile-time parsing
+  and optimized paths are unavailable.
 
-## Touki’s approach
+## Touki's approach
 
-Touki (登器) provides low allocation interpolated‑string support for .NET Framework 4.7.2 and a number of additional helpers for *all* .NET versions. Touki ports portions of the .NET runtime under the MIT license and augments them with extra functionality. On .NET 10 it defers to the built‑in handler; on .NET Framework 4.7.2 it provides its own implementation.
+Touki (登器) provides low-allocation interpolated-string support for .NET
+Framework 4.7.2 and additional helpers for all supported targets. Touki ports
+portions of the .NET runtime under the MIT license and augments them with extra
+functionality. On .NET 10 it defers to the built-in handler; on .NET Framework
+4.7.2 it provides its own implementation.
 
 ### `ValueStringBuilder`: the core string builder
 
-`ValueStringBuilder` is a `ref struct` that builds strings on the stack when small and rents from `ArrayPool<char>` when they grow (see source code ([ValueStringBuilder.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Text/ValueStringBuilder.cs))). It also serves as an **interpolated‑string handler** so helper methods can accept it directly. Based on the `ValueStringBuilder` .NET uses internally, you can now leverage it for your performance critical scenarios.
+`ValueStringBuilder` is a `ref struct` that starts with caller-supplied storage,
+typically a small stack buffer, and rents pooled byte-backed storage when it
+grows (see [`ValueStringBuilder.cs`](../touki/Touki/Text/ValueStringBuilder.cs)).
+It also serves as an **interpolated-string handler** so helper methods can accept
+it directly. Based on the `ValueStringBuilder` .NET uses internally, you can now
+leverage it for performance-critical scenarios.
 
-Touki’s polyfilled `DefaultInterpolatedStringHandler` for .NET 4.7.2 ([source](https://github.com/JeremyKuhne/touki/blob/main/touki/Framework/Polyfills/System.Runtime.CompilerServices/DefaultInterpolatedStringHandler.cs)) simply wraps a `ValueStringBuilder`. On .NET Framework the compiler targets interpolated strings to this handler, giving you the same low‐allocation benefits that newer runtimes provide.
+Touki's polyfilled `DefaultInterpolatedStringHandler` for .NET 4.7.2
+([source](../touki/Framework/Polyfills/System.Runtime.CompilerServices/DefaultInterpolatedStringHandler.cs))
+wraps a `ValueStringBuilder`. On .NET Framework the compiler targets interpolated
+strings to this handler, providing low-allocation formatting similar to newer
+runtimes.
 
-### `Strings`: lower‑cost `Format` methods
+### `StringExtensions`: lower-cost `Format` methods
 
-The static `StringExtensions` class augments `string.Format` methods. Its `FormatValue` overloads accept either **unmanaged generic arguments** or **Touki’s `Value` struct** to avoid boxing (see [Strings.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Text/Strings.cs)). Internally it builds the result with a `ValueStringBuilder` and a lightly modified version of the runtime’s `StringBuilder.AppendFormatHelper` ([ValueStringBuilder.Formatting.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Text/ValueStringBuilder.Formatting.cs)) that:
+The static `StringExtensions` class augments `string.Format`-style formatting.
+`FormatValue<T>` accepts one unmanaged argument, while `FormatValues` accepts
+Touki `Value` arguments to avoid boxing heterogeneous primitive values (see
+[`StringExtensions.cs`](../touki/Touki/Text/StringExtensions.cs)). Internally it
+builds the result with a `ValueStringBuilder` and a modified version of the
+runtime's `StringBuilder.AppendFormatHelper`
+([`ValueStringBuilder.Formatting.cs`](../touki/Touki/Text/ValueStringBuilder.Formatting.cs))
+that:
 
-1. Uses a small stack‑allocated span for formatting value types,
-2. Avoids the internal `ISpanFormattable` interface that doesn’t exist on .NET Framework,
-3. Uses Touki’s `Value` struct to skip boxing,
+1. Uses a small stack-allocated span for formatting value types,
+2. Avoids the internal `ISpanFormattable` interface that doesn't exist on .NET Framework,
+3. Uses Touki's `Value` struct to skip boxing,
 4. Works with `ReadOnlySpan<char>` and `ReadOnlySpan<Value>` so neither the format string nor argument array allocates.
 
 ```csharp
@@ -43,13 +84,14 @@ using Touki.Text;
 string fmt = "{0} - {1:F2}";
 double num = 3.14159;
 
-// No boxing for either the string or the double, no intermediate strings
+// No boxing for the int or double; only the result string is materialized.
 string result = string.FormatValues(fmt, 42, num);
 ```
 
 ### `StringSegment`: efficient substring handling
 
-`StringSegment` ([source](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Text/StringSegment.cs)) wraps a section of an existing string in a normal (non-ref) struct that can be stored off of the stack:
+[`StringSegment`](../touki/Touki/Text/StringSegment.cs) wraps a section of an
+existing string in a normal (non-ref) struct that can be stored off the stack:
 
 ```csharp
 string csv = "apple,banana,cherry";
@@ -60,7 +102,7 @@ StringSegment first = full[..comma]; // "apple"
 // or iterate via
 
 StringSegment right = full;
-while (right.TrySplit(';', out StringSegment left, out right))
+while (right.TrySplit(',', out StringSegment left, out right))
 {
     // left will be "apple", "banana", "cherry" in each iteration
 }
@@ -68,30 +110,65 @@ while (right.TrySplit(';', out StringSegment left, out right))
 
 ### `Value` struct: variant values without boxing
 
-Touki’s `Value` struct ([source](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Value.cs)) holds primitive, nullable and enum types without boxing. `Strings.Format` overloads take `Value` to avoid boxing even when argument types vary:
+Touki's [`Value`](../touki/Touki/Value.cs) struct
+holds primitive, nullable, and enum types without boxing. `string.FormatValues`
+overloads take `Value` to avoid boxing even when argument types vary:
 
 ```csharp
 string fmt = "{0} - {1} - {2}";
 string result = string.FormatValues(fmt, 1, 2.5, "three"); // "1 - 2.5 - three"
 ```
-For fully supported types there are implicit conversions to `Value`. `Value.Create<T>()` creates for all other types. Note that *all* enums are also supported, but do not have implicit converters.
+For fully supported types there are implicit conversions to `Value`.
+`Value.Create<T>()` creates values for all other types. All enums are supported,
+but do not have implicit conversions.
 
-### `Stream` and `StreamWriter` extensions
+### `Stream` and `TextWriter` extensions
 
-`StreamExtensions` adds `WriteFormatted` so you can stream interpolated strings without an intermediate allocation ([StreamExtensions.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Touki/Io/StreamExtensions.cs)). Unit tests demonstrate the pattern ([StreamExtensionsTests.cs](https://github.com/JeremyKuhne/touki/blob/main/touki.tests/Touki/StreamExtensionsTests.cs)):
+`StreamExtensions` and `TextWriterExtensions` add handler-backed `WriteFormatted`
+overloads that format an interpolated value without materializing a result string
+([`StreamExtensions.cs`](../touki/Touki/Io/StreamExtensions.cs) and
+[`TextWriterExtensions.cs`](../touki/Touki/Io/TextWriterExtensions.cs)). Unit
+tests demonstrate the pattern
+([`StreamExtensionsTests.cs`](../touki.tests/Touki/StreamExtensionsTests.cs)):
 
 ```csharp
+using Touki.Io;
+
+string name = "Touki";
+Version version = new(1, 0);
 using MemoryStream stream = new();
+using StringWriter textWriter = new();
+
 stream.WriteFormatted($"Library: {name}, Version: {version}");
 
-textWriter.WriteFormatted($"Library: {name}, Version: {version}")
+textWriter.WriteFormatted($"Library: {name}, Version: {version}");
 ```
 
-The builder writes directly to the stream buffer, so no extra string is created.
+The handler formats through `ValueStringBuilder`-backed storage and writes that
+content to the target, so this overload does not create an intermediate result
+string. On .NET, a separate optimization overload accepts an existing `string`;
+that overload is not available on .NET Framework.
 
-## Bringing modern interpolation to .NET Framework 4.7.2
+The `Stream` overload writes raw UTF-16 code-unit bytes without applying a text
+encoding or byte-order mark. Use a `TextWriter` such as `StreamWriter` when the
+target is an encoded text file or protocol.
 
-C# 10 lets you define **custom interpolated‐string handlers**. Touki supplies `DefaultInterpolatedStringHandler` and `AssertInterpolatedStringHandler` ([AssertInterpolatedStringHandler.cs](https://github.com/JeremyKuhne/touki/blob/main/touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs)). The former is the special class C# looks for to implement interpolated strings. The latter is used to provide a low allocation cross compiled assertions in the `Debugging` class:
+### Related text views and comparers
+
+[`StringSpan`](../touki/Touki/Text/StringSpan.cs) provides a stack-only view over
+string data when the slice does not need to be stored, while `StringSegment` is a
+normal struct that can live in fields and collections.
+[`StringSegmentComparer`](../touki/Touki/Text/StringSegmentComparer.cs) provides
+ordinal and ordinal-ignore-case equality and ordering for `StringSegment` values.
+
+## Bringing modern interpolation to .NET Framework 4.7.2
+
+C# 10 lets you define **custom interpolated-string handlers**. Touki supplies
+`DefaultInterpolatedStringHandler` and `AssertInterpolatedStringHandler`
+([AssertInterpolatedStringHandler.cs](../touki/Framework/Polyfills/System.Diagnostics/AssertInterpolatedStringHandler.cs)).
+The former is the special class C# looks for to implement interpolated strings.
+The latter provides low-allocation cross-compiled assertions in the `Debugging`
+class:
 
 ```csharp
 // Works on *both* .NET 10 and .NET Framework 4.7.2

--- a/sample/README.md
+++ b/sample/README.md
@@ -14,9 +14,7 @@ points are:
   via `<TargetFrameworks>`.
 - Set `<ImplicitUsings>disable</ImplicitUsings>` so you can redirect
   `System.IO` to `Microsoft.IO` on .NET Framework without ambiguity.
-- Reference `KlutzyNinja.Touki`. On .NET Framework, also reference
-  `Microsoft.Bcl.Memory` (Touki's transitive dependency surfaces a
-  security advisory until the Touki package is updated).
+- Reference `KlutzyNinja.Touki`.
 - On .NET (non-framework), opt into `<IsAotCompatible>true</IsAotCompatible>`
   to get the AOT analyzer. Touki itself is written to be AOT-friendly.
 
@@ -34,16 +32,14 @@ of the BCL in your code:
   `Touki.Interop`, `Touki.Io`, and `Touki.Text` so extension members
   light up on the BCL types you already use (`Convert`, `Random`,
   `string`, `Stream`, ...).
-- On .NET Framework, adds `Framework.Touki` for the small amount of
-  Touki-specific framework-only code.
 
 ## What the example demonstrates
 
 [ExampleClass.cs](ExampleClass.cs) calls a handful of APIs that "just
 work" on both targets thanks to Touki:
 
-- `DefaultInterpolatedStringHandler` (interpolated strings without
-  allocations on .NET Framework).
+- `DefaultInterpolatedStringHandler` (low-allocation interpolation on .NET
+  Framework without boxing or intermediate formatting strings).
 - `System.Numerics.BitOperations` (`LeadingZeroCount`, `TrailingZeroCount`,
   `PopCount`, `IsPow2`).
 - `System.Threading.Lock` and `lock(Lock)` syntax.

--- a/sample/sample.csproj
+++ b/sample/sample.csproj
@@ -54,11 +54,6 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
-  <!-- Silence the security warning until we take an updated Touki -->
-  <ItemGroup Condition="'$(TargetFramework)' == '$(DotNetFrameworkVersion)'">
-    <PackageReference Include="Microsoft.Bcl.Memory" />
-  </ItemGroup>
-
   <!--
     Resource related
   -->

--- a/touki/Touki/Io/Globbing/GlobDialect.cs
+++ b/touki/Touki/Io/Globbing/GlobDialect.cs
@@ -9,15 +9,18 @@ namespace Touki.Io.Globbing;
 /// </summary>
 /// <remarks>
 ///  <para>
-///   Each dialect targets the documented behavior of an existing matcher. See
-///   <c>docs/globbing.md</c> for the dialect matrix and intentional deviations.
+///   Each dialect models the syntax and core behavior of an existing matcher.
+///   Defaults and edge cases are not always drop-in compatible. See
+///   <c>docs/globbing.md</c> for the dialect matrix and intentional differences.
 ///  </para>
 /// </remarks>
 public enum GlobDialect
 {
     /// <summary>
     ///  POSIX <c>fnmatch</c> without <c>FNM_PATHNAME</c>. Wildcards match across
-    ///  any character including <c>/</c>.
+    ///  any character including <c>/</c>. Touki applies <c>FNM_PERIOD</c>-style
+    ///  leading-dot protection by default; use <see cref="GlobOptions.MatchLeadingDot"/>
+    ///  to model a call without that flag.
     /// </summary>
     /// <remarks>
     ///  <para>
@@ -30,7 +33,8 @@ public enum GlobDialect
 
     /// <summary>
     ///  <see cref="Posix"/> with path-mode semantics (<c>FNM_PATHNAME</c>). Wildcards
-    ///  do not cross separator characters.
+    ///  do not cross separator characters. Leading-dot protection currently applies
+    ///  only at the start of the complete input, not after every separator.
     /// </summary>
     PosixPath,
 
@@ -47,7 +51,9 @@ public enum GlobDialect
     Bash,
 
     /// <summary>
-    ///  Git <c>wildmatch</c> / <c>.gitignore</c> semantics.
+    ///  Git <c>wildmatch</c> / <c>.gitignore</c> semantics. Touki protects a
+    ///  leading dot by default; use <see cref="GlobOptions.MatchLeadingDot"/> to
+    ///  align with ordinary Git <c>wildmatch</c> behavior.
     /// </summary>
     /// <remarks>
     ///  <para>
@@ -69,7 +75,8 @@ public enum GlobDialect
 
     /// <summary>
     ///  <c>Microsoft.Extensions.FileSystemGlobbing.Matcher</c> semantics. May diverge
-    ///  from <see cref="MSBuild"/> on edge cases; see <c>docs/globbing.md</c>.
+    ///  from <see cref="MSBuild"/> on edge cases. Touki is case-sensitive by default,
+    ///  unlike the parameterless <c>Matcher</c>; see <c>docs/globbing.md</c>.
     /// </summary>
     /// <remarks>
     ///  <para>
@@ -80,7 +87,9 @@ public enum GlobDialect
     FileSystemGlobbing,
 
     /// <summary>
-    ///  Simple file-name expression matching (<c>*</c> and <c>?</c> only).
+    ///  Simple file-name expression matching (<c>*</c> and <c>?</c> only). Touki
+    ///  defaults to case-sensitive matching and treats backslash literally, unlike
+    ///  the defaults of <c>FileSystemName.MatchesSimpleExpression</c>.
     /// </summary>
     /// <remarks>
     ///  <para>
@@ -91,7 +100,10 @@ public enum GlobDialect
     Simple,
 
     /// <summary>
-    ///  PowerShell <c>-like</c> / <c>WildcardPattern</c> semantics.
+    ///  PowerShell <c>WildcardPattern</c>-style semantics. Touki defaults to
+    ///  case-sensitive matching; use <see cref="GlobOptions.IgnoreCase"/> for
+    ///  <c>-like</c>-style casing. Bracket-expression extensions differ; see
+    ///  <c>docs/globbing.md</c>.
     /// </summary>
     /// <remarks>
     ///  <para>

--- a/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
+++ b/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
@@ -63,12 +63,13 @@ internal static class GlobDialectExtensions
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   POSIX-family, MSBuild, and FileSystemGlobbing dialects use backslash
-    ///   (<c>\</c>) as the escape character. PowerShell <c>WildcardPattern</c> /
+    ///   POSIX, PosixPath, Bash, and Git dialects use backslash (<c>\</c>) as
+    ///   the escape character. PowerShell <c>WildcardPattern</c> /
     ///   <c>-like</c> uses backtick (<c>`</c>) per
     ///   <see href="https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_wildcards">
-    ///   about_Wildcards</see>. The <see cref="GlobDialect.Simple"/> dialect (matching
-    ///   <c>FileSystemName.MatchesSimpleExpression</c>) has no escape character.
+    ///   about_Wildcards</see>. <see cref="GlobDialect.Simple"/>,
+    ///   <see cref="GlobDialect.MSBuild"/>, and
+    ///   <see cref="GlobDialect.FileSystemGlobbing"/> have no escape character.
     ///  </para>
     ///  <para>
     ///   When <see cref="GlobOptions.NoEscape"/> is set the method returns <c>'\0'</c>
@@ -89,19 +90,19 @@ internal static class GlobDialectExtensions
     }
 
     /// <summary>
-    ///  Returns <see langword="true"/> when the dialect's documented default allows a
+    ///  Returns <see langword="true"/> when the dialect's current default allows a
     ///  leading <c>.</c> in the input to be matched by a wildcard (<c>?</c>, <c>*</c>,
     ///  or a character class), without the caller having to set
     ///  <see cref="GlobOptions.MatchLeadingDot"/> explicitly.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   POSIX-family dialects (<see cref="GlobDialect.Posix"/>,
-    ///   <see cref="GlobDialect.PosixPath"/>, <see cref="GlobDialect.Bash"/>,
-    ///   <see cref="GlobDialect.Git"/>) treat a leading <c>.</c> as a "hidden" marker
-    ///   per <c>fnmatch</c>'s <c>FNM_PERIOD</c> rule, requiring a literal <c>.</c>
-    ///   in the pattern. All other dialects - including PowerShell,
-    ///   Simple, MSBuild, FileSystemGlobbing - do not.
+    ///   POSIX, PosixPath, Bash, and Git currently require a literal leading
+    ///   <c>.</c>; all other dialects allow wildcard matches. The POSIX-family
+    ///   behavior models <c>FNM_PERIOD</c> only at the start of the complete input,
+    ///   not after each path separator. Git <c>wildmatch</c> normally allows a
+    ///   wildcard to match a leading dot, so use <see cref="GlobOptions.MatchLeadingDot"/>
+    ///   when that compatibility is required.
     ///  </para>
     /// </remarks>
     public static bool MatchesLeadingDotByDefault(this GlobDialect dialect) => dialect switch

--- a/touki/Touki/Io/Globbing/GlobOptions.cs
+++ b/touki/Touki/Io/Globbing/GlobOptions.cs
@@ -41,7 +41,7 @@ public enum GlobOptions
     ///     <description>
     ///      <b>Globstar</b> (<c>**</c>): implicitly enabled for
     ///      <see cref="GlobDialect.MSBuild"/>, <see cref="GlobDialect.FileSystemGlobbing"/>,
-    ///      <see cref="GlobDialect.Bash"/>, and <see cref="GlobDialect.Git"/>. Other
+    ///      and <see cref="GlobDialect.Git"/>. <see cref="GlobDialect.Bash"/> and other
     ///      path-aware dialects require <see cref="AllowGlobStar"/>.
     ///     </description>
     ///    </item>
@@ -109,19 +109,21 @@ public enum GlobOptions
 
     /// <summary>
     ///  When set, wildcards (<c>?</c>, <c>*</c>, character classes) may match a leading
-    ///  <c>.</c>. Equivalent to <c>fnmatch</c> being called without <c>FNM_PERIOD</c>.
+    ///  <c>.</c>, overriding dialects that otherwise require a literal dot.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   The default (flag cleared) matches POSIX behavior: a leading <c>.</c> must be
-    ///   matched by a literal <c>.</c> in the pattern.
+    ///   Defaults vary by dialect. POSIX-family dialects and the current Git dialect
+    ///   require a literal leading dot; other dialects allow wildcard matches. The
+    ///   current path-aware implementation applies this restriction only at the start
+    ///   of the complete input, not after each separator.
     ///  </para>
     /// </remarks>
     MatchLeadingDot = 1 << 1,
 
     /// <summary>
-    ///  Treat the backslash character as a literal rather than as an escape character.
-    ///  Equivalent to <c>FNM_NOESCAPE</c>.
+    ///  Disable the dialect's escape character, treating it as a literal. This is
+    ///  backslash for POSIX-family, Bash, and Git patterns, and backtick for PowerShell.
     /// </summary>
     NoEscape = 1 << 2,
 
@@ -134,13 +136,13 @@ public enum GlobOptions
     AllowGlobStar = 1 << 3,
 
     /// <summary>
-    ///  Enable extended-glob constructs: <c>?(…)</c>, <c>*(…)</c>, <c>+(…)</c>,
-    ///  <c>@(…)</c>, <c>!(…)</c>.
+    ///  Enable extended-glob constructs: <c>?(...)</c>, <c>*(...)</c>, <c>+(...)</c>,
+    ///  <c>@(...)</c>, <c>!(...)</c>.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Models bash extglob (<c>shopt -s extglob</c>) and POSIX
-    ///   <c>fnmatch(FNM_EXTMATCH)</c>. Each construct is a
+    ///   Models bash extglob (<c>shopt -s extglob</c>) and the GNU/glibc
+    ///   <c>fnmatch(FNM_EXTMATCH)</c> extension. Each construct is a
     ///   <c>|</c>-separated list of inner glob patterns. Inner wildcards still
     ///   respect path semantics - <c>*</c> and <c>?</c> inside an
     ///   alternative do not cross the path separator on path-aware dialects.

--- a/touki/Touki/Io/Globbing/GlobSpecification.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.cs
@@ -11,8 +11,10 @@ namespace Touki.Io.Globbing;
 ///  <para>
 ///   <see cref="GlobSpecification"/> is the output of
 ///   <see cref="Compile(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>:
-///   a thread-safe, allocation-free-to-evaluate parse result that holds the encoded
-///   pattern (literal table, opcode program, etc.) and the pattern-level flags.
+///   a thread-safe parse result that holds the encoded pattern (literal table,
+///   opcode program, etc.) and the pattern-level flags. Common evaluation paths
+///   allocate no managed objects; separator coalescing and complex extglob matching
+///   may rent or allocate temporary storage.
 ///   The specification is not bound to any enumeration root and may be reused
 ///   concurrently against many different roots via <see cref="CreateMatcher(string?)"/>.
 ///  </para>

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -82,7 +82,10 @@ public class MSBuildEnumerator : MatchEnumerator<string>
     ///  The specification of files to enumerate, which can include wildcards.
     /// </param>
     /// <param name="projectDirectory">
-    ///  The project directory. Returns paths relative to this directory.
+    ///  The project directory used to resolve the specification. Relative
+    ///  specifications return paths relative to this directory. When
+    ///  <see langword="null"/>, <see cref="Environment.CurrentDirectory"/> is used
+    ///  for resolution and results are fully qualified.
     /// </param>
     /// <param name="options">
     ///  Enumeration options that control matching behavior and recursion. If <see langword="null"/>,


### PR DESCRIPTION
## Summary

- Expand the README to cover compiled globbing, resources, gitignore/clipboard, collections, and interop.
- Add dedicated globbing and resources guides; correct linked overview examples, ownership rules, compatibility limits, and analyzer availability.
- Align public glob/MSBuild XML docs and remove the sample's obsolete direct package workaround.

## Validation

- Debug and Release tests: `net10.0`, `net11.0`, `net481`
- Release library and sample builds
- NuGet pack/readme inspection
- Documentation link, line-length, and whitespace checks