### PR TITLE
Clarify MSBuild glob casing defaults

### DIFF
--- a/docs/globbing.md
+++ b/docs/globbing.md
@@ -72,9 +72,11 @@ or edge case.
     literals rather than single-character wildcards.
 * **`MSBuild`** - `GlobSpecification` models `MSBuildGlob`'s in-memory logical
     matcher, including recursive repeated anchors, `*.*`, and trailing-dot
-    patterns. Physical `FileMatcher.GetFiles` also inherits platform filesystem
-    wildcard behavior; use `MSBuildEnumerator` when that enumeration behavior is
-    required.
+    patterns. The dialect uses Unicode ordinal case-insensitive matching by
+    default. Current `MSBuildGlob` and `FileMatcher.IsMatch` APIs do not expose
+    case-sensitive matching. Physical `FileMatcher.GetFiles` also inherits
+    platform filesystem wildcard behavior; use `MSBuildEnumerator` when that
+    enumeration behavior is required.
 * **`PowerShell`** - Touki defaults to case-sensitive matching like a bare
     `WildcardPattern`; PowerShell `-like` is case-insensitive, so use
     `IgnoreCase` for that casing. Touki additionally accepts POSIX-style bracket
@@ -90,7 +92,7 @@ is not already provided by a dialect's defaults:
 
 | Option | Effect |
 | --- | --- |
-| `IgnoreCase` | Enables the dialect's case-insensitive comparison mode. |
+| `IgnoreCase` | Enables the dialect's case-insensitive comparison mode; redundant for `MSBuild`, which is already case-insensitive by default. |
 | `MatchLeadingDot` | Allows wildcards to consume a leading `.`. |
 | `NoEscape` | Treats the dialect's escape character as a literal. |
 | `AllowGlobStar` | Enables path-aware `**` matching where it is not enabled by default. |
@@ -154,9 +156,10 @@ while (enumerator.MoveNext())
 }
 ```
 
-Results are relative to `rootDirectory`. Use `GlobOptions.IgnoreCase` to select
-case-insensitive matching. Set `GlobEnumerationOptions.EnumerationOptions` to customize
-recursion, inaccessible-directory handling, and other file-system traversal behavior.
+Results are relative to `rootDirectory`. Except for `MSBuild`, dialects are
+case-sensitive by default; use `GlobOptions.IgnoreCase` to select case-insensitive
+matching. Set `GlobEnumerationOptions.EnumerationOptions` to customize recursion,
+inaccessible-directory handling, and other file-system traversal behavior.
 
 ## Compose custom matchers
 

--- a/docs/io.md
+++ b/docs/io.md
@@ -1,7 +1,7 @@
 # IO Helpers
 
 [`Touki.Io`](../touki/Touki/Io/) collects file-system, path, and stream
-helpers that are useful on both .NET 10 and .NET Framework 4.7.2.
+helpers that are useful on .NET 10, .NET 11, and .NET Framework 4.7.2.
 
 ## Glob matching and enumeration
 
@@ -56,7 +56,9 @@ spec is not fully qualified. A null project directory produces fully qualified
 results. Physical filesystem traversal follows platform casing (case-insensitive
 on Windows / macOS / iOS, case-sensitive on Linux); MSBuild's logical wildcard
 post-filter phases remain case-insensitive. Pass an `EnumerationOptions` to
-override the physical matching options.
+override the physical matching options. Current `MSBuildGlob` and
+`FileMatcher.IsMatch` APIs do not expose case-sensitive matching;
+`GlobDialect.MSBuild` likewise uses case-insensitive matching by default.
 
 Use `MSBuildEnumerator.CreateResult(request)` when the caller needs to distinguish a
 normal [`MSBuildSearchResult`](../touki/Touki/Io/MSBuildSearchResult.cs), an invalid

--- a/touki.tests/Touki/Io/Globbing/GlobAdditionalCoverageTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobAdditionalCoverageTests.cs
@@ -318,8 +318,8 @@ public class GlobAdditionalCoverageTests
     [TestMethod]
     public void LiteralGlobStrategy_MatchesFile_TwoSpan_Unicode()
     {
-        // MSBuild dialect's default IgnoreCaseKind is Unicode; a pure literal pattern
-        // routes to LiteralGlobStrategy with the Unicode branch in two-span MatchCore.
+        // MSBuild selects Unicode by default; a pure literal pattern routes to
+        // LiteralGlobStrategy with the Unicode branch in two-span MatchCore.
         using GlobMatch matcher = GlobSpecification.Compile(
             "a/b/file.cs",
             GlobDialect.MSBuild).CreateSession(Root);

--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
@@ -228,6 +228,13 @@ public partial class GlobSpecificationTests
             .IsMatch(input).Should().Be(expected);
 
     [TestMethod]
+    [DataRow(GlobOptions.None)]
+    [DataRow(GlobOptions.IgnoreCase)]
+    public void IsMatch_MSBuildDialect_IsCaseInsensitiveByDefault(GlobOptions options) =>
+        GlobSpecification.Compile("*.CS", GlobDialect.MSBuild, options)
+            .IsMatch("source.cs").Should().BeTrue();
+
+    [TestMethod]
     [DataRow(".hidden", ".hidden", true)]
     [DataRow("*hidden", ".hidden", false)]
     [DataRow("?hidden", ".hidden", false)]

--- a/touki.tests/Touki/Io/Globbing/IgnoreCaseKindTests.cs
+++ b/touki.tests/Touki/Io/Globbing/IgnoreCaseKindTests.cs
@@ -25,7 +25,6 @@ public class IgnoreCaseKindTests
         dialect.DefaultIgnoreCaseKind(GlobOptions.None).Should().Be(IgnoreCaseKind.Off);
 
     [TestMethod]
-    // MSBuild matches case-insensitively regardless of the IgnoreCase option.
     [DataRow(GlobOptions.None)]
     [DataRow(GlobOptions.IgnoreCase)]
     [DataRow(GlobOptions.NoEscape)]
@@ -33,7 +32,7 @@ public class IgnoreCaseKindTests
         GlobDialect.MSBuild.DefaultIgnoreCaseKind(options).Should().Be(IgnoreCaseKind.Unicode);
 
     [TestMethod]
-    // POSIX-family dialects default to strict ASCII case folding.
+    // POSIX-family dialects use strict ASCII folding when IgnoreCase is set.
     [DataRow(GlobDialect.Posix)]
     [DataRow(GlobDialect.PosixPath)]
     [DataRow(GlobDialect.Bash)]
@@ -42,7 +41,7 @@ public class IgnoreCaseKindTests
         dialect.DefaultIgnoreCaseKind(GlobOptions.IgnoreCase).Should().Be(IgnoreCaseKind.Ascii);
 
     [TestMethod]
-    // .NET-native dialects default to full Unicode ordinal case folding.
+    // .NET-native dialects use full Unicode ordinal folding when IgnoreCase is set.
     [DataRow(GlobDialect.MSBuild)]
     [DataRow(GlobDialect.FileSystemGlobbing)]
     [DataRow(GlobDialect.Simple)]
@@ -67,6 +66,8 @@ public class IgnoreCaseKindTests
     // verify the dialect's default flowed through to the runtime path.
     [DataRow(GlobDialect.Posix, GlobOptions.None, (int)IgnoreCaseKind.Off)]
     [DataRow(GlobDialect.Posix, GlobOptions.IgnoreCase, (int)IgnoreCaseKind.Ascii)]
+    [DataRow(GlobDialect.MSBuild, GlobOptions.None, (int)IgnoreCaseKind.Unicode)]
+    [DataRow(GlobDialect.MSBuild, GlobOptions.IgnoreCase, (int)IgnoreCaseKind.Unicode)]
     [DataRow(GlobDialect.Simple, GlobOptions.None, (int)IgnoreCaseKind.Off)]
     [DataRow(GlobDialect.Simple, GlobOptions.IgnoreCase, (int)IgnoreCaseKind.Unicode)]
     [DataRow(GlobDialect.PowerShell, GlobOptions.None, (int)IgnoreCaseKind.Off)]

--- a/touki/Touki/Io/Globbing/GlobDialect.cs
+++ b/touki/Touki/Io/Globbing/GlobDialect.cs
@@ -63,7 +63,9 @@ public enum GlobDialect
     Git,
 
     /// <summary>
-    ///  MSBuild item-wildcard semantics.
+    ///  MSBuild item-wildcard semantics. This dialect uses Unicode ordinal
+    ///  case-insensitive matching by default. Current <c>MSBuildGlob</c> and
+    ///  <c>FileMatcher.IsMatch</c> APIs do not expose case-sensitive matching.
     /// </summary>
     /// <remarks>
     ///  <para>

--- a/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
+++ b/touki/Touki/Io/Globbing/GlobDialectExtensions.cs
@@ -11,32 +11,33 @@ namespace Touki.Io.Globbing;
 internal static class GlobDialectExtensions
 {
     /// <summary>
-    ///  Returns the case-fold rule a given dialect applies when
-    ///  <see cref="GlobOptions.IgnoreCase"/> is set. See
+    ///  Returns the case-fold rule for a dialect and its options. See
     ///  <see cref="GlobDialect"/> for the per-dialect source citations.
     /// </summary>
     /// <remarks>
     ///  <para>
     ///   POSIX-family dialects (<see cref="GlobDialect.Posix"/>,
     ///   <see cref="GlobDialect.PosixPath"/>, <see cref="GlobDialect.Bash"/>,
-    ///   <see cref="GlobDialect.Git"/>) default to <see cref="IgnoreCaseKind.Ascii"/> because
-    ///   the documented reference implementations fold only the ASCII letter range in their
-    ///   POSIX/C locale.
+    ///   <see cref="GlobDialect.Git"/>) use <see cref="IgnoreCaseKind.Ascii"/> when
+    ///   <see cref="GlobOptions.IgnoreCase"/> is set because the documented reference
+    ///   implementations fold only the ASCII letter range in their POSIX/C locale.
     ///  </para>
     ///  <para>
     ///   .NET-native dialects
     ///   (<see cref="GlobDialect.MSBuild"/>, <see cref="GlobDialect.FileSystemGlobbing"/>,
     ///   <see cref="GlobDialect.Simple"/>,
-    ///   <see cref="GlobDialect.PowerShell"/>) default to <see cref="IgnoreCaseKind.Unicode"/>
+    ///   <see cref="GlobDialect.PowerShell"/>) use <see cref="IgnoreCaseKind.Unicode"/>
     ///   because their documented implementations use
     ///   <see cref="StringComparison.OrdinalIgnoreCase"/> or the Windows kernel
-    ///   <c>RtlUpcaseUnicodeChar</c> case table.
+    ///   <c>RtlUpcaseUnicodeChar</c> case table. MSBuild uses this mode by default;
+    ///   the other dialects require <see cref="GlobOptions.IgnoreCase"/>.
     ///  </para>
     /// </remarks>
     public static IgnoreCaseKind DefaultIgnoreCaseKind(this GlobDialect dialect, GlobOptions options)
     {
-        // MSBuild matches case-insensitively by default; the IgnoreCase flag is
-        // implicit. All other dialects require the flag to be set explicitly.
+        // Current MSBuildGlob and FileMatcher.IsMatch are case-insensitive and do
+        // not expose a case-sensitive mode, so IgnoreCase is implicit for MSBuild.
+        // Every other dialect requires the option explicitly.
         if (dialect == GlobDialect.MSBuild)
         {
             return IgnoreCaseKind.Unicode;

--- a/touki/Touki/Io/Globbing/GlobOptions.cs
+++ b/touki/Touki/Io/Globbing/GlobOptions.cs
@@ -22,9 +22,11 @@ public enum GlobOptions
     ///   <list type="bullet">
     ///    <item>
     ///     <description>
-    ///      <b>Case folding</b>: <see cref="GlobDialect.MSBuild"/> is
-    ///      case-insensitive (Unicode) even without <see cref="IgnoreCase"/>; every
-    ///      other dialect is case-sensitive by default.
+    ///      <b>Case folding</b>: <see cref="GlobDialect.MSBuild"/> is Unicode ordinal
+    ///      case-insensitive by default; every other dialect is case-sensitive by
+    ///      default and requires <see cref="IgnoreCase"/> for case-insensitive matching.
+    ///      Current <c>MSBuildGlob</c> and <c>FileMatcher.IsMatch</c> APIs do not expose
+    ///      case-sensitive matching.
     ///     </description>
     ///    </item>
     ///    <item>

--- a/touki/Touki/Io/Globbing/IgnoreCaseKind.cs
+++ b/touki/Touki/Io/Globbing/IgnoreCaseKind.cs
@@ -5,17 +5,16 @@
 namespace Touki.Io.Globbing;
 
 /// <summary>
-///  Selects which case-folding rules a <see cref="GlobSpecification"/> applies when
-///  <see cref="GlobOptions.IgnoreCase"/> is set. Each <see cref="GlobDialect"/> has a
-///  documented default (see <see cref="GlobDialectExtensions.DefaultIgnoreCaseKind"/>);
-///  the value is currently chosen by the factory and not user-configurable. See the
-///  follow-up note on <see cref="GlobOptions.IgnoreCase"/>.
+///  Selects which case-folding rules a <see cref="GlobSpecification"/> applies.
+///  <see cref="GlobDialect.MSBuild"/> selects Unicode folding by default; other
+///  dialects select their documented fold only when <see cref="GlobOptions.IgnoreCase"/>
+///  is set. The value is chosen by the factory and is not directly user-configurable.
 /// </summary>
 internal enum IgnoreCaseKind
 {
     /// <summary>
-    ///  Case-sensitive ordinal matching. Selected when
-    ///  <see cref="GlobOptions.IgnoreCase"/> is clear regardless of dialect.
+    ///  Case-sensitive ordinal matching. Selected when <see cref="GlobOptions.IgnoreCase"/>
+    ///  is clear for every dialect except <see cref="GlobDialect.MSBuild"/>.
     /// </summary>
     Off,
 
@@ -40,8 +39,9 @@ internal enum IgnoreCaseKind
 
     /// <summary>
     ///  Full Unicode ordinal case fold matching <see cref="StringComparison.OrdinalIgnoreCase"/>.
-    ///  Implements the behavior of MSBuild item globs, <c>Microsoft.Extensions.FileSystemGlobbing.Matcher</c>,
-    ///  the .NET <c>FileSystemName.MatchesSimpleExpression</c>, and PowerShell's <c>-like</c> operator.
+    ///  Implements the behavior of MSBuild item globs and, when case-insensitive matching
+    ///  is requested, <c>Microsoft.Extensions.FileSystemGlobbing.Matcher</c>, the .NET
+    ///  <c>FileSystemName.MatchesSimpleExpression</c>, and PowerShell's <c>-like</c> operator.
     /// </summary>
     /// <remarks>
     ///  <para>


### PR DESCRIPTION
## Summary

- document MSBuild as the only case-insensitive-by-default glob dialect
- clarify that current `MSBuildGlob` and `FileMatcher.IsMatch` APIs do not expose case-sensitive matching
- pin the casing matrix and optimized MSBuild matching paths with tests
- update globbing documentation to include the .NET 11 target

## Behavior

No runtime behavior change. `GlobDialect.MSBuild` remains Unicode ordinal case-insensitive by default; every other dialect remains case-sensitive unless `GlobOptions.IgnoreCase` is set.

## Validation

- `dotnet build touki.slnx -c Release`
- full Release suite: 22,671 passed, 260 expected skips, 0 failed