### PR TITLE
Align globbing APIs with runtime proposal

### DIFF
--- a/docs/globbing.md
+++ b/docs/globbing.md
@@ -1,13 +1,15 @@
 # Compiled Glob Matching and File-System Enumeration
 
 Touki separates glob compilation from file-system enumeration. Use
+[`Glob`](../touki/Touki/Io/Globbing/Glob.cs) for one-shot matching and simple
+single-pattern enumeration,
 [`GlobSpecification`](../touki/Touki/Io/Globbing/GlobSpecification.cs) to
 compile and reuse a pattern, [`GlobEnumerator`](../touki/Touki/Io/GlobEnumerator.cs)
-to apply compiled glob semantics to a directory tree, and
+for Touki's advanced include/exclude enumeration API, and
 [`MSBuildEnumerator`](../touki/Touki/Io/MSBuildEnumerator.cs) when compatibility
 with MSBuild item specifications is the primary requirement.
 
-All three APIs are available on .NET 10 and .NET Framework 4.7.2.
+These APIs are available on .NET 10, .NET 11, and .NET Framework 4.7.2.
 
 ## Compile and reuse a pattern
 
@@ -99,10 +101,36 @@ intentional differences between supported dialects.
 
 ## Enumerate a directory tree
 
-`GlobEnumerator` accepts one include and a `GlobEnumerationOptions` object containing
-zero or more excludes, the dialect, glob options, and optional traversal options. Its
-default dialect is `PosixPath`; select another dialect explicitly when the pattern
-comes from another ecosystem.
+`Glob.EnumerateFiles` is the simplest way to lazily enumerate one pattern. It
+compiles the pattern and snapshots the traversal options when called. Each
+enumeration creates an independent matcher session and returns canonical
+root-relative paths with `/` separators.
+
+```csharp
+using Touki.Io.Globbing;
+
+IEnumerable<string> sourceFiles = Glob.EnumerateFiles(
+    rootDirectory: projectDirectory,
+    pattern: "**/*.cs",
+    dialect: GlobDialect.PosixPath,
+    options: GlobOptions.AllowGlobStar);
+
+foreach (string file in sourceFiles)
+{
+    Console.WriteLine(file);
+}
+```
+
+Pattern and root validation happen before `EnumerateFiles` returns; file-system
+traversal starts during enumeration. Relative roots are resolved against the current
+directory at call time. The convenience method is intended for trusted or prevalidated
+patterns because it does not expose `maxPatternLength`; compile untrusted patterns
+separately with a finite limit and use `FileSystemPathEnumerator`.
+
+For multiple excludes, Touki also provides `GlobEnumerator`. It accepts one include and
+a `GlobEnumerationOptions` object containing zero or more excludes, the dialect, glob
+options, and optional traversal options. Its default dialect is `PosixPath`; select
+another dialect explicitly when the pattern comes from another ecosystem.
 
 ```csharp
 using Touki.Io;

--- a/touki.perf/GlobEnumerateExtGlobPerf.cs
+++ b/touki.perf/GlobEnumerateExtGlobPerf.cs
@@ -120,10 +120,12 @@ public class GlobEnumerateExtGlobPerf
         {
             for (int index = 0; index < _patterns.Length; index++)
             {
-                includes[index] = GlobSpecification.Compile(
-                    _patterns[index],
-                    GlobDialect.Bash,
-                    GlobOptions.AllowGlobStar);
+                includes[index] = GlobSpecification
+                    .Compile(
+                        _patterns[index],
+                        GlobDialect.Bash,
+                        GlobOptions.AllowGlobStar)
+                    .CreateFileSystemMatcher();
             }
 
             IFileSystemMatcher matcher = FileSystemMatcher.CreateExclusionWins(includes);

--- a/touki.perf/GlobEnumeratorApiPerf.cs
+++ b/touki.perf/GlobEnumeratorApiPerf.cs
@@ -61,6 +61,16 @@ public class GlobEnumeratorApiPerf
             throw new InvalidOperationException("The include-only fixture returned an unexpected count.");
         }
 
+        if (EnumerateFacade() != ModuleCount * 3)
+        {
+            throw new InvalidOperationException("The facade fixture returned an unexpected count.");
+        }
+
+        if (EnumeratePathEnumerator() != ModuleCount * 3)
+        {
+            throw new InvalidOperationException("The path-enumerator fixture returned an unexpected count.");
+        }
+
         if (Enumerate(s_excludes) != ModuleCount)
         {
             throw new InvalidOperationException("The exclude fixture returned an unexpected count.");
@@ -82,12 +92,53 @@ public class GlobEnumeratorApiPerf
     [Benchmark]
     public int IncludeWithExcludes() => Enumerate(s_excludes);
 
+    [Benchmark]
+    public int IncludeOnlyFacade() => EnumerateFacade();
+
+    [Benchmark]
+    public int IncludeOnlyPathEnumerator() => EnumeratePathEnumerator();
+
     private int Enumerate(IReadOnlyList<string>? excludes)
     {
         using GlobEnumerator enumerator = GlobEnumerator.Create(
             "**/*.cs",
             _root,
             excludes is null ? s_includeOnlyOptions : s_excludeOptions);
+
+        int count = 0;
+        while (enumerator.MoveNext())
+        {
+            count++;
+        }
+
+        return count;
+    }
+
+    private int EnumerateFacade()
+    {
+        int count = 0;
+        foreach (string path in Glob.EnumerateFiles(
+            _root,
+            "**/*.cs",
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar))
+        {
+            _ = path;
+            count++;
+        }
+
+        return count;
+    }
+
+    private int EnumeratePathEnumerator()
+    {
+        GlobSpecification specification = GlobSpecification.Compile(
+            "**/*.cs",
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar);
+        using FileSystemPathEnumerator enumerator = FileSystemPathEnumerator.Create(
+            _root,
+            specification.CreateFileSystemMatcher());
 
         int count = 0;
         while (enumerator.MoveNext())

--- a/touki.perf/GlobSpecificationPerf.cs
+++ b/touki.perf/GlobSpecificationPerf.cs
@@ -191,6 +191,8 @@ public partial class GlobSpecificationPerf
 [SimpleJob(RuntimeMoniker.HostProcess, warmupCount: 1, iterationCount: 5, launchCount: 1)]
 public class GlobSpecificationCompilePerf
 {
+    private const string SlicedPatternSource = "prefix**/*.cssuffix";
+
     [Benchmark]
     public GlobSpecification Compile_Literal() => GlobSpecification.Compile("Program.cs", GlobDialect.Posix);
 
@@ -223,4 +225,15 @@ public class GlobSpecificationCompilePerf
     [Benchmark]
     public GlobSpecification Compile_MixedClassesAndNamed() =>
         GlobSpecification.Compile("[[:upper:]][a-z]*_[[:digit:]][0-9].[ch]s", GlobDialect.Posix);
+
+    [Benchmark]
+    public GlobSpecification Compile_Property_FullString() =>
+        GlobSpecification.Compile("**/*.cs", GlobDialect.PosixPath, GlobOptions.AllowGlobStar);
+
+    [Benchmark]
+    public GlobSpecification Compile_Property_StringSegmentSlice() =>
+        GlobSpecification.Compile(
+            new Touki.Text.StringSegment(SlicedPatternSource, 6, 7),
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar);
 }

--- a/touki.tests/Touki/Io/Globbing/GlobAdditionalCoverageTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobAdditionalCoverageTests.cs
@@ -6,7 +6,8 @@ namespace Touki.Io.Globbing;
 
 /// <summary>
 ///  Targeted coverage tests for branches not exercised by the dialect/oracle suites:
-///  the one-shot <see cref="Glob.IsMatch"/> helper, the specialized matcher
+///  the one-shot
+///  <see cref="Glob.IsMatch(string, ReadOnlySpan{char}, GlobDialect, GlobOptions)"/> helper, the specialized matcher
 ///  case-insensitive paths, leading-dot fail paths on Suffix/Contains matchers, the
 ///  <c>NeverMatchGlobStrategy</c> two-span entry point reached via
 ///  <see cref="GlobMatch.MatchesFile"/>, and the path-aware
@@ -23,6 +24,143 @@ public class GlobAdditionalCoverageTests
     [DataRow("a*c", "abz", false)]
     public void Glob_IsMatch_OneShotHelper(string pattern, string input, bool expected) =>
         Glob.IsMatch(pattern, input.AsSpan(), GlobDialect.Posix).Should().Be(expected);
+
+    [TestMethod]
+    public void IsMatch_NullPattern_Throws()
+    {
+        Action action = () => Glob.IsMatch((string)null!, "input", GlobDialect.Posix);
+
+        action.Should().Throw<ArgumentNullException>().WithParameterName("pattern");
+    }
+
+    [TestMethod]
+    public void EnumerateFiles_LazyRepeatableAndOptionsSnapshotted()
+    {
+        using TempFolder folder = new();
+        string sourceDirectory = Path.Combine(folder, "src");
+        Directory.CreateDirectory(sourceDirectory);
+        File.WriteAllText(Path.Combine(folder, "top.cs"), string.Empty);
+        EnumerationOptions enumerationOptions = new()
+        {
+            IgnoreInaccessible = true,
+            MatchCasing = MatchCasing.PlatformDefault,
+            MatchType = MatchType.Simple,
+            RecurseSubdirectories = true
+        };
+
+        IEnumerable<string> files = Glob.EnumerateFiles(
+            folder,
+            "**/*.cs",
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar,
+            enumerationOptions);
+
+        enumerationOptions.RecurseSubdirectories = false;
+        File.WriteAllText(Path.Combine(sourceDirectory, "nested.cs"), string.Empty);
+
+        string[] expected = ["top.cs", "src/nested.cs"];
+        files.Should().BeEquivalentTo(expected);
+        files.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void EnumerateFiles_InterleavedEnumerators_AreIndependent()
+    {
+        using TempFolder folder = new();
+        string sourceDirectory = Path.Combine(folder, "src");
+        string nestedDirectory = Path.Combine(sourceDirectory, "nested");
+        Directory.CreateDirectory(nestedDirectory);
+        File.WriteAllText(Path.Combine(sourceDirectory, "first.cs"), string.Empty);
+        File.WriteAllText(Path.Combine(nestedDirectory, "second.cs"), string.Empty);
+        IEnumerable<string> files = Glob.EnumerateFiles(
+            folder,
+            "src/**/*.cs",
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar);
+
+        using IEnumerator<string> first = files.GetEnumerator();
+        using IEnumerator<string> second = files.GetEnumerator();
+        List<string> firstResults = [];
+        List<string> secondResults = [];
+        while (true)
+        {
+            bool firstMoved = first.MoveNext();
+            bool secondMoved = second.MoveNext();
+            firstMoved.Should().Be(secondMoved);
+            if (!firstMoved)
+            {
+                break;
+            }
+
+            firstResults.Add(first.Current);
+            secondResults.Add(second.Current);
+        }
+
+        firstResults.Should().BeEquivalentTo("src/first.cs", "src/nested/second.cs");
+        secondResults.Should().BeEquivalentTo(firstResults);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void EnumerateFiles_RelativeRoot_ResolvesAtCallTime()
+    {
+        using TempFolder parentFolder = new();
+        string sourceDirectory = Path.Combine(parentFolder, "source");
+        string otherDirectory = Path.Combine(parentFolder, "other");
+        Directory.CreateDirectory(sourceDirectory);
+        Directory.CreateDirectory(otherDirectory);
+        File.WriteAllText(Path.Combine(sourceDirectory, "source.cs"), string.Empty);
+        string originalDirectory = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = parentFolder;
+            const string relativeRoot = "source";
+            Path.IsPathFullyQualified(relativeRoot).Should().BeFalse();
+            IEnumerable<string> files = Glob.EnumerateFiles(
+                relativeRoot,
+                "*.cs",
+                GlobDialect.PosixPath);
+
+            Environment.CurrentDirectory = otherDirectory;
+            files.Should().ContainSingle().Which.Should().Be("source.cs");
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDirectory;
+        }
+    }
+
+    [TestMethod]
+    public void EnumerateFiles_InvalidPattern_ThrowsBeforeReturning()
+    {
+        using TempFolder folder = new();
+
+        Func<IEnumerable<string>> action = () => Glob.EnumerateFiles(
+            folder,
+            "?(unterminated",
+            GlobDialect.Bash,
+            GlobOptions.AllowExtGlob);
+
+        action.Should().Throw<GlobFormatException>();
+    }
+
+    [TestMethod]
+    public void EnumerateFiles_NullArguments_ThrowBeforeReturning()
+    {
+        using TempFolder folder = new();
+
+        Func<IEnumerable<string>> nullRoot = () => Glob.EnumerateFiles(
+            null!,
+            "*.cs",
+            GlobDialect.PosixPath);
+        Func<IEnumerable<string>> nullPattern = () => Glob.EnumerateFiles(
+            folder,
+            null!,
+            GlobDialect.PosixPath);
+
+        nullRoot.Should().Throw<ArgumentNullException>().WithParameterName("rootDirectory");
+        nullPattern.Should().Throw<ArgumentNullException>().WithParameterName("pattern");
+    }
 
     [TestMethod]
     // Path-unaware Posix with IgnoreCase picks the Ascii fold path for Prefix.

--- a/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
+++ b/touki.tests/Touki/Io/Globbing/GlobSpecificationTests.cs
@@ -2,10 +2,131 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using Touki.Text;
+
 namespace Touki.Io.Globbing;
 
 public partial class GlobSpecificationTests
 {
+    [TestMethod]
+    public void TryCompile_DefaultOptions_UsesDialectDefaults()
+    {
+        bool success = GlobSpecification.TryCompile(
+            "*.CS",
+            GlobDialect.MSBuild,
+            out GlobSpecification? specification,
+            out GlobCompileError error);
+
+        success.Should().BeTrue();
+        error.IsError.Should().BeFalse();
+        error.Message.Should().BeEmpty();
+        specification.Should().NotBeNull();
+        specification!.IsMatch("source.cs").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Compile_NullPattern_Throws()
+    {
+        Action action = () => GlobSpecification.Compile((string)null!, GlobDialect.Posix);
+
+        action.Should().Throw<ArgumentNullException>().WithParameterName("pattern");
+    }
+
+    [TestMethod]
+    public void TryCompile_NullPattern_ThrowsForEveryStringOverload()
+    {
+        Action defaultOptions = () => GlobSpecification.TryCompile(
+            (string)null!,
+            GlobDialect.Posix,
+            out _,
+            out _);
+        Action suppliedOptions = () => GlobSpecification.TryCompile(
+            (string)null!,
+            GlobDialect.Posix,
+            GlobOptions.None,
+            out _,
+            out _);
+        Action allArguments = () => GlobSpecification.TryCompile(
+            (string)null!,
+            GlobDialect.Posix,
+            GlobOptions.None,
+            GlobPathSeparator.DialectDefault,
+            maxPatternLength: -1,
+            out _,
+            out _);
+
+        defaultOptions.Should().Throw<ArgumentNullException>().WithParameterName("pattern");
+        suppliedOptions.Should().Throw<ArgumentNullException>().WithParameterName("pattern");
+        allArguments.Should().Throw<ArgumentNullException>().WithParameterName("pattern");
+    }
+
+    [TestMethod]
+    public void Message_Default_ReturnsEmpty() =>
+        default(GlobCompileError).Message.Should().BeEmpty();
+
+    [TestMethod]
+    public void CreateFileSystemMatcher_ReturnsSeparateReusableAdapter()
+    {
+        GlobSpecification specification = GlobSpecification.Compile("*.cs", GlobDialect.Posix);
+
+        specification.Should().NotBeAssignableTo<IFileSystemMatcher>();
+        IFileSystemMatcher matcher = specification.CreateFileSystemMatcher();
+        matcher.Should().BeSameAs(specification.CreateFileSystemMatcher());
+        using IFileSystemMatcherSession first = matcher.CreateSession("root");
+        using IFileSystemMatcherSession second = matcher.CreateSession("root");
+        first.Should().NotBeSameAs(second);
+        first.MatchesFile("root", "file.cs").Should().BeTrue();
+    }
+
+    [TestMethod]
+    public void Pattern_StringInput_ReturnsOriginalReference()
+    {
+        string pattern = "src/**/*.cs";
+
+        GlobSpecification specification = GlobSpecification.Compile(
+            pattern,
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar);
+
+        specification.Pattern.Should().BeSameAs(pattern);
+    }
+
+    [TestMethod]
+    public void Pattern_StringSegmentInput_MaterializesSlice()
+    {
+        StringSegment pattern = new("prefix/**/*.cs;suffix", 7, 7);
+
+        GlobSpecification specification = GlobSpecification.Compile(
+            pattern,
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar);
+
+        specification.Pattern.Should().Be("**/*.cs");
+    }
+
+    [TestMethod]
+    public void Constructor_NullMessage_Throws()
+    {
+        Action action = () => new GlobCompileError(GlobCompileErrorCode.PatternTooLarge, null!);
+
+        action.Should().Throw<ArgumentNullException>().WithParameterName("message");
+    }
+
+    [TestMethod]
+    [DataRow("*.cs", "")]
+    [DataRow("src/**/*.cs", "src/")]
+    public void LiteralPathPrefix_Pattern_ReturnsExpectedString(
+        string pattern,
+        string expected)
+    {
+        GlobSpecification specification = GlobSpecification.Compile(
+            pattern,
+            GlobDialect.PosixPath,
+            GlobOptions.AllowGlobStar);
+
+        specification.LiteralPathPrefix.Should().Be(expected);
+    }
+
     [TestMethod]
     [DataRow("", "", true)]
     [DataRow("", "a", false)]

--- a/touki/Touki/Io/Globbing/Glob.cs
+++ b/touki/Touki/Io/Globbing/Glob.cs
@@ -13,7 +13,7 @@ public static class Glob
     /// <summary>
     ///  Compiles <paramref name="pattern"/> and tests whether <paramref name="input"/>
     ///  matches it. Equivalent to
-    ///  <see cref="GlobSpecification.Compile(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>
+    ///  <see cref="GlobSpecification.Compile(string, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>
     ///  followed by <see cref="GlobSpecification.IsMatch(ReadOnlySpan{char})"/>.
     /// </summary>
     /// <remarks>
@@ -22,7 +22,21 @@ public static class Glob
     ///   same pattern, compile once and cache the resulting <see cref="GlobSpecification"/>.
     ///  </para>
     /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="pattern"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="GlobFormatException">The pattern is invalid.</exception>
+    public static bool IsMatch(
+        string pattern,
+        ReadOnlySpan<char> input,
+        GlobDialect dialect,
+        GlobOptions options = GlobOptions.None)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return IsMatch(new StringSegment(pattern), input, dialect, options);
+    }
+
+    /// <inheritdoc cref="IsMatch(string, ReadOnlySpan{char}, GlobDialect, GlobOptions)"/>
     public static bool IsMatch(
         StringSegment pattern,
         ReadOnlySpan<char> input,
@@ -31,5 +45,65 @@ public static class Glob
     {
         GlobSpecification specification = GlobSpecification.Compile(pattern, dialect, options);
         return specification.IsMatch(input);
+    }
+
+    /// <summary>
+    ///  Compiles <paramref name="pattern"/> and lazily enumerates matching files below
+    ///  <paramref name="rootDirectory"/> as canonical root-relative paths.
+    /// </summary>
+    /// <remarks>
+    ///  <para>
+    ///   Pattern compilation, root normalization, and enumeration-option snapshotting occur
+    ///   before this method returns. File-system traversal begins when the returned sequence is
+    ///   enumerated. Relative roots are resolved against the current directory at call time.
+    ///   Each enumeration owns an independent matcher session. Returned paths are relative to
+    ///   the normalized root and use <c>/</c> separators.
+    ///  </para>
+    ///  <para>
+    ///   A <see langword="null"/> <paramref name="enumerationOptions"/> selects recursive
+    ///   traversal that ignores inaccessible entries. This method does not impose a pattern-length
+    ///   bound and is intended for trusted or prevalidated patterns. Compile untrusted patterns
+    ///   separately with a finite <c>maxPatternLength</c>.
+    ///  </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="rootDirectory"/> or <paramref name="pattern"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="GlobFormatException">The pattern is invalid.</exception>
+    public static IEnumerable<string> EnumerateFiles(
+        string rootDirectory,
+        string pattern,
+        GlobDialect dialect,
+        GlobOptions options = GlobOptions.None,
+        EnumerationOptions? enumerationOptions = null)
+    {
+        ArgumentNullException.ThrowIfNull(rootDirectory);
+        ArgumentNullException.ThrowIfNull(pattern);
+
+        GlobSpecification specification = GlobSpecification.Compile(pattern, dialect, options);
+        FileSystemMatchEnumeratorArguments arguments = new(
+            rootDirectory,
+            specification.CreateFileSystemMatcher(),
+            enumerationOptions);
+
+        return EnumerateFilesIterator(
+            arguments.RootDirectory,
+            arguments.Matcher,
+            arguments.Options);
+
+        static IEnumerable<string> EnumerateFilesIterator(
+            string normalizedRoot,
+            IFileSystemMatcher matcher,
+            EnumerationOptions snapshottedOptions)
+        {
+            using FileSystemPathEnumerator enumerator = FileSystemPathEnumerator.Create(
+                normalizedRoot,
+                matcher,
+                snapshottedOptions);
+            while (enumerator.MoveNext())
+            {
+                yield return enumerator.Current;
+            }
+        }
     }
 }

--- a/touki/Touki/Io/Globbing/GlobCompileError.cs
+++ b/touki/Touki/Io/Globbing/GlobCompileError.cs
@@ -10,6 +10,8 @@ namespace Touki.Io.Globbing;
 /// </summary>
 public readonly struct GlobCompileError
 {
+    private readonly string? _message;
+
     /// <summary>
     ///  Initializes a new instance of the <see cref="GlobCompileError"/> struct.
     /// </summary>
@@ -21,9 +23,11 @@ public readonly struct GlobCompileError
     /// <param name="message">A human-readable description of the failure.</param>
     public GlobCompileError(GlobCompileErrorCode code, int position, string message)
     {
+        ArgumentNullException.ThrowIfNull(message);
+
         Code = code;
         Position = position;
-        Message = message;
+        _message = message;
     }
 
     /// <inheritdoc cref="GlobCompileError(GlobCompileErrorCode, int, string)"/>
@@ -43,7 +47,7 @@ public readonly struct GlobCompileError
     /// <summary>
     ///  Gets a human-readable description of the failure.
     /// </summary>
-    public string Message { get; }
+    public string Message => _message ?? string.Empty;
 
     /// <summary>
     ///  Gets a value indicating whether this error represents a failure.

--- a/touki/Touki/Io/Globbing/GlobFileSystemMatcher.cs
+++ b/touki/Touki/Io/Globbing/GlobFileSystemMatcher.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Io.Globbing;
+
+internal sealed class GlobFileSystemMatcher(GlobSpecification specification) : IFileSystemMatcher
+{
+    public IFileSystemMatcherSession CreateSession(string rootDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(rootDirectory);
+        return specification.CreateSession(rootDirectory);
+    }
+}

--- a/touki/Touki/Io/Globbing/GlobSpecification.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.cs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Threading;
+
 namespace Touki.Io.Globbing;
 
 /// <summary>
@@ -10,7 +12,7 @@ namespace Touki.Io.Globbing;
 /// <remarks>
 ///  <para>
 ///   <see cref="GlobSpecification"/> is the output of
-///   <see cref="Compile(StringSegment, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>:
+///   <see cref="Compile(string, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>:
 ///   a thread-safe parse result that holds the encoded pattern (literal table,
 ///   opcode program, etc.) and the pattern-level flags. Common evaluation paths
 ///   allocate no managed objects; separator coalescing and complex extglob matching
@@ -27,12 +29,14 @@ namespace Touki.Io.Globbing;
 ///  </para>
 ///  <para>
 ///   This mirrors the <see cref="MSBuildSpecification"/> / <see cref="MatchMSBuild"/>
-///   split: the specification is the value-ish parse output; the matcher binds it to
-///   a root and owns mutable enumeration state.
+///   split: the specification is the value-ish parse output; the reusable matcher is
+///   root-independent, and each session binds it to a root and owns mutable enumeration state.
 ///  </para>
 /// </remarks>
-public sealed partial class GlobSpecification : IFileSystemMatcher
+public sealed partial class GlobSpecification
 {
+    private IFileSystemMatcher? _fileSystemMatcher;
+
     private readonly GlobStrategy _strategy;
     private readonly StringSegment _msbuildTrailingDotFileNamePattern;
     private readonly bool _hasMSBuildTrailingDotFileNamePattern;
@@ -61,7 +65,7 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
         _msbuildTrailingDotNegatedAlternatives = msbuildTrailingDotNegatedAlternatives;
         _msbuildTrailingDotPositiveAlternatives = msbuildTrailingDotPositiveAlternatives;
         _msbuildTrailingDotNeverMatches = msbuildTrailingDotNeverMatches;
-        Pattern = pattern;
+        Pattern = pattern.ToString();
     }
 
     /// <summary>
@@ -73,9 +77,7 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
     ///  each value (ignored for path-unaware dialects).
     /// </summary>
     /// <param name="pattern">
-    ///  The glob pattern. Accepted as a <see cref="StringSegment"/> so callers that
-    ///  already hold a backing string (item-include strings, gitignore lines, glob
-    ///  lists from configuration) can slice without copying.
+    ///  The glob pattern.
     /// </param>
     /// <param name="maxPatternLength">
     ///  Optional upper bound on <paramref name="pattern"/>'s length, in characters.
@@ -86,6 +88,26 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
     /// <exception cref="GlobFormatException">
     ///  The pattern is invalid for the requested dialect or options.
     /// </exception>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="pattern"/> is <see langword="null"/>.
+    /// </exception>
+    public static GlobSpecification Compile(
+        string pattern,
+        GlobDialect dialect,
+        GlobOptions options = GlobOptions.None,
+        GlobPathSeparator separator = GlobPathSeparator.DialectDefault,
+        int maxPatternLength = -1)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return Compile(new StringSegment(pattern), dialect, options, separator, maxPatternLength);
+    }
+
+    /// <inheritdoc cref="Compile(string, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>
+    /// <remarks>
+    ///  <para>
+    ///   This Touki-specific overload retains a slice of a backing string without copying.
+    ///  </para>
+    /// </remarks>
     public static GlobSpecification Compile(
         StringSegment pattern,
         GlobDialect dialect,
@@ -102,26 +124,92 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
             ? result
             : throw new GlobFormatException(error);
 
+    /// <inheritdoc cref="TryCompile(string, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobSpecification, out GlobCompileError)"/>
+    public static bool TryCompile(
+        string pattern,
+        GlobDialect dialect,
+        [NotNullWhen(true)] out GlobSpecification? result,
+        out GlobCompileError error)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return TryCompile(new StringSegment(pattern), dialect, out result, out error);
+    }
+
+    /// <inheritdoc cref="TryCompile(string, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobSpecification, out GlobCompileError)"/>
+    public static bool TryCompile(
+        string pattern,
+        GlobDialect dialect,
+        GlobOptions options,
+        [NotNullWhen(true)] out GlobSpecification? result,
+        out GlobCompileError error)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return TryCompile(new StringSegment(pattern), dialect, options, out result, out error);
+    }
+
     /// <summary>
     ///  Attempts to compile <paramref name="pattern"/>. On failure,
     ///  <paramref name="result"/> is <see langword="null"/> and
     ///  <paramref name="error"/> is populated.
     /// </summary>
-    public static bool TryCompile(
-        StringSegment pattern,
-        GlobDialect dialect,
-        GlobOptions options,
-        out GlobSpecification? result,
-        out GlobCompileError error) =>
-        TryCompile(pattern, dialect, options, GlobPathSeparator.DialectDefault, maxPatternLength: -1, out result, out error);
-
-    /// <inheritdoc cref="TryCompile(StringSegment, GlobDialect, GlobOptions, out GlobSpecification, out GlobCompileError)"/>
+    /// <param name="pattern">The glob pattern.</param>
+    /// <param name="dialect">The pattern dialect.</param>
+    /// <param name="options">Options that modify compilation and matching.</param>
     /// <param name="separator">Explicit path separator override; ignored for path-unaware dialects.</param>
     /// <param name="maxPatternLength">
     ///  Optional upper bound on <paramref name="pattern"/>'s length, in characters. Pass
     ///  <c>-1</c> to disable the check; otherwise oversized patterns fail with
     ///  <see cref="GlobCompileErrorCode.PatternTooLarge"/>.
     /// </param>
+    /// <param name="result">The compiled specification on success; otherwise <see langword="null"/>.</param>
+    /// <param name="error">The compilation error on failure; otherwise the default value.</param>
+    /// <returns><see langword="true"/> when compilation succeeds; otherwise <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="pattern"/> is <see langword="null"/>.
+    /// </exception>
+    public static bool TryCompile(
+        string pattern,
+        GlobDialect dialect,
+        GlobOptions options,
+        GlobPathSeparator separator,
+        int maxPatternLength,
+        [NotNullWhen(true)] out GlobSpecification? result,
+        out GlobCompileError error)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        return TryCompile(
+            new StringSegment(pattern),
+            dialect,
+            options,
+            separator,
+            maxPatternLength,
+            out result,
+            out error);
+    }
+
+    /// <inheritdoc cref="TryCompile(string, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobSpecification, out GlobCompileError)"/>
+    public static bool TryCompile(
+        StringSegment pattern,
+        GlobDialect dialect,
+        [NotNullWhen(true)] out GlobSpecification? result,
+        out GlobCompileError error) =>
+        TryCompile(pattern, dialect, GlobOptions.None, out result, out error);
+
+    /// <inheritdoc cref="TryCompile(string, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobSpecification, out GlobCompileError)"/>
+    public static bool TryCompile(
+        StringSegment pattern,
+        GlobDialect dialect,
+        GlobOptions options,
+        [NotNullWhen(true)] out GlobSpecification? result,
+        out GlobCompileError error) =>
+        TryCompile(pattern, dialect, options, GlobPathSeparator.DialectDefault, maxPatternLength: -1, out result, out error);
+
+    /// <inheritdoc cref="TryCompile(string, GlobDialect, GlobOptions, GlobPathSeparator, int, out GlobSpecification, out GlobCompileError)"/>
+    /// <remarks>
+    ///  <para>
+    ///   This Touki-specific overload retains a slice of a backing string without copying.
+    ///  </para>
+    /// </remarks>
     public static bool TryCompile(
         StringSegment pattern,
         GlobDialect dialect,
@@ -673,19 +761,20 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
     }
 
     /// <summary>
-    ///  The pattern source as supplied to <see cref="Compile"/>.
+    ///  The pattern source as supplied to
+    ///  <see cref="Compile(string, GlobDialect, GlobOptions, GlobPathSeparator, int)"/>.
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   When the caller passes a backing string (the common case via
-    ///   <see cref="StringSegment"/>), this property slices that string rather
-    ///   than allocating. Dialect-specific normalization that the factory may
+    ///   The <see langword="string"/> overload retains the caller's original instance.
+    ///   The Touki-specific <see cref="StringSegment"/> overload materializes a new
+    ///   string when the segment is a partial slice. Dialect-specific normalization that the factory may
     ///   apply (separator coalescing, gitignore marker stripping, etc.) does
     ///   <em>not</em> flow back into this property - it always reflects
     ///   the user-supplied input.
     ///  </para>
     /// </remarks>
-    public StringSegment Pattern { get; }
+    public string Pattern { get; }
 
     /// <summary>
     ///  The dialect this specification was compiled with.
@@ -746,12 +835,11 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
     /// </summary>
     /// <remarks>
     ///  <para>
-    ///   Exposed as a <see cref="StringSegment"/> so consumers can slice without
-    ///   copying. The underlying bytes are owned by the strategy and remain valid
-    ///   for the lifetime of this specification.
+    ///   The returned string is owned by the compiled strategy and remains valid for
+    ///   the lifetime of this specification.
     ///  </para>
     /// </remarks>
-    public StringSegment LiteralPathPrefix => _strategy.LiteralPathPrefix;
+    public string LiteralPathPrefix => _strategy.LiteralPathPrefix;
 
     /// <summary>
     ///  <see langword="true"/> when the compiled pattern contains at least one
@@ -832,12 +920,16 @@ public sealed partial class GlobSpecification : IFileSystemMatcher
     /// <summary>
     ///  Creates a reusable definition that binds this specification to a root for each file-system enumeration.
     /// </summary>
-    public IFileSystemMatcher CreateFileSystemMatcher() => this;
-
-    IFileSystemMatcherSession IFileSystemMatcher.CreateSession(string rootDirectory)
+    public IFileSystemMatcher CreateFileSystemMatcher()
     {
-        ArgumentNullException.ThrowIfNull(rootDirectory);
-        return new GlobMatch(this, rootDirectory);
+        IFileSystemMatcher? matcher = _fileSystemMatcher;
+        if (matcher is not null)
+        {
+            return matcher;
+        }
+
+        matcher = new GlobFileSystemMatcher(this);
+        return Interlocked.CompareExchange(ref _fileSystemMatcher, matcher, null) ?? matcher;
     }
 
     internal GlobMatch CreateSession(string? rootDirectory = null) => new(this, rootDirectory);

--- a/touki/Touki/Io/Globbing/GlobSpecification.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.cs
@@ -922,7 +922,7 @@ public sealed partial class GlobSpecification
     /// </summary>
     public IFileSystemMatcher CreateFileSystemMatcher()
     {
-        IFileSystemMatcher? matcher = _fileSystemMatcher;
+        IFileSystemMatcher? matcher = Volatile.Read(ref _fileSystemMatcher);
         if (matcher is not null)
         {
             return matcher;


### PR DESCRIPTION
## Summary

- add exact `string` overloads and the lazy, repeatable `Glob.EnumerateFiles` facade
- separate `GlobSpecification` from `IFileSystemMatcher` through a cached reusable adapter
- expose proposed `string` properties and guarantee non-null `GlobCompileError.Message`
- retain Touki split-span predicates, replay support, advanced `GlobEnumerator`, and Git-ignore APIs
- add contract tests, documentation, and public-path benchmarks

## Compatibility

This intentionally breaks direct `GlobSpecification` matcher assignability and changes `Pattern` / `LiteralPathPrefix` from `StringSegment` to `string`. Use `CreateFileSystemMatcher()` for enumeration composition.

## Performance

- modern .NET RyuJIT: facade 6.117 ms vs. 5.975 ms legacy, ratio 1.03 (SD 0.08), within variation
- .NET Framework 4.8.1 RyuJIT: facade 6.349 ms vs. 6.371 ms legacy, ratio 1.00 (SD 0.09)
- retained sliced `StringSegment` overload adds 40 B per compile; no cost for proposed `string` callers

## Validation

- `dotnet build touki.slnx -c Release`
- full Release suite: 22,707 passed, 260 expected skips, 0 failed
- analyzer tests: 302 passed
- AOT tests: 13 passed