### PR TITLE
Add XML documentation formatting analyzer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -62,6 +62,10 @@ dotnet_diagnostic.TOUKI0041.severity = warning
 # tab_width below; no rule-specific key is needed.
 dotnet_diagnostic.TOUKI0022.severity = warning
 
+# TOUKI0024 ships disabled because XML documentation layout is a house style. Touki uses
+# one additional space for each XML nesting level and the rule's default 120-character limit.
+dotnet_diagnostic.TOUKI0024.severity = warning
+
 # P/Invoke declarations keep the spelling of the native symbol they bind to, which is what makes
 # them greppable against the native header. Naming a rule two symbol groups gives the "either
 # attribute" match that a single required_attributes list cannot express.

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -2,8 +2,8 @@
 
 `KlutzyNinja.Touki` ships a set of Roslyn analyzers **inside the package**. There is no
 separate analyzer package to install - adding the package reference is enough. The shipped
-rules start running on the next build and in the IDE. TOUKI0041 and TOUKI0022 ship disabled
-unless a project opts in.
+rules start running on the next build and in the IDE. TOUKI0022, TOUKI0024, and TOUKI0041 ship
+disabled unless a project opts in.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
@@ -24,6 +24,7 @@ name a field for what it actually is.
 | [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
 | [TOUKI0022](#touki0022) | Avoid tab characters | Maintainability | **Disabled** | Yes | - |
 | [TOUKI0023](#touki0023) | Remove trailing whitespace | Maintainability | Warning | - | - |
+| [TOUKI0024](#touki0024) | Format XML documentation as nested XML | Maintainability | **Disabled** | Yes | - |
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
 | [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
@@ -296,6 +297,71 @@ line and stops at the first character that is not whitespace; a combining mark i
 whitespace, so a space that carries a following mark is never the last character on the
 line and is never reported.
 
+## TOUKI0024
+
+**Format XML documentation as nested XML.** Enforces the repository's one-space-per-XML-level
+layout for structured `///` comments while preserving documentation text and intentional prose
+line breaks.
+
+`<summary>` is always a block:
+
+```csharp
+/// <summary>
+///  Gets the requested name.
+/// </summary>
+```
+
+Other top-level paired elements may stay on one line when the complete physical source line fits
+within the configured limit. A three-line element with exactly one content line is compacted when
+it fits:
+
+```csharp
+/// <returns>The requested name.</returns>
+```
+
+An element with two or more content lines is never compacted. Nested block elements are expanded
+and indented; inline elements such as `<see>`, `<paramref>`, and `<c>` remain in prose. The
+contents of `<code>` and CDATA sections retain their relative indentation. Self-closing elements
+remain self-closing. Malformed XML and `/** */` documentation comments are left alone.
+
+Indentation is evaluated per contiguous logical block, such as a start tag, end tag, or run of
+prose. When the first line is correctly indented, the rest of that block is left unchanged so
+deliberate hanging indentation survives. When the first line is misindented, every line in the
+block is shifted by the same amount.
+
+Compaction removes only ordinary ASCII spaces and tabs that belong to the `///` layout; Unicode
+whitespace such as NBSP remains documentation content. Content under effective
+`xml:space="preserve"` is opaque, including inherited preservation. A nested
+`xml:space="default"` element resumes normal formatting.
+
+The rule ships **disabled** because documentation layout is a house style. Enable it with:
+
+```ini
+dotnet_diagnostic.TOUKI0024.severity = warning
+```
+
+The XML indentation step defaults to one space and can be overridden per path:
+
+```ini
+dotnet_code_quality.TOUKI0024.indent_size = 1
+```
+
+Values from 1 through 16 are accepted. Missing, invalid, non-positive, and larger values use the
+default of 1.
+
+The maximum physical line length uses the first positive integer from this list:
+
+1. `dotnet_code_quality.TOUKI0024.max_line_length`
+2. `max_line_length` - the standard EditorConfig property
+3. 120
+
+The physical length includes source indentation and the `/// ` prefix. Invalid and non-positive
+values fall through to the next source rather than failing the build.
+
+To keep analysis bounded on adversarial source, the rule stays silent for an individual comment
+larger than 1 MiB, containing more than 4,096 structured XML nodes, nested more than 128 XML
+elements deep, or whose formatted replacement would exceed 4 MiB.
+
 ## TOUKI0030
 
 **Use `ValueStringBuilder` to build strings.** Reports a `StringBuilder` that is only used
@@ -536,6 +602,9 @@ same documents.
 syntax and both support Fix All. The tab fix computes each run's spaces from the original
 columns, so several fixes on one line compose without having to be applied in order.
 
+`FormatXmlDocumentationCodeFixProvider` fixes TOUKI0024 by applying the complete replacement
+computed by the analyzer from the file's options. It supports Fix All.
+
 ## Relationship to IDE0055
 
 The .NET SDK's `IDE0055` ([Fix formatting](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055))
@@ -567,6 +636,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 | 0.7.0 | TOUKI0022, TOUKI0023 |
+| Unshipped | TOUKI0024 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/touki.analyzers.codefixes/FormatXmlDocumentationCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/FormatXmlDocumentationCodeFixProvider.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Offers a "Format XML documentation comment" fix for <c>TOUKI0024</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The analyzer computes the complete replacement because it owns the per-file indentation and line-length
+///   configuration. The fix applies that replacement without reinterpreting the documentation XML.
+///  </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FormatXmlDocumentationCodeFixProvider))]
+[Shared]
+public sealed class FormatXmlDocumentationCodeFixProvider : CodeFixProvider
+{
+    // Hardcoded to avoid a dependency on the analyzer assembly; these are stable public contracts.
+    private const string XmlDocumentationFormattingId = "TOUKI0024";
+    private const string ReplacementProperty = "Replacement";
+
+    private static readonly ImmutableArray<string> s_fixableDiagnosticIds = [XmlDocumentationFormattingId];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => s_fixableDiagnosticIds;
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            if (!diagnostic.Properties.TryGetValue(ReplacementProperty, out string? replacement)
+                || replacement is null)
+            {
+                continue;
+            }
+
+            TextSpan span = diagnostic.Location.SourceSpan;
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Format XML documentation comment",
+                    cancellationToken => ReplaceAsync(context.Document, span, replacement, cancellationToken),
+                    equivalenceKey: nameof(FormatXmlDocumentationCodeFixProvider)),
+                diagnostic);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static async Task<Document> ReplaceAsync(
+        Document document,
+        TextSpan span,
+        string replacement,
+        CancellationToken cancellationToken)
+    {
+        SourceText text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        return document.WithText(text.WithChanges(new TextChange(span, replacement)));
+    }
+}

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Touki.Analyzers;
 
@@ -38,6 +39,28 @@ internal static class AnalyzerTestHarness
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
     {
         CSharpCompilation compilation = CreateCompilation(source, fileName);
+
+        return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    ///  Runs <paramref name="analyzer"/> against instrumented <paramref name="source"/>. The callback runs after
+    ///  parsing and before analyzer execution, allowing parser activity to be excluded from instrumentation.
+    /// </summary>
+    public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
+        DiagnosticAnalyzer analyzer,
+        SourceText source,
+        Action beforeAnalysis,
+        IReadOnlyDictionary<string, string>? options = null,
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
+    {
+        SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            assemblyName: "Touki.Analyzers.TestCompilation",
+            syntaxTrees: [syntaxTree],
+            references: s_references.Value,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+        beforeAnalysis();
 
         return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
     }

--- a/touki.analyzers.tests/CountingSourceText.cs
+++ b/touki.analyzers.tests/CountingSourceText.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Wraps source text and counts character reads after parsing has completed.
+/// </summary>
+internal sealed class CountingSourceText(SourceText inner) : SourceText
+{
+    private long _characterReads;
+
+    public long CharacterReads => Interlocked.Read(ref _characterReads);
+
+    public override Encoding? Encoding => inner.Encoding;
+
+    public override int Length => inner.Length;
+
+    public override char this[int position]
+    {
+        get
+        {
+            Interlocked.Increment(ref _characterReads);
+            return inner[position];
+        }
+    }
+
+    public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+    {
+        Interlocked.Add(ref _characterReads, count);
+        inner.CopyTo(sourceIndex, destination, destinationIndex, count);
+    }
+
+    public void Reset() => Interlocked.Exchange(ref _characterReads, 0);
+}

--- a/touki.analyzers.tests/XmlDocumentationFormattingAnalyzerTests.Security.cs
+++ b/touki.analyzers.tests/XmlDocumentationFormattingAnalyzerTests.Security.cs
@@ -1,0 +1,197 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+public partial class XmlDocumentationFormattingAnalyzerTests
+{
+    [TestMethod]
+    public async Task Analyze_CommentAtSafetyLimit_ReportsDiagnostic()
+    {
+        const int maximumCommentLength = 1024 * 1024;
+        const string prefix = "/// <summary>";
+        const string suffix = "</summary>";
+        string content = new('x', maximumCommentLength - prefix.Length - suffix.Length);
+        string source = $"{prefix}{content}{suffix}\nclass Sample {{ }}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task Analyze_CommentJustOverSafetyLimit_ReportsNothing()
+    {
+        const int maximumCommentLength = 1024 * 1024;
+        const string prefix = "/// <summary>";
+        const string suffix = "</summary>";
+        string content = new('x', maximumCommentLength - prefix.Length - suffix.Length + 1);
+        string source = $"{prefix}{content}{suffix}\nclass Sample {{ }}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_OversizedIndentedComment_RejectsBeforeRescanningIndentation()
+    {
+        string indentation = new(' ', (1024 * 1024) + 1);
+        CountingSourceText source = new(SourceText.From(
+            $"{indentation}/// <summary>Text.</summary>\nclass Sample {{ }}\n"));
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            source,
+            source.Reset,
+            diagnosticOptions: s_enabled).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+        source.CharacterReads.Should().BeLessThan(source.Length * 2L);
+    }
+
+    [TestMethod]
+    public async Task Analyze_NodeCountAtSafetyLimit_ReportsDiagnostic()
+    {
+        string source =
+            $"/// <summary>x{string.Concat(Enumerable.Repeat("<br/>", 2044))}</summary>\n"
+            + "class Sample { }\n";
+
+        GetStructuredNodeCount(source).Should().Be(4096);
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task Analyze_NodeCountJustOverSafetyLimit_ReportsNothing()
+    {
+        string source =
+            $"/// <summary>x{string.Concat(Enumerable.Repeat("<br/>", 2044))}y</summary>\n"
+            + "class Sample { }\n";
+
+        GetStructuredNodeCount(source).Should().Be(4097);
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_NestingAtSafetyLimit_ReportsDiagnostic()
+    {
+        string opening = string.Concat(Enumerable.Repeat("<para>", 127));
+        string closing = string.Concat(Enumerable.Repeat("</para>", 127));
+        string source = $"/// <summary>{opening}Text.{closing}</summary>\nclass Sample {{ }}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task Analyze_NestingJustOverSafetyLimit_ReportsNothing()
+    {
+        string opening = string.Concat(Enumerable.Repeat("<para>", 128));
+        string closing = string.Concat(Enumerable.Repeat("</para>", 128));
+        string source = $"/// <summary>{opening}Text.{closing}</summary>\nclass Sample {{ }}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_ReplacementAtSafetyLimit_ReportsDiagnostic()
+    {
+        string indentation = new(' ', 838_847);
+        string source = $"{indentation}/// <remarks><para>Text.more</para></remarks>\nclass Sample {{ }}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Length.Should().Be(4 * 1024 * 1024);
+    }
+
+    [TestMethod]
+    public async Task Analyze_ReplacementJustOverSafetyLimit_ReportsNothing()
+    {
+        string indentation = new(' ', 838_847);
+        string source = $"{indentation}/// <remarks><para>Text.more!</para></remarks>\nclass Sample {{ }}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_ManyLinesBelowSafetyLimit_CompletesWithinBound()
+    {
+        string content = string.Concat(Enumerable.Repeat("/// Text.\n", 30_000));
+        CountingSourceText source = new(SourceText.From(
+            $"/// <summary>\n{content}/// </summary>\nclass Sample {{ }}\n"));
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            source,
+            source.Reset,
+            diagnosticOptions: s_enabled).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        source.CharacterReads.Should().BeLessThan(source.Length * 20L);
+    }
+
+    [TestMethod]
+    public async Task Analyze_WideSingleLineBelowSafetyLimit_KeepsCharacterReadsLinear()
+    {
+        string indentation = new(' ', 512 * 1024);
+        string paragraphs = string.Concat(Enumerable.Repeat("<para>x</para>", 400));
+        CountingSourceText source = new(SourceText.From(
+            $"{indentation}/// <remarks>{paragraphs}</remarks>\nclass Sample {{ }}\n"));
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            source,
+            source.Reset,
+            diagnosticOptions: s_enabled).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+        source.CharacterReads.Should().BeLessThan(source.Length * 20L);
+    }
+
+    [TestMethod]
+    public async Task Analyze_WidePostExteriorWhitespaceBelowSafetyLimit_KeepsCharacterReadsLinear()
+    {
+        string padding = new(' ', 512 * 1024);
+        string paragraphs = string.Concat(Enumerable.Repeat("<para>x</para>", 400));
+        CountingSourceText source = new(SourceText.From(
+            $"///{padding}<remarks>{paragraphs}</remarks>\nclass Sample {{ }}\n"));
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            source,
+            source.Reset,
+            diagnosticOptions: s_enabled).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        source.CharacterReads.Should().BeLessThan(source.Length * 20L);
+    }
+
+    private static int GetStructuredNodeCount(string source)
+    {
+        SyntaxNode root = CSharpSyntaxTree.ParseText(source).GetRoot();
+        DocumentationCommentTriviaSyntax documentation = root
+            .DescendantTrivia(descendIntoTrivia: true)
+            .Select(static trivia => trivia.GetStructure())
+            .OfType<DocumentationCommentTriviaSyntax>()
+            .Single();
+
+        return documentation.DescendantNodes().Count();
+    }
+}

--- a/touki.analyzers.tests/XmlDocumentationFormattingAnalyzerTests.cs
+++ b/touki.analyzers.tests/XmlDocumentationFormattingAnalyzerTests.cs
@@ -1,0 +1,770 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Globalization;
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public partial class XmlDocumentationFormattingAnalyzerTests
+{
+    private const string ReplacementProperty = "Replacement";
+
+    private static readonly Dictionary<string, ReportDiagnostic> s_enabled =
+        new() { [XmlDocumentationFormattingAnalyzer.DiagnosticId] = ReportDiagnostic.Warn };
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        string source,
+        Dictionary<string, string>? options = null)
+        => await AnalyzerTestHarness
+            .GetDiagnosticsAsync(
+                new XmlDocumentationFormattingAnalyzer(),
+                source,
+                options,
+                fileName: null,
+                s_enabled)
+            .ConfigureAwait(false);
+
+    private static string Replacement(Diagnostic diagnostic) =>
+        diagnostic.Properties[ReplacementProperty]!;
+
+    [TestMethod]
+    public async Task Analyze_SingleLineSummary_ReportsExpandedReplacement()
+    {
+        string source =
+            "class Sample\n{\n    /// <summary>The name.</summary>\n    string Name => \"name\";\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(XmlDocumentationFormattingAnalyzer.DiagnosticId);
+        Replacement(diagnostics[0]).Should().Be(
+            "    /// <summary>\n    ///  The name.\n    /// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_SingleLineTopLevelElementWithinLimit_ReportsNothing()
+    {
+        string source =
+            "class Sample\n{\n    /// <returns>The name.</returns>\n    string Name() => \"name\";\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_EmptySingleLineTopLevelElementWithinLimit_ReportsNothing()
+    {
+        string source =
+            "class Sample\n{\n    /// <param name=\"value\"></param>\n    void Method(string value) { }\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_SingleLineTopLevelElementOverLimit_ReportsExpandedReplacement()
+    {
+        string source =
+            "class Sample\n{\n    /// <returns>The requested display name.</returns>\n    string Name() => \"name\";\n}\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "40"
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "    /// <returns>\n    ///  The requested display name.\n    /// </returns>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_SingleLineElementWithEdgeWhitespace_MeasuresActualLine()
+    {
+        string source =
+            "/// <returns> The name. </returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "32"
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task Analyze_ThreeLineTopLevelElementWithOneContentLine_ReportsCompactReplacement()
+    {
+        string source =
+            "class Sample\n{\n    /// <returns>\n    ///  The name.\n    /// </returns>\n"
+            + "    string Name() => \"name\";\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be("    /// <returns>The name.</returns>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_Compaction_PreservesNonBreakingSpaces()
+    {
+        string source =
+            "/// <returns>\n///  \u00a0The name.\u00a0\n/// </returns>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <returns>\u00a0The name.\u00a0</returns>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_XmlSpacePreserveContent_RemainsOpaque()
+    {
+        string source =
+            "/// <returns xml:space=\"preserve\">\n///    The name.  \n/// </returns>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_InheritedXmlSpacePreserveContent_RemainsOpaque()
+    {
+        string source =
+            "/// <remarks xml:space=\"preserve\">\n///  <para>  Text.  </para>\n/// </remarks>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_XmlSpaceDefault_ResetsInheritedPreservation()
+    {
+        string source =
+            "/// <remarks xml:space=\"preserve\">\n"
+            + "///  <para xml:space=\"default\">Text.</para>\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks xml:space=\"preserve\">\n"
+            + "///  <para xml:space=\"default\">\n"
+            + "///   Text.\n"
+            + "///  </para>\n"
+            + "/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_SameLineXmlSpaceDefault_PreservesParentOwnedWhitespace()
+    {
+        string source =
+            "/// <remarks xml:space=\"preserve\">before <para xml:space=\"default\">Text.</para> after</remarks>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks xml:space=\"preserve\">before <para xml:space=\"default\">\n"
+            + "///   Text.\n"
+            + "///  </para> after</remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_SameLineDefaultCode_PreservesParentOwnedWhitespace()
+    {
+        string source =
+            "/// <remarks xml:space=\"preserve\">before <code xml:space=\"default\">x</code> after</remarks>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_DefaultChildOpeningIndentation_IsOwnedByPreservedParent()
+    {
+        string source =
+            "/// <remarks xml:space=\"preserve\">\n"
+            + "///       <para xml:space=\"default\">\n"
+            + "///   Text.\n"
+            + "///  </para>\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_EntityNormalizedXmlSpacePreserve_RemainsOpaque()
+    {
+        string source =
+            "/// <remarks xml:space=\"pre&#x73;erve\">\n///       Text.  \n/// </remarks>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_NonBreakingSpaceOnlyContent_PreservesContentAndConverges()
+    {
+        string source = "/// <summary>\u00a0</summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        string replacement = Replacement(diagnostics[0]);
+        replacement.Should().Be("/// <summary>\n///  \u00a0\n/// </summary>");
+
+        ImmutableArray<Diagnostic> replacementDiagnostics = await AnalyzeAsync(
+            $"{replacement}\nclass Sample {{ }}\n").ConfigureAwait(false);
+        replacementDiagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_TopLevelElementWithTwoContentLines_ReportsNothing()
+    {
+        string source =
+            "class Sample\n{\n    /// <returns>\n    ///  The requested name,\n"
+            + "    ///  or null when unavailable.\n    /// </returns>\n"
+            + "    string? Name() => null;\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_CorrectlyIndentedBlockWithHangingIndent_PreservesRelativeIndentation()
+    {
+        string source =
+            "/// <remarks>\n///  <para>\n"
+            + "///   - <c>Class</c> / <c>NegClass</c>: matches one character\n"
+            + "///     against the class body.\n"
+            + "///  </para>\n/// </remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_ExpandedFirstContentLineWithHangingContinuation_PreservesRelativeIndentation()
+    {
+        string source =
+            "/// <summary>First line\n"
+            + "///     hanging continuation.\n"
+            + "/// </summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <summary>\n"
+            + "///  First line\n"
+            + "///     hanging continuation.\n"
+            + "/// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_ExpandedNestedFirstContentLineWithHangingContinuation_PreservesRelativeIndentation()
+    {
+        string source =
+            "/// <remarks><para>First line\n"
+            + "///      hanging continuation.\n"
+            + "/// </para></remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks>\n"
+            + "///  <para>\n"
+            + "///   First line\n"
+            + "///      hanging continuation.\n"
+            + "///  </para>\n"
+            + "/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_ProseAfterSameLineNestedBlock_ComputesNewBlockIndentation()
+    {
+        string source =
+            "/// <remarks>Intro.<para>Nested.</para>\n"
+            + "/// Trailing block.\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks>\n"
+            + "///  Intro.\n"
+            + "///  <para>\n"
+            + "///   Nested.\n"
+            + "///  </para>\n"
+            + "///  Trailing block.\n"
+            + "/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_FirstProseRunBeforeNestedBlock_DoesNotLeakIntoLaterProse()
+    {
+        string source =
+            "/// <remarks>First line\n"
+            + "///     hanging before child.<para>Nested.</para>\n"
+            + "/// Trailing block.\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks>\n"
+            + "///  First line\n"
+            + "///     hanging before child.\n"
+            + "///  <para>\n"
+            + "///   Nested.\n"
+            + "///  </para>\n"
+            + "///  Trailing block.\n"
+            + "/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_ProseGeneratedAfterNestedBlock_PreservesHangingContinuation()
+    {
+        string source =
+            "/// <remarks><para>Nested.</para>Trailing first\n"
+            + "///      hanging continuation.\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks>\n"
+            + "///  <para>\n"
+            + "///   Nested.\n"
+            + "///  </para>\n"
+            + "///  Trailing first\n"
+            + "///      hanging continuation.\n"
+            + "/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_UnderIndentedBlock_ShiftsEveryLineBySameAmount()
+    {
+        string source =
+            "/// <summary>\n"
+            + "/// Text starts one space too far left.\n"
+            + "///   Its hanging continuation is two spaces deeper.\n"
+            + "/// </summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <summary>\n"
+            + "///  Text starts one space too far left.\n"
+            + "///    Its hanging continuation is two spaces deeper.\n"
+            + "/// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_OverLimitMultilineElementWithUnderIndentedContent_CorrectsIndentation()
+    {
+        string source =
+            "/// <summary>Summary.</summary>\n/// <param name=\"value\">A deliberately long parameter description.</param>\n"
+            + "/// <returns>\n/// The deliberately long return description.\n/// </returns>\n"
+            + "class Sample { string Method(string value) => value; }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "40"
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Contain("///  The deliberately long return description.");
+    }
+
+    [TestMethod]
+    public async Task Analyze_OverLimitReturnsAfterLongParameter_CorrectsInlineXmlContentIndentation()
+    {
+        string source =
+            "    /// <summary>\n    ///  Attempts to retrieve the value as the specified type.\n    /// </summary>\n"
+            + "    /// <typeparam name=\"T\">The type to retrieve the value as.</typeparam>\n"
+            + "    /// <param name=\"value\">When this method returns, contains the value if the conversion succeeded.</param>\n"
+            + "    /// <returns>\n"
+            + "    /// <see langword=\"true\"/> if the value was successfully retrieved; otherwise, <see langword=\"false\"/>.\n"
+            + "    /// </returns>\n"
+            + "    public bool TryGetValue<T>(out T value) { value = default!; return true; }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Contain(
+            "    ///  <see langword=\"true\"/> if the value was successfully retrieved;");
+    }
+
+    [TestMethod]
+    public async Task Analyze_NestedElements_UsesConfiguredIndentSize()
+    {
+        string source =
+            "/// <remarks>\n///  <para>\n///   Text.\n///  </para>\n/// </remarks>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.IndentSizeOption] = "2"
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks>\n///   <para>\n///     Text.\n///   </para>\n/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_CompactNestedBlockElements_ExpandsEveryLevel()
+    {
+        string source = "/// <remarks><para>Text.</para></remarks>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <remarks>\n///  <para>\n///   Text.\n///  </para>\n/// </remarks>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_StandardMaxLineLength_ControlsExpansion()
+    {
+        string source =
+            "/// <returns>The requested display name.</returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new() { ["max_line_length"] = "45" };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Contain("\n");
+    }
+
+    [TestMethod]
+    public async Task Analyze_RuleMaxLineLength_OverridesStandardValue()
+    {
+        string source =
+            "/// <returns>The requested display name.</returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "120",
+            ["max_line_length"] = "20"
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_InvalidRuleMaxLineLength_FallsThroughToStandardValue()
+    {
+        string source =
+            "/// <returns>The requested display name.</returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "invalid",
+            ["max_line_length"] = "45"
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task Analyze_MaximumIntegerLineLength_DoesNotOverflow()
+    {
+        string source =
+            "/// <returns>The requested display name.</returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = int.MaxValue.ToString(CultureInfo.InvariantCulture)
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_OversizedIndentSize_FallsBackToDefault()
+    {
+        string source =
+            "/// <remarks>\n///  <para>\n///   Text.\n///  </para>\n/// </remarks>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.IndentSizeOption] = int.MaxValue.ToString(CultureInfo.InvariantCulture)
+        };
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, options).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_InlineAndSelfClosingElements_PreservesTheirText()
+    {
+        string source =
+            "/// <summary>Gets <see cref=\"string\"/> for <paramref name=\"value\"/>.</summary>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <summary>\n///  Gets <see cref=\"string\"/> for <paramref name=\"value\"/>.\n"
+            + "/// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_EmphasisElement_RemainsInline()
+    {
+        string source =
+            "/// <summary>Uses the <em>requested name</em>.</summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <summary>\n///  Uses the <em>requested name</em>.\n/// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_WrappedInlineElement_DoesNotAddNestingIndent()
+    {
+        string source =
+            "/// <summary>\n///  Uses <b>bold text that wraps\n///  across source lines</b>.\n"
+            + "/// </summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_CodePayload_PreservesRelativeIndentation()
+    {
+        string source =
+            "/// <example>\n/// <code>\n///       if (ready)\n///       {\n///           Run();\n///       }\n"
+            + "/// </code>\n/// </example>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <example>\n///  <code>\n///       if (ready)\n///       {\n///           Run();\n///       }\n"
+            + "///  </code>\n/// </example>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_XmlLookingCodePayload_RemainsOpaque()
+    {
+        string source =
+            "/// <example><code><summary>literal text</summary></code></example>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <example>\n///  <code><summary>literal text</summary></code>\n/// </example>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_CDataPayload_RemainsOpaque()
+    {
+        string source =
+            "/// <summary><![CDATA[  <tag> value </tag>  ]]></summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <summary>\n///  <![CDATA[  <tag> value </tag>  ]]>\n/// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_MultilineCData_AlignsDelimitersAndPreservesPayloadIndentation()
+    {
+        string source =
+            "/// <summary>\n/// <![CDATA[\n///       <tag> value </tag>\n/// ]]>\n/// </summary>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <summary>\n///  <![CDATA[\n///       <tag> value </tag>\n///  ]]>\n/// </summary>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_CDataInsideCode_RemainsOpaque()
+    {
+        string source =
+            "/// <example><code><![CDATA[  <tag> value </tag>  ]]></code></example>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <example>\n///  <code><![CDATA[  <tag> value </tag>  ]]></code>\n/// </example>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_MultipleCDataSectionsInsideCode_KeepInterveningPayloadOpaque()
+    {
+        string source =
+            "/// <example>\n///  <code>\n///       <![CDATA[first]]>\n///       middle <tag>text</tag>\n"
+            + "///       <![CDATA[second]]>\n///  </code>\n/// </example>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_MultilineCDataInsideCode_AlignsDelimitersAndPreservesBody()
+    {
+        string source =
+            "/// <example>\n///  <code>\n/// <![CDATA[\n///       payload\n/// ]]>\n///  </code>\n"
+            + "/// </example>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "/// <example>\n///  <code>\n///   <![CDATA[\n///       payload\n///   ]]>\n///  </code>\n"
+            + "/// </example>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_CDataClosingDelimiterAfterPayload_PreservesPayloadIndentation()
+    {
+        string source =
+            "/// <summary>\n///  <![CDATA[\n///       payload]]>\n/// </summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_MultilineStartTag_PreservesAttributeIndentationAndFormatsContent()
+    {
+        string source =
+            "class Sample\n{\n    /// <exception\n    /// cref=\"ArgumentException\">Invalid.</exception>\n"
+            + "    void Method() { }\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "    /// <exception\n    /// cref=\"ArgumentException\">\n"
+            + "    ///  Invalid.\n    /// </exception>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_MultilineAttributeValue_PreservesLeadingWhitespaceData()
+    {
+        string source =
+            "/// <summary>\n///  <a href=\"first\n///       second\">Text.</a>\n/// </summary>\n"
+            + "class Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_WhitespaceOnlyAttributeValueContinuation_PreservesWhitespaceData()
+    {
+        string source =
+            "/// <summary>\n///  <a href=\"first\n///       \n///       second\">Text.</a>\n"
+            + "/// </summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_MultilineSelfClosingElementWithCorrectFirstLine_PreservesBlock()
+    {
+        string source =
+            "class Sample\n{\n    /// <inheritdoc\n    /// cref=\"Sample.Method()\"/>\n"
+            + "    void Method() { }\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_UnderIndentedMultilineSelfClosingElement_ShiftsWholeBlock()
+    {
+        string source =
+            "class Sample\n{\n    ///<inheritdoc\n    ///  cref=\"Sample.Method()\"/>\n"
+            + "    void Method() { }\n}\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+        Replacement(diagnostics[0]).Should().Be(
+            "    /// <inheritdoc\n    ///   cref=\"Sample.Method()\"/>");
+    }
+
+    [TestMethod]
+    public async Task Analyze_MalformedXml_ReportsNothing()
+    {
+        string source = "/// <summary>Missing close tag.\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_DelimitedDocumentationComment_ReportsNothing()
+    {
+        string source = "/** <summary>Text.</summary> */\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task Analyze_GeneratedCode_ReportsNothing()
+    {
+        string source = "// <auto-generated/>\n/// <summary>Text.</summary>\nclass Sample { }\n";
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/XmlDocumentationFormattingCodeFixTests.cs
+++ b/touki.analyzers.tests/XmlDocumentationFormattingCodeFixTests.cs
@@ -1,0 +1,353 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class XmlDocumentationFormattingCodeFixTests
+{
+    private static readonly Dictionary<string, ReportDiagnostic> s_enabled =
+        new() { [XmlDocumentationFormattingAnalyzer.DiagnosticId] = ReportDiagnostic.Warn };
+
+    private static async Task<string> ApplyFixAsync(
+        string source,
+        Dictionary<string, string>? options = null)
+        => await CodeFixTestHarness.ApplyFixAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            new FormatXmlDocumentationCodeFixProvider(),
+            source,
+            XmlDocumentationFormattingAnalyzer.DiagnosticId,
+            options,
+            s_enabled).ConfigureAwait(false);
+
+    [TestMethod]
+    public async Task Format_SingleLineSummary_ExpandsIt()
+    {
+        string source =
+            "class Sample\n{\n    /// <summary>The name.</summary>\n    string Name => \"name\";\n}\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "class Sample\n{\n    /// <summary>\n    ///  The name.\n    /// </summary>\n"
+            + "    string Name => \"name\";\n}\n");
+    }
+
+    [TestMethod]
+    public async Task Format_ExpandedFirstContentLineWithHangingContinuation_PreservesRelativeIndentation()
+    {
+        string source =
+            "/// <summary>First line\n"
+            + "///     hanging continuation.\n"
+            + "/// </summary>\nclass Sample { }\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <summary>\n"
+            + "///  First line\n"
+            + "///     hanging continuation.\n"
+            + "/// </summary>\nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_FirstProseRunBeforeNestedBlock_DoesNotLeakIntoLaterProse()
+    {
+        string source =
+            "/// <remarks>First line\n"
+            + "///     hanging before child.<para>Nested.</para>\n"
+            + "/// Trailing block.\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <remarks>\n"
+            + "///  First line\n"
+            + "///     hanging before child.\n"
+            + "///  <para>\n"
+            + "///   Nested.\n"
+            + "///  </para>\n"
+            + "///  Trailing block.\n"
+            + "/// </remarks>\nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_ProseGeneratedAfterNestedBlock_PreservesHangingContinuation()
+    {
+        string source =
+            "/// <remarks><para>Nested.</para>Trailing first\n"
+            + "///      hanging continuation.\n"
+            + "/// </remarks>\nclass Sample { }\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <remarks>\n"
+            + "///  <para>\n"
+            + "///   Nested.\n"
+            + "///  </para>\n"
+            + "///  Trailing first\n"
+            + "///      hanging continuation.\n"
+            + "/// </remarks>\nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_ThreeLineTopLevelElement_CompactsIt()
+    {
+        string source =
+            "class Sample\n{\n    /// <returns>\n    ///  The name.\n    /// </returns>\n"
+            + "    string Name() => \"name\";\n}\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "class Sample\n{\n    /// <returns>The name.</returns>\n"
+            + "    string Name() => \"name\";\n}\n");
+    }
+
+    [TestMethod]
+    public async Task Format_ConfiguredIndentSize_UsesConfiguredIndentation()
+    {
+        string source =
+            "/// <remarks><para>Text.</para></remarks>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.IndentSizeOption] = "2"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <remarks>\n///   <para>\n///     Text.\n///   </para>\n/// </remarks>\n"
+            + "class Sample { }\n");
+    }
+
+    [TestMethod]
+    public async Task Format_CrlfSource_PreservesLineEndings()
+    {
+        string source =
+            "/// <summary>Text.</summary>\r\nclass Sample { }\r\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <summary>\r\n///  Text.\r\n/// </summary>\r\nclass Sample { }\r\n");
+    }
+
+    [TestMethod]
+    public async Task Format_CodePayload_PreservesPayloadIndentation()
+    {
+        string source =
+            "/// <example>\n/// <code>\n///       if (ready)\n///       {\n///           Run();\n///       }\n"
+            + "/// </code>\n/// </example>\nclass Sample { }\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <example>\n///  <code>\n///       if (ready)\n///       {\n///           Run();\n///       }\n"
+            + "///  </code>\n/// </example>\nclass Sample { }\n");
+    }
+
+    [TestMethod]
+    public async Task Format_AlreadyFixedSource_IsIdempotent()
+    {
+        string source = "/// <summary>Text.</summary>\nclass Sample { }\n";
+
+        string fixedSource = await ApplyFixAsync(source).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource).ConfigureAwait(false);
+
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_OverLimitSingleLineWithEdgeWhitespace_IsIdempotent()
+    {
+        string source = "/// <returns> The name. </returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "32"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be("/// <returns>The name.</returns>\nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_CompactedElementWithExtraPrefixSpaces_IsIdempotent()
+    {
+        string source = "///    <returns> The name. </returns>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "32"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be("/// <returns>The name.</returns>\nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_ExactLimitCompactElementWithTrailingSuffix_IsIdempotent()
+    {
+        string source = "/// <returns> The name. </returns> \nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "32"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be("/// <returns>\n///  The name.\n/// </returns> \nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_NeighboringCompactElementsOnOverLimitLine_IsIdempotent()
+    {
+        string source =
+            "/// <param name=\"value\">The value.</param><returns>The result.</returns>\n"
+            + "class Sample { string Method(string value) => value; }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "50"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <param name=\"value\">The value.</param>\n"
+            + "/// <returns>The result.</returns>\n"
+            + "class Sample { string Method(string value) => value; }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_LastCrowdedElementWithTrailingSuffix_IsIdempotent()
+    {
+        string source =
+            "/// <param name=\"v\">x</param><returns>x</returns>          \n"
+            + "class Sample { string Method(string v) => v; }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "30"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <param name=\"v\">x</param>\n"
+            + "/// <returns>\n///  x\n/// </returns>          \n"
+            + "class Sample { string Method(string v) => v; }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_LaterCrowdedElementRequiringNormalization_IsIdempotent()
+    {
+        string source =
+            "/// <param name=\"v\">x</param><returns> x </returns>\n"
+            + "class Sample { string Method(string v) => v; }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "35"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <param name=\"v\">x</param>\n"
+            + "/// <returns>x</returns>\n"
+            + "class Sample { string Method(string v) => v; }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task Format_PairedElementCrowdedBySelfClosingSibling_IsIdempotent()
+    {
+        string source = "/// <returns>x</returns><inheritdoc/>\nclass Sample { }\n";
+        Dictionary<string, string> options = new()
+        {
+            [XmlDocumentationFormattingAnalyzer.MaxLineLengthOption] = "30"
+        };
+
+        string fixedSource = await ApplyFixAsync(source, options).ConfigureAwait(false);
+        string fixedAgain = await ApplyFixAsync(fixedSource, options).ConfigureAwait(false);
+
+        fixedSource.Should().Be(
+            "/// <returns>x</returns>\n/// <inheritdoc/>\nclass Sample { }\n");
+        fixedAgain.Should().Be(fixedSource);
+    }
+
+    [TestMethod]
+    public async Task FormatAll_MultipleDocuments_FixesEveryComment()
+    {
+        (string Name, string FilePath, string Source)[] sources =
+        [
+            ("One.cs", "One.cs", "/// <summary>One.</summary>\nclass One { }\n"),
+            ("Two.cs", "Two.cs", "/// <summary>Two.</summary>\nclass Two { }\n")
+        ];
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            new FormatXmlDocumentationCodeFixProvider(),
+            sources,
+            XmlDocumentationFormattingAnalyzer.DiagnosticId,
+            fixAll: true,
+            diagnosticOptions: s_enabled).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        result.Documents.Should().OnlyContain(
+            document => document.Source.Contains("///  ", StringComparison.Ordinal)
+                && !document.Source.Contains("<summary>One.</summary>", StringComparison.Ordinal)
+                && !document.Source.Contains("<summary>Two.</summary>", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public async Task FormatAll_MultipleCommentsInOneDocument_FixesEveryComment()
+    {
+        (string Name, string FilePath, string Source)[] sources =
+        [
+            (
+                "Both.cs",
+                "Both.cs",
+                "/// <summary>One.</summary>\nclass One { }\n\n"
+                + "/// <summary>Two.</summary>\nclass Two { }\n")
+        ];
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new XmlDocumentationFormattingAnalyzer(),
+            new FormatXmlDocumentationCodeFixProvider(),
+            sources,
+            XmlDocumentationFormattingAnalyzer.DiagnosticId,
+            fixAll: true,
+            diagnosticOptions: s_enabled).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        result.Documents.Should().ContainSingle()
+            .Which.Source.Should().Be(
+                "/// <summary>\n///  One.\n/// </summary>\nclass One { }\n\n"
+                + "/// <summary>\n///  Two.\n/// </summary>\nclass Two { }\n");
+    }
+
+}

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -1,2 +1,8 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML

--- a/touki.analyzers/XmlDocumentationCommentFormatter.cs
+++ b/touki.analyzers/XmlDocumentationCommentFormatter.cs
@@ -1,0 +1,1705 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Produces the canonical text for one structured single-line XML documentation comment.
+/// </summary>
+internal static class XmlDocumentationCommentFormatter
+{
+    internal const int MaximumCommentLength = 1024 * 1024;
+    private const int MaximumIndentationColumns = 4096;
+    private const int MaximumReplacementLength = 4 * 1024 * 1024;
+    private const int MaximumStructuredNodeCount = 4096;
+    private const int MaximumXmlNestingDepth = 128;
+
+    public static bool TryFormat(
+        SourceText source,
+        DocumentationCommentTriviaSyntax documentation,
+        TextSpan commentSpan,
+        string newLine,
+        int indentSize,
+        int maxLineLength,
+        CancellationToken cancellationToken,
+        out string replacement)
+    {
+        if (commentSpan.Length > MaximumCommentLength)
+        {
+            replacement = string.Empty;
+            return false;
+        }
+
+        List<XmlElementSyntax> elements = [];
+        List<XmlEmptyElementSyntax> emptyElements = [];
+        List<XmlCDataSectionSyntax> cdataSections = [];
+        List<XmlTextAttributeSyntax> textAttributes = [];
+        HashSet<XmlElementSyntax> preservedElements = [];
+        int nodeCount = 0;
+
+        foreach (SyntaxNode node in documentation.DescendantNodes())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (++nodeCount > MaximumStructuredNodeCount)
+            {
+                replacement = string.Empty;
+                return false;
+            }
+
+            if (node is XmlElementSyntax element)
+            {
+                if (GetXmlNestingDepth(element) > MaximumXmlNestingDepth)
+                {
+                    replacement = string.Empty;
+                    return false;
+                }
+
+                elements.Add(element);
+                if (IsEffectiveXmlSpacePreserve(source, element, preservedElements))
+                {
+                    preservedElements.Add(element);
+                }
+            }
+            else if (node is XmlEmptyElementSyntax emptyElement)
+            {
+                emptyElements.Add(emptyElement);
+            }
+            else if (node is XmlCDataSectionSyntax cdata)
+            {
+                cdataSections.Add(cdata);
+            }
+            else if (node is XmlTextAttributeSyntax textAttribute)
+            {
+                textAttributes.Add(textAttribute);
+            }
+        }
+
+        List<TextChange> changes = [];
+        List<TextSpan> compactedSpans = [];
+        Dictionary<int, int> exteriorIndexCache = [];
+        Dictionary<int, int> contentStartCache = [];
+        HashSet<int> crowdedTopLevelLines = GetCrowdedTopLevelLines(
+            source,
+            elements,
+            emptyElements);
+        long projectedLength = commentSpan.Length;
+
+        foreach (XmlElementSyntax element in elements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (preservedElements.Contains(element)
+                || HasElementAncestor(element)
+                || crowdedTopLevelLines.Contains(GetLineNumber(source, element.SpanStart))
+                || !TryCreateCompactChange(
+                    source,
+                    element,
+                    maxLineLength,
+                    exteriorIndexCache,
+                    out TextChange change))
+            {
+                continue;
+            }
+
+            if (!TryReserveChange(change.NewText!.Length, change.Span.Length, ref projectedLength))
+            {
+                replacement = string.Empty;
+                return false;
+            }
+
+            changes.Add(change);
+            compactedSpans.Add(element.Span);
+        }
+
+        compactedSpans.Sort(static (left, right) => left.Start.CompareTo(right.Start));
+
+        List<TextSpan> opaqueSpans = GetOpaqueSpans(elements, cdataSections);
+        Dictionary<int, BreakBoundary> boundaries = [];
+        HashSet<TextSpan> generatedProseBlocks = [];
+
+        foreach (XmlElementSyntax element in elements)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (IsWithinAny(element.SpanStart, compactedSpans)
+                || preservedElements.Contains(element)
+                || HasCodeAncestor(element))
+            {
+                continue;
+            }
+
+            string name = element.StartTag.Name.LocalName.ValueText;
+            int depth = GetBlockAncestorDepth(element);
+
+            if (string.Equals(name, "code", StringComparison.Ordinal))
+            {
+                if (!IsInPreservedElement(element.Parent, preservedElements))
+                {
+                    AddOpaqueNodeBoundaries(
+                        source,
+                        element,
+                        depth,
+                        boundaries,
+                        generatedProseBlocks,
+                        exteriorIndexCache,
+                        contentStartCache);
+                }
+
+                continue;
+            }
+
+            bool isTopLevel = depth == 0;
+            bool isInline = IsInlineElement(name);
+            if (!isTopLevel && isInline)
+            {
+                continue;
+            }
+
+            bool simpleTopLevel = isTopLevel
+                && !string.Equals(name, "summary", StringComparison.Ordinal)
+                && HasOnlyInlineContent(element);
+
+            if (simpleTopLevel && IsSingleLine(source, element))
+            {
+                if (ExistingLineFits(source, element, maxLineLength))
+                {
+                    continue;
+                }
+
+                int lineNumber = GetLineNumber(source, element.SpanStart);
+                if (crowdedTopLevelLines.Contains(lineNumber)
+                    && TryKeepCrowdedElementCompact(
+                        source,
+                        element,
+                        maxLineLength,
+                        exteriorIndexCache,
+                        contentStartCache,
+                        boundaries,
+                        changes,
+                        ref projectedLength))
+                {
+                    continue;
+                }
+            }
+
+            AddBlockElementBoundaries(
+                source,
+                element,
+                depth,
+                preserveExterior: IsInPreservedElement(element.Parent, preservedElements),
+                boundaries,
+                generatedProseBlocks,
+                exteriorIndexCache,
+                contentStartCache);
+        }
+
+        foreach (XmlCDataSectionSyntax cdata in cdataSections)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!IsWithinAny(cdata.SpanStart, compactedSpans)
+                && !IsInPreservedElement(cdata, preservedElements)
+                && !HasCodeAncestor(cdata))
+            {
+                AddOpaqueNodeBoundaries(
+                    source,
+                    cdata,
+                    GetBlockAncestorDepth(cdata),
+                    boundaries,
+                    generatedProseBlocks,
+                    exteriorIndexCache,
+                    contentStartCache);
+            }
+        }
+
+        foreach (BreakBoundary boundary in boundaries.Values)
+        {
+            if (!TryCreateBoundaryChange(
+                source,
+                boundary,
+                newLine,
+                indentSize,
+                exteriorIndexCache,
+                ref projectedLength,
+                out TextChange change))
+            {
+                replacement = string.Empty;
+                return false;
+            }
+
+            changes.Add(change);
+        }
+
+        List<TextSpan> structuralChangeSpans = new(changes.Count);
+        foreach (TextChange change in changes)
+        {
+            structuralChangeSpans.Add(change.Span);
+        }
+
+        structuralChangeSpans.Sort(static (left, right) =>
+        {
+            int result = left.Start.CompareTo(right.Start);
+            return result != 0 ? result : left.Length.CompareTo(right.Length);
+        });
+
+        HashSet<int> protectedAttributeValueLines = GetProtectedAttributeValueLines(source, textAttributes);
+        HashSet<int> cdataDelimiterLines = GetMultilineCDataDelimiterLines(
+            source,
+            cdataSections,
+            exteriorIndexCache,
+            contentStartCache);
+
+        if (!TryAddIndentationChanges(
+            source,
+            documentation,
+            commentSpan,
+            indentSize,
+            opaqueSpans,
+            cdataDelimiterLines,
+            protectedAttributeValueLines,
+            preservedElements,
+            generatedProseBlocks,
+            structuralChangeSpans,
+            exteriorIndexCache,
+            changes,
+            ref projectedLength,
+            cancellationToken))
+        {
+            replacement = string.Empty;
+            return false;
+        }
+
+        if (changes.Count == 0)
+        {
+            replacement = string.Empty;
+            return false;
+        }
+
+        changes.Sort(static (left, right) =>
+        {
+            int result = left.Span.Start.CompareTo(right.Span.Start);
+            return result != 0 ? result : left.Span.Length.CompareTo(right.Span.Length);
+        });
+
+        if (!AreChangesIndependent(changes, commentSpan))
+        {
+            replacement = string.Empty;
+            return false;
+        }
+
+        SourceText comment = SourceText.From(source.ToString(commentSpan));
+        TextChange[] relativeChanges = new TextChange[changes.Count];
+        for (int index = 0; index < changes.Count; index++)
+        {
+            TextChange change = changes[index];
+            relativeChanges[index] = new(
+                new TextSpan(change.Span.Start - commentSpan.Start, change.Span.Length),
+                change.NewText!);
+        }
+
+        replacement = comment.WithChanges(relativeChanges).ToString();
+        return !string.Equals(comment.ToString(), replacement, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    ///  Finds the zero-based column where the <c>///</c> documentation-comment exterior begins after leading
+    ///  source indentation. The index is relative to <see cref="TextLine.Start"/>; when the line does not start
+    ///  with a documentation-comment exterior, returns <see langword="false"/> and sets the index to <c>-1</c>.
+    /// </summary>
+    internal static bool TryGetExteriorIndex(SourceText source, TextLine line, out int exteriorIndex)
+    {
+        int index = line.Start;
+        while (index < line.End && char.IsWhiteSpace(source[index]))
+        {
+            index++;
+        }
+
+        if (index + 2 < line.End
+            && source[index] == '/'
+            && source[index + 1] == '/'
+            && source[index + 2] == '/')
+        {
+            exteriorIndex = index - line.Start;
+            return true;
+        }
+
+        exteriorIndex = -1;
+        return false;
+    }
+
+    private static HashSet<int> GetCrowdedTopLevelLines(
+        SourceText source,
+        List<XmlElementSyntax> elements,
+        List<XmlEmptyElementSyntax> emptyElements)
+    {
+        Dictionary<int, int> counts = [];
+        HashSet<int> crowded = [];
+
+        foreach (XmlElementSyntax element in elements)
+        {
+            if (HasElementAncestor(element) || !IsSingleLine(source, element))
+            {
+                continue;
+            }
+
+            AddCrowdedLine(GetLineNumber(source, element.SpanStart), counts, crowded);
+        }
+
+        foreach (XmlEmptyElementSyntax element in emptyElements)
+        {
+            if (HasElementAncestor(element)
+                || GetLineNumber(source, element.SpanStart) != GetLineNumber(source, element.Span.End - 1))
+            {
+                continue;
+            }
+
+            AddCrowdedLine(GetLineNumber(source, element.SpanStart), counts, crowded);
+        }
+
+        return crowded;
+    }
+
+    private static void AddCrowdedLine(
+        int line,
+        Dictionary<int, int> counts,
+        HashSet<int> crowded)
+    {
+        if (counts.TryGetValue(line, out int count))
+        {
+            counts[line] = count + 1;
+            crowded.Add(line);
+        }
+        else
+        {
+            counts.Add(line, 1);
+        }
+    }
+
+    private static bool TryKeepCrowdedElementCompact(
+        SourceText source,
+        XmlElementSyntax element,
+        int maxLineLength,
+        Dictionary<int, int> exteriorIndexCache,
+        Dictionary<int, int> contentStartCache,
+        Dictionary<int, BreakBoundary> boundaries,
+        List<TextChange> changes,
+        ref long projectedLength)
+    {
+        string candidate = TryGetMeaningfulContentBounds(element, out SyntaxToken first, out SyntaxToken last)
+            ? CreateCompactText(source, element, first, last)
+            : source.ToString(element.Span).Trim();
+
+        if (!FitsOnOwnLine(source, element, candidate, maxLineLength, exteriorIndexCache))
+        {
+            return false;
+        }
+
+        string current = source.ToString(element.Span);
+        if (!string.Equals(current, candidate, StringComparison.Ordinal))
+        {
+            if (!TryReserveChange(candidate.Length, element.Span.Length, ref projectedLength))
+            {
+                return false;
+            }
+
+            changes.Add(new(element.Span, candidate));
+        }
+
+        AddBreakBeforeIfNeeded(
+            source,
+            element.SpanStart,
+            depth: 0,
+            boundaries,
+            exteriorIndexCache,
+            contentStartCache);
+        AddBreakAfterIfNeeded(source, element.Span.End, depth: 0, boundaries);
+        return true;
+    }
+
+    private static bool FitsOnOwnLine(
+        SourceText source,
+        XmlElementSyntax element,
+        string candidate,
+        int maxLineLength,
+        Dictionary<int, int> exteriorIndexCache)
+    {
+        TextLine line = source.Lines.GetLineFromPosition(element.SpanStart);
+        int suffixLength = HasOnlyWhitespaceAfter(source, element.Span.End)
+            ? line.End - element.Span.End
+            : 0;
+        return TryGetExteriorIndex(source, line, exteriorIndexCache, out int exteriorIndex)
+            && (long)exteriorIndex + 4 + candidate.Length + suffixLength <= maxLineLength;
+    }
+
+    private static bool TryCreateCompactChange(
+        SourceText source,
+        XmlElementSyntax element,
+        int maxLineLength,
+        Dictionary<int, int> exteriorIndexCache,
+        out TextChange change)
+    {
+        string name = element.StartTag.Name.LocalName.ValueText;
+        int startLine = GetLineNumber(source, element.StartTag.SpanStart);
+        int endLine = GetLineNumber(source, element.EndTag.Span.End - 1);
+
+        if (string.Equals(name, "summary", StringComparison.Ordinal)
+            || string.Equals(name, "code", StringComparison.Ordinal)
+            || !HasOnlyInlineContent(element)
+            || !TryGetMeaningfulContentBounds(element, out SyntaxToken first, out SyntaxToken last))
+        {
+            change = default;
+            return false;
+        }
+
+        string candidate = CreateCompactText(source, element, first, last);
+        if (startLine == endLine)
+        {
+            string current = source.ToString(element.Span);
+            if (ExistingLineFits(source, element, maxLineLength)
+                || string.Equals(current, candidate, StringComparison.Ordinal)
+                || !FitsOnLineAfterReplacement(
+                    source,
+                    element,
+                    candidate,
+                    maxLineLength,
+                    exteriorIndexCache))
+            {
+                change = default;
+                return false;
+            }
+
+            change = new(element.Span, candidate);
+            return true;
+        }
+
+        if (endLine - startLine != 2
+            || GetLineNumber(source, first.SpanStart) != startLine + 1
+            || GetLineNumber(source, last.Span.End - 1) != startLine + 1
+            || !LineContainsOnly(source, element.StartTag.Span)
+            || !LineContainsOnly(source, TextSpan.FromBounds(first.SpanStart, last.Span.End))
+            || !LineContainsOnly(source, element.EndTag.Span))
+        {
+            change = default;
+            return false;
+        }
+
+        if (!FitsOnLineAfterReplacement(
+            source,
+            element,
+            candidate,
+            maxLineLength,
+            exteriorIndexCache))
+        {
+            change = default;
+            return false;
+        }
+
+        change = new(element.Span, candidate);
+        return true;
+    }
+
+    private static void AddBlockElementBoundaries(
+        SourceText source,
+        XmlElementSyntax element,
+        int depth,
+        bool preserveExterior,
+        Dictionary<int, BreakBoundary> boundaries,
+        HashSet<TextSpan> generatedProseBlocks,
+        Dictionary<int, int> exteriorIndexCache,
+        Dictionary<int, int> contentStartCache)
+    {
+        if (!preserveExterior)
+        {
+            AddBreakBeforeIfNeeded(
+                source,
+                element.StartTag.SpanStart,
+                depth,
+                boundaries,
+                exteriorIndexCache,
+                contentStartCache);
+            if (AddBreakAfterIfNeeded(source, element.EndTag.Span.End, depth, boundaries)
+                && TryGetFollowingProseBlockSpan(element, out TextSpan followingProseBlock))
+            {
+                generatedProseBlocks.Add(followingProseBlock);
+            }
+        }
+
+        if (!TryGetMeaningfulContentBounds(element, out SyntaxToken first, out SyntaxToken last))
+        {
+            if (GetLineNumber(source, element.StartTag.Span.End - 1)
+                == GetLineNumber(source, element.EndTag.SpanStart))
+            {
+                AddBoundary(source, element.StartTag.Span.End, depth, includeBlankLine: true, boundaries);
+            }
+
+            return;
+        }
+
+        if (GetLineNumber(source, element.StartTag.Span.End - 1)
+            == GetLineNumber(source, first.SpanStart))
+        {
+            AddBoundary(source, element.StartTag.Span.End, depth + 1, includeBlankLine: false, boundaries);
+            if (TryGetProseBlockSpan(first, out TextSpan generatedProseBlock))
+            {
+                generatedProseBlocks.Add(generatedProseBlock);
+            }
+        }
+
+        if (GetLineNumber(source, last.Span.End - 1)
+            == GetLineNumber(source, element.EndTag.SpanStart))
+        {
+            AddBoundary(source, element.EndTag.SpanStart, depth, includeBlankLine: false, boundaries);
+        }
+
+    }
+
+    private static void AddOpaqueNodeBoundaries(
+        SourceText source,
+        XmlNodeSyntax node,
+        int depth,
+        Dictionary<int, BreakBoundary> boundaries,
+        HashSet<TextSpan> generatedProseBlocks,
+        Dictionary<int, int> exteriorIndexCache,
+        Dictionary<int, int> contentStartCache)
+    {
+        AddBreakBeforeIfNeeded(
+            source,
+            node.SpanStart,
+            depth,
+            boundaries,
+            exteriorIndexCache,
+            contentStartCache);
+        if (AddBreakAfterIfNeeded(source, node.Span.End, depth, boundaries)
+            && TryGetFollowingProseBlockSpan(node, out TextSpan followingProseBlock))
+        {
+            generatedProseBlocks.Add(followingProseBlock);
+        }
+    }
+
+    private static void AddBreakBeforeIfNeeded(
+        SourceText source,
+        int position,
+        int depth,
+        Dictionary<int, BreakBoundary> boundaries,
+        Dictionary<int, int> exteriorIndexCache,
+        Dictionary<int, int> contentStartCache)
+    {
+        if (!HasOnlyWhitespaceBefore(
+            source,
+            position,
+            exteriorIndexCache,
+            contentStartCache))
+        {
+            AddBoundary(source, position, depth, includeBlankLine: false, boundaries);
+        }
+    }
+
+    private static bool AddBreakAfterIfNeeded(
+        SourceText source,
+        int position,
+        int depth,
+        Dictionary<int, BreakBoundary> boundaries)
+    {
+        if (HasOnlyWhitespaceAfter(source, position))
+        {
+            return false;
+        }
+
+        AddBoundary(source, position, depth, includeBlankLine: false, boundaries);
+        return true;
+    }
+
+    private static void AddBoundary(
+        SourceText source,
+        int position,
+        int depth,
+        bool includeBlankLine,
+        Dictionary<int, BreakBoundary> boundaries)
+    {
+        TextLine line = source.Lines.GetLineFromPosition(Math.Min(position, source.Length));
+        int start = position;
+        int end = position;
+
+        while (start > line.Start && IsHorizontalWhitespace(source[start - 1]))
+        {
+            start--;
+        }
+
+        while (end < line.End && IsHorizontalWhitespace(source[end]))
+        {
+            end++;
+        }
+
+        if (boundaries.TryGetValue(start, out BreakBoundary? boundary))
+        {
+            boundary.End = Math.Max(boundary.End, end);
+            boundary.Depth = Math.Min(boundary.Depth, depth);
+            boundary.IncludeBlankLine |= includeBlankLine;
+        }
+        else
+        {
+            boundaries.Add(start, new(start, end, depth, includeBlankLine));
+        }
+    }
+
+    private static bool TryAddIndentationChanges(
+        SourceText source,
+        DocumentationCommentTriviaSyntax documentation,
+        TextSpan commentSpan,
+        int indentSize,
+        List<TextSpan> opaqueSpans,
+        HashSet<int> cdataDelimiterLines,
+        HashSet<int> protectedAttributeValueLines,
+        HashSet<XmlElementSyntax> preservedElements,
+        HashSet<TextSpan> generatedProseBlocks,
+        List<TextSpan> structuralChangeSpans,
+        Dictionary<int, int> exteriorIndexCache,
+        List<TextChange> changes,
+        ref long projectedLength,
+        CancellationToken cancellationToken)
+    {
+        int firstLine = GetLineNumber(source, commentSpan.Start);
+        int lastLine = GetLineNumber(source, Math.Max(commentSpan.Start, commentSpan.End - 1));
+        Dictionary<int, string> indentationCache = [];
+        int structuralChangeIndex = 0;
+        int currentBlockStart = -1;
+        int currentBlockKind = -1;
+        int currentBlockIndentationDelta = 0;
+
+        for (int lineNumber = firstLine; lineNumber <= lastLine; lineNumber++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            TextLine line = source.Lines[lineNumber];
+            if (protectedAttributeValueLines.Contains(lineNumber)
+                || !TryGetExteriorIndex(
+                    source,
+                    line,
+                    exteriorIndexCache,
+                    out int exteriorIndex))
+            {
+                currentBlockStart = -1;
+                continue;
+            }
+
+            int whitespaceStart = line.Start + exteriorIndex + 3;
+            int contentStart = whitespaceStart;
+            while (contentStart < line.End && IsHorizontalWhitespace(source[contentStart]))
+            {
+                contentStart++;
+            }
+
+            int opacityProbe = contentStart < line.End ? contentStart : whitespaceStart;
+            if (IsWithinAny(opacityProbe, opaqueSpans)
+                && !cdataDelimiterLines.Contains(lineNumber))
+            {
+                currentBlockStart = -1;
+                continue;
+            }
+
+            int tokenPosition = contentStart < line.End
+                ? contentStart
+                : Math.Min(line.End, Math.Max(commentSpan.Start, commentSpan.End - 1));
+            SyntaxToken token = documentation.FindToken(tokenPosition, findInsideTrivia: true);
+            if (IsIndentationOwnedByPreservedElement(token, preservedElements))
+            {
+                currentBlockStart = -1;
+                continue;
+            }
+
+            TextSpan indentationSpan = TextSpan.FromBounds(whitespaceStart, contentStart);
+            if (OverlapsStructuralChange(
+                indentationSpan,
+                structuralChangeSpans,
+                ref structuralChangeIndex))
+            {
+                currentBlockStart = -1;
+                continue;
+            }
+
+            if (contentStart == line.End)
+            {
+                currentBlockStart = -1;
+                if (indentationSpan.Length > 0)
+                {
+                    if (!TryReserveChange(0, indentationSpan.Length, ref projectedLength))
+                    {
+                        return false;
+                    }
+
+                    changes.Add(new(indentationSpan, string.Empty));
+                }
+
+                continue;
+            }
+
+            SyntaxNode? tag = null;
+            for (SyntaxNode? node = token.Parent; node is not null; node = node.Parent)
+            {
+                if (node is XmlElementStartTagSyntax or XmlElementEndTagSyntax or XmlEmptyElementSyntax)
+                {
+                    tag = node;
+                    break;
+                }
+            }
+
+            int blockStart = -1;
+            int blockKind = 0;
+            bool generatedProseBlock = false;
+
+            if (tag is XmlElementStartTagSyntax startTag
+                && startTag.Parent is XmlElementSyntax startElement
+                && !IsInlineElement(startElement.StartTag.Name.LocalName.ValueText))
+            {
+                blockStart = startTag.SpanStart;
+                blockKind = 1;
+            }
+            else if (tag is XmlElementEndTagSyntax endTag
+                && endTag.Parent is XmlElementSyntax endElement
+                && !IsInlineElement(endElement.StartTag.Name.LocalName.ValueText))
+            {
+                blockStart = endTag.SpanStart;
+                blockKind = 2;
+            }
+            else if (tag is XmlEmptyElementSyntax emptyElement
+                && !IsInlineElement(emptyElement.Name.LocalName.ValueText))
+            {
+                blockStart = emptyElement.SpanStart;
+                blockKind = 3;
+            }
+
+            if (blockStart < 0)
+            {
+                if (TryGetProseBlockSpan(token, out TextSpan proseBlock))
+                {
+                    blockStart = proseBlock.Start;
+                    generatedProseBlock = generatedProseBlocks.Contains(proseBlock);
+                }
+                else
+                {
+                    blockStart = documentation.SpanStart;
+                }
+
+                blockKind = 4;
+            }
+
+            if (blockStart != currentBlockStart || blockKind != currentBlockKind)
+            {
+                currentBlockStart = blockStart;
+                currentBlockKind = blockKind;
+
+                if (generatedProseBlock)
+                {
+                    currentBlockIndentationDelta = 0;
+                }
+                else
+                {
+                    int depth = GetIndentationDepth(source, lineNumber, token);
+                    if (!TryGetIndentationCount(depth, indentSize, out int expectedIndentation))
+                    {
+                        return false;
+                    }
+
+                    currentBlockIndentationDelta = expectedIndentation - indentationSpan.Length;
+                }
+            }
+
+            if (currentBlockIndentationDelta != 0)
+            {
+                int count = indentationSpan.Length + currentBlockIndentationDelta;
+                if (count < 0)
+                {
+                    return false;
+                }
+
+                if (!TryReserveChange(count, indentationSpan.Length, ref projectedLength)
+                    || !TryGetIndentation(count, indentationCache, out string indentation))
+                {
+                    return false;
+                }
+
+                changes.Add(new(indentationSpan, indentation));
+            }
+        }
+
+        return true;
+    }
+
+    private static int GetIndentationDepth(SourceText source, int lineNumber, SyntaxToken token)
+    {
+        if (token.Parent is null)
+        {
+            return 0;
+        }
+
+        SyntaxNode? tag = null;
+        for (SyntaxNode? node = token.Parent; node is not null; node = node.Parent)
+        {
+            if (node is XmlElementStartTagSyntax or XmlElementEndTagSyntax or XmlEmptyElementSyntax)
+            {
+                tag = node;
+                break;
+            }
+        }
+
+        XmlElementSyntax? taggedElement = tag is XmlElementStartTagSyntax or XmlElementEndTagSyntax
+            ? tag.Parent as XmlElementSyntax
+            : null;
+        int depth = 0;
+
+        for (SyntaxNode? node = token.Parent; node is not null; node = node.Parent)
+        {
+            if (node is XmlElementSyntax element
+                && !ReferenceEquals(element, taggedElement)
+                && !IsInlineElement(element.StartTag.Name.LocalName.ValueText))
+            {
+                depth++;
+            }
+        }
+
+        SyntaxNode? attributeContainer = GetAttributeContainer(token.Parent);
+        if (attributeContainer is not null
+            && HasAttributeAncestor(token.Parent)
+            && lineNumber > GetLineNumber(source, attributeContainer.SpanStart))
+        {
+            depth++;
+        }
+
+        return depth;
+    }
+
+    private static bool TryGetIndentation(
+        int count,
+        Dictionary<int, string> cache,
+        out string indentation)
+    {
+        if (!cache.TryGetValue(count, out indentation!))
+        {
+            indentation = new(' ', count);
+            cache.Add(count, indentation);
+        }
+
+        return true;
+    }
+
+    private static bool TryCreateBoundaryChange(
+        SourceText source,
+        BreakBoundary boundary,
+        string newLine,
+        int indentSize,
+        Dictionary<int, int> exteriorIndexCache,
+        ref long projectedLength,
+        out TextChange change)
+    {
+        if (!TryGetIndentationCount(boundary.Depth, indentSize, out int indentationCount))
+        {
+            change = default;
+            return false;
+        }
+
+        TextLine line = source.Lines.GetLineFromPosition(Math.Min(boundary.Start, source.Length));
+        int codeIndentationLength = TryGetExteriorIndex(
+            source,
+            line,
+            exteriorIndexCache,
+            out int exteriorIndex)
+            ? exteriorIndex
+            : 0;
+        long newTextLength = boundary.IncludeBlankLine
+            ? (long)newLine.Length * 2 + (long)codeIndentationLength * 2 + 6 + indentationCount
+            : (long)newLine.Length + codeIndentationLength + 3 + indentationCount;
+
+        if (!TryReserveChange(
+            newTextLength,
+            boundary.End - boundary.Start,
+            ref projectedLength))
+        {
+            change = default;
+            return false;
+        }
+
+        string codeIndentation = codeIndentationLength == 0
+            ? string.Empty
+            : source.ToString(TextSpan.FromBounds(line.Start, line.Start + codeIndentationLength));
+        string prefix = $"{codeIndentation}///{new string(' ', indentationCount)}";
+        string newText = boundary.IncludeBlankLine
+            ? $"{newLine}{codeIndentation}///{newLine}{prefix}"
+            : $"{newLine}{prefix}";
+        change = new(TextSpan.FromBounds(boundary.Start, boundary.End), newText);
+        return true;
+    }
+
+    private static bool TryGetIndentationCount(int depth, int indentSize, out int count)
+    {
+        long columns = 1L + (long)depth * indentSize;
+        if (columns > MaximumIndentationColumns)
+        {
+            count = 0;
+            return false;
+        }
+
+        count = (int)columns;
+        return true;
+    }
+
+    private static HashSet<int> GetProtectedAttributeValueLines(
+        SourceText source,
+        List<XmlTextAttributeSyntax> attributes)
+    {
+        HashSet<int> lines = [];
+
+        foreach (XmlTextAttributeSyntax attribute in attributes)
+        {
+            int startLine = GetLineNumber(source, attribute.StartQuoteToken.Span.End);
+            int endPosition = attribute.EndQuoteToken.IsMissing
+                ? attribute.Span.End
+                : attribute.EndQuoteToken.SpanStart;
+            int endLine = GetLineNumber(source, Math.Max(attribute.StartQuoteToken.Span.End, endPosition));
+
+            for (int line = startLine + 1; line <= endLine; line++)
+            {
+                lines.Add(line);
+            }
+        }
+
+        return lines;
+    }
+
+    private static List<TextSpan> GetOpaqueSpans(
+        List<XmlElementSyntax> elements,
+        List<XmlCDataSectionSyntax> cdataSections)
+    {
+        List<TextSpan> spans = [];
+
+        foreach (XmlElementSyntax element in elements)
+        {
+            if (string.Equals(element.StartTag.Name.LocalName.ValueText, "code", StringComparison.Ordinal)
+                && element.StartTag.Span.End < element.EndTag.SpanStart)
+            {
+                spans.Add(TextSpan.FromBounds(element.StartTag.Span.End, element.EndTag.SpanStart));
+            }
+        }
+
+        foreach (XmlCDataSectionSyntax cdata in cdataSections)
+        {
+            if (cdata.StartCDataToken.Span.End < cdata.EndCDataToken.SpanStart)
+            {
+                spans.Add(TextSpan.FromBounds(
+                    cdata.StartCDataToken.Span.End,
+                    cdata.EndCDataToken.SpanStart));
+            }
+        }
+
+        spans.Sort(static (left, right) => left.Start.CompareTo(right.Start));
+        CoalesceSpans(spans);
+        return spans;
+    }
+
+    private static HashSet<int> GetMultilineCDataDelimiterLines(
+        SourceText source,
+        List<XmlCDataSectionSyntax> cdataSections,
+        Dictionary<int, int> exteriorIndexCache,
+        Dictionary<int, int> contentStartCache)
+    {
+        HashSet<int> lines = [];
+
+        foreach (XmlCDataSectionSyntax cdata in cdataSections)
+        {
+            int startLine = GetLineNumber(source, cdata.StartCDataToken.SpanStart);
+            int endLine = GetLineNumber(source, cdata.EndCDataToken.SpanStart);
+            if (startLine != endLine)
+            {
+                if (HasOnlyWhitespaceBefore(
+                    source,
+                    cdata.StartCDataToken.SpanStart,
+                    exteriorIndexCache,
+                    contentStartCache))
+                {
+                    lines.Add(startLine);
+                }
+
+                if (HasOnlyWhitespaceBefore(
+                    source,
+                    cdata.EndCDataToken.SpanStart,
+                    exteriorIndexCache,
+                    contentStartCache))
+                {
+                    lines.Add(endLine);
+                }
+            }
+        }
+
+        return lines;
+    }
+
+    private static void CoalesceSpans(List<TextSpan> spans)
+    {
+        if (spans.Count < 2)
+        {
+            return;
+        }
+
+        int writeIndex = 0;
+        TextSpan current = spans[0];
+
+        for (int readIndex = 1; readIndex < spans.Count; readIndex++)
+        {
+            TextSpan next = spans[readIndex];
+            if (next.Start <= current.End)
+            {
+                current = TextSpan.FromBounds(current.Start, Math.Max(current.End, next.End));
+                continue;
+            }
+
+            spans[writeIndex++] = current;
+            current = next;
+        }
+
+        spans[writeIndex++] = current;
+        if (writeIndex < spans.Count)
+        {
+            spans.RemoveRange(writeIndex, spans.Count - writeIndex);
+        }
+    }
+
+    private static bool HasCodeAncestor(SyntaxNode node)
+    {
+        for (SyntaxNode? ancestorNode = node.Parent; ancestorNode is not null; ancestorNode = ancestorNode.Parent)
+        {
+            if (ancestorNode is XmlElementSyntax ancestor
+                && string.Equals(
+                    ancestor.StartTag.Name.LocalName.ValueText,
+                    "code",
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasElementAncestor(SyntaxNode element)
+    {
+        for (SyntaxNode? node = element.Parent; node is not null; node = node.Parent)
+        {
+            if (node is XmlElementSyntax)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Determines whether whitespace preservation is effective for <paramref name="element"/>. An explicit
+    ///  <c>xml:space="preserve"</c> enables preservation, <c>xml:space="default"</c> resets it, and no recognized
+    ///  local value inherits the nearest parent element's effective mode.
+    /// </summary>
+    private static bool IsEffectiveXmlSpacePreserve(
+        SourceText source,
+        XmlElementSyntax element,
+        HashSet<XmlElementSyntax> preservedElements)
+    {
+        foreach (XmlAttributeSyntax attribute in element.StartTag.Attributes)
+        {
+            if (attribute is not XmlTextAttributeSyntax textAttribute
+                || !SourceTextEquals(source, textAttribute.Name.Span, "xml:space"))
+            {
+                continue;
+            }
+
+            if (AttributeValueEquals(textAttribute, "preserve"))
+            {
+                return true;
+            }
+
+            if (AttributeValueEquals(textAttribute, "default"))
+            {
+                return false;
+            }
+
+            break;
+        }
+
+        for (SyntaxNode? node = element.Parent; node is not null; node = node.Parent)
+        {
+            if (node is XmlElementSyntax parent)
+            {
+                return preservedElements.Contains(parent);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsInPreservedElement(
+        SyntaxNode? node,
+        HashSet<XmlElementSyntax> preservedElements)
+    {
+        for (SyntaxNode? ancestor = node; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is XmlElementSyntax element)
+            {
+                return preservedElements.Contains(element);
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsIndentationOwnedByPreservedElement(
+        SyntaxToken token,
+        HashSet<XmlElementSyntax> preservedElements)
+    {
+        if (token.IsKind(SyntaxKind.LessThanToken))
+        {
+            if (token.Parent is XmlElementStartTagSyntax startTag
+                && startTag.Parent is XmlElementSyntax element)
+            {
+                return IsInPreservedElement(element.Parent, preservedElements);
+            }
+
+            if (token.Parent is XmlEmptyElementSyntax emptyElement)
+            {
+                return IsInPreservedElement(emptyElement.Parent, preservedElements);
+            }
+        }
+
+        return IsInPreservedElement(token.Parent, preservedElements);
+    }
+
+    private static bool AttributeValueEquals(XmlTextAttributeSyntax attribute, string value)
+    {
+        int valueIndex = 0;
+
+        foreach (SyntaxToken token in attribute.TextTokens)
+        {
+            string tokenValue = token.ValueText;
+            for (int tokenIndex = 0; tokenIndex < tokenValue.Length; tokenIndex++)
+            {
+                if (valueIndex >= value.Length || tokenValue[tokenIndex] != value[valueIndex++])
+                {
+                    return false;
+                }
+            }
+        }
+
+        return valueIndex == value.Length;
+    }
+
+    private static bool SourceTextEquals(SourceText source, TextSpan span, string value)
+    {
+        if (span.Length != value.Length)
+        {
+            return false;
+        }
+
+        for (int index = 0; index < value.Length; index++)
+        {
+            if (source[span.Start + index] != value[index])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static int GetBlockAncestorDepth(SyntaxNode node)
+    {
+        int depth = 0;
+
+        for (SyntaxNode? ancestor = node.Parent; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is XmlElementSyntax element
+                && !IsInlineElement(element.StartTag.Name.LocalName.ValueText))
+            {
+                depth++;
+            }
+        }
+
+        return depth;
+    }
+
+    private static int GetXmlNestingDepth(XmlElementSyntax element)
+    {
+        int depth = 1;
+
+        for (SyntaxNode? node = element.Parent; node is not null; node = node.Parent)
+        {
+            if (node is XmlElementSyntax)
+            {
+                depth++;
+            }
+        }
+
+        return depth;
+    }
+
+    private static bool HasOnlyInlineContent(XmlElementSyntax element)
+    {
+        foreach (XmlNodeSyntax content in element.Content)
+        {
+            switch (content)
+            {
+                case XmlTextSyntax:
+                    break;
+                case XmlEmptyElementSyntax emptyElement when IsInlineElement(emptyElement.Name.LocalName.ValueText):
+                    break;
+                case XmlElementSyntax child when IsInlineElement(child.StartTag.Name.LocalName.ValueText)
+                    && HasOnlyInlineContent(child):
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetProseBlockSpan(SyntaxToken token, out TextSpan span)
+    {
+        for (SyntaxNode? node = token.Parent; node is not null; node = node.Parent)
+        {
+            if (node is not XmlNodeSyntax content)
+            {
+                continue;
+            }
+
+            if (content.Parent is DocumentationCommentTriviaSyntax documentation)
+            {
+                return TryGetProseBlockSpan(documentation.Content, content, out span);
+            }
+
+            if (content.Parent is XmlElementSyntax element
+                && !IsInlineElement(element.StartTag.Name.LocalName.ValueText))
+            {
+                return TryGetProseBlockSpan(element.Content, content, out span);
+            }
+        }
+
+        span = default;
+        return false;
+    }
+
+    private static bool TryGetProseBlockSpan(
+        SyntaxList<XmlNodeSyntax> content,
+        XmlNodeSyntax target,
+        out TextSpan span)
+    {
+        int targetIndex = GetContentIndex(content, target);
+        if (targetIndex < 0 || !IsInlineContent(content[targetIndex]))
+        {
+            span = default;
+            return false;
+        }
+
+        int startIndex = targetIndex;
+        while (startIndex > 0 && IsInlineContent(content[startIndex - 1]))
+        {
+            startIndex--;
+        }
+
+        int endIndex = targetIndex;
+        while (endIndex + 1 < content.Count && IsInlineContent(content[endIndex + 1]))
+        {
+            endIndex++;
+        }
+
+        span = TextSpan.FromBounds(content[startIndex].SpanStart, content[endIndex].Span.End);
+        return true;
+    }
+
+    private static bool TryGetFollowingProseBlockSpan(XmlNodeSyntax node, out TextSpan span)
+    {
+        SyntaxList<XmlNodeSyntax> content;
+
+        if (node.Parent is DocumentationCommentTriviaSyntax documentation)
+        {
+            content = documentation.Content;
+        }
+        else if (node.Parent is XmlElementSyntax element)
+        {
+            content = element.Content;
+        }
+        else
+        {
+            span = default;
+            return false;
+        }
+
+        int nodeIndex = GetContentIndex(content, node);
+        span = default;
+        return nodeIndex >= 0
+            && nodeIndex + 1 < content.Count
+            && TryGetProseBlockSpan(content, content[nodeIndex + 1], out span);
+    }
+
+    private static int GetContentIndex(SyntaxList<XmlNodeSyntax> content, XmlNodeSyntax target)
+    {
+        for (int index = 0; index < content.Count; index++)
+        {
+            XmlNodeSyntax candidate = content[index];
+            if (candidate.RawKind == target.RawKind && candidate.Span == target.Span)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static bool IsInlineContent(XmlNodeSyntax content) => content switch
+    {
+        XmlTextSyntax => true,
+        XmlEmptyElementSyntax emptyElement => IsInlineElement(emptyElement.Name.LocalName.ValueText),
+        XmlElementSyntax element => IsInlineElement(element.StartTag.Name.LocalName.ValueText)
+            && HasOnlyInlineContent(element),
+        _ => false
+    };
+
+    private static bool IsInlineElement(string name) => name is
+        "a" or "b" or "br" or "c" or "em" or "i" or "paramref" or "see" or "strong" or "sub" or "sup"
+        or "typeparamref" or "u";
+
+    private static bool TryGetMeaningfulContentBounds(
+        XmlElementSyntax element,
+        out SyntaxToken first,
+        out SyntaxToken last)
+    {
+        first = default;
+        last = default;
+
+        foreach (XmlNodeSyntax content in element.Content)
+        {
+            foreach (SyntaxToken token in content.DescendantTokens())
+            {
+                if (token.IsKind(SyntaxKind.XmlTextLiteralNewLineToken)
+                    || token.IsKind(SyntaxKind.XmlTextLiteralToken) && IsLayoutWhitespace(token.ValueText))
+                {
+                    continue;
+                }
+
+                if (first == default)
+                {
+                    first = token;
+                }
+
+                last = token;
+            }
+        }
+
+        return first != default;
+    }
+
+    private static bool IsLayoutWhitespace(string value)
+    {
+        foreach (char character in value)
+        {
+            if (!IsHorizontalWhitespace(character))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ExistingLineFits(SourceText source, XmlElementSyntax element, int maxLineLength)
+    {
+        TextLine line = source.Lines.GetLineFromPosition(element.SpanStart);
+        return (long)line.End - line.Start <= maxLineLength;
+    }
+
+    private static bool FitsOnLineAfterReplacement(
+        SourceText source,
+        XmlElementSyntax element,
+        string candidate,
+        int maxLineLength,
+        Dictionary<int, int> exteriorIndexCache)
+    {
+        TextLine startLine = source.Lines.GetLineFromPosition(element.SpanStart);
+        TextLine endLine = source.Lines.GetLineFromPosition(Math.Max(element.SpanStart, element.Span.End - 1));
+        long prefixLength = element.SpanStart - startLine.Start;
+
+        if (TryGetExteriorIndex(source, startLine, exteriorIndexCache, out int exteriorIndex)
+            && ContainsOnlyHorizontalWhitespace(
+                source,
+                startLine.Start + exteriorIndex + 3,
+                element.SpanStart))
+        {
+            prefixLength = exteriorIndex + 4L;
+        }
+
+        long suffixLength = endLine.End - element.Span.End;
+        return prefixLength + candidate.Length + suffixLength <= maxLineLength;
+    }
+
+    private static string CreateCompactText(
+        SourceText source,
+        XmlElementSyntax element,
+        SyntaxToken first,
+        SyntaxToken last) =>
+        $"{source.ToString(element.StartTag.Span)}"
+        + GetHorizontallyTrimmedText(source, TextSpan.FromBounds(first.SpanStart, last.Span.End))
+        + source.ToString(element.EndTag.Span);
+
+    private static string GetHorizontallyTrimmedText(SourceText source, TextSpan span)
+    {
+        int start = span.Start;
+        int end = span.End;
+
+        while (start < end && IsHorizontalWhitespace(source[start]))
+        {
+            start++;
+        }
+
+        while (end > start && IsHorizontalWhitespace(source[end - 1]))
+        {
+            end--;
+        }
+
+        return source.ToString(TextSpan.FromBounds(start, end));
+    }
+
+    private static bool IsSingleLine(SourceText source, XmlElementSyntax element) =>
+        GetLineNumber(source, element.SpanStart) == GetLineNumber(source, element.Span.End - 1);
+
+    private static bool LineContainsOnly(SourceText source, TextSpan span) =>
+        HasOnlyWhitespaceBefore(source, span.Start) && HasOnlyWhitespaceAfter(source, span.End);
+
+    private static bool HasOnlyWhitespaceBefore(SourceText source, int position)
+    {
+        TextLine line = source.Lines.GetLineFromPosition(position);
+        if (!TryGetExteriorIndex(source, line, out int exteriorIndex))
+        {
+            return false;
+        }
+
+        int start = line.Start + exteriorIndex + 3;
+        for (int index = start; index < position; index++)
+        {
+            if (!IsHorizontalWhitespace(source[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool HasOnlyWhitespaceBefore(
+        SourceText source,
+        int position,
+        Dictionary<int, int> exteriorIndexCache,
+        Dictionary<int, int> contentStartCache)
+    {
+        TextLine line = source.Lines.GetLineFromPosition(position);
+        if (!TryGetExteriorIndex(source, line, exteriorIndexCache, out int exteriorIndex))
+        {
+            return false;
+        }
+
+        if (!contentStartCache.TryGetValue(line.LineNumber, out int contentStart))
+        {
+            contentStart = line.Start + exteriorIndex + 3;
+            while (contentStart < line.End && IsHorizontalWhitespace(source[contentStart]))
+            {
+                contentStart++;
+            }
+
+            contentStartCache.Add(line.LineNumber, contentStart);
+        }
+
+        return position <= contentStart;
+    }
+
+    private static bool HasOnlyWhitespaceAfter(SourceText source, int position)
+    {
+        TextLine line = source.Lines.GetLineFromPosition(Math.Min(position, source.Length));
+        for (int index = position; index < line.End; index++)
+        {
+            if (!IsHorizontalWhitespace(source[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsWithinAny(int position, List<TextSpan> spans)
+    {
+        int low = 0;
+        int high = spans.Count - 1;
+
+        while (low <= high)
+        {
+            int middle = low + ((high - low) / 2);
+            TextSpan span = spans[middle];
+            if (span.Contains(position))
+            {
+                return true;
+            }
+
+            if (position < span.Start)
+            {
+                high = middle - 1;
+            }
+            else
+            {
+                low = middle + 1;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool OverlapsStructuralChange(
+        TextSpan span,
+        List<TextSpan> structuralChanges,
+        ref int index)
+    {
+        while (index < structuralChanges.Count)
+        {
+            TextSpan change = structuralChanges[index];
+            if (change.End < span.Start
+                || change.End == span.Start && !change.IsEmpty)
+            {
+                index++;
+                continue;
+            }
+
+            return span.OverlapsWith(change)
+                || span.Start == change.Start && (span.IsEmpty || change.IsEmpty);
+        }
+
+        return false;
+    }
+
+    private static bool AreChangesIndependent(List<TextChange> changes, TextSpan commentSpan)
+    {
+        int previousEnd = commentSpan.Start;
+        int previousStart = -1;
+
+        foreach (TextChange change in changes)
+        {
+            if (change.Span.Start < commentSpan.Start
+                || change.Span.End > commentSpan.End
+                || change.Span.Start < previousEnd
+                || change.Span.Start == previousStart && change.Span.IsEmpty)
+            {
+                return false;
+            }
+
+            previousStart = change.Span.Start;
+            previousEnd = change.Span.End;
+        }
+
+        return true;
+    }
+
+    private static int GetLineNumber(SourceText source, int position) =>
+        source.Lines.GetLinePosition(Math.Min(position, source.Length)).Line;
+
+    private static bool IsHorizontalWhitespace(char value) => value is ' ' or '\t';
+
+    private static bool ContainsOnlyHorizontalWhitespace(SourceText source, int start, int end)
+    {
+        for (int index = start; index < end; index++)
+        {
+            if (!IsHorizontalWhitespace(source[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///  Gets the zero-based column of the <c>///</c> documentation-comment exterior, caching the result by line
+    ///  number for repeated formatting decisions within one comment.
+    /// </summary>
+    private static bool TryGetExteriorIndex(
+        SourceText source,
+        TextLine line,
+        Dictionary<int, int> cache,
+        out int exteriorIndex)
+    {
+        if (cache.TryGetValue(line.LineNumber, out exteriorIndex))
+        {
+            return exteriorIndex >= 0;
+        }
+
+        bool found = TryGetExteriorIndex(source, line, out exteriorIndex);
+        cache.Add(line.LineNumber, found ? exteriorIndex : -1);
+        return found;
+    }
+
+    private static bool TryReserveChange(long newTextLength, int oldLength, ref long projectedLength)
+    {
+        long nextLength = projectedLength - oldLength + newTextLength;
+        if (nextLength is < 0 or > MaximumReplacementLength)
+        {
+            return false;
+        }
+
+        projectedLength = nextLength;
+        return true;
+    }
+
+    private static SyntaxNode? GetAttributeContainer(SyntaxNode node)
+    {
+        for (SyntaxNode? ancestor = node; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is XmlElementStartTagSyntax or XmlEmptyElementSyntax)
+            {
+                return ancestor;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool HasAttributeAncestor(SyntaxNode node)
+    {
+        for (SyntaxNode? ancestor = node; ancestor is not null; ancestor = ancestor.Parent)
+        {
+            if (ancestor is XmlAttributeSyntax)
+            {
+                return true;
+            }
+
+            if (ancestor is XmlElementStartTagSyntax or XmlEmptyElementSyntax)
+            {
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class BreakBoundary(int start, int end, int depth, bool includeBlankLine)
+    {
+        public int Start { get; } = start;
+
+        public int End { get; set; } = end;
+
+        public int Depth { get; set; } = depth;
+
+        public bool IncludeBlankLine { get; set; } = includeBlankLine;
+    }
+}

--- a/touki.analyzers/XmlDocumentationFormattingAnalyzer.cs
+++ b/touki.analyzers/XmlDocumentationFormattingAnalyzer.cs
@@ -1,0 +1,239 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports single-line XML documentation comments that do not follow the configured nested XML layout.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The rule formats paired XML elements as blocks, with one configurable indentation step for every XML
+///   nesting level. A top-level element other than <c>summary</c> may stay on one line when it fits within the
+///   configured maximum line length. A three-line element with exactly one content line is compacted when it
+///   fits; elements with two or more content lines retain those line breaks.
+///  </para>
+///  <para>
+///   Indentation is evaluated per contiguous logical block. A correctly indented first line preserves the
+///   block's relative indentation; otherwise every line in the block is shifted by the same amount.
+///  </para>
+///  <para>
+///   Unicode whitespace is documentation content rather than layout, and effective
+///   <c>xml:space="preserve"</c> regions are not rewritten.
+///  </para>
+///  <para>
+///   The rule ships disabled because documentation layout is a house style. Enable it with
+///   <code>dotnet_diagnostic.TOUKI0024.severity = warning</code>.
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class XmlDocumentationFormattingAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0024";
+
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that controls the spaces added for each nested XML level.
+    /// </summary>
+    public const string IndentSizeOption = "dotnet_code_quality.TOUKI0024.indent_size";
+
+    /// <summary>
+    ///  The <c>.editorconfig</c> key that overrides the maximum physical line length.
+    /// </summary>
+    public const string MaxLineLengthOption = "dotnet_code_quality.TOUKI0024.max_line_length";
+
+    /// <summary>
+    ///  The indentation added for each nested XML level when <see cref="IndentSizeOption"/> is not configured.
+    /// </summary>
+    public const int DefaultIndentSize = 1;
+
+    /// <summary>
+    ///  The largest accepted XML indentation step. Larger configured values use
+    ///  <see cref="DefaultIndentSize"/>.
+    /// </summary>
+    public const int MaximumIndentSize = 16;
+
+    /// <summary>
+    ///  The maximum physical line length when neither <see cref="MaxLineLengthOption"/> nor the standard
+    ///  <c>max_line_length</c> key supplies one.
+    /// </summary>
+    public const int DefaultMaxLineLength = 120;
+
+    /// <summary>
+    ///  The diagnostic property carrying the complete replacement documentation comment.
+    /// </summary>
+    internal const string ReplacementProperty = "Replacement";
+
+    private const string StandardMaxLineLengthOption = "max_line_length";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Format XML documentation as nested XML",
+        messageFormat: "Format XML documentation as nested XML",
+        category: "Maintainability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "XML documentation should use a consistent nested layout while preserving intentional prose line breaks.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterSyntaxTreeAction(AnalyzeSyntaxTree);
+    }
+
+    private static void AnalyzeSyntaxTree(SyntaxTreeAnalysisContext context)
+    {
+        SourceText source = context.Tree.GetText(context.CancellationToken);
+        if (!ContainsDocumentationCommentPrefix(source, context.CancellationToken))
+        {
+            return;
+        }
+
+        AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree);
+        int indentSize = TryGetPositiveInteger(options, IndentSizeOption, out int configuredIndentSize)
+            && configuredIndentSize <= MaximumIndentSize
+                ? configuredIndentSize
+                : DefaultIndentSize;
+        int maxLineLength = TryGetPositiveInteger(options, MaxLineLengthOption, out int configuredMaxLineLength)
+            || TryGetPositiveInteger(options, StandardMaxLineLengthOption, out configuredMaxLineLength)
+                ? configuredMaxLineLength
+                : DefaultMaxLineLength;
+        SyntaxNode root = context.Tree.GetRoot(context.CancellationToken);
+
+        foreach (SyntaxTrivia trivia in root.DescendantTrivia(descendIntoTrivia: true))
+        {
+            context.CancellationToken.ThrowIfCancellationRequested();
+
+            if (!trivia.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia)
+                || trivia.GetStructure() is not DocumentationCommentTriviaSyntax documentation
+                || documentation.ContainsDiagnostics
+                || !TryGetCommentSpan(source, trivia, context.CancellationToken, out TextSpan span))
+            {
+                continue;
+            }
+
+            TextLine firstLine = source.Lines.GetLineFromPosition(span.Start);
+            string lineBreak = firstLine.EndIncludingLineBreak > firstLine.End
+                ? source.ToString(TextSpan.FromBounds(firstLine.End, firstLine.EndIncludingLineBreak))
+                : "\n";
+
+            if (!XmlDocumentationCommentFormatter.TryFormat(
+                source,
+                documentation,
+                span,
+                lineBreak,
+                indentSize,
+                maxLineLength,
+                context.CancellationToken,
+                out string replacement))
+            {
+                continue;
+            }
+
+            ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+                .Add(ReplacementProperty, replacement);
+
+            context.ReportDiagnostic(
+                Diagnostic.Create(s_rule, Location.Create(context.Tree, span), properties));
+        }
+    }
+
+    private static bool ContainsDocumentationCommentPrefix(
+        SourceText source,
+        CancellationToken cancellationToken)
+    {
+        for (int index = 0; index <= source.Length - 3; index++)
+        {
+            if ((index & 0xFFF) == 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+            }
+
+            if (source[index] == '/' && source[index + 1] == '/' && source[index + 2] == '/')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryGetCommentSpan(
+        SourceText source,
+        SyntaxTrivia trivia,
+        CancellationToken cancellationToken,
+        out TextSpan span)
+    {
+        int firstLineNumber = source.Lines.GetLinePosition(trivia.SpanStart).Line;
+        int firstLineStart = source.Lines[firstLineNumber].Start;
+        int lastLineNumber = firstLineNumber - 1;
+
+        for (int lineNumber = firstLineNumber; lineNumber < source.Lines.Count; lineNumber++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TextLine line = source.Lines[lineNumber];
+            if (line.Start >= trivia.FullSpan.End)
+            {
+                break;
+            }
+
+            if (line.End - firstLineStart > XmlDocumentationCommentFormatter.MaximumCommentLength)
+            {
+                span = default;
+                return false;
+            }
+
+            if (!XmlDocumentationCommentFormatter.TryGetExteriorIndex(source, line, out _))
+            {
+                break;
+            }
+
+            lastLineNumber = lineNumber;
+        }
+
+        if (lastLineNumber < firstLineNumber)
+        {
+            span = default;
+            return false;
+        }
+
+        span = TextSpan.FromBounds(
+            source.Lines[firstLineNumber].Start,
+            source.Lines[lastLineNumber].End);
+
+        return true;
+    }
+
+    private static bool TryGetPositiveInteger(AnalyzerConfigOptions options, string key, out int value)
+    {
+        if (options.TryGetValue(key, out string? raw)
+            && int.TryParse(raw.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out value)
+            && value > 0)
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+}

--- a/touki/Framework/Polyfills/.editorconfig
+++ b/touki/Framework/Polyfills/.editorconfig
@@ -12,6 +12,10 @@ dotnet_diagnostic.TOUKI0001.severity = none
 # code that uses them; splitting them would make future ports harder to diff.
 dotnet_diagnostic.TOUKI0020.severity = none
 
+# TOUKI0024: Format XML documentation as nested XML. Upstream documentation layout is retained
+# so future ports remain easy to compare.
+dotnet_diagnostic.TOUKI0024.severity = none
+
 # TOUKI0030: Use ValueStringBuilder to build strings. Upstream builds these strings with
 # StringBuilder; rewriting them would make future ports harder to diff.
 dotnet_diagnostic.TOUKI0030.severity = none

--- a/touki/Framework/Touki/EnumDataCache.cs
+++ b/touki/Framework/Touki/EnumDataCache.cs
@@ -48,9 +48,7 @@ internal static partial class EnumDataCache
     ///   Returns the BCL's internal cached arrays - callers must not mutate them.
     ///  </para>
     /// </remarks>
-    /// <exception cref="ArgumentException">
-    ///  <paramref name="type"/> is not an enum type.
-    /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="type"/> is not an enum type.</exception>
     public static (ulong[] Values, string[] Names) GetEnumValuesAndNames(Type type)
     {
         if (!type.IsEnum)

--- a/touki/Framework/Touki/NumberExtensions.cs
+++ b/touki/Framework/Touki/NumberExtensions.cs
@@ -17,7 +17,9 @@ public static unsafe partial class NumberExtensions
 {
     extension(decimal decimalValue)
     {
-        /// <summary>Determines whether the specified value is negative.</summary>
+        /// <summary>
+        ///  Determines whether the specified value is negative.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNegative(decimal value)
         {
@@ -109,7 +111,9 @@ public static unsafe partial class NumberExtensions
 
     extension(float floatValue)
     {
-        /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
+        /// <summary>
+        ///  Determines whether the specified value is finite (zero, subnormal, or normal).
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsFinite()
         {
@@ -117,14 +121,18 @@ public static unsafe partial class NumberExtensions
             return (bits & 0x7FFFFFFF) < 0x7F800000;
         }
 
-        /// <summary>Determines whether the specified value is negative.</summary>
+        /// <summary>
+        ///  Determines whether the specified value is negative.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsNegative() => (*(int*)&floatValue) < 0;
     }
 
     extension(double doubleValue)
     {
-        /// <summary>Determines whether the specified value is finite (zero, subnormal, or normal).</summary>
+        /// <summary>
+        ///  Determines whether the specified value is finite (zero, subnormal, or normal).
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsFinite()
         {
@@ -132,7 +140,9 @@ public static unsafe partial class NumberExtensions
             return (bits & 0x7FFFFFFFFFFFFFFF) < 0x7FF0000000000000;
         }
 
-        /// <summary>Determines whether the specified value is negative.</summary>
+        /// <summary>
+        ///  Determines whether the specified value is negative.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool IsNegative() => BitConverter.DoubleToInt64Bits(doubleValue) < 0;
     }

--- a/touki/Framework/Touki/Text/StringExtensions.cs
+++ b/touki/Framework/Touki/Text/StringExtensions.cs
@@ -111,7 +111,9 @@ public static partial class StringExtensions
         /// </summary>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <param name="handler">The interpolated string.</param>
-        /// <returns>The string that results for formatting the interpolated string using the specified format provider.</returns>
+        /// <returns>
+        ///  The string that results for formatting the interpolated string using the specified format provider.
+        /// </returns>
         public static string Create(
             IFormatProvider? provider,
             [InterpolatedStringHandlerArgument("provider")] ref DefaultInterpolatedStringHandler handler) =>
@@ -126,7 +128,9 @@ public static partial class StringExtensions
         ///  The contents of this buffer may be overwritten.
         /// </param>
         /// <param name="handler">The interpolated string.</param>
-        /// <returns>The string that results for formatting the interpolated string using the specified format provider.</returns>
+        /// <returns>
+        ///  The string that results for formatting the interpolated string using the specified format provider.
+        /// </returns>
         public static string Create(
             IFormatProvider? provider,
             Span<char> initialBuffer,

--- a/touki/Framework/Touki/Text/StringExtensions_DotNetFoundation.cs
+++ b/touki/Framework/Touki/Text/StringExtensions_DotNetFoundation.cs
@@ -19,56 +19,56 @@ public static partial class StringExtensions
     extension(string stringValue)
     {
         /// <summary>
-        /// Replaces all newline sequences in the current string with <see cref="Environment.NewLine"/>.
+        ///  Replaces all newline sequences in the current string with <see cref="Environment.NewLine"/>.
         /// </summary>
         /// <returns>
-        /// A string whose contents match the current string, but with all newline sequences replaced
-        /// with <see cref="Environment.NewLine"/>.
+        ///  A string whose contents match the current string, but with all newline sequences replaced
+        ///  with <see cref="Environment.NewLine"/>.
         /// </returns>
         /// <remarks>
-        /// This method searches for all newline sequences within the string and canonicalizes them to match
-        /// the newline sequence for the current environment. For example, when running on Windows, all
-        /// occurrences of non-Windows newline sequences will be replaced with the sequence CRLF. When
-        /// running on Unix, all occurrences of non-Unix newline sequences will be replaced with
-        /// a single LF character.
+        ///  This method searches for all newline sequences within the string and canonicalizes them to match
+        ///  the newline sequence for the current environment. For example, when running on Windows, all
+        ///  occurrences of non-Windows newline sequences will be replaced with the sequence CRLF. When
+        ///  running on Unix, all occurrences of non-Unix newline sequences will be replaced with
+        ///  a single LF character.
         ///
-        /// It is not recommended that protocol parsers utilize this API. Protocol specifications often
-        /// mandate specific newline sequences. For example, HTTP/1.1 (RFC 8615) mandates that the request
-        /// line, status line, and headers lines end with CRLF. Since this API operates over a wide range
-        /// of newline sequences, a protocol parser utilizing this API could exhibit behaviors unintended
-        /// by the protocol's authors.
+        ///  It is not recommended that protocol parsers utilize this API. Protocol specifications often
+        ///  mandate specific newline sequences. For example, HTTP/1.1 (RFC 8615) mandates that the request
+        ///  line, status line, and headers lines end with CRLF. Since this API operates over a wide range
+        ///  of newline sequences, a protocol parser utilizing this API could exhibit behaviors unintended
+        ///  by the protocol's authors.
         ///
-        /// This overload is equivalent to calling <see cref="ReplaceLineEndings(string)"/>, passing
-        /// <see cref="Environment.NewLine"/> as the <em>replacementText</em> parameter.
+        ///  This overload is equivalent to calling <see cref="ReplaceLineEndings(string)"/>, passing
+        ///  <see cref="Environment.NewLine"/> as the <em>replacementText</em> parameter.
         ///
-        /// This method is guaranteed O(n) complexity, where <em>n</em> is the length of the input string.
+        ///  This method is guaranteed O(n) complexity, where <em>n</em> is the length of the input string.
         /// </remarks>
         public string ReplaceLineEndings() => stringValue.ReplaceLineEndings(NewLineConst);
 
         /// <summary>
-        /// Replaces all newline sequences in the current string with <paramref name="replacementText"/>.
+        ///  Replaces all newline sequences in the current string with <paramref name="replacementText"/>.
         /// </summary>
         /// <returns>
-        /// A string whose contents match the current string, but with all newline sequences replaced
-        /// with <paramref name="replacementText"/>.
+        ///  A string whose contents match the current string, but with all newline sequences replaced
+        ///  with <paramref name="replacementText"/>.
         /// </returns>
         /// <remarks>
-        /// This method searches for all newline sequences within the string and canonicalizes them to the
-        /// newline sequence provided by <paramref name="replacementText"/>. If <paramref name="replacementText"/>
-        /// is <see cref="Empty"/>, all newline sequences within the string will be removed.
+        ///  This method searches for all newline sequences within the string and canonicalizes them to the
+        ///  newline sequence provided by <paramref name="replacementText"/>. If <paramref name="replacementText"/>
+        ///  is <see cref="Empty"/>, all newline sequences within the string will be removed.
         ///
-        /// It is not recommended that protocol parsers utilize this API. Protocol specifications often
-        /// mandate specific newline sequences. For example, HTTP/1.1 (RFC 8615) mandates that the request
-        /// line, status line, and headers lines end with CRLF. Since this API operates over a wide range
-        /// of newline sequences, a protocol parser utilizing this API could exhibit behaviors unintended
-        /// by the protocol's authors.
+        ///  It is not recommended that protocol parsers utilize this API. Protocol specifications often
+        ///  mandate specific newline sequences. For example, HTTP/1.1 (RFC 8615) mandates that the request
+        ///  line, status line, and headers lines end with CRLF. Since this API operates over a wide range
+        ///  of newline sequences, a protocol parser utilizing this API could exhibit behaviors unintended
+        ///  by the protocol's authors.
         ///
-        /// The list of recognized newline sequences is CR (U+000D), LF (U+000A), CRLF (U+000D U+000A),
-        /// NEL (U+0085), LS (U+2028), FF (U+000C), and PS (U+2029). This list is given by the Unicode
-        /// Standard, Sec. 5.8, Recommendation R4 and Table 5-2.
+        ///  The list of recognized newline sequences is CR (U+000D), LF (U+000A), CRLF (U+000D U+000A),
+        ///  NEL (U+0085), LS (U+2028), FF (U+000C), and PS (U+2029). This list is given by the Unicode
+        ///  Standard, Sec. 5.8, Recommendation R4 and Table 5-2.
         ///
-        /// This method is guaranteed O(n * r) complexity, where <em>n</em> is the length of the input string,
-        /// and where <em>r</em> is the length of <paramref name="replacementText"/>.
+        ///  This method is guaranteed O(n * r) complexity, where <em>n</em> is the length of the input string,
+        ///  and where <em>r</em> is the length of <paramref name="replacementText"/>.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public string ReplaceLineEndings(string replacementText)

--- a/touki/Touki/Buffers/BufferScope.cs
+++ b/touki/Touki/Buffers/BufferScope.cs
@@ -122,13 +122,13 @@ public ref struct BufferScope<T>
     /// </summary>
     /// <param name="start">The index at which to begin the slice.</param>
     /// <param name="length">The desired length of the slice.</param>
-    /// <returns>A span that consists of <paramref name="length"/> elements from the buffer starting at <paramref name="start"/>.</returns>
+    /// <returns>
+    ///  A span that consists of <paramref name="length"/> elements from the buffer starting at <paramref name="start"/>.
+    /// </returns>
     public readonly Span<T> Slice(int start, int length) => _span.Slice(start, length);
 
     /// <inheritdoc cref="Span{T}.GetPinnableReference"/>
-    /// <remarks>
-    ///  This is used by C# to enable using the buffer in a fixed statement.
-    /// </remarks>
+    /// <remarks>This is used by C# to enable using the buffer in a fixed statement.</remarks>
     public readonly ref T GetPinnableReference() => ref _span.GetPinnableReference();
 
     /// <summary>

--- a/touki/Touki/Collections/RefCountedCache.cs
+++ b/touki/Touki/Collections/RefCountedCache.cs
@@ -20,14 +20,12 @@ namespace Touki.Collections;
 ///  The type of data to associate with a cache entry. For a simple cache this can be the same type as
 ///  <typeparamref name="TKey"/>.
 /// </typeparam>
-/// <typeparam name="TKey">
-///  The type of key used to look up cache entries.
-/// </typeparam>
+/// <typeparam name="TKey">The type of key used to look up cache entries.</typeparam>
 /// <remarks>
 ///  <para>
 ///   A simple cache that maintains a list of `Pen` to `Color` keys would be defined as:
 ///   <code>
-///<![CDATA[ public sealed class PenCache : RefCountedCache<Pen, Color, Color>
+///    <![CDATA[ public sealed class PenCache : RefCountedCache<Pen, Color, Color>
 /// {
 ///   protected override CacheEntry CreateEntry(Color key, bool cached) => new PenCacheEntry(key, cached);
 ///   protected override bool IsMatch(Color key, CacheEntry entry) => key == entry.Data;

--- a/touki/Touki/ComponentModel/ITypedServiceProvider.cs
+++ b/touki/Touki/ComponentModel/ITypedServiceProvider.cs
@@ -20,7 +20,9 @@ public interface ITypedServiceProvider : IServiceProvider
     ///  Attempts to get a service of the specified type.
     /// </summary>
     /// <typeparam name="T">The type of service to get.</typeparam>
-    /// <param name="service">When this method returns, contains the service instance, or <see langword="null"/> if not found.</param>
+    /// <param name="service">
+    ///  When this method returns, contains the service instance, or <see langword="null"/> if not found.
+    /// </param>
     /// <returns><see langword="true"/> if the service was found; otherwise, <see langword="false"/>.</returns>
     bool TryGetService<T>([NotNullWhen(true)] out T? service) where T : class;
 }

--- a/touki/Touki/DisposableBase.cs
+++ b/touki/Touki/DisposableBase.cs
@@ -16,9 +16,7 @@ public abstract partial class DisposableBase : IDisposable
     /// <summary>
     ///  Gets a value indicating whether the object has been disposed.
     /// </summary>
-    /// <value>
-    ///  <see langword="true"/> if the object has been disposed; otherwise, <see langword="false"/>.
-    /// </value>
+    /// <value><see langword="true"/> if the object has been disposed; otherwise, <see langword="false"/>.</value>
     protected bool Disposed => _disposedValue != 0;
 
     /// <summary>

--- a/touki/Touki/Interop/HandleRef.cs
+++ b/touki/Touki/Interop/HandleRef.cs
@@ -63,7 +63,9 @@ public readonly struct HandleRef<THandle> : IHandle<THandle>, IEquatable<HandleR
     /// </summary>
     /// <param name="left">The first handle reference to compare.</param>
     /// <param name="right">The second handle reference to compare.</param>
-    /// <returns><see langword="true"/> if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if <paramref name="left"/> and <paramref name="right"/> are equal; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator ==(HandleRef<THandle> left, HandleRef<THandle> right) => left.Equals(right);
 
     /// <summary>
@@ -71,7 +73,9 @@ public readonly struct HandleRef<THandle> : IHandle<THandle>, IEquatable<HandleR
     /// </summary>
     /// <param name="left">The first handle reference to compare.</param>
     /// <param name="right">The second handle reference to compare.</param>
-    /// <returns><see langword="true"/> if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if <paramref name="left"/> and <paramref name="right"/> are not equal; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator !=(HandleRef<THandle> left, HandleRef<THandle> right) => !(left == right);
 
     /// <summary>

--- a/touki/Touki/Io/Clipboard.cs
+++ b/touki/Touki/Io/Clipboard.cs
@@ -87,9 +87,7 @@ public static class Clipboard
     ///  When this method returns <see langword="true"/>, contains the clipboard text.
     ///  When <see langword="false"/>, contains <see langword="null"/>.
     /// </param>
-    /// <returns>
-    ///  <see langword="true"/> if text was successfully read; otherwise <see langword="false"/>.
-    /// </returns>
+    /// <returns><see langword="true"/> if text was successfully read; otherwise <see langword="false"/>.</returns>
     public static bool TryGetText([NotNullWhen(true)] out string? text) => s_provider.TryGetText(out text);
 
     /// <summary>

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.EngineInputs.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.EngineInputs.cs
@@ -24,28 +24,44 @@ internal sealed partial class CompiledGlobStrategy
     /// </remarks>
     private readonly ref struct EngineInputs
     {
-        /// <summary>Directory-prefix span; the first half of the virtual input.</summary>
+        /// <summary>
+        ///  Directory-prefix span; the first half of the virtual input.
+        /// </summary>
         public readonly ReadOnlySpan<char> First;
 
-        /// <summary>File-name span; the second half of the virtual input.</summary>
+        /// <summary>
+        ///  File-name span; the second half of the virtual input.
+        /// </summary>
         public readonly ReadOnlySpan<char> Second;
 
-        /// <summary>The compiled bytecode program (extglob subset).</summary>
+        /// <summary>
+        ///  The compiled bytecode program (extglob subset).
+        /// </summary>
         public readonly ReadOnlySpan<char> Program;
 
-        /// <summary>Path separator, or <c>'\0'</c> when the matcher is path-unaware.</summary>
+        /// <summary>
+        ///  Path separator, or <c>'\0'</c> when the matcher is path-unaware.
+        /// </summary>
         public readonly char Separator;
 
-        /// <summary>Case-sensitivity policy for literal/class comparisons.</summary>
+        /// <summary>
+        ///  Case-sensitivity policy for literal/class comparisons.
+        /// </summary>
         public readonly IgnoreCaseKind Kind;
 
-        /// <summary>Whether <c>?</c> uses MSBuild trailing-dot two-character semantics.</summary>
+        /// <summary>
+        ///  Whether <c>?</c> uses MSBuild trailing-dot two-character semantics.
+        /// </summary>
         public readonly bool UseMSBuildTrailingDotAny;
 
-        /// <summary>Whether the synthetic input represents a Windows all-dot filename.</summary>
+        /// <summary>
+        ///  Whether the synthetic input represents a Windows all-dot filename.
+        /// </summary>
         public readonly bool UseMSBuildAllDotInput;
 
-        /// <summary>Required effective-double-star state for an accepting execution path.</summary>
+        /// <summary>
+        ///  Required effective-double-star state for an accepting execution path.
+        /// </summary>
         public readonly EffectiveDoubleStarMode EffectiveDoubleStarMode;
 
         public EngineInputs(

--- a/touki/Touki/Io/Globbing/CompiledGlobStrategy.EngineScratch.cs
+++ b/touki/Touki/Io/Globbing/CompiledGlobStrategy.EngineScratch.cs
@@ -22,19 +22,29 @@ internal sealed partial class CompiledGlobStrategy
     /// </remarks>
     private readonly ref struct EngineScratch
     {
-        /// <summary>Explicit backtrack stack of choice points.</summary>
+        /// <summary>
+        ///  Explicit backtrack stack of choice points.
+        /// </summary>
         public readonly Span<Frame> Frames;
 
-        /// <summary>Range-snapshot arena backing each frame's saved configuration.</summary>
+        /// <summary>
+        ///  Range-snapshot arena backing each frame's saved configuration.
+        /// </summary>
         public readonly Span<ProgramRange> Arena;
 
-        /// <summary>The active ("work") range list the forward loop advances.</summary>
+        /// <summary>
+        ///  The active ("work") range list the forward loop advances.
+        /// </summary>
         public readonly Span<ProgramRange> Work;
 
-        /// <summary>Scratch list used while building an alternative's range list.</summary>
+        /// <summary>
+        ///  Scratch list used while building an alternative's range list.
+        /// </summary>
         public readonly Span<ProgramRange> Rest;
 
-        /// <summary>Failure-memo serialization key buffer.</summary>
+        /// <summary>
+        ///  Failure-memo serialization key buffer.
+        /// </summary>
         public readonly Span<int> Key;
 
         public EngineScratch(

--- a/touki/Touki/Io/Globbing/Glob.cs
+++ b/touki/Touki/Io/Globbing/Glob.cs
@@ -22,9 +22,7 @@ public static class Glob
     ///   same pattern, compile once and cache the resulting <see cref="GlobSpecification"/>.
     ///  </para>
     /// </remarks>
-    /// <exception cref="ArgumentNullException">
-    ///  <paramref name="pattern"/> is <see langword="null"/>.
-    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/>.</exception>
     /// <exception cref="GlobFormatException">The pattern is invalid.</exception>
     public static bool IsMatch(
         string pattern,

--- a/touki/Touki/Io/Globbing/GlobOpCodes.cs
+++ b/touki/Touki/Io/Globbing/GlobOpCodes.cs
@@ -12,10 +12,14 @@ namespace Touki.Io.Globbing;
 /// </summary>
 internal static class GlobOpCodes
 {
-    /// <summary>Match exactly one character (<c>?</c>). No payload.</summary>
+    /// <summary>
+    ///  Match exactly one character (<c>?</c>). No payload.
+    /// </summary>
     public const char Any = '\uFDD0';
 
-    /// <summary>Match zero or more characters (<c>*</c>). No payload.</summary>
+    /// <summary>
+    ///  Match zero or more characters (<c>*</c>). No payload.
+    /// </summary>
     public const char AnyRun = '\uFDD1';
 
     /// <summary>

--- a/touki/Touki/Io/Globbing/GlobSpecification.cs
+++ b/touki/Touki/Io/Globbing/GlobSpecification.cs
@@ -76,21 +76,15 @@ public sealed partial class GlobSpecification
     ///  documented default; see <see cref="GlobPathSeparator"/> for the semantics of
     ///  each value (ignored for path-unaware dialects).
     /// </summary>
-    /// <param name="pattern">
-    ///  The glob pattern.
-    /// </param>
+    /// <param name="pattern">The glob pattern.</param>
     /// <param name="maxPatternLength">
     ///  Optional upper bound on <paramref name="pattern"/>'s length, in characters.
     ///  Pass <c>-1</c> to disable the check. Callers that compile patterns supplied
     ///  by untrusted input should set this to an application-specific limit;
     ///  oversized patterns fail with <see cref="GlobCompileErrorCode.PatternTooLarge"/>.
     /// </param>
-    /// <exception cref="GlobFormatException">
-    ///  The pattern is invalid for the requested dialect or options.
-    /// </exception>
-    /// <exception cref="ArgumentNullException">
-    ///  <paramref name="pattern"/> is <see langword="null"/>.
-    /// </exception>
+    /// <exception cref="GlobFormatException">The pattern is invalid for the requested dialect or options.</exception>
+    /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/>.</exception>
     public static GlobSpecification Compile(
         string pattern,
         GlobDialect dialect,
@@ -164,9 +158,7 @@ public sealed partial class GlobSpecification
     /// <param name="result">The compiled specification on success; otherwise <see langword="null"/>.</param>
     /// <param name="error">The compilation error on failure; otherwise the default value.</param>
     /// <returns><see langword="true"/> when compilation succeeds; otherwise <see langword="false"/>.</returns>
-    /// <exception cref="ArgumentNullException">
-    ///  <paramref name="pattern"/> is <see langword="null"/>.
-    /// </exception>
+    /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/>.</exception>
     public static bool TryCompile(
         string pattern,
         GlobDialect dialect,

--- a/touki/Touki/Io/MSBuildEnumerator.cs
+++ b/touki/Touki/Io/MSBuildEnumerator.cs
@@ -12,23 +12,40 @@ namespace Touki.Io;
 ///  Enumerates files that match a glob pattern with zero allocations until matches are found.
 /// </summary>
 /// <remarks>
-///  <para>The following wildcard patterns are supported:
+///  <para>
+///   The following wildcard patterns are supported:
 ///   <list type="table">
 ///    <listheader>
-///     <term>Pattern</term>
-///     <description>Description</description>
+///     <term>
+///      Pattern
+///     </term>
+///     <description>
+///      Description
+///     </description>
 ///    </listheader>
 ///    <item>
-///     <term>*</term>
-///     <description>Matches zero or more characters within a file or directory name</description>
+///     <term>
+///      *
+///     </term>
+///     <description>
+///      Matches zero or more characters within a file or directory name
+///     </description>
 ///    </item>
 ///    <item>
-///     <term>**</term>
-///     <description>Matches zero or more directories (recursive wildcard)</description>
+///     <term>
+///      **
+///     </term>
+///     <description>
+///      Matches zero or more directories (recursive wildcard)
+///     </description>
 ///    </item>
 ///    <item>
-///     <term>?</term>
-///     <description>Matches a single character</description>
+///     <term>
+///      ?
+///     </term>
+///     <description>
+///      Matches a single character
+///     </description>
 ///    </item>
 ///   </list>
 ///  </para>

--- a/touki/Touki/Io/MSBuildMatchBuilder.cs
+++ b/touki/Touki/Io/MSBuildMatchBuilder.cs
@@ -66,9 +66,7 @@ internal static class MSBuildMatchBuilder
     ///  The root directory used to fully qualify non-rooted specifications. If <see langword="null"/>,
     ///  the <see cref="Environment.CurrentDirectory"/> is used.
     /// </param>
-    /// <returns>
-    ///  The owned matcher session and resolved enumeration start directory.
-    /// </returns>
+    /// <returns>The owned matcher session and resolved enumeration start directory.</returns>
     /// <remarks>
     ///  <para>
     ///   When the include is a simple recursive match (e.g. <c>**/*.cs</c>), a specialized fast matcher is used.

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -399,13 +399,29 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
     ///   the subset that is actually meaningful for this library:
     ///  </para>
     ///  <list type="bullet">
-    ///   <item><description>Embedded null character ('\0'). MSBuild&#39;s <c>MSBuildConstants.InvalidPathChars</c>
-    ///    historically had a larger set; in practice only the null byte is universally illegal.</description></item>
-    ///   <item><description>The literal substring <c>"..."</c> (three or more consecutive dots).</description></item>
-    ///   <item><description>A <c>**</c> recursive wildcard that is not a standalone path segment
-    ///    (e.g. <c>a**b</c>, <c>*.cs**</c>); standalone <c>**</c> at either end of the spec or between
-    ///    separators is legal.</description></item>
-    ///   <item><description>A <c>..</c> substring in the wildcard-directory portion.</description></item>
+    ///   <item>
+    ///    <description>
+    ///     Embedded null character ('\0'). MSBuild&#39;s <c>MSBuildConstants.InvalidPathChars</c>
+    ///     historically had a larger set; in practice only the null byte is universally illegal.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     The literal substring <c>"..."</c> (three or more consecutive dots).
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     A <c>**</c> recursive wildcard that is not a standalone path segment
+    ///     (e.g. <c>a**b</c>, <c>*.cs**</c>); standalone <c>**</c> at either end of the spec or between
+    ///     separators is legal.
+    ///    </description>
+    ///   </item>
+    ///   <item>
+    ///    <description>
+    ///     A <c>..</c> substring in the wildcard-directory portion.
+    ///    </description>
+    ///   </item>
     ///  </list>
     ///  <para>
     ///   Not validated (intentionally): MSBuild&#39;s "colon not at position 1" rule (breaks Unix

--- a/touki/Touki/Io/MappedMemoryManager.cs
+++ b/touki/Touki/Io/MappedMemoryManager.cs
@@ -53,9 +53,7 @@ public sealed unsafe class MappedMemoryManager : MemoryManager<byte>
     /// <param name="path">The path of the file to map.</param>
     /// <returns>A manager that owns the mapping until it is disposed.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="path"/> is <see langword="null"/>.</exception>
-    /// <exception cref="IOException">
-    ///  The file is empty or larger than <see cref="int.MaxValue"/> bytes.
-    /// </exception>
+    /// <exception cref="IOException">The file is empty or larger than <see cref="int.MaxValue"/> bytes.</exception>
     public static MappedMemoryManager CreateFromFile(string path)
     {
         ArgumentNullException.ThrowIfNull(path);

--- a/touki/Touki/Io/Paths.cs
+++ b/touki/Touki/Io/Paths.cs
@@ -185,9 +185,7 @@ public static class Paths
     /// </summary>
     /// <param name="path">The path to simplify.</param>
     /// <param name="builder">String builder that will store the result.</param>
-    /// <returns>
-    ///  <see langword="true"/> if the path was modified in copying to the <paramref name="builder"/>
-    /// </returns>
+    /// <returns><see langword="true"/> if the path was modified in copying to the <paramref name="builder"/></returns>
     public static bool RemoveRelativeSegments(ReadOnlySpan<char> path, ref ValueStringBuilder builder)
     {
         // Need to get the length up front to allow for replacing in place.

--- a/touki/Touki/Io/SpanReader.cs
+++ b/touki/Touki/Io/SpanReader.cs
@@ -40,9 +40,7 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     /// <summary>
     ///  Gets or sets the current position of the reader within the span.
     /// </summary>
-    /// <value>
-    ///  The zero-based position of the reader. Setting this value repositions the reader.
-    /// </value>
+    /// <value>The zero-based position of the reader. Setting this value repositions the reader.</value>
     /// <exception cref="ArgumentOutOfRangeException">
     ///  Thrown when the value is negative or greater than <see cref="Length"/>.
     /// </exception>
@@ -130,7 +128,9 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     /// </summary>
     /// <param name="span">The read data, if any.</param>
     /// <param name="delimiter">The delimiter to look for.</param>
-    /// <param name="advancePastDelimiter"><see langword="true"/> to move past the <paramref name="delimiter"/> if found.</param>
+    /// <param name="advancePastDelimiter">
+    ///  <see langword="true"/> to move past the <paramref name="delimiter"/> if found.
+    /// </param>
     /// <returns><see langword="true"/> if the <paramref name="delimiter"/> was found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryReadTo(T delimiter, bool advancePastDelimiter, out ReadOnlySpan<T> span)
@@ -164,7 +164,9 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     /// </summary>
     /// <param name="span">The read data, if any.</param>
     /// <param name="delimiters">The delimiters to look for.</param>
-    /// <param name="advancePastDelimiter">True to move past the first found instance of any of the given <paramref name="delimiters"/>.</param>
+    /// <param name="advancePastDelimiter">
+    ///  True to move past the first found instance of any of the given <paramref name="delimiters"/>.
+    /// </param>
     /// <returns>True if any of the <paramref name="delimiters"/> were found.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryReadToAny(scoped ReadOnlySpan<T> delimiters, bool advancePastDelimiter, out ReadOnlySpan<T> span)
@@ -269,7 +271,9 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     /// <param name="value">
     ///  When this method returns, contains the value that was read, or the default value if not enough data was available.
     /// </param>
-    /// <returns><see langword="true"/> if the value was successfully read; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the value was successfully read; otherwise, <see langword="false"/>.
+    /// </returns>
     /// <exception cref="ArgumentException">
     ///  Thrown when the size of <typeparamref name="TValue"/> is not evenly divisible by the size of <typeparamref name="T"/>.
     /// </exception>
@@ -360,7 +364,7 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     }
 
     /// <summary>
-    /// Peeks at the next value without advancing the reader.
+    ///  Peeks at the next value without advancing the reader.
     /// </summary>
     /// <param name="value">The next value or default if at the end.</param>
     /// <returns>False if at the end of the reader.</returns>
@@ -433,7 +437,9 @@ public unsafe ref struct SpanReader<T>(ReadOnlySpan<T> span) where T : unmanaged
     ///  Try to advance the reader by the given <paramref name="count"/>.
     /// </summary>
     /// <param name="count">The number of positions to advance.</param>
-    /// <returns><see langword="true"/> if the reader was successfully advanced; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the reader was successfully advanced; otherwise, <see langword="false"/>.
+    /// </returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TryAdvance(int count)
     {

--- a/touki/Touki/Io/SpanReaderExtensions.cs
+++ b/touki/Touki/Io/SpanReaderExtensions.cs
@@ -18,7 +18,9 @@ public static class SpanReaderExtensions
         ///  Tries to read an integer from the current position of the <see cref="SpanReader{T}"/>.
         /// </summary>
         /// <param name="value">When successful, contains the read integer.</param>
-        /// <returns><see langword="true"/> if an integer was successfully read; otherwise, <see langword="false"/>.</returns>
+        /// <returns>
+        ///  <see langword="true"/> if an integer was successfully read; otherwise, <see langword="false"/>.
+        /// </returns>
         public bool TryReadPositiveInteger(out uint value)
         {
             // Read digits until we hit a non-digit character or the end of the span.
@@ -70,7 +72,9 @@ public static class SpanReaderExtensions
         ///  </para>
         /// </remarks>
         /// <param name="value">On success, the value read.</param>
-        /// <returns><see langword="true"/> if a well-formed value was read; otherwise <see langword="false"/>.</returns>
+        /// <returns>
+        ///  <see langword="true"/> if a well-formed value was read; otherwise <see langword="false"/>.
+        /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool TryRead7BitEncodedInt32(out int value)
         {

--- a/touki/Touki/Io/SpanWriter.cs
+++ b/touki/Touki/Io/SpanWriter.cs
@@ -19,9 +19,7 @@ public unsafe ref struct SpanWriter<T>(Span<T> span) where T : unmanaged
     /// <summary>
     ///  Gets or sets the current position of the writer within the span.
     /// </summary>
-    /// <value>
-    ///  The zero-based position of the writer. Setting this value repositions the writer.
-    /// </value>
+    /// <value>The zero-based position of the writer. Setting this value repositions the writer.</value>
     /// <exception cref="ArgumentOutOfRangeException">
     ///  Thrown when the value is negative or greater than <see cref="Length"/>.
     /// </exception>
@@ -45,7 +43,9 @@ public unsafe ref struct SpanWriter<T>(Span<T> span) where T : unmanaged
     ///  Try to write the given value.
     /// </summary>
     /// <param name="value">The value to write.</param>
-    /// <returns><see langword="true"/> if the value was successfully written; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the value was successfully written; otherwise, <see langword="false"/>.
+    /// </returns>
     public bool TryWrite(T value)
     {
         bool success = false;
@@ -64,7 +64,9 @@ public unsafe ref struct SpanWriter<T>(Span<T> span) where T : unmanaged
     ///  Try to write the given values.
     /// </summary>
     /// <param name="values">The values to write.</param>
-    /// <returns><see langword="true"/> if all values were successfully written; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if all values were successfully written; otherwise, <see langword="false"/>.
+    /// </returns>
     public bool TryWrite(ReadOnlySpan<T> values)
     {
         bool success = false;
@@ -84,7 +86,9 @@ public unsafe ref struct SpanWriter<T>(Span<T> span) where T : unmanaged
     /// </summary>
     /// <param name="count">The number of times to write the value.</param>
     /// <param name="value">The value to write.</param>
-    /// <returns><see langword="true"/> if all values were successfully written; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if all values were successfully written; otherwise, <see langword="false"/>.
+    /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count"/> is negative.</exception>
     public bool TryWrite(int count, T value)
     {

--- a/touki/Touki/Resources/RawResourceReader.cs
+++ b/touki/Touki/Resources/RawResourceReader.cs
@@ -225,9 +225,7 @@ public sealed class RawResourceReader : DisposableBase
     ///  idempotent; after it, member access throws <see cref="ObjectDisposedException"/>. A reader
     ///  constructed directly over a <see cref="ReadOnlyMemory{T}"/> owns no mapping to release.
     /// </summary>
-    /// <param name="disposing">
-    ///  <see langword="true"/> when called from <see cref="DisposableBase.Dispose()"/>.
-    /// </param>
+    /// <param name="disposing"><see langword="true"/> when called from <see cref="DisposableBase.Dispose()"/>.</param>
     protected override void Dispose(bool disposing)
     {
         if (disposing)
@@ -438,7 +436,9 @@ public sealed class RawResourceReader : DisposableBase
     /// <param name="index">A resource index in the range <c>[0, <see cref="ResourceCount"/>)</c>.</param>
     /// <param name="destination">The span to copy the name characters into.</param>
     /// <param name="charsWritten">On success, the number of characters written.</param>
-    /// <returns><see langword="false"/> if <paramref name="destination"/> is too small; otherwise <see langword="true"/>.</returns>
+    /// <returns>
+    ///  <see langword="false"/> if <paramref name="destination"/> is too small; otherwise <see langword="true"/>.
+    /// </returns>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is out of range.</exception>
     /// <exception cref="BadImageFormatException">The file is malformed.</exception>
     public bool TryGetResourceName(int index, Span<char> destination, out int charsWritten)

--- a/touki/Touki/Text/HexConverter.cs
+++ b/touki/Touki/Text/HexConverter.cs
@@ -14,7 +14,9 @@ internal static partial class HexConverter
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int FromChar(int c) => c >= CharToHexLookup.Length ? 0xFF : CharToHexLookup[c];
 
-    /// <summary>Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.</summary>
+    /// <summary>
+    ///  Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.
+    /// </summary>
     public static ReadOnlySpan<byte> CharToHexLookup =>
     [
         0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 15

--- a/touki/Touki/Text/StringExtensions.cs
+++ b/touki/Touki/Text/StringExtensions.cs
@@ -100,12 +100,8 @@ public static partial class StringExtensions
         /// <summary>
         ///  Generates <paramref name="count"/> random UTF-16 strings.
         /// </summary>
-        /// <param name="minLength">
-        ///  Minimum length of the generated strings in UTF-16 code units, inclusive.
-        /// </param>
-        /// <param name="maxLength">
-        ///  Maximum length of the generated strings in UTF-16 code units, inclusive.
-        /// </param>
+        /// <param name="minLength">Minimum length of the generated strings in UTF-16 code units, inclusive.</param>
+        /// <param name="maxLength">Maximum length of the generated strings in UTF-16 code units, inclusive.</param>
         /// <remarks>
         ///  <para>
         ///   Length bounds are inclusive and measure UTF-16 code units (i.e., C# char count).

--- a/touki/Touki/Text/StringSegment.cs
+++ b/touki/Touki/Text/StringSegment.cs
@@ -167,7 +167,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="startIndex">The start index.</param>
     /// <param name="length">The length of the new segment.</param>
-    /// <returns>A new <see cref="StringSegment"/> that starts at the specified index and has the specified length.</returns>
+    /// <returns>
+    ///  A new <see cref="StringSegment"/> that starts at the specified index and has the specified length.
+    /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">
     ///  Thrown when <paramref name="startIndex"/> or <paramref name="length"/> are negative, or if
     ///  <paramref name="startIndex"/> + <paramref name="length"/> exceeds <see cref="Length"/>.
@@ -219,9 +221,7 @@ public readonly struct StringSegment :
     /// <summary>
     ///  Splits on the next separator, or returns the entire segment if no separator is found.
     /// </summary>
-    /// <returns>
-    ///  <see langword="false"/> if the current segment is empty, otherwise <see langword="true"/>.
-    /// </returns>
+    /// <returns><see langword="false"/> if the current segment is empty, otherwise <see langword="true"/>.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool TrySplitAny(char value0, char value1, out StringSegment left, out StringSegment right)
     {
@@ -372,9 +372,7 @@ public readonly struct StringSegment :
     /// <summary>
     ///  Replace all occurrences of a character in the segment with another character.
     /// </summary>
-    /// <returns>
-    ///  The new <see cref="StringSegment"/> with the specified character replaced.
-    /// </returns>
+    /// <returns>The new <see cref="StringSegment"/> with the specified character replaced.</returns>
     /// <remarks>
     ///  <para>
     ///   This API will never allocate a new backing string unless the segment contains the character to be replaced.
@@ -765,7 +763,9 @@ public readonly struct StringSegment :
     ///  Gets a value indicating whether the segment equals the specified object.
     /// </summary>
     /// <param name="obj">The object to compare with.</param>
-    /// <returns><see langword="true"/> if the segment equals the specified object; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the segment equals the specified object; otherwise, <see langword="false"/>.
+    /// </returns>
     public override bool Equals(object? obj) => (obj is StringSegment other && Equals(other))
         || (obj is string otherString && Equals(otherString));
 
@@ -904,7 +904,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The first segment.</param>
     /// <param name="right">The second segment.</param>
-    /// <returns><see langword="true"/> if the left segment is less than the right segment; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the left segment is less than the right segment; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator <(StringSegment left, StringSegment right) => left.CompareTo(right) < 0;
 
     /// <summary>
@@ -912,7 +914,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The first segment.</param>
     /// <param name="right">The second segment.</param>
-    /// <returns><see langword="true"/> if the left segment is less than or equal to the right segment; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the left segment is less than or equal to the right segment; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator <=(StringSegment left, StringSegment right) => left.CompareTo(right) <= 0;
 
     /// <summary>
@@ -920,7 +924,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The first segment.</param>
     /// <param name="right">The second segment.</param>
-    /// <returns><see langword="true"/> if the left segment is greater than the right segment; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the left segment is greater than the right segment; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator >(StringSegment left, StringSegment right) => left.CompareTo(right) > 0;
 
     /// <summary>
@@ -928,7 +934,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The first segment.</param>
     /// <param name="right">The second segment.</param>
-    /// <returns><see langword="true"/> if the left segment is greater than or equal to the right segment; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the left segment is greater than or equal to the right segment; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator >=(StringSegment left, StringSegment right) => left.CompareTo(right) >= 0;
 
     /// <summary>
@@ -936,7 +944,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The segment.</param>
     /// <param name="right">The string to compare with.</param>
-    /// <returns><see langword="true"/> if the segment is less than the string; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the segment is less than the string; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator <(StringSegment left, string right) => left.CompareTo(right) < 0;
 
     /// <summary>
@@ -944,7 +954,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The segment.</param>
     /// <param name="right">The string to compare with.</param>
-    /// <returns><see langword="true"/> if the segment is less than or equal to the string; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the segment is less than or equal to the string; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator <=(StringSegment left, string right) => left.CompareTo(right) <= 0;
 
     /// <summary>
@@ -952,7 +964,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The segment.</param>
     /// <param name="right">The string to compare with.</param>
-    /// <returns><see langword="true"/> if the segment is greater than the string; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the segment is greater than the string; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator >(StringSegment left, string right) => left.CompareTo(right) > 0;
 
     /// <summary>
@@ -960,7 +974,9 @@ public readonly struct StringSegment :
     /// </summary>
     /// <param name="left">The segment.</param>
     /// <param name="right">The string to compare with.</param>
-    /// <returns><see langword="true"/> if the segment is greater than or equal to the string; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the segment is greater than or equal to the string; otherwise, <see langword="false"/>.
+    /// </returns>
     public static bool operator >=(StringSegment left, string right) => left.CompareTo(right) >= 0;
 
     /// <summary>

--- a/touki/Touki/Text/ValueStringBuilder.Formatting.cs
+++ b/touki/Touki/Text/ValueStringBuilder.Formatting.cs
@@ -505,12 +505,15 @@ public ref partial struct ValueStringBuilder
         }
     }
 
-    /// <summary>Writes the specified value to the handler.</summary>
+    /// <summary>
+    ///  Writes the specified value to the handler.
+    /// </summary>
     /// <param name="value">The value to write.</param>
     /// <param name="format">The format string.</param>
     /// <param name="alignment">
     ///  Minimum number of characters that should be written for this value. If the value is negative,
-    ///  it indicates left-aligned and the required minimum is the absolute value.</param>
+    ///  it indicates left-aligned and the required minimum is the absolute value.
+    /// </param>
     public void AppendFormatted(scoped ReadOnlySpan<char> value, int alignment = 0, string? format = null)
     {
         bool leftAlign = false;
@@ -548,7 +551,9 @@ public ref partial struct ValueStringBuilder
         }
     }
 
-    /// <summary>Formats the value using the custom formatter from the provider.</summary>
+    /// <summary>
+    ///  Formats the value using the custom formatter from the provider.
+    /// </summary>
     /// <param name="value">The value to write.</param>
     /// <param name="format">The format string.</param>
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/touki/Touki/Text/ValueStringBuilder.cs
+++ b/touki/Touki/Text/ValueStringBuilder.cs
@@ -113,7 +113,9 @@ public ref partial struct ValueStringBuilder
         _hasCustomFormatter = provider is not null && HasCustomFormatter(provider);
     }
 
-    /// <summary>Gets whether the provider provides a custom formatter.</summary>
+    /// <summary>
+    ///  Gets whether the provider provides a custom formatter.
+    /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)] // only used in a few hot path call sites
     internal static bool HasCustomFormatter(IFormatProvider provider)
     {
@@ -243,7 +245,9 @@ public ref partial struct ValueStringBuilder
     ///  Forms a slice out of the buffer starting at a specified index.
     /// </summary>
     /// <param name="start">The index at which to begin the slice.</param>
-    /// <returns>A span that consists of the remaining elements from the buffer starting at <paramref name="start"/>.</returns>
+    /// <returns>
+    ///  A span that consists of the remaining elements from the buffer starting at <paramref name="start"/>.
+    /// </returns>
     public readonly ReadOnlySpan<char> Slice(int start)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(start);
@@ -256,7 +260,9 @@ public ref partial struct ValueStringBuilder
     /// </summary>
     /// <param name="start">The index at which to begin the slice.</param>
     /// <param name="length">The desired length of the slice.</param>
-    /// <returns>A span that consists of <paramref name="length"/> elements from the buffer starting at <paramref name="start"/>.</returns>
+    /// <returns>
+    ///  A span that consists of <paramref name="length"/> elements from the buffer starting at <paramref name="start"/>.
+    /// </returns>
     public readonly ReadOnlySpan<char> Slice(int start, int length)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(start);
@@ -290,8 +296,12 @@ public ref partial struct ValueStringBuilder
     ///  Attempts to copy the contents of this builder to the destination span.
     /// </summary>
     /// <param name="destination">The destination span to copy the contents to.</param>
-    /// <param name="charsWritten">When this method returns, contains the number of characters written to the destination.</param>
-    /// <returns><see langword="true"/> if the copy operation was successful; otherwise, <see langword="false"/>.</returns>
+    /// <param name="charsWritten">
+    ///  When this method returns, contains the number of characters written to the destination.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the copy operation was successful; otherwise, <see langword="false"/>.
+    /// </returns>
     /// <remarks>
     ///  This method disposes the builder after attempting the copy operation, making it unusable afterwards.
     /// </remarks>
@@ -382,9 +392,7 @@ public ref partial struct ValueStringBuilder
     /// <summary>
     ///  Append a string to the builder. If the string is <see langword="null"/>, this method does nothing.
     /// </summary>
-    /// <devdoc>
-    ///  Name must be AppendLiteral to work with interpolated strings.
-    /// </devdoc>
+    /// <devdoc>Name must be AppendLiteral to work with interpolated strings.</devdoc>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void AppendLiteral(string? s)
     {
@@ -537,9 +545,7 @@ public ref partial struct ValueStringBuilder
     /// <summary>
     ///  Replace all occurrences of a character in the segment with another character.
     /// </summary>
-    /// <returns>
-    ///  The new <see cref="StringSegment"/> with the specified character replaced.
-    /// </returns>
+    /// <returns>The new <see cref="StringSegment"/> with the specified character replaced.</returns>
     public readonly void Replace(char oldValue, char newValue)
     {
         if (_length == 0 || oldValue == newValue)
@@ -561,9 +567,7 @@ public ref partial struct ValueStringBuilder
     ///  Resize the internal buffer either by doubling current buffer size or by adding
     ///  <paramref name="additionalCapacityBeyondPos"/> to <see cref="_length"/> whichever is greater.
     /// </summary>
-    /// <param name="additionalCapacityBeyondPos">
-    ///  Number of chars requested beyond current position.
-    /// </param>
+    /// <param name="additionalCapacityBeyondPos">Number of chars requested beyond current position.</param>
     [MethodImpl(MethodImplOptions.NoInlining)]
     [MemberNotNull(nameof(_arrayToReturnToPool))]
     private void Grow(int additionalCapacityBeyondPos)

--- a/touki/Touki/Value.IUnionMembers.cs
+++ b/touki/Touki/Value.IUnionMembers.cs
@@ -32,118 +32,194 @@ public readonly partial struct Value : Value.IUnionMembers
     /// </summary>
     public interface IUnionMembers
     {
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="bool"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="bool"/> (union case type).
+        /// </summary>
         static Value Create(bool value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="byte"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="byte"/> (union case type).
+        /// </summary>
         static Value Create(byte value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from an <see cref="sbyte"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from an <see cref="sbyte"/> (union case type).
+        /// </summary>
         static Value Create(sbyte value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="char"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="char"/> (union case type).
+        /// </summary>
         static Value Create(char value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="short"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="short"/> (union case type).
+        /// </summary>
         static Value Create(short value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="ushort"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="ushort"/> (union case type).
+        /// </summary>
         static Value Create(ushort value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from an <see cref="int"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from an <see cref="int"/> (union case type).
+        /// </summary>
         static Value Create(int value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="uint"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="uint"/> (union case type).
+        /// </summary>
         static Value Create(uint value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="long"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="long"/> (union case type).
+        /// </summary>
         static Value Create(long value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="ulong"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="ulong"/> (union case type).
+        /// </summary>
         static Value Create(ulong value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="float"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="float"/> (union case type).
+        /// </summary>
         static Value Create(float value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="double"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="double"/> (union case type).
+        /// </summary>
         static Value Create(double value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="DateTime"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="DateTime"/> (union case type).
+        /// </summary>
         static Value Create(DateTime value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="DateTimeOffset"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="DateTimeOffset"/> (union case type).
+        /// </summary>
         static Value Create(DateTimeOffset value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="string"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="string"/> (union case type).
+        /// </summary>
         static Value Create(string value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from an <see cref="ArraySegment{T}"/> of <see cref="byte"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from an <see cref="ArraySegment{T}"/> of <see cref="byte"/> (union case type).
+        /// </summary>
         static Value Create(ArraySegment<byte> value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from an <see cref="ArraySegment{T}"/> of <see cref="char"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from an <see cref="ArraySegment{T}"/> of <see cref="char"/> (union case type).
+        /// </summary>
         static Value Create(ArraySegment<char> value) => value;
 
-        /// <summary>Creates a <see cref="Value"/> from a <see cref="StringSegment"/> (union case type).</summary>
+        /// <summary>
+        ///  Creates a <see cref="Value"/> from a <see cref="StringSegment"/> (union case type).
+        /// </summary>
         static Value Create(StringSegment value) => value;
 
-        /// <summary>Gets the contents boxed, or <see langword="null"/> when empty. Mandatory union member.</summary>
+        /// <summary>
+        ///  Gets the contents boxed, or <see langword="null"/> when empty. Mandatory union member.
+        /// </summary>
         object? Value { get; }
 
-        /// <summary>Gets a value indicating whether the union holds a non-null value.</summary>
+        /// <summary>
+        ///  Gets a value indicating whether the union holds a non-null value.
+        /// </summary>
         bool HasValue { get; }
 
-        /// <summary>Non-boxing access for the <see cref="bool"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="bool"/> case.
+        /// </summary>
         bool TryGetValue(out bool value);
 
-        /// <summary>Non-boxing access for the <see cref="byte"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="byte"/> case.
+        /// </summary>
         bool TryGetValue(out byte value);
 
-        /// <summary>Non-boxing access for the <see cref="sbyte"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="sbyte"/> case.
+        /// </summary>
         bool TryGetValue(out sbyte value);
 
-        /// <summary>Non-boxing access for the <see cref="char"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="char"/> case.
+        /// </summary>
         bool TryGetValue(out char value);
 
-        /// <summary>Non-boxing access for the <see cref="short"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="short"/> case.
+        /// </summary>
         bool TryGetValue(out short value);
 
-        /// <summary>Non-boxing access for the <see cref="ushort"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="ushort"/> case.
+        /// </summary>
         bool TryGetValue(out ushort value);
 
-        /// <summary>Non-boxing access for the <see cref="int"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="int"/> case.
+        /// </summary>
         bool TryGetValue(out int value);
 
-        /// <summary>Non-boxing access for the <see cref="uint"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="uint"/> case.
+        /// </summary>
         bool TryGetValue(out uint value);
 
-        /// <summary>Non-boxing access for the <see cref="long"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="long"/> case.
+        /// </summary>
         bool TryGetValue(out long value);
 
-        /// <summary>Non-boxing access for the <see cref="ulong"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="ulong"/> case.
+        /// </summary>
         bool TryGetValue(out ulong value);
 
-        /// <summary>Non-boxing access for the <see cref="float"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="float"/> case.
+        /// </summary>
         bool TryGetValue(out float value);
 
-        /// <summary>Non-boxing access for the <see cref="double"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="double"/> case.
+        /// </summary>
         bool TryGetValue(out double value);
 
-        /// <summary>Non-boxing access for the <see cref="DateTime"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="DateTime"/> case.
+        /// </summary>
         bool TryGetValue(out DateTime value);
 
-        /// <summary>Non-boxing access for the <see cref="DateTimeOffset"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="DateTimeOffset"/> case.
+        /// </summary>
         bool TryGetValue(out DateTimeOffset value);
 
-        /// <summary>Non-boxing access for the <see cref="string"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="string"/> case.
+        /// </summary>
         bool TryGetValue(out string? value);
 
-        /// <summary>Non-boxing access for the <see cref="ArraySegment{T}"/> of <see cref="byte"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="ArraySegment{T}"/> of <see cref="byte"/> case.
+        /// </summary>
         bool TryGetValue(out ArraySegment<byte> value);
 
-        /// <summary>Non-boxing access for the <see cref="ArraySegment{T}"/> of <see cref="char"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="ArraySegment{T}"/> of <see cref="char"/> case.
+        /// </summary>
         bool TryGetValue(out ArraySegment<char> value);
 
-        /// <summary>Non-boxing access for the <see cref="StringSegment"/> case.</summary>
+        /// <summary>
+        ///  Non-boxing access for the <see cref="StringSegment"/> case.
+        /// </summary>
         bool TryGetValue(out StringSegment value);
     }
 }

--- a/touki/Touki/Value.cs
+++ b/touki/Touki/Value.cs
@@ -902,7 +902,9 @@ public readonly partial struct Value
     /// </summary>
     /// <param name="value">The <see cref="Value"/> to convert.</param>
     /// <returns>The nullable <see cref="DateTimeOffset"/> value stored in the <see cref="Value"/>.</returns>
-    /// <exception cref="InvalidCastException">The stored value is not a nullable <see cref="DateTimeOffset"/>.</exception>
+    /// <exception cref="InvalidCastException">
+    ///  The stored value is not a nullable <see cref="DateTimeOffset"/>.
+    /// </exception>
     public static explicit operator DateTimeOffset?(in Value value) => value.As<DateTimeOffset?>();
     #endregion
 
@@ -1210,7 +1212,8 @@ public readonly partial struct Value
     }
 
     /// <summary>
-    ///  Use this method to avoid generic instantiation for an unsupported value type (T) on <see cref="Create{T}(T)"/>    /// </summary>
+    ///  Use this method to avoid generic instantiation for an unsupported value type (T) on <see cref="Create{T}(T)"/>
+    /// </summary>
     public static Value Box(object? value) => new Value(value);
 
     private Value(object o, ulong u)
@@ -1224,7 +1227,9 @@ public readonly partial struct Value
     /// </summary>
     /// <typeparam name="T">The type to retrieve the value as.</typeparam>
     /// <param name="value">When this method returns, contains the value if the conversion succeeded.</param>
-    /// <returns><see langword="true"/> if the value was successfully retrieved; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    ///  <see langword="true"/> if the value was successfully retrieved; otherwise, <see langword="false"/>.
+    /// </returns>
     public readonly unsafe bool TryGetValue<T>(out T value)
     {
         bool success;


### PR DESCRIPTION
## Summary

- Add disabled-by-default `TOUKI0024` and a Batch Fix All code fix for repository-style structured `///` XML documentation.
- Support configurable XML indentation and line-length precedence while preserving authored prose breaks, block-relative hanging indentation, `xml:space`, `<code>`, CDATA, and Unicode content.
- Bound analysis by comment length, structured-node count, XML depth, replacement growth, and deterministic linear-read tests.
- Enable and dogfood the rule in Touki, exempt faithful polyfill ports, migrate existing documentation, and repair the malformed `Value.Box` summary terminator required for structured parsing.

## Validation

- `dotnet build touki.slnx -c Release --nologo`
- Direct `net10.0`, `net11.0`, and `net481` runtime hosts in Debug and Release, excluding only the two host-dependent OS clipboard classes
- 383 analyzer tests in Debug and Release; 81 focused TOUKI0024 tests
- 13 AOT tests
- NuGet package contains both analyzer and code-fix assemblies under `analyzers/dotnet/cs/`
- TOUKI0024 analyzer time: 0.206 s versus 0.302 s for TOUKI0041 and 20.493 s total