### PR TITLE
Consolidate analyzer utility helpers

### DIFF
--- a/touki.analyzers.codefixes/DocumentFileUtilities.cs
+++ b/touki.analyzers.codefixes/DocumentFileUtilities.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.IO;
+using Microsoft.CodeAnalysis;
+
+namespace Touki.Analyzers;
+
+internal static class DocumentFileUtilities
+{
+    /// <summary>
+    ///  Determines whether another document in the solution has the same file path as
+    ///  <paramref name="document"/>, using an ordinal case-insensitive comparison.
+    /// </summary>
+    public static bool HasSharedFilePath(Solution solution, Document document)
+    {
+        string filePath = document.FilePath!;
+
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document candidate in project.Documents)
+            {
+                if (candidate.Id != document.Id
+                    && string.Equals(candidate.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Determines whether a document in <paramref name="solution"/> has <paramref name="filePath"/>, using an
+    ///  ordinal case-insensitive comparison and optionally excluding one document.
+    /// </summary>
+    public static bool HasDocumentWithFilePath(
+        Solution solution,
+        string filePath,
+        DocumentId? excludedDocumentId = null)
+    {
+        foreach (Project project in solution.Projects)
+        {
+            foreach (Document candidate in project.Documents)
+            {
+                if (candidate.Id != excludedDocumentId
+                    && string.Equals(candidate.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///  Determines whether <paramref name="targetFilePath"/> is available on the file system, treating the
+    ///  current document path as available and path-inspection failures as collisions.
+    /// </summary>
+    public static bool IsFileSystemDestinationAvailable(string currentFilePath, string targetFilePath)
+    {
+        string fullCurrentPath = Path.GetFullPath(currentFilePath);
+        string fullTargetPath = Path.GetFullPath(targetFilePath);
+        if (string.Equals(fullCurrentPath, fullTargetPath, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        string? directory = Path.GetDirectoryName(fullTargetPath);
+        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+        {
+            return true;
+        }
+
+        string targetName = Path.GetFileName(fullTargetPath);
+
+        try
+        {
+            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
+            {
+                string fullEntryPath = Path.GetFullPath(entry);
+                if (string.Equals(fullEntryPath, fullCurrentPath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (string.Equals(Path.GetFileName(fullEntryPath), targetName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return false;
+                }
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    ///  Gets the path for <paramref name="fileName"/> in the directory containing <paramref name="document"/>.
+    /// </summary>
+    /// <returns>
+    ///  The target path, or <see langword="null"/> when the document has no file path.
+    /// </returns>
+    public static string? GetTargetFilePath(Document document, string fileName)
+    {
+        if (document.FilePath is null)
+        {
+            return null;
+        }
+
+        string? directory = Path.GetDirectoryName(document.FilePath);
+        return string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+    }
+}

--- a/touki.analyzers.codefixes/FormatXmlDocumentationCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/FormatXmlDocumentationCodeFixProvider.cs
@@ -4,12 +4,9 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Touki.Analyzers;
 
@@ -49,25 +46,14 @@ public sealed class FormatXmlDocumentationCodeFixProvider : CodeFixProvider
                 continue;
             }
 
-            TextSpan span = diagnostic.Location.SourceSpan;
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    "Format XML documentation comment",
-                    cancellationToken => ReplaceAsync(context.Document, span, replacement, cancellationToken),
-                    equivalenceKey: nameof(FormatXmlDocumentationCodeFixProvider)),
-                diagnostic);
+            TextChangeCodeFix.Register(
+                context,
+                diagnostic,
+                "Format XML documentation comment",
+                replacement,
+                nameof(FormatXmlDocumentationCodeFixProvider));
         }
 
         return Task.CompletedTask;
-    }
-
-    private static async Task<Document> ReplaceAsync(
-        Document document,
-        TextSpan span,
-        string replacement,
-        CancellationToken cancellationToken)
-    {
-        SourceText text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        return document.WithText(text.WithChanges(new TextChange(span, replacement)));
     }
 }

--- a/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
@@ -35,8 +35,7 @@ public sealed class MakeMemberReadonlyCodeFixProvider : CodeFixProvider
     private const string NonCopyableDefensiveCopyId = "TOUKI0003";
 
     /// <inheritdoc/>
-    public override ImmutableArray<string> FixableDiagnosticIds =>
-        ImmutableArray.Create(DefensiveCopyId, NonCopyableDefensiveCopyId);
+    public override ImmutableArray<string> FixableDiagnosticIds => [DefensiveCopyId, NonCopyableDefensiveCopyId];
 
     /// <inheritdoc/>
     public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;

--- a/touki.analyzers.codefixes/MoveTypeToFileCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MoveTypeToFileCodeFixProvider.cs
@@ -121,7 +121,7 @@ public sealed class MoveTypeToFileCodeFixProvider : CodeFixProvider
             || document.Project.Solution.Workspace.Kind == WorkspaceKind.MSBuild
             || !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.AddDocument)
             || !document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocument)
-            || HasSharedFilePath(document.Project.Solution, document)
+            || DocumentFileUtilities.HasSharedFilePath(document.Project.Solution, document)
             || ContainsDirective(root)
             || ContainsFileLocalDeclaration(root))
         {
@@ -281,25 +281,6 @@ public sealed class MoveTypeToFileCodeFixProvider : CodeFixProvider
         }
     }
 
-    private static bool HasSharedFilePath(Solution solution, Document document)
-    {
-        string filePath = document.FilePath!;
-
-        foreach (Project project in solution.Projects)
-        {
-            foreach (Document candidate in project.Documents)
-            {
-                if (candidate.Id != document.Id
-                    && string.Equals(candidate.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
     private static char GetDetailSeparator(Document document, SyntaxTree syntaxTree)
     {
         AnalyzerConfigOptions options = document.Project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GetOptions(syntaxTree);
@@ -379,76 +360,9 @@ public sealed class MoveTypeToFileCodeFixProvider : CodeFixProvider
 
     private static bool IsDestinationAvailable(Solution solution, Document document, string fileName)
     {
-        string targetFilePath = GetTargetFilePath(document, fileName)!;
-
-        foreach (Project project in solution.Projects)
-        {
-            foreach (Document candidate in project.Documents)
-            {
-                if (string.Equals(candidate.FilePath, targetFilePath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-            }
-        }
-
-        return IsFileSystemDestinationAvailable(document.FilePath!, targetFilePath);
-    }
-
-    private static bool IsFileSystemDestinationAvailable(string currentFilePath, string targetFilePath)
-    {
-        string fullCurrentPath = Path.GetFullPath(currentFilePath);
-        string fullTargetPath = Path.GetFullPath(targetFilePath);
-        if (string.Equals(fullCurrentPath, fullTargetPath, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        string? directory = Path.GetDirectoryName(fullTargetPath);
-        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
-        {
-            return true;
-        }
-
-        string targetName = Path.GetFileName(fullTargetPath);
-
-        try
-        {
-            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
-            {
-                string fullEntryPath = Path.GetFullPath(entry);
-                if (string.Equals(fullEntryPath, fullCurrentPath, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (string.Equals(Path.GetFileName(fullEntryPath), targetName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-            }
-        }
-        catch (IOException)
-        {
-            return false;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static string? GetTargetFilePath(Document document, string fileName)
-    {
-        if (document.FilePath is null)
-        {
-            return null;
-        }
-
-        string? directory = Path.GetDirectoryName(document.FilePath);
-        return string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+        string targetFilePath = DocumentFileUtilities.GetTargetFilePath(document, fileName)!;
+        return !DocumentFileUtilities.HasDocumentWithFilePath(solution, targetFilePath)
+            && DocumentFileUtilities.IsFileSystemDestinationAvailable(document.FilePath!, targetFilePath);
     }
 
     private static async Task<Solution> MoveAsync(
@@ -468,7 +382,7 @@ public sealed class MoveTypeToFileCodeFixProvider : CodeFixProvider
             await GetDeclarationsToMoveAsync(document, root, declaration, cancellationToken).ConfigureAwait(false);
         CompilationUnitSyntax destinationRoot = CreateDestinationRoot(root, declarations, generator);
         CompilationUnitSyntax sourceRoot = CreateSourceRoot(root, declarations, generator);
-        string? targetFilePath = GetTargetFilePath(document, fileName);
+        string? targetFilePath = DocumentFileUtilities.GetTargetFilePath(document, fileName);
         if (targetFilePath is null)
         {
             return document.Project.Solution;

--- a/touki.analyzers.codefixes/RemoveTrailingWhitespaceCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/RemoveTrailingWhitespaceCodeFixProvider.cs
@@ -4,12 +4,9 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Touki.Analyzers;
 
@@ -43,25 +40,14 @@ public sealed class RemoveTrailingWhitespaceCodeFixProvider : CodeFixProvider
     {
         foreach (Diagnostic diagnostic in context.Diagnostics)
         {
-            TextSpan span = diagnostic.Location.SourceSpan;
-
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    "Remove trailing whitespace",
-                    cancellationToken => RemoveAsync(context.Document, span, cancellationToken),
-                    equivalenceKey: nameof(RemoveTrailingWhitespaceCodeFixProvider)),
-                diagnostic);
+            TextChangeCodeFix.Register(
+                context,
+                diagnostic,
+                "Remove trailing whitespace",
+                string.Empty,
+                nameof(RemoveTrailingWhitespaceCodeFixProvider));
         }
 
         return Task.CompletedTask;
-    }
-
-    private static async Task<Document> RemoveAsync(
-        Document document,
-        TextSpan span,
-        CancellationToken cancellationToken)
-    {
-        SourceText text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        return document.WithText(text.WithChanges(new TextChange(span, string.Empty)));
     }
 }

--- a/touki.analyzers.codefixes/RenameFileToMatchTypeCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/RenameFileToMatchTypeCodeFixProvider.cs
@@ -100,26 +100,7 @@ public sealed class RenameFileToMatchTypeCodeFixProvider : CodeFixProvider
         document.FilePath is not null
         && document.Project.Solution.Workspace.Kind != WorkspaceKind.MSBuild
         && document.Project.Solution.Workspace.CanApplyChange(ApplyChangesKind.ChangeDocumentInfo)
-        && !HasSharedFilePath(document.Project.Solution, document);
-
-    private static bool HasSharedFilePath(Solution solution, Document document)
-    {
-        string filePath = document.FilePath!;
-
-        foreach (Project project in solution.Projects)
-        {
-            foreach (Document candidate in project.Documents)
-            {
-                if (candidate.Id != document.Id
-                    && string.Equals(candidate.FilePath, filePath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
+        && !DocumentFileUtilities.HasSharedFilePath(document.Project.Solution, document);
 
     private static string GetAvailableFileName(
         Solution solution,
@@ -147,78 +128,10 @@ public sealed class RenameFileToMatchTypeCodeFixProvider : CodeFixProvider
 
     private static bool IsDestinationAvailable(Solution solution, Document document, string fileName)
     {
-        string targetFilePath = GetTargetFilePath(document, fileName)!;
+        string targetFilePath = DocumentFileUtilities.GetTargetFilePath(document, fileName)!;
         string currentFilePath = document.FilePath!;
-
-        foreach (Project project in solution.Projects)
-        {
-            foreach (Document candidate in project.Documents)
-            {
-                if (candidate.Id != document.Id
-                    && string.Equals(candidate.FilePath, targetFilePath, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-            }
-        }
-
-        return IsFileSystemDestinationAvailable(currentFilePath, targetFilePath);
-    }
-
-    private static bool IsFileSystemDestinationAvailable(string currentFilePath, string targetFilePath)
-    {
-        string fullCurrentPath = Path.GetFullPath(currentFilePath);
-        string fullTargetPath = Path.GetFullPath(targetFilePath);
-        if (string.Equals(fullCurrentPath, fullTargetPath, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        string? directory = Path.GetDirectoryName(fullTargetPath);
-        if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
-        {
-            return true;
-        }
-
-        string targetName = Path.GetFileName(fullTargetPath);
-
-        try
-        {
-            foreach (string entry in Directory.EnumerateFileSystemEntries(directory))
-            {
-                string fullEntryPath = Path.GetFullPath(entry);
-                if (string.Equals(fullEntryPath, fullCurrentPath, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (string.Equals(Path.GetFileName(fullEntryPath), targetName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return false;
-                }
-            }
-        }
-        catch (IOException)
-        {
-            return false;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static string? GetTargetFilePath(Document document, string fileName)
-    {
-        if (document.FilePath is null)
-        {
-            return null;
-        }
-
-        string? directory = Path.GetDirectoryName(document.FilePath);
-        return string.IsNullOrEmpty(directory) ? fileName : Path.Combine(directory, fileName);
+        return !DocumentFileUtilities.HasDocumentWithFilePath(solution, targetFilePath, document.Id)
+            && DocumentFileUtilities.IsFileSystemDestinationAvailable(currentFilePath, targetFilePath);
     }
 
     private static Task<Solution> RenameDocumentAsync(
@@ -228,7 +141,7 @@ public sealed class RenameFileToMatchTypeCodeFixProvider : CodeFixProvider
         CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        string? targetFilePath = GetTargetFilePath(document, fileName);
+        string? targetFilePath = DocumentFileUtilities.GetTargetFilePath(document, fileName);
         if (targetFilePath is null)
         {
             return Task.FromResult(solution);

--- a/touki.analyzers.codefixes/ReplaceTabsWithSpacesCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/ReplaceTabsWithSpacesCodeFixProvider.cs
@@ -4,12 +4,9 @@
 
 using System.Collections.Immutable;
 using System.Composition;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Touki.Analyzers;
 
@@ -52,26 +49,14 @@ public sealed class ReplaceTabsWithSpacesCodeFixProvider : CodeFixProvider
                 continue;
             }
 
-            TextSpan span = diagnostic.Location.SourceSpan;
-
-            context.RegisterCodeFix(
-                CodeAction.Create(
-                    "Replace tabs with spaces",
-                    cancellationToken => ReplaceAsync(context.Document, span, replacement, cancellationToken),
-                    equivalenceKey: nameof(ReplaceTabsWithSpacesCodeFixProvider)),
-                diagnostic);
+            TextChangeCodeFix.Register(
+                context,
+                diagnostic,
+                "Replace tabs with spaces",
+                replacement,
+                nameof(ReplaceTabsWithSpacesCodeFixProvider));
         }
 
         return Task.CompletedTask;
-    }
-
-    private static async Task<Document> ReplaceAsync(
-        Document document,
-        TextSpan span,
-        string replacement,
-        CancellationToken cancellationToken)
-    {
-        SourceText text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        return document.WithText(text.WithChanges(new TextChange(span, replacement)));
     }
 }

--- a/touki.analyzers.codefixes/TextChangeCodeFix.cs
+++ b/touki.analyzers.codefixes/TextChangeCodeFix.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+internal static class TextChangeCodeFix
+{
+    /// <summary>
+    ///  Registers a code action that replaces the diagnostic's source span with <paramref name="replacement"/>.
+    /// </summary>
+    public static void Register(
+        CodeFixContext context,
+        Diagnostic diagnostic,
+        string title,
+        string replacement,
+        string equivalenceKey)
+    {
+        TextSpan span = diagnostic.Location.SourceSpan;
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title,
+                cancellationToken => ReplaceAsync(context.Document, span, replacement, cancellationToken),
+                equivalenceKey),
+            diagnostic);
+    }
+
+    private static async Task<Document> ReplaceAsync(
+        Document document,
+        TextSpan span,
+        string replacement,
+        CancellationToken cancellationToken)
+    {
+        SourceText text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        return document.WithText(text.WithChanges(new TextChange(span, replacement)));
+    }
+}

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -14,8 +14,6 @@ namespace Touki.Analyzers;
 /// </summary>
 internal static class AnalyzerTestHarness
 {
-    private static readonly Lazy<ImmutableArray<MetadataReference>> s_references = new(CreateReferences);
-
     /// <summary>
     ///  Runs <paramref name="analyzer"/> against <paramref name="source"/> and returns the
     ///  analyzer-produced diagnostics.
@@ -58,7 +56,7 @@ internal static class AnalyzerTestHarness
         CSharpCompilation compilation = CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
             syntaxTrees: [syntaxTree],
-            references: s_references.Value,
+            references: RoslynTestEnvironment.References,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
         beforeAnalysis();
 
@@ -82,19 +80,14 @@ internal static class AnalyzerTestHarness
 
     private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         DiagnosticAnalyzer analyzer,
-        CSharpCompilation compilation,
+        Compilation compilation,
         IReadOnlyDictionary<string, string>? options,
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions)
     {
-
-        if (diagnosticOptions is not null)
-        {
-            compilation = compilation.WithOptions(
-                compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
-        }
+        compilation = RoslynTestEnvironment.ApplyDiagnosticOptions(compilation, diagnosticOptions);
 
         CompilationWithAnalyzers compilationWithAnalyzers =
-            compilation.WithAnalyzers([analyzer], CreateAnalyzerOptions(options));
+            compilation.WithAnalyzers([analyzer], RoslynTestEnvironment.CreateAnalyzerOptions(options));
 
         return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
     }
@@ -114,26 +107,7 @@ internal static class AnalyzerTestHarness
         return CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
             syntaxTrees: syntaxTrees,
-            references: s_references.Value,
+            references: RoslynTestEnvironment.References,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
-    }
-
-    private static AnalyzerOptions CreateAnalyzerOptions(IReadOnlyDictionary<string, string>? options) =>
-        new(
-            additionalFiles: [],
-            optionsProvider: new TestAnalyzerConfigOptionsProvider(
-                options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
-
-    private static ImmutableArray<MetadataReference> CreateReferences()
-    {
-        string trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
-
-        return
-        [
-            .. trustedAssemblies
-                .Split(Path.PathSeparator)
-                .Where(path => path.Length > 0)
-                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-        ];
     }
 }

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -17,8 +17,6 @@ namespace Touki.Analyzers;
 /// </summary>
 internal static class CodeFixTestHarness
 {
-    private static readonly Lazy<ImmutableArray<MetadataReference>> s_references = new(CreateReferences);
-
     /// <summary>
     ///  Runs <paramref name="analyzer"/> against <paramref name="source"/>, applies <paramref name="codeFix"/> to
     ///  the first diagnostic with id <paramref name="diagnosticId"/>, and returns the fixed source. Returns the
@@ -42,22 +40,14 @@ internal static class CodeFixTestHarness
         using AdhocWorkspace workspace = new();
         Project project = workspace
             .AddProject("TestProject", LanguageNames.CSharp)
-            .AddMetadataReferences(s_references.Value)
+            .AddMetadataReferences(RoslynTestEnvironment.References)
             .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
         Document document = project.AddDocument("Test.cs", source);
 
         Compilation compilation = (await document.Project.GetCompilationAsync().ConfigureAwait(false))!;
 
-        if (diagnosticOptions is not null)
-        {
-            compilation = compilation.WithOptions(
-                compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
-        }
-
-        AnalyzerOptions analyzerOptions = new(
-            additionalFiles: [],
-            optionsProvider: new TestAnalyzerConfigOptionsProvider(
-                options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
+        compilation = RoslynTestEnvironment.ApplyDiagnosticOptions(compilation, diagnosticOptions);
+        AnalyzerOptions analyzerOptions = RoslynTestEnvironment.CreateAnalyzerOptions(options);
 
         CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
         ImmutableArray<Diagnostic> diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
@@ -107,7 +97,7 @@ internal static class CodeFixTestHarness
             : new AdhocWorkspace(MefHostServices.DefaultHost, workspaceKind);
         Project project = workspace
             .AddProject("TestProject", LanguageNames.CSharp)
-            .AddMetadataReferences(s_references.Value)
+            .AddMetadataReferences(RoslynTestEnvironment.References)
             .WithCompilationOptions(new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 allowUnsafe: true));
@@ -124,16 +114,8 @@ internal static class CodeFixTestHarness
 
         Compilation compilation = (await project.GetCompilationAsync().ConfigureAwait(false))!;
 
-        if (diagnosticOptions is not null)
-        {
-            compilation = compilation.WithOptions(
-                compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
-        }
-
-        AnalyzerOptions analyzerOptions = new(
-            additionalFiles: [],
-            optionsProvider: new TestAnalyzerConfigOptionsProvider(
-                options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
+        compilation = RoslynTestEnvironment.ApplyDiagnosticOptions(compilation, diagnosticOptions);
+        AnalyzerOptions analyzerOptions = RoslynTestEnvironment.CreateAnalyzerOptions(options);
 
         CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
         ImmutableArray<Diagnostic> diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
@@ -251,11 +233,7 @@ internal static class CodeFixTestHarness
             }
 
             Compilation compilation = (await project.GetCompilationAsync().ConfigureAwait(false))!;
-            if (diagnosticOptions is not null)
-            {
-                compilation = compilation.WithOptions(
-                    compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
-            }
+            compilation = RoslynTestEnvironment.ApplyDiagnosticOptions(compilation, diagnosticOptions);
 
             compilerErrors.AddRange(
                 compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
@@ -307,18 +285,6 @@ internal static class CodeFixTestHarness
             Task.FromResult<IEnumerable<Diagnostic>>(diagnostics);
     }
 
-    private static ImmutableArray<MetadataReference> CreateReferences()
-    {
-        string trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
-
-        return
-        [
-            .. trustedAssemblies
-                .Split(Path.PathSeparator)
-                .Where(path => path.Length > 0)
-                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
-        ];
-    }
 }
 
 internal sealed record CodeFixTestResult(

--- a/touki.analyzers.tests/RoslynTestEnvironment.cs
+++ b/touki.analyzers.tests/RoslynTestEnvironment.cs
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+internal static class RoslynTestEnvironment
+{
+    private static readonly Lazy<ImmutableArray<MetadataReference>> s_references = new(CreateReferences);
+
+    /// <summary>
+    ///  Gets metadata references for the trusted platform assemblies of the current test process.
+    /// </summary>
+    public static ImmutableArray<MetadataReference> References => s_references.Value;
+
+    /// <summary>
+    ///  Creates analyzer options backed by the supplied EditorConfig values.
+    /// </summary>
+    public static AnalyzerOptions CreateAnalyzerOptions(IReadOnlyDictionary<string, string>? options) =>
+        new(
+            additionalFiles: [],
+            optionsProvider: new TestAnalyzerConfigOptionsProvider(
+                options is null ? TestAnalyzerConfigOptions.Empty : new TestAnalyzerConfigOptions(options)));
+
+    /// <summary>
+    ///  Applies per-diagnostic reporting options to <paramref name="compilation"/>.
+    /// </summary>
+    /// <returns>
+    ///  The original compilation when no options are supplied; otherwise, a compilation with the options applied.
+    /// </returns>
+    public static Compilation ApplyDiagnosticOptions(
+        Compilation compilation,
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions) =>
+        diagnosticOptions is null
+            ? compilation
+            : compilation.WithOptions(compilation.Options.WithSpecificDiagnosticOptions(diagnosticOptions));
+
+    private static ImmutableArray<MetadataReference> CreateReferences()
+    {
+        string trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
+
+        return
+        [
+            .. trustedAssemblies
+                .Split(Path.PathSeparator)
+                .Where(path => path.Length > 0)
+                .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+        ];
+    }
+}

--- a/touki.analyzers/AnalyzerConfigOptionsExtensions.cs
+++ b/touki.analyzers/AnalyzerConfigOptionsExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Globalization;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+internal static class AnalyzerConfigOptionsExtensions
+{
+    /// <summary>
+    ///  Attempts to read the value for <paramref name="key"/> as a positive integer.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> when the option contains a positive integer; otherwise, <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetPositiveInteger(this AnalyzerConfigOptions options, string key, out int value)
+    {
+        if (options.TryGetValue(key, out string? raw)
+            && int.TryParse(raw.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out value)
+            && value > 0)
+        {
+            return true;
+        }
+
+        value = 0;
+        return false;
+    }
+}

--- a/touki.analyzers/NoTabsAnalyzer.cs
+++ b/touki.analyzers/NoTabsAnalyzer.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -180,28 +179,10 @@ public sealed class NoTabsAnalyzer : DiagnosticAnalyzer
 
         // The rule-specific key wins so a project can decouple this rule from its editor settings; the
         // standard keys are consulted next so the common case needs no new configuration at all.
-        return TryGetPositiveInteger(options, SpacesPerTabOption, out int width)
-            || TryGetPositiveInteger(options, TabWidthOption, out width)
-            || TryGetPositiveInteger(options, IndentSizeOption, out width)
+        return options.TryGetPositiveInteger(SpacesPerTabOption, out int width)
+            || options.TryGetPositiveInteger(TabWidthOption, out width)
+            || options.TryGetPositiveInteger(IndentSizeOption, out width)
             ? width
             : DefaultSpacesPerTab;
-    }
-
-    /// <summary>
-    ///  Reads <paramref name="key"/> as a positive integer. A missing, unparsable, or non-positive value
-    ///  yields <see langword="false"/> so the next source is consulted rather than failing the build over an
-    ///  editor setting this rule does not own. <c>indent_size = tab</c> is the common non-numeric value.
-    /// </summary>
-    private static bool TryGetPositiveInteger(AnalyzerConfigOptions options, string key, out int value)
-    {
-        if (options.TryGetValue(key, out string? raw)
-            && int.TryParse(raw.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out value)
-            && value > 0)
-        {
-            return true;
-        }
-
-        value = 0;
-        return false;
     }
 }

--- a/touki.analyzers/XmlDocumentationFormattingAnalyzer.cs
+++ b/touki.analyzers/XmlDocumentationFormattingAnalyzer.cs
@@ -3,7 +3,6 @@
 // See LICENSE file in the project root for full license information
 
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -110,12 +109,12 @@ public sealed class XmlDocumentationFormattingAnalyzer : DiagnosticAnalyzer
         }
 
         AnalyzerConfigOptions options = context.Options.AnalyzerConfigOptionsProvider.GetOptions(context.Tree);
-        int indentSize = TryGetPositiveInteger(options, IndentSizeOption, out int configuredIndentSize)
+        int indentSize = options.TryGetPositiveInteger(IndentSizeOption, out int configuredIndentSize)
             && configuredIndentSize <= MaximumIndentSize
                 ? configuredIndentSize
                 : DefaultIndentSize;
-        int maxLineLength = TryGetPositiveInteger(options, MaxLineLengthOption, out int configuredMaxLineLength)
-            || TryGetPositiveInteger(options, StandardMaxLineLengthOption, out configuredMaxLineLength)
+        int maxLineLength = options.TryGetPositiveInteger(MaxLineLengthOption, out int configuredMaxLineLength)
+            || options.TryGetPositiveInteger(StandardMaxLineLengthOption, out configuredMaxLineLength)
                 ? configuredMaxLineLength
                 : DefaultMaxLineLength;
         SyntaxNode root = context.Tree.GetRoot(context.CancellationToken);
@@ -222,18 +221,5 @@ public sealed class XmlDocumentationFormattingAnalyzer : DiagnosticAnalyzer
             source.Lines[lastLineNumber].End);
 
         return true;
-    }
-
-    private static bool TryGetPositiveInteger(AnalyzerConfigOptions options, string key, out int value)
-    {
-        if (options.TryGetValue(key, out string? raw)
-            && int.TryParse(raw.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out value)
-            && value > 0)
-        {
-            return true;
-        }
-
-        value = 0;
-        return false;
     }
 }


### PR DESCRIPTION
## Summary

- centralize positive-integer analyzer option parsing
- share document path and collision checks between structural code fixes
- share source-span text replacement registration across text-based fixes
- consolidate Roslyn test references, analyzer options, and diagnostic severity setup
- document every non-private member introduced by the helpers

## Validation

- `dotnet test -c Debug --no-restore` (23,093 passed, 260 expected skips)
- `dotnet test -c Release --no-restore`
- focused analyzer/code-fix suite (383 passed)
- pre-PR `touki-reviewer` pass: no findings
- `git diff --check`