### PR TITLE
Harden analyzer and code fix validation

### DIFF
--- a/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
@@ -107,7 +107,7 @@ public sealed class MakeMemberReadonlyCodeFixProvider : CodeFixProvider
     private static async Task<Solution> MakeMemberReadonlyAsync(Solution solution, ISymbol member, CancellationToken cancellationToken)
     {
         Dictionary<DocumentId, List<SyntaxNode>> declarationsByDocument = [];
-        List<ISymbol> members = [member];
+        HashSet<ISymbol> members = new(SymbolEqualityComparer.Default) { member };
 
         if (member is IMethodSymbol method)
         {

--- a/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/MakeMemberReadonlyCodeFixProvider.cs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 // See LICENSE file in the project root for full license information
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
 using System.Threading;
@@ -9,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 
@@ -104,17 +106,68 @@ public sealed class MakeMemberReadonlyCodeFixProvider : CodeFixProvider
 
     private static async Task<Solution> MakeMemberReadonlyAsync(Solution solution, ISymbol member, CancellationToken cancellationToken)
     {
+        Dictionary<DocumentId, List<SyntaxNode>> declarationsByDocument = [];
+        List<ISymbol> members = [member];
+
+        if (member is IMethodSymbol method)
+        {
+            if (method.PartialDefinitionPart is { } definition)
+            {
+                members.Add(definition);
+            }
+
+            if (method.PartialImplementationPart is { } implementation)
+            {
+                members.Add(implementation);
+            }
+        }
+        else if (member is IPropertySymbol property)
+        {
+            if (property.PartialDefinitionPart is { } definition)
+            {
+                members.Add(definition);
+            }
+
+            if (property.PartialImplementationPart is { } implementation)
+            {
+                members.Add(implementation);
+            }
+        }
+
+        foreach (ISymbol declaredMember in members)
+        {
+            foreach (SyntaxReference reference in declaredMember.DeclaringSyntaxReferences)
+            {
+                Document? document = solution.GetDocument(reference.SyntaxTree);
+                if (document is null)
+                {
+                    continue;
+                }
+
+                SyntaxNode declaration = await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
+                if (!declarationsByDocument.TryGetValue(document.Id, out List<SyntaxNode>? declarations))
+                {
+                    declarations = [];
+                    declarationsByDocument.Add(document.Id, declarations);
+                }
+
+                if (!declarations.Contains(declaration))
+                {
+                    declarations.Add(declaration);
+                }
+            }
+        }
+
         Solution updatedSolution = solution;
 
-        foreach (SyntaxReference reference in member.DeclaringSyntaxReferences)
+        foreach (KeyValuePair<DocumentId, List<SyntaxNode>> entry in declarationsByDocument)
         {
-            Document? document = updatedSolution.GetDocument(reference.SyntaxTree);
+            Document? document = updatedSolution.GetDocument(entry.Key);
             if (document is null)
             {
                 continue;
             }
 
-            SyntaxNode declaration = await reference.GetSyntaxAsync(cancellationToken).ConfigureAwait(false);
             SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             if (root is null)
             {
@@ -122,18 +175,44 @@ public sealed class MakeMemberReadonlyCodeFixProvider : CodeFixProvider
             }
 
             SyntaxGenerator generator = SyntaxGenerator.GetGenerator(document);
-            DeclarationModifiers modifiers = generator.GetModifiers(declaration);
-            if (modifiers.IsReadOnly)
-            {
-                continue;
-            }
-
-            SyntaxNode updatedDeclaration = generator.WithModifiers(declaration, modifiers.WithIsReadOnly(true));
             updatedSolution = updatedSolution.WithDocumentSyntaxRoot(
                 document.Id,
-                root.ReplaceNode(declaration, updatedDeclaration));
+                root.ReplaceNodes(
+                    entry.Value,
+                    (_, rewritten) => MakeReadonly(rewritten, generator)));
         }
 
         return updatedSolution;
+    }
+
+    private static SyntaxNode MakeReadonly(SyntaxNode declaration, SyntaxGenerator generator)
+    {
+        return declaration switch
+        {
+            MethodDeclarationSyntax method => method.WithModifiers(AddReadonly(method.Modifiers)),
+            PropertyDeclarationSyntax property => property.WithModifiers(AddReadonly(property.Modifiers)),
+            IndexerDeclarationSyntax indexer => indexer.WithModifiers(AddReadonly(indexer.Modifiers)),
+            _ => generator.WithModifiers(
+                declaration,
+                generator.GetModifiers(declaration).WithIsReadOnly(true))
+        };
+    }
+
+    private static SyntaxTokenList AddReadonly(SyntaxTokenList modifiers)
+    {
+        if (modifiers.Any(SyntaxKind.ReadOnlyKeyword))
+        {
+            return modifiers;
+        }
+
+        for (int index = 0; index < modifiers.Count; index++)
+        {
+            if (modifiers[index].IsKind(SyntaxKind.PartialKeyword))
+            {
+                return modifiers.Insert(index, SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
+            }
+        }
+
+        return modifiers.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
     }
 }

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -29,28 +29,41 @@ internal static class AnalyzerTestHarness
     ///  Optional per-diagnostic severities, standing in for <c>dotnet_diagnostic.&lt;id&gt;.severity</c>
     ///  entries. A rule that ships disabled produces nothing until it is enabled this way.
     /// </param>
+    /// <param name="expectedCompilerDiagnosticIds">
+    ///  Compiler error identifiers expected from the source. The default requires the source to compile without errors.
+    /// </param>
     public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         DiagnosticAnalyzer analyzer,
         string source,
         IReadOnlyDictionary<string, string>? options = null,
         string? fileName = null,
-        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
+        IReadOnlyCollection<string>? expectedCompilerDiagnosticIds = null)
     {
         CSharpCompilation compilation = CreateCompilation(source, fileName);
 
-        return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
+        return await GetDiagnosticsAsync(
+            analyzer,
+            compilation,
+            options,
+            diagnosticOptions,
+            expectedCompilerDiagnosticIds).ConfigureAwait(false);
     }
 
     /// <summary>
     ///  Runs <paramref name="analyzer"/> against instrumented <paramref name="source"/>. The callback runs after
     ///  parsing and before analyzer execution, allowing parser activity to be excluded from instrumentation.
     /// </summary>
+    /// <param name="expectedCompilerDiagnosticIds">
+    ///  Compiler error identifiers expected from the source. The default requires the source to compile without errors.
+    /// </param>
     public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         DiagnosticAnalyzer analyzer,
         SourceText source,
         Action beforeAnalysis,
         IReadOnlyDictionary<string, string>? options = null,
-        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
+        IReadOnlyCollection<string>? expectedCompilerDiagnosticIds = null)
     {
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(source);
         CSharpCompilation compilation = CSharpCompilation.Create(
@@ -60,31 +73,57 @@ internal static class AnalyzerTestHarness
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
         beforeAnalysis();
 
-        return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
+        return await GetDiagnosticsAsync(
+            analyzer,
+            compilation,
+            options,
+            diagnosticOptions,
+            expectedCompilerDiagnosticIds).ConfigureAwait(false);
     }
 
     /// <summary>
     ///  Runs <paramref name="analyzer"/> against several named source files in one compilation and returns the
     ///  analyzer-produced diagnostics.
     /// </summary>
+    /// <param name="expectedCompilerDiagnosticIds">
+    ///  Compiler error identifiers expected from the sources. The default requires the sources to compile without errors.
+    /// </param>
     public static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         DiagnosticAnalyzer analyzer,
         IReadOnlyList<(string Source, string FileName)> sources,
         IReadOnlyDictionary<string, string>? options = null,
-        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
+        IReadOnlyCollection<string>? expectedCompilerDiagnosticIds = null)
     {
         CSharpCompilation compilation = CreateCompilation(sources);
 
-        return await GetDiagnosticsAsync(analyzer, compilation, options, diagnosticOptions).ConfigureAwait(false);
+        return await GetDiagnosticsAsync(
+            analyzer,
+            compilation,
+            options,
+            diagnosticOptions,
+            expectedCompilerDiagnosticIds).ConfigureAwait(false);
     }
 
     private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsAsync(
         DiagnosticAnalyzer analyzer,
         Compilation compilation,
         IReadOnlyDictionary<string, string>? options,
-        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions)
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions,
+        IReadOnlyCollection<string>? expectedCompilerDiagnosticIds)
     {
         compilation = RoslynTestEnvironment.ApplyDiagnosticOptions(compilation, diagnosticOptions);
+
+        ImmutableArray<Diagnostic> compilerErrors =
+            [.. compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)];
+        string[] actualIds = [.. compilerErrors.Select(diagnostic => diagnostic.Id).OrderBy(id => id)];
+        string[] expectedIds = [.. (expectedCompilerDiagnosticIds ?? []).OrderBy(id => id)];
+        if (!actualIds.SequenceEqual(expectedIds, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Analyzer test source compiler errors did not match. Expected: [{string.Join(", ", expectedIds)}]. "
+                + $"Actual:{Environment.NewLine}{string.Join(Environment.NewLine, compilerErrors)}");
+        }
 
         CompilationWithAnalyzers compilationWithAnalyzers =
             compilation.WithAnalyzers([analyzer], RoslynTestEnvironment.CreateAnalyzerOptions(options));

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -47,12 +47,13 @@ internal static class CodeFixTestHarness
         Compilation compilation = (await document.Project.GetCompilationAsync().ConfigureAwait(false))!;
 
         compilation = RoslynTestEnvironment.ApplyDiagnosticOptions(compilation, diagnosticOptions);
+        ThrowIfCompilerErrors(compilation, "Code-fix test source");
         AnalyzerOptions analyzerOptions = RoslynTestEnvironment.CreateAnalyzerOptions(options);
 
         CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
         ImmutableArray<Diagnostic> diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
 
-        Diagnostic? target = diagnostics.FirstOrDefault(diagnostic => diagnostic.Id == diagnosticId);
+        Diagnostic? target = GetFirstDiagnostic(diagnostics, diagnosticId);
         if (target is null)
         {
             return source;
@@ -75,6 +76,8 @@ internal static class CodeFixTestHarness
             await actions[0].GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
         ApplyChangesOperation applyChanges = operations.OfType<ApplyChangesOperation>().Single();
         Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+        Compilation changedCompilation = (await changedDocument.Project.GetCompilationAsync().ConfigureAwait(false))!;
+        ThrowIfCompilerErrors(changedCompilation, "Code-fix result");
         SourceText text = await changedDocument.GetTextAsync().ConfigureAwait(false);
         return text.ToString();
     }
@@ -119,7 +122,7 @@ internal static class CodeFixTestHarness
 
         CompilationWithAnalyzers withAnalyzers = compilation.WithAnalyzers([analyzer], analyzerOptions);
         ImmutableArray<Diagnostic> diagnostics = await withAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
-        Diagnostic? target = diagnostics.FirstOrDefault(diagnostic => diagnostic.Id == diagnosticId);
+        Diagnostic? target = GetFirstDiagnostic(diagnostics, diagnosticId);
         if (target is null || target.Location.SourceTree is null)
         {
             return await CreateResultAsync(
@@ -247,6 +250,24 @@ internal static class CodeFixTestHarness
             compilerErrors.ToImmutable(),
             analyzerDiagnostics.ToImmutable(),
             fixAllActionOffered);
+    }
+
+    private static Diagnostic? GetFirstDiagnostic(ImmutableArray<Diagnostic> diagnostics, string diagnosticId) =>
+        diagnostics
+            .Where(diagnostic => diagnostic.Id == diagnosticId)
+            .OrderBy(diagnostic => diagnostic.Location.SourceTree?.FilePath, StringComparer.Ordinal)
+            .ThenBy(diagnostic => diagnostic.Location.SourceSpan.Start)
+            .FirstOrDefault();
+
+    private static void ThrowIfCompilerErrors(Compilation compilation, string context)
+    {
+        ImmutableArray<Diagnostic> compilerErrors =
+            [.. compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)];
+        if (!compilerErrors.IsEmpty)
+        {
+            throw new InvalidOperationException(
+                $"{context} contains compiler errors:{Environment.NewLine}{string.Join(Environment.NewLine, compilerErrors)}");
+        }
     }
 
     private static string GetAbsoluteTestPath(string filePath, string temporaryRoot)

--- a/touki.analyzers.tests/MakeMemberReadonlyCodeFixTests.cs
+++ b/touki.analyzers.tests/MakeMemberReadonlyCodeFixTests.cs
@@ -66,6 +66,236 @@ public class MakeMemberReadonlyCodeFixTests
     }
 
     [TestMethod]
+    public async Task DefensiveCopy_OnPartialMethod_AddsReadonlyToBothDeclarations()
+    {
+        const string source = """
+            using System;
+            using Touki;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+
+            [NonCopyable]
+            partial struct Pooled
+            {
+                private int _value;
+                public partial int Read();
+                public partial int Read() => _value;
+            }
+
+            class C
+            {
+                int M(in Pooled p) => p.Read();
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            source,
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId).ConfigureAwait(false);
+
+        fixedSource.Should().Contain("public readonly partial int Read();");
+        fixedSource.Should().Contain("public readonly partial int Read() => _value;");
+    }
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnPartialMethodAcrossDocuments_AddsReadonlyToBothDeclarations()
+    {
+        const string Marker = """
+            using System;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+            """;
+        const string Definition = """
+            using Touki;
+
+            [NonCopyable]
+            partial struct Pooled
+            {
+                public partial int Read();
+            }
+            """;
+        const string Implementation = """
+            partial struct Pooled
+            {
+                private int _value;
+                public partial int Read() => _value;
+            }
+
+            class C
+            {
+                int M(in Pooled p) => p.Read();
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            [
+                ("Marker.cs", "C:\\src\\Marker.cs", Marker),
+                ("Definition.cs", "C:\\src\\Definition.cs", Definition),
+                ("Implementation.cs", "C:\\src\\Implementation.cs", Implementation)
+            ],
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId,
+            fixAll: false).ConfigureAwait(false);
+
+        result.CompilerErrors.Should().BeEmpty();
+        result.Documents.Single(document => document.Name == "Definition.cs").Source
+            .Should().Contain("public readonly partial int Read();");
+        result.Documents.Single(document => document.Name == "Implementation.cs").Source
+            .Should().Contain("public readonly partial int Read() => _value;");
+    }
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnPartialProperty_AddsReadonlyToBothDeclarations()
+    {
+        const string source = """
+            using System;
+            using Touki;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+
+            [NonCopyable]
+            partial struct Pooled
+            {
+                private int _value;
+                public partial int Prop { get; }
+                public partial int Prop => _value;
+            }
+
+            class C
+            {
+                int M(in Pooled p) => p.Prop;
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            source,
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId).ConfigureAwait(false);
+
+        fixedSource.Should().Contain("public readonly partial int Prop { get; }");
+        fixedSource.Should().Contain("public readonly partial int Prop => _value;");
+    }
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnPartialPropertyAcrossDocuments_AddsReadonlyToBothDeclarations()
+    {
+        const string Marker = """
+            using System;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+            """;
+        const string Definition = """
+            using Touki;
+
+            [NonCopyable]
+            partial struct Pooled
+            {
+                public partial int Prop { get; }
+            }
+            """;
+        const string Implementation = """
+            partial struct Pooled
+            {
+                private int _value;
+                public partial int Prop => _value;
+            }
+
+            class C
+            {
+                int M(in Pooled p) => p.Prop;
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            [
+                ("Marker.cs", "C:\\src\\Marker.cs", Marker),
+                ("Definition.cs", "C:\\src\\Definition.cs", Definition),
+                ("Implementation.cs", "C:\\src\\Implementation.cs", Implementation)
+            ],
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId,
+            fixAll: false).ConfigureAwait(false);
+
+        result.CompilerErrors.Should().BeEmpty();
+        result.Documents.Single(document => document.Name == "Definition.cs").Source
+            .Should().Contain("public readonly partial int Prop { get; }");
+        result.Documents.Single(document => document.Name == "Implementation.cs").Source
+            .Should().Contain("public readonly partial int Prop => _value;");
+    }
+
+    [TestMethod]
+    public async Task DefensiveCopy_OnPartialIndexerAcrossDocuments_AddsReadonlyToBothDeclarations()
+    {
+        const string Marker = """
+            using System;
+
+            namespace Touki
+            {
+                [AttributeUsage(AttributeTargets.Struct)]
+                sealed class NonCopyableAttribute : Attribute { }
+            }
+            """;
+        const string Definition = """
+            using Touki;
+
+            [NonCopyable]
+            partial struct Pooled
+            {
+                public partial int this[int index] { get; }
+            }
+            """;
+        const string Implementation = """
+            partial struct Pooled
+            {
+                private int _value;
+                public partial int this[int index] { get => _value + index; }
+            }
+
+            class C
+            {
+                int M(in Pooled p) => p[0];
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new DefensiveCopyAnalyzer(),
+            new MakeMemberReadonlyCodeFixProvider(),
+            [
+                ("Marker.cs", "C:\\src\\Marker.cs", Marker),
+                ("Definition.cs", "C:\\src\\Definition.cs", Definition),
+                ("Implementation.cs", "C:\\src\\Implementation.cs", Implementation)
+            ],
+            DefensiveCopyAnalyzer.NonCopyableDefensiveCopyId,
+            fixAll: false).ConfigureAwait(false);
+
+        result.CompilerErrors.Should().BeEmpty();
+        result.Documents.Single(document => document.Name == "Definition.cs").Source
+            .Should().Contain("public readonly partial int this[int index] { get; }");
+        result.Documents.Single(document => document.Name == "Implementation.cs").Source
+            .Should().Contain("public readonly partial int this[int index] { get => _value + index; }");
+    }
+
+    [TestMethod]
     public async Task DefensiveCopy_OnPropertyWithSetter_OffersNoFix()
     {
         // A member-level 'readonly' would also mark the setter readonly, which is a compiler error. The fix must

--- a/touki.analyzers.tests/OneTypePerFileAnalyzerTests.cs
+++ b/touki.analyzers.tests/OneTypePerFileAnalyzerTests.cs
@@ -450,7 +450,10 @@ public class OneTypePerFileAnalyzerTests
             }
             """;
 
-        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new OneTypePerFileAnalyzer(),
+            source,
+            expectedCompilerDiagnosticIds: ["CS0261"]).ConfigureAwait(false);
 
         diagnostics.Should().ContainSingle()
             .Which.Id.Should().Be(OneTypePerFileAnalyzer.DiagnosticId);
@@ -561,35 +564,6 @@ public class OneTypePerFileAnalyzerTests
 
         Location location = diagnostics.Should().ContainSingle().Subject.Location;
         location.SourceTree!.GetText().ToString(location.SourceSpan).Should().Be("Scoped");
-    }
-
-    [TestMethod]
-    public async Task AnalyzeSyntaxTree_ExtensionBlocks_ReportsNothing()
-    {
-        // An extension block is a TypeDeclarationSyntax with no identifier, which the analyzer must not count.
-        // The harness pins Roslyn 4.14.0, which predates the syntax, so today this only pins the "no crash, no
-        // report" outcome and becomes a real guard on the next Roslyn bump. The behavior is verified now by
-        // touki's own build, which dogfoods the rule over sources that use extension blocks.
-        const string source = """
-            namespace Sample;
-
-            public static class StringExtensions
-            {
-                extension(string value)
-                {
-                    public bool IsEmpty => value.Length == 0;
-                }
-
-                extension(int value)
-                {
-                    public bool IsZero => value == 0;
-                }
-            }
-            """;
-
-        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
-
-        diagnostics.Should().BeEmpty();
     }
 
     [TestMethod]

--- a/touki.analyzers.tests/XmlDocumentationFormattingAnalyzerTests.cs
+++ b/touki.analyzers.tests/XmlDocumentationFormattingAnalyzerTests.cs
@@ -408,13 +408,15 @@ public partial class XmlDocumentationFormattingAnalyzerTests
     public async Task Analyze_OverLimitReturnsAfterLongParameter_CorrectsInlineXmlContentIndentation()
     {
         string source =
-            "    /// <summary>\n    ///  Attempts to retrieve the value as the specified type.\n    /// </summary>\n"
+            "class Sample\n{\n"
+            + "    /// <summary>\n    ///  Attempts to retrieve the value as the specified type.\n    /// </summary>\n"
             + "    /// <typeparam name=\"T\">The type to retrieve the value as.</typeparam>\n"
             + "    /// <param name=\"value\">When this method returns, contains the value if the conversion succeeded.</param>\n"
             + "    /// <returns>\n"
             + "    /// <see langword=\"true\"/> if the value was successfully retrieved; otherwise, <see langword=\"false\"/>.\n"
             + "    /// </returns>\n"
-            + "    public bool TryGetValue<T>(out T value) { value = default!; return true; }\n";
+            + "    public bool TryGetValue<T>(out T value) { value = default!; return true; }\n"
+            + "}\n";
 
         ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary

- make the readonly code fix update every declaration of partial methods, properties, and indexers, including declarations split across documents
- preserve C# modifier tokens when adding `readonly`, covering syntax newer than the Roslyn workspace abstraction
- require analyzer fixtures to declare expected compiler errors and require single-document code fixes to produce compiler-valid output
- select target diagnostics deterministically and remove or repair vacuous invalid fixtures

## Validation

- `dotnet build -c Release`
- `dotnet test -c Release`
- `dotnet test -c Debug`
- focused readonly code-fix tests in Release

All builds and tests completed with zero failures; platform-specific oracle cases were skipped/inconclusive as expected.