### PR TITLE
Enforce disposable base and validate VS platforms

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -47,6 +47,7 @@ jobs:
       tfm: net10.0
       additional-tfm: net481
       native-aot-rid: win-x64
+      validate-solution-platforms: true
 
   # Keep one native Windows ARM64 smoke leg, also limited to the supported net10.0 baseline.
   windows-arm64:

--- a/.github/workflows/platform-tests.yml
+++ b/.github/workflows/platform-tests.yml
@@ -39,6 +39,9 @@ on:
       native-aot-rid:
         default: ''
         type: string
+      validate-solution-platforms:
+        default: false
+        type: boolean
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -63,6 +66,10 @@ jobs:
           ${{ runner.os }}-${{ runner.arch }}-nuget-
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
+    - name: Validate Visual Studio solution platforms
+      if: inputs.validate-solution-platforms
+      shell: pwsh
+      run: pwsh tools/Test-SolutionProjectPlatforms.ps1 -SolutionPath ./touki.slnx
     - name: Install Linux desktop dependencies
       if: inputs.linux-desktop
       shell: bash

--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -2,8 +2,8 @@
 
 `KlutzyNinja.Touki` ships a set of Roslyn analyzers **inside the package**. There is no
 separate analyzer package to install - adding the package reference is enough. The shipped
-rules start running on the next build and in the IDE. TOUKI0022, TOUKI0024, and TOUKI0041 ship
-disabled unless a project opts in.
+rules start running on the next build and in the IDE. TOUKI0012, TOUKI0022, TOUKI0024, and TOUKI0041
+ship disabled unless a project opts in.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
@@ -20,6 +20,7 @@ name a field for what it actually is.
 | [TOUKI0004](#touki0004) | By-value copy of a non-copyable struct | Reliability | Warning | - | `[NonCopyable]` |
 | [TOUKI0010](#touki0010) | Dispose a `[MustDispose]` value deterministically | Reliability | Warning | - | `[MustDispose]` |
 | [TOUKI0011](#touki0011) | Avoid large `stackalloc` allocations | Reliability | Warning | Yes | - |
+| [TOUKI0012](#touki0012) | Derive disposable classes from `DisposableBase` | Reliability | **Disabled** | - | `DisposableBase` |
 | [TOUKI0020](#touki0020) | Declare one type per file | Maintainability | Warning | Yes | - |
 | [TOUKI0021](#touki0021) | File name should match the type it declares | Maintainability | Warning | Yes | - |
 | [TOUKI0022](#touki0022) | Avoid tab characters | Maintainability | **Disabled** | Yes | - |
@@ -28,8 +29,9 @@ name a field for what it actually is.
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
 | [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
-Rules that list a requirement only fire on code that opts in by applying the named
-attribute. The rest apply to any C# the compiler hands them.
+Rules that require an attribute only fire on code that applies it. TOUKI0012 requires
+the compilation to reference `Touki.DisposableBase`. The rest apply to any C# the
+compiler hands them.
 
 Generated code is excluded from every rule.
 
@@ -136,6 +138,28 @@ The rule only reports what it can size from source: a compile-time constant leng
 primitive, enum, pointer, or native-integer element type. A run-time length or a custom
 struct element is left alone, because the total is not knowable at compile time. Native
 integers and pointers are counted as 8 bytes.
+
+## TOUKI0012
+
+**Derive disposable classes from `DisposableBase`.** Reports a class that declares
+`IDisposable` in its own base list without deriving from `Touki.DisposableBase`. The base
+provides thread-safe, idempotent disposal and a consistent `Dispose(bool)` override point.
+
+```csharp
+sealed class ManualResource : IDisposable           // TOUKI0012
+{
+  public void Dispose() { }
+}
+
+sealed class StandardResource : DisposableBase
+{
+  protected override void Dispose(bool disposing) { }
+}
+```
+
+The rule deliberately stays silent for structs, generated code, and classes that only
+inherit an `IDisposable` implementation from a base class. It also does not run when the
+compilation cannot resolve `Touki.DisposableBase`.
 
 ## TOUKI0020
 
@@ -636,7 +660,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 | 0.7.0 | TOUKI0022, TOUKI0023 |
-| Unshipped | TOUKI0024 |
+| Unshipped | TOUKI0012, TOUKI0024 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/tools/Test-SolutionProjectPlatforms.ps1
+++ b/tools/Test-SolutionProjectPlatforms.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    Verify that every project advertises the platform mapped to it by a solution.
+
+.DESCRIPTION
+    Visual Studio skips a project when its solution platform mapping selects a
+    platform that is absent from the project's evaluated Platforms property.
+    Command-line solution builds do not expose this mismatch reliably and may
+    build the project anyway.
+
+    This script reads each project mapping from a .slnx file, asks MSBuild for
+    the project's evaluated Platforms property, and fails on any mismatch.
+
+.PARAMETER SolutionPath
+    Path to the .slnx file to validate.
+
+.EXAMPLE
+    pwsh tools/Test-SolutionProjectPlatforms.ps1 -SolutionPath ./touki.slnx
+#>
+[CmdletBinding()]
+param(
+    [string]$SolutionPath = './touki.slnx'
+)
+
+Set-StrictMode -Version 3.0
+$ErrorActionPreference = 'Stop'
+
+$solutionFile = Get-Item $SolutionPath
+[xml]$solution = Get-Content -Raw $solutionFile.FullName
+$solutionDirectory = $solutionFile.DirectoryName
+$failures = [System.Collections.Generic.List[string]]::new()
+
+foreach ($project in $solution.SelectNodes('//Project')) {
+    $projectPath = Join-Path $solutionDirectory ([string]$project.Path)
+    $platformOutput = & dotnet msbuild $projectPath -getProperty:Platforms -nologo
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not evaluate Platforms for '$projectPath'."
+    }
+
+    [string[]]$platforms = @(
+        ([string]$platformOutput).Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)
+        | ForEach-Object { $_.Trim() }
+    )
+
+    foreach ($mapping in $project.Platform) {
+        $mappedPlatform = [string]$mapping.Project
+        if ([string]::IsNullOrWhiteSpace($mappedPlatform)) {
+            continue
+        }
+
+        if ($platforms -notcontains $mappedPlatform) {
+            $failures.Add(
+                "'$($project.Path)' maps to '$mappedPlatform' but advertises Platforms='$($platforms -join ';')'.")
+        }
+        else {
+            Write-Host "OK: $($project.Path) -> $mappedPlatform"
+        }
+    }
+}
+
+if ($failures.Count -gt 0) {
+    Write-Error "Solution project-platform mappings are invalid:`n$($failures -join "`n")"
+}
+
+Write-Host "All solution project-platform mappings are valid."

--- a/touki.analyzers.codefixes/touki.analyzers.codefixes.csproj
+++ b/touki.analyzers.codefixes/touki.analyzers.codefixes.csproj
@@ -2,6 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Platforms>x64;AnyCPU</Platforms>
+
     <!--
       Code-fix providers reference the Roslyn Workspaces APIs, which must not live in the analyzer assembly
       (RS1022). They ship in a separate assembly that is packed alongside the analyzer under analyzers/dotnet/cs

--- a/touki.analyzers.tests/UseDisposableBaseAnalyzerTests.cs
+++ b/touki.analyzers.tests/UseDisposableBaseAnalyzerTests.cs
@@ -256,7 +256,7 @@ public class UseDisposableBaseAnalyzerTests
     }
 
     [TestMethod]
-    public async Task AnalyzeNamedType_InheritsIDisposableImplementation_ReportsNothing()
+    public async Task AnalyzeNamedType_BaseClassDirectlyImplementsIDisposable_ReportsBaseClass()
     {
         string source = DisposableBase + """
             class Parent : IDisposable

--- a/touki.analyzers.tests/UseDisposableBaseAnalyzerTests.cs
+++ b/touki.analyzers.tests/UseDisposableBaseAnalyzerTests.cs
@@ -1,0 +1,343 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class UseDisposableBaseAnalyzerTests
+{
+    private const string DisposableBase = """
+        using System;
+
+        namespace Touki
+        {
+            public abstract class DisposableBase : IDisposable
+            {
+                public void Dispose() { }
+            }
+        }
+
+        """;
+
+    private static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source, string? fileName = null) =>
+        AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseDisposableBaseAnalyzer(),
+            source,
+            fileName: fileName,
+            diagnosticOptions: new Dictionary<string, ReportDiagnostic>
+            {
+                [UseDisposableBaseAnalyzer.DiagnosticId] = ReportDiagnostic.Warn
+            });
+
+    private static Task<ImmutableArray<Diagnostic>> AnalyzeAsync(
+        IReadOnlyList<(string Source, string FileName)> sources) =>
+        AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseDisposableBaseAnalyzer(),
+            sources,
+            diagnosticOptions: new Dictionary<string, ReportDiagnostic>
+            {
+                [UseDisposableBaseAnalyzer.DiagnosticId] = ReportDiagnostic.Warn
+            });
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_DirectIDisposableClass_ReportsAtIdentifier()
+    {
+        string source = DisposableBase + """
+            sealed class Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        Diagnostic diagnostic = diagnostics.Should().ContainSingle().Subject;
+        diagnostic.Id.Should().Be(UseDisposableBaseAnalyzer.DiagnosticId);
+        diagnostic.Location.SourceTree!.GetText().ToString(diagnostic.Location.SourceSpan).Should().Be("Resource");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_ExplicitIDisposableImplementation_Reports()
+    {
+        string source = DisposableBase + """
+            sealed class Resource : IDisposable
+            {
+                void IDisposable.Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_AbstractIDisposableClass_Reports()
+    {
+        string source = DisposableBase + """
+            abstract class Resource : IDisposable
+            {
+                public abstract void Dispose();
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_ClassWithAnotherBase_Reports()
+    {
+        string source = DisposableBase + """
+            class Parent { }
+
+            sealed class Resource : Parent, IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_PartialClass_ReportsOnce()
+    {
+        string source = DisposableBase + """
+            partial class Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+
+            partial class Resource { }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_PartialClassDeclaresIDisposableTwice_ReportsOnce()
+    {
+        string source = DisposableBase + """
+            partial class Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+
+            partial class Resource : IDisposable { }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_RecordClass_Reports()
+    {
+        string source = DisposableBase + """
+            sealed record Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_RecordStruct_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            readonly record struct Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_UserPartialDeclaresIDisposable_ReportsUserDeclaration()
+    {
+        IReadOnlyList<(string Source, string FileName)> sources =
+        [
+            (DisposableBase, "DisposableBase.cs"),
+            ("// <auto-generated/>\npartial class Resource { }", "Resource.g.cs"),
+            ("partial class Resource : System.IDisposable { public void Dispose() { } }", "Resource.cs")
+        ];
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(sources).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Location.SourceTree!.FilePath.Should().Be("Resource.cs");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_OnlyGeneratedPartialDeclaresIDisposable_ReportsNothing()
+    {
+        IReadOnlyList<(string Source, string FileName)> sources =
+        [
+            (DisposableBase, "DisposableBase.cs"),
+            (
+                "// <auto-generated/>\npartial class Resource : System.IDisposable { public void Dispose() { } }",
+                "Resource.g.cs"),
+            ("partial class Resource { }", "Resource.cs")
+        ];
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(sources).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_DisposableBase_ReportsNothing()
+    {
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(DisposableBase).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_DerivedFromDisposableBase_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            sealed class Resource : Touki.DisposableBase
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_IndirectlyDerivedFromDisposableBase_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            abstract class ResourceBase : Touki.DisposableBase
+            {
+            }
+
+            sealed class Resource : ResourceBase, IDisposable
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_DerivedFromDisposableBaseAndRedundantInterface_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            sealed class Resource : Touki.DisposableBase, IDisposable
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_InheritsIDisposableImplementation_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            class Parent : IDisposable
+            {
+                public void Dispose() { }
+            }
+
+            sealed class Resource : Parent
+            {
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.GetMessage().Should().Contain("Parent");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_ImplementsInterfaceDerivedFromIDisposable_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            interface IResource : IDisposable
+            {
+            }
+
+            sealed class Resource : IResource
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_IDisposableStruct_ReportsNothing()
+    {
+        string source = DisposableBase + """
+            struct Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_NoDisposableBaseInCompilation_ReportsNothing()
+    {
+        const string source = """
+            using System;
+
+            sealed class Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeNamedType_GeneratedClass_ReportsNothing()
+    {
+        string source = "// <auto-generated/>\n" + DisposableBase + """
+            sealed class Resource : IDisposable
+            {
+                public void Dispose() { }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source, "Resource.g.cs").ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -5,4 +5,5 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+TOUKI0012 | Reliability | Disabled | Disposable class does not derive from Touki.DisposableBase
 TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML

--- a/touki.analyzers/UseDisposableBaseAnalyzer.cs
+++ b/touki.analyzers/UseDisposableBaseAnalyzer.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports classes that directly implement <see cref="System.IDisposable"/> without deriving from
+///  <c>Touki.DisposableBase</c>.
+/// </summary>
+/// <remarks>
+///  <para>
+///   The rule reports only a class that declares <see cref="System.IDisposable"/> in its own base list. A class
+///   that merely inherits the interface is left alone because its base type owns the disposal implementation.
+///   Structs are excluded because they cannot derive from <c>Touki.DisposableBase</c>.
+///  </para>
+///  <para>
+///   Analysis is disabled when the compilation does not reference <c>Touki.DisposableBase</c>.
+///  </para>
+/// </remarks>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseDisposableBaseAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0012";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Derive disposable classes from DisposableBase",
+        messageFormat: "Class '{0}' implements IDisposable directly and should derive from Touki.DisposableBase",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: false,
+        description: "Classes that directly implement IDisposable should derive from Touki.DisposableBase for thread-safe, idempotent disposal.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId),
+        customTags: WellKnownDiagnosticTags.CompilationEnd);
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(static compilationContext =>
+        {
+            INamedTypeSymbol? disposable = compilationContext.Compilation.GetTypeByMetadataName("System.IDisposable");
+            INamedTypeSymbol? disposableBase = compilationContext.Compilation.GetTypeByMetadataName("Touki.DisposableBase");
+            if (disposable is null || disposableBase is null)
+            {
+                return;
+            }
+
+            ConcurrentDictionary<INamedTypeSymbol, TypeDeclarationSyntax> candidates =
+                new(SymbolEqualityComparer.Default);
+            compilationContext.RegisterSyntaxNodeAction(
+                syntaxContext => AnalyzeTypeDeclaration(
+                    syntaxContext,
+                    disposable,
+                    disposableBase,
+                    candidates),
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.RecordDeclaration);
+            compilationContext.RegisterCompilationEndAction(endContext =>
+            {
+                foreach (KeyValuePair<INamedTypeSymbol, TypeDeclarationSyntax> candidate in candidates)
+                {
+                    endContext.ReportDiagnostic(
+                        Diagnostic.Create(
+                            s_rule,
+                            candidate.Value.Identifier.GetLocation(),
+                            candidate.Key.Name));
+                }
+            });
+        });
+    }
+
+    private static void AnalyzeTypeDeclaration(
+        SyntaxNodeAnalysisContext context,
+        INamedTypeSymbol disposable,
+        INamedTypeSymbol disposableBase,
+        ConcurrentDictionary<INamedTypeSymbol, TypeDeclarationSyntax> candidates)
+    {
+        TypeDeclarationSyntax declaration = (TypeDeclarationSyntax)context.Node;
+        if (declaration.BaseList is null
+            || context.SemanticModel.GetDeclaredSymbol(declaration, context.CancellationToken) is not INamedTypeSymbol type
+            || type.TypeKind != TypeKind.Class
+            || DerivesFrom(type, disposableBase))
+        {
+            return;
+        }
+
+        foreach (BaseTypeSyntax baseType in declaration.BaseList.Types)
+        {
+            ITypeSymbol? baseTypeSymbol = context.SemanticModel.GetTypeInfo(baseType.Type, context.CancellationToken).Type;
+            if (SymbolEqualityComparer.Default.Equals(baseTypeSymbol, disposable))
+            {
+                candidates.AddOrUpdate(
+                    type,
+                    declaration,
+                    (_, current) => IsEarlier(declaration, current) ? declaration : current);
+                return;
+            }
+        }
+    }
+
+    private static bool IsEarlier(TypeDeclarationSyntax candidate, TypeDeclarationSyntax current)
+    {
+        int pathComparison = string.Compare(
+            candidate.SyntaxTree.FilePath,
+            current.SyntaxTree.FilePath,
+            StringComparison.Ordinal);
+
+        return pathComparison < 0
+            || (pathComparison == 0 && candidate.SpanStart < current.SpanStart);
+    }
+
+    private static bool DerivesFrom(INamedTypeSymbol type, INamedTypeSymbol disposableBase)
+    {
+        for (INamedTypeSymbol? current = type; current is not null; current = current.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, disposableBase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/touki.analyzers/touki.analyzers.csproj
+++ b/touki.analyzers/touki.analyzers.csproj
@@ -2,6 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Platforms>x64;AnyCPU</Platforms>
+
     <!--
       Roslyn analyzers must target netstandard2.0 so they load in every compiler
       host (command line, Visual Studio, VS Code). This is enforced by RS1038.

--- a/touki.testsupport/touki.testsupport.csproj
+++ b/touki.testsupport/touki.testsupport.csproj
@@ -2,6 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Platforms>x64;AnyCPU</Platforms>
+
     <!--
       Multitarget .NET Core and .NET Framework
       https://learn.microsoft.com/dotnet/standard/frameworks

--- a/touki/touki.csproj
+++ b/touki/touki.csproj
@@ -2,6 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Platforms>x64;AnyCPU</Platforms>
+
     <!--
       Multitarget .NET Core and .NET Framework
       https://learn.microsoft.com/dotnet/standard/frameworks


### PR DESCRIPTION
## Summary

- add opt-in `TOUKI0012` for classes that directly implement `IDisposable` without deriving from `Touki.DisposableBase`
- cover partial, generated, record, interface, and inheritance boundaries
- declare `AnyCPU` for the four projects mapped to that platform by `touki.slnx`
- validate `.slnx` project-platform mappings in the required Windows x64 CI leg

## Validation

- focused `UseDisposableBaseAnalyzerTests`: 19 passed
- complete analyzer suite: 403 passed
- Visual Studio `Debug|x64` rebuild: 11 succeeded, 0 failed, 0 skipped
- solution-platform validator passed and caught the original mismatch under mutation
- `dotnet test -c Debug`: 23,182 passed, 260 skipped, 0 failed
- `dotnet test -c Release`: 23,216 passed, 260 skipped, 0 failed