### PR TITLE
Add TextWriter WriteFormatted analyzer

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -7,8 +7,8 @@ ship disabled unless a project opts in.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
-they get large, keep types easy to find by file name, keep whitespace out of the way, and
-name a field for what it actually is.
+they get large, write formatted text without temporary strings, keep types easy to find
+by file name, keep whitespace out of the way, and name a field for what it actually is.
 
 ## Rules
 
@@ -27,10 +27,12 @@ name a field for what it actually is.
 | [TOUKI0023](#touki0023) | Remove trailing whitespace | Maintainability | Warning | - | - |
 | [TOUKI0024](#touki0024) | Format XML documentation as nested XML | Maintainability | **Disabled** | Yes | - |
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
+| [TOUKI0031](#touki0031) | Use `WriteFormatted` for interpolated strings | Performance | Warning | - | C# 10, `TextWriterExtensions` |
 | [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
 Rules that require an attribute only fire on code that applies it. TOUKI0012 requires
-the compilation to reference `Touki.DisposableBase`. The rest apply to any C# the
+the compilation to reference `Touki.DisposableBase`. TOUKI0031 requires C# 10 or later
+and the Touki `TextWriterExtensions` handler overload. The rest apply to any C# the
 compiler hands them.
 
 Generated code is excluded from every rule.
@@ -423,6 +425,40 @@ is misleading:
 Once `Touki.Text` is imported the accessible type wins and the internal one is ignored,
 including when `using System.Text;` sits in an inner scope.
 
+## TOUKI0031
+
+**Use `WriteFormatted` for interpolated strings.** Reports a non-constant interpolated
+string passed directly to the one-argument `TextWriter.Write(string)` method when the
+receiver is statically typed as `TextWriter`, `StringWriter`, or `StreamWriter`, or is a
+type parameter directly constrained to one of those types. `Write` first creates the complete string;
+`Touki.Io.TextWriterExtensions.WriteFormatted` instead formats through
+`ValueStringBuilder`. Exact `StringWriter` and `StreamWriter` instances receive the
+builder content directly, without allocating that intermediate string. Custom writer
+types receive a string through their virtual `Write(string)` method so overrides and
+their side effects are preserved.
+
+```csharp
+writer.Write($"Rows written: {count}"); // TOUKI0031
+
+writer.WriteFormatted($"Rows written: {count}");
+```
+
+The code fix renames the call and adds `using Touki.Io;` when needed. A named `value:`
+argument is changed to the handler parameter name, `builder:`. The fix is only offered
+after Roslyn proves that the changed call binds to Touki's exact handler overload, so a
+competing extension or instance method cannot silently capture it. Project-level global
+usings are honored. A required `using Touki.Io;` is added only when it introduces no
+compiler errors or binding changes elsewhere in the document. Fix All is supported.
+
+The rule deliberately stays silent for `WriteLine`, because a rename would lose the line
+terminator; compile-time-constant interpolated strings, which create no intermediate
+run-time string; string values built before the call; C# versions before 10; expression
+trees, which cannot contain handler conversions; `base.Write(...)`; applicable instance
+`WriteFormatted` methods; receivers statically known to be custom writer subclasses;
+conditional access; and calls without an explicit receiver. Those forms cannot be
+converted by the same behavior-preserving local edit or cannot use the optimized writer
+path.
+
 ## TOUKI0041
 
 **Naming rule violation** - a name does not follow the configured naming rules. A
@@ -629,6 +665,9 @@ columns, so several fixes on one line compose without having to be applied in or
 `FormatXmlDocumentationCodeFixProvider` fixes TOUKI0024 by applying the complete replacement
 computed by the analyzer from the file's options. It supports Fix All.
 
+`UseTextWriterWriteFormattedCodeFixProvider` fixes TOUKI0031 by renaming the diagnosed
+`Write` call and importing `Touki.Io` when necessary. It supports Fix All.
+
 ## Relationship to IDE0055
 
 The .NET SDK's `IDE0055` ([Fix formatting](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055))
@@ -660,7 +699,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 | 0.7.0 | TOUKI0022, TOUKI0023 |
-| Unshipped | TOUKI0012, TOUKI0024 |
+| Unshipped | TOUKI0012, TOUKI0024, TOUKI0031 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/docs/io.md
+++ b/docs/io.md
@@ -170,8 +170,10 @@ cancellation-token support for the asynchronous forms.
 its `Stream`-targeted partial in
 [`StreamExtensions.cs`](../touki/Touki/Io/StreamExtensions.cs)) adds
 `WriteFormatted` overloads that accept a `ValueStringBuilder`-backed
-interpolated string handler, so formatted output flows directly into the
-target without an intermediate `string` allocation. See
+interpolated string handler. Formatted output flows directly into a `Stream`,
+an exact `StreamWriter`, or an exact `StringWriter` without an intermediate
+`string` allocation. Custom `TextWriter` types receive a string through their
+virtual `Write(string)` method so their behavior is preserved. See
 [strings.md](strings.md) for the full picture.
 
 ```csharp

--- a/docs/strings.md
+++ b/docs/strings.md
@@ -125,10 +125,10 @@ but do not have implicit conversions.
 ### `Stream` and `TextWriter` extensions
 
 `StreamExtensions` and `TextWriterExtensions` add handler-backed `WriteFormatted`
-overloads that format an interpolated value without materializing a result string
-([`StreamExtensions.cs`](../touki/Touki/Io/StreamExtensions.cs) and
-[`TextWriterExtensions.cs`](../touki/Touki/Io/TextWriterExtensions.cs)). Unit
-tests demonstrate the pattern
+overloads that format an interpolated value through `ValueStringBuilder`-backed
+storage ([`StreamExtensions.cs`](../touki/Touki/Io/StreamExtensions.cs) and
+[`TextWriterExtensions.cs`](../touki/Touki/Io/TextWriterExtensions.cs)). Unit tests
+demonstrate the pattern
 ([`StreamExtensionsTests.cs`](../touki.tests/Touki/StreamExtensionsTests.cs)):
 
 ```csharp
@@ -144,10 +144,12 @@ stream.WriteFormatted($"Library: {name}, Version: {version}");
 textWriter.WriteFormatted($"Library: {name}, Version: {version}");
 ```
 
-The handler formats through `ValueStringBuilder`-backed storage and writes that
-content to the target, so this overload does not create an intermediate result
-string. On .NET, a separate optimization overload accepts an existing `string`;
-that overload is not available on .NET Framework.
+The handler writes directly to a `Stream`, an exact `StreamWriter`, or an exact
+`StringWriter`, so those paths do not create an intermediate result string. A
+custom `TextWriter` instead receives a string through its virtual `Write(string)`
+method, preserving overrides and their side effects. On .NET, a separate
+optimization overload accepts an existing `string`; that overload is not available
+on .NET Framework.
 
 The `Stream` overload writes raw UTF-16 code-unit bytes without applying a text
 encoding or byte-order mark. Use a `TextWriter` such as `StreamWriter` when the

--- a/touki.analyzers.codefixes/UseTextWriterWriteFormattedCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/UseTextWriterWriteFormattedCodeFixProvider.cs
@@ -1,0 +1,504 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Offers a "Use WriteFormatted" fix for <c>TOUKI0031</c>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UseTextWriterWriteFormattedCodeFixProvider))]
+[Shared]
+public sealed class UseTextWriterWriteFormattedCodeFixProvider : CodeFixProvider
+{
+    // Hardcoded to avoid a dependency on the analyzer assembly; this is a stable public contract.
+    private const string UseTextWriterWriteFormattedId = "TOUKI0031";
+    private const string ExtensionNamespace = "Touki.Io";
+    private const string TextWriterMetadataName = "System.IO.TextWriter";
+    private const string TextWriterExtensionsMetadataName = "Touki.Io.TextWriterExtensions";
+    private const string InterpolatedStringHandlerAttributeMetadataName =
+        "System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute";
+
+    private static readonly ImmutableArray<string> s_fixableDiagnosticIds = [UseTextWriterWriteFormattedId];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => s_fixableDiagnosticIds;
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode? root =
+            await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null
+            || root.SyntaxTree.Options is not CSharpParseOptions parseOptions
+            || parseOptions.LanguageVersion < LanguageVersion.CSharp10)
+        {
+            return;
+        }
+
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            SimpleNameSyntax? methodName = node as SimpleNameSyntax ?? node.FirstAncestorOrSelf<SimpleNameSyntax>();
+            InvocationExpressionSyntax? invocation = methodName?.Parent switch
+            {
+                MemberAccessExpressionSyntax memberAccess => memberAccess.Parent as InvocationExpressionSyntax,
+                MemberBindingExpressionSyntax memberBinding => memberBinding.Parent as InvocationExpressionSyntax,
+                _ => null
+            };
+
+            if (invocation is null)
+            {
+                continue;
+            }
+
+            Document? changedDocument = await TryUseWriteFormattedAsync(
+                context.Document,
+                invocation.Span,
+                context.CancellationToken).ConfigureAwait(false);
+            if (changedDocument is null)
+            {
+                continue;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use WriteFormatted",
+                    createChangedDocument: _ => Task.FromResult(changedDocument),
+                    equivalenceKey: nameof(UseTextWriterWriteFormattedCodeFixProvider)),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document?> TryUseWriteFormattedAsync(
+        Document document,
+        TextSpan invocationSpan,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is not CompilationUnitSyntax compilationUnit)
+        {
+            return null;
+        }
+
+        SemanticModel? originalSemanticModel =
+            await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (originalSemanticModel is null)
+        {
+            return null;
+        }
+
+        SyntaxNode currentNode = compilationUnit.FindNode(invocationSpan, getInnermostNodeForTie: true);
+        InvocationExpressionSyntax? invocation = currentNode as InvocationExpressionSyntax
+            ?? currentNode.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        if (invocation is null || invocation.Span != invocationSpan)
+        {
+            return null;
+        }
+
+        if (!IsEligibleInvocation(invocation, originalSemanticModel, cancellationToken))
+        {
+            return null;
+        }
+
+        SimpleNameSyntax? originalMethodName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+            _ => null
+        };
+        SimpleNameSyntax? originalArgumentName = invocation.ArgumentList.Arguments[0].NameColon?.Name;
+        if (originalMethodName is null)
+        {
+            return null;
+        }
+
+        List<BindingSnapshot> bindingSnapshots = [];
+        Dictionary<SyntaxNode, SyntaxAnnotation> bindingAnnotations = [];
+        foreach (SyntaxNode descendant in compilationUnit.DescendantNodes())
+        {
+            if (descendant is not SimpleNameSyntax and not InvocationExpressionSyntax
+                || ReferenceEquals(descendant, invocation)
+                || ReferenceEquals(descendant, originalMethodName)
+                || ReferenceEquals(descendant, originalArgumentName))
+            {
+                continue;
+            }
+
+            ISymbol? symbol = originalSemanticModel.GetSymbolInfo(descendant, cancellationToken).Symbol;
+            if (symbol is null)
+            {
+                continue;
+            }
+
+            SyntaxAnnotation annotation = new();
+            bindingAnnotations.Add(descendant, annotation);
+            bindingSnapshots.Add(new(annotation, GetSymbolIdentity(symbol)));
+        }
+
+        compilationUnit = compilationUnit.ReplaceNodes(
+            bindingAnnotations.Keys,
+            (original, rewritten) => rewritten.WithAdditionalAnnotations(bindingAnnotations[original]));
+        currentNode = compilationUnit.FindNode(invocationSpan, getInnermostNodeForTie: true);
+        invocation = currentNode as InvocationExpressionSyntax
+            ?? currentNode.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        if (invocation is null || invocation.Span != invocationSpan)
+        {
+            return null;
+        }
+
+        SimpleNameSyntax? methodName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+            MemberBindingExpressionSyntax memberBinding => memberBinding.Name,
+            _ => null
+        };
+        if (methodName is null)
+        {
+            return null;
+        }
+
+        IdentifierNameSyntax replacementName = SyntaxFactory.IdentifierName(
+            SyntaxFactory.Identifier(
+                methodName.Identifier.LeadingTrivia,
+                "WriteFormatted",
+                methodName.Identifier.TrailingTrivia));
+        SyntaxAnnotation invocationAnnotation = new();
+        InvocationExpressionSyntax replacement = invocation
+            .ReplaceNode(methodName, replacementName)
+            .WithAdditionalAnnotations(invocationAnnotation);
+
+        ArgumentSyntax argument = replacement.ArgumentList.Arguments[0];
+        if (argument.NameColon is { } nameColon)
+        {
+            IdentifierNameSyntax builderName = SyntaxFactory.IdentifierName(
+                SyntaxFactory.Identifier(
+                    nameColon.Name.Identifier.LeadingTrivia,
+                    "builder",
+                    nameColon.Name.Identifier.TrailingTrivia));
+            replacement = replacement.ReplaceNode(argument, argument.WithNameColon(nameColon.WithName(builderName)));
+        }
+
+        CompilationUnitSyntax updatedRoot = compilationUnit.ReplaceNode(invocation, replacement);
+        Document changedDocument = document.WithSyntaxRoot(updatedRoot);
+        if (await BindsToTextWriterExtensionAsync(
+            changedDocument,
+            invocationAnnotation,
+            cancellationToken).ConfigureAwait(false)
+            && await ReplacementPreservesDocumentAsync(
+                originalSemanticModel,
+                changedDocument,
+                bindingSnapshots,
+                cancellationToken).ConfigureAwait(false))
+        {
+            return changedDocument;
+        }
+
+        UsingDirectiveSyntax usingDirective = SyntaxFactory.UsingDirective(
+                SyntaxFactory.ParseName(ExtensionNamespace))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+        changedDocument = document.WithSyntaxRoot(updatedRoot.AddUsings(usingDirective));
+        if (!await BindsToTextWriterExtensionAsync(
+            changedDocument,
+            invocationAnnotation,
+            cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        if (!await ReplacementPreservesDocumentAsync(
+            originalSemanticModel,
+            changedDocument,
+            bindingSnapshots,
+            cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        return await Formatter.FormatAsync(
+            changedDocument,
+            Formatter.Annotation,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsEligibleInvocation(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
+    {
+        if (invocation.Expression is not MemberAccessExpressionSyntax
+            {
+                Expression: not BaseExpressionSyntax,
+                Name.Identifier.ValueText: "Write"
+            }
+            || invocation.ArgumentList.Arguments.Count != 1
+            || GetInterpolatedString(invocation.ArgumentList.Arguments[0].Expression) is null
+            || semanticModel.GetOperation(invocation, cancellationToken) is not IInvocationOperation operation
+            || operation.Arguments.Length != 1
+            || operation.Arguments[0].Value.ConstantValue.HasValue
+            || operation.TargetMethod.IsStatic
+            || operation.TargetMethod.Name != "Write"
+            || operation.TargetMethod.Parameters.Length != 1
+            || operation.TargetMethod.Parameters[0].Type.SpecialType != SpecialType.System_String)
+        {
+            return false;
+        }
+
+        Compilation compilation = semanticModel.Compilation;
+        if (compilation.GetTypeByMetadataName(TextWriterMetadataName) is not { } textWriter
+            || compilation.GetTypeByMetadataName("System.IO.StringWriter") is not { } stringWriter
+            || compilation.GetTypeByMetadataName("System.IO.StreamWriter") is not { } streamWriter
+            || !IsTextWriterWrite(operation.TargetMethod, textWriter)
+            || !CanUseOptimizedWriter(operation.Instance?.Type, textWriter, stringWriter, streamWriter))
+        {
+            return false;
+        }
+
+        INamedTypeSymbol? expression = compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
+        return !IsInsideExpressionTree(operation, expression);
+    }
+
+    private static bool IsTextWriterWrite(IMethodSymbol method, INamedTypeSymbol textWriter)
+    {
+        for (IMethodSymbol? current = method; current is not null; current = current.OverriddenMethod)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.ContainingType, textWriter))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool CanUseOptimizedWriter(
+        ITypeSymbol? receiverType,
+        INamedTypeSymbol textWriter,
+        INamedTypeSymbol stringWriter,
+        INamedTypeSymbol streamWriter)
+    {
+        if (SymbolEqualityComparer.Default.Equals(receiverType, textWriter)
+            || SymbolEqualityComparer.Default.Equals(receiverType, stringWriter)
+            || SymbolEqualityComparer.Default.Equals(receiverType, streamWriter))
+        {
+            return true;
+        }
+
+        if (receiverType is ITypeParameterSymbol typeParameter)
+        {
+            foreach (ITypeSymbol constraint in typeParameter.ConstraintTypes)
+            {
+                if (SymbolEqualityComparer.Default.Equals(constraint, textWriter)
+                    || SymbolEqualityComparer.Default.Equals(constraint, stringWriter)
+                    || SymbolEqualityComparer.Default.Equals(constraint, streamWriter))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static InterpolatedStringExpressionSyntax? GetInterpolatedString(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+
+        return expression as InterpolatedStringExpressionSyntax;
+    }
+
+    private static bool IsInsideExpressionTree(IOperation operation, INamedTypeSymbol? expression)
+    {
+        if (expression is null)
+        {
+            return false;
+        }
+
+        for (IOperation? current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is IConversionOperation { Type: INamedTypeSymbol convertedType }
+                && SymbolEqualityComparer.Default.Equals(convertedType.OriginalDefinition, expression))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<bool> BindsToTextWriterExtensionAsync(
+        Document document,
+        SyntaxAnnotation invocationAnnotation,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null || semanticModel is null)
+        {
+            return false;
+        }
+
+        InvocationExpressionSyntax? invocation = null;
+        foreach (SyntaxNode node in root.GetAnnotatedNodes(invocationAnnotation))
+        {
+            if (node is InvocationExpressionSyntax candidate)
+            {
+                invocation = candidate;
+                break;
+            }
+        }
+
+        if (invocation is null)
+        {
+            return false;
+        }
+
+        SymbolInfo invocationSymbol = semanticModel.GetSymbolInfo(invocation, cancellationToken);
+        SymbolInfo expressionSymbol = semanticModel.GetSymbolInfo(invocation.Expression, cancellationToken);
+        IOperation? invocationOperation = semanticModel.GetOperation(invocation, cancellationToken);
+        IMethodSymbol? method = invocationSymbol.Symbol as IMethodSymbol;
+        method ??= expressionSymbol.Symbol as IMethodSymbol;
+        if (method is null
+            && invocationOperation is IInvocationOperation operation)
+        {
+            method = operation.TargetMethod;
+        }
+
+        if (method is null)
+        {
+            return false;
+        }
+
+        IMethodSymbol definition = method.ReducedFrom ?? method;
+        Compilation compilation = semanticModel.Compilation;
+        return compilation.GetTypeByMetadataName(TextWriterMetadataName) is { } textWriter
+            && compilation.GetTypeByMetadataName(TextWriterExtensionsMetadataName) is { } extensions
+            && compilation.GetTypeByMetadataName(InterpolatedStringHandlerAttributeMetadataName)
+                is { } handlerAttribute
+            && SymbolEqualityComparer.Default.Equals(definition.ContainingType, extensions)
+            && definition.IsExtensionMethod
+            && definition.IsStatic
+            && definition.ReturnsVoid
+            && definition.Parameters.Length == 2
+            && definition.Parameters[0].RefKind == RefKind.None
+            && SymbolEqualityComparer.Default.Equals(definition.Parameters[0].Type, textWriter)
+            && definition.Parameters[1].RefKind == RefKind.Ref
+            && HasAttribute(definition.Parameters[1].Type, handlerAttribute);
+    }
+
+    private static async Task<bool> ReplacementPreservesDocumentAsync(
+        SemanticModel originalSemanticModel,
+        Document changedDocument,
+        List<BindingSnapshot> bindingSnapshots,
+        CancellationToken cancellationToken)
+    {
+        SemanticModel? changedSemanticModel =
+            await changedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        SyntaxNode? changedRoot = await changedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (changedSemanticModel is null || changedRoot is null)
+        {
+            return false;
+        }
+
+        Dictionary<string, int> originalErrors = [];
+        foreach (Diagnostic diagnostic in originalSemanticModel.GetDiagnostics(cancellationToken: cancellationToken))
+        {
+            if (diagnostic.Severity == DiagnosticSeverity.Error)
+            {
+                string key = GetDiagnosticKey(diagnostic);
+                originalErrors.TryGetValue(key, out int count);
+                originalErrors[key] = count + 1;
+            }
+        }
+
+        foreach (Diagnostic diagnostic in changedSemanticModel.GetDiagnostics(cancellationToken: cancellationToken))
+        {
+            if (diagnostic.Severity != DiagnosticSeverity.Error)
+            {
+                continue;
+            }
+
+            string key = GetDiagnosticKey(diagnostic);
+            if (!originalErrors.TryGetValue(key, out int count) || count == 0)
+            {
+                return false;
+            }
+
+            originalErrors[key] = count - 1;
+        }
+
+        foreach (BindingSnapshot snapshot in bindingSnapshots)
+        {
+            SyntaxNode? changedNode = null;
+            foreach (SyntaxNode annotatedNode in changedRoot.GetAnnotatedNodes(snapshot.Annotation))
+            {
+                changedNode = annotatedNode;
+                break;
+            }
+
+            ISymbol? changedSymbol = changedNode is null
+                ? null
+                : changedSemanticModel.GetSymbolInfo(changedNode, cancellationToken).Symbol;
+            if (changedSymbol is null || GetSymbolIdentity(changedSymbol) != snapshot.SymbolIdentity)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string GetDiagnosticKey(Diagnostic diagnostic) =>
+        $"{diagnostic.Id}\0{diagnostic.GetMessage()}";
+
+    private static string GetSymbolIdentity(ISymbol symbol)
+    {
+        if (symbol is IAliasSymbol alias)
+        {
+            return $"Alias|{alias.Name}|{GetSymbolIdentity(alias.Target)}";
+        }
+
+        return $"{symbol.Kind}|{symbol.ContainingAssembly?.Identity}|"
+            + symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+    }
+
+    private static bool HasAttribute(ITypeSymbol type, INamedTypeSymbol attributeType)
+    {
+        foreach (AttributeData attribute in type.GetAttributes())
+        {
+            if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, attributeType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private sealed class BindingSnapshot(SyntaxAnnotation annotation, string symbolIdentity)
+    {
+        public SyntaxAnnotation Annotation { get; } = annotation;
+
+        public string SymbolIdentity { get; } = symbolIdentity;
+    }
+}

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -38,9 +38,17 @@ internal static class AnalyzerTestHarness
         IReadOnlyDictionary<string, string>? options = null,
         string? fileName = null,
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
-        IReadOnlyCollection<string>? expectedCompilerDiagnosticIds = null)
+        IReadOnlyCollection<string>? expectedCompilerDiagnosticIds = null,
+        CSharpParseOptions? parseOptions = null,
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null)
     {
-        CSharpCompilation compilation = CreateCompilation(source, fileName);
+        CSharpCompilation compilation = parseOptions is null
+            ? CreateCompilation(source, fileName, additionalReferences)
+            : CSharpCompilation.Create(
+                assemblyName: "Touki.Analyzers.TestCompilation",
+                syntaxTrees: [CSharpSyntaxTree.ParseText(source, parseOptions, fileName ?? string.Empty)],
+                references: RoslynTestEnvironment.GetReferences(additionalReferences),
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
 
         return await GetDiagnosticsAsync(
             analyzer,
@@ -131,10 +139,15 @@ internal static class AnalyzerTestHarness
         return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
     }
 
-    private static CSharpCompilation CreateCompilation(string source, string? fileName)
-        => CreateCompilation([(source, fileName ?? string.Empty)]);
+    private static CSharpCompilation CreateCompilation(
+        string source,
+        string? fileName,
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null) =>
+        CreateCompilation([(source, fileName ?? string.Empty)], additionalReferences);
 
-    private static CSharpCompilation CreateCompilation(IReadOnlyList<(string Source, string FileName)> sources)
+    private static CSharpCompilation CreateCompilation(
+        IReadOnlyList<(string Source, string FileName)> sources,
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null)
     {
         SyntaxTree[] syntaxTrees = new SyntaxTree[sources.Count];
 
@@ -146,7 +159,7 @@ internal static class AnalyzerTestHarness
         return CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
             syntaxTrees: syntaxTrees,
-            references: RoslynTestEnvironment.References,
+            references: RoslynTestEnvironment.GetReferences(additionalReferences),
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
     }
 }

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -35,13 +35,16 @@ internal static class CodeFixTestHarness
         string source,
         string diagnosticId,
         IReadOnlyDictionary<string, string>? options = null,
-        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null)
+        IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null,
+        CSharpParseOptions? parseOptions = null)
     {
         using AdhocWorkspace workspace = new();
         Project project = workspace
             .AddProject("TestProject", LanguageNames.CSharp)
-            .AddMetadataReferences(RoslynTestEnvironment.References)
-            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            .AddMetadataReferences(RoslynTestEnvironment.GetReferences(additionalReferences))
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .WithParseOptions(parseOptions ?? new CSharpParseOptions(LanguageVersion.Preview));
         Document document = project.AddDocument("Test.cs", source);
 
         Compilation compilation = (await document.Project.GetCompilationAsync().ConfigureAwait(false))!;
@@ -93,14 +96,15 @@ internal static class CodeFixTestHarness
         bool fixAll,
         IReadOnlyDictionary<string, string>? options = null,
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
-        string? workspaceKind = null)
+        string? workspaceKind = null,
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null)
     {
         using AdhocWorkspace workspace = workspaceKind is null
             ? new AdhocWorkspace()
             : new AdhocWorkspace(MefHostServices.DefaultHost, workspaceKind);
         Project project = workspace
             .AddProject("TestProject", LanguageNames.CSharp)
-            .AddMetadataReferences(RoslynTestEnvironment.References)
+            .AddMetadataReferences(RoslynTestEnvironment.GetReferences(additionalReferences))
             .WithCompilationOptions(new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 allowUnsafe: true));

--- a/touki.analyzers.tests/RoslynTestEnvironment.cs
+++ b/touki.analyzers.tests/RoslynTestEnvironment.cs
@@ -16,6 +16,15 @@ internal static class RoslynTestEnvironment
     public static ImmutableArray<MetadataReference> References => s_references.Value;
 
     /// <summary>
+    ///  Gets the platform references followed by any test-specific references.
+    /// </summary>
+    public static ImmutableArray<MetadataReference> GetReferences(
+        IReadOnlyCollection<MetadataReference>? additionalReferences) =>
+        additionalReferences is null || additionalReferences.Count == 0
+            ? References
+            : References.AddRange(additionalReferences);
+
+    /// <summary>
     ///  Creates analyzer options backed by the supplied EditorConfig values.
     /// </summary>
     public static AnalyzerOptions CreateAnalyzerOptions(IReadOnlyDictionary<string, string>? options) =>
@@ -40,12 +49,14 @@ internal static class RoslynTestEnvironment
     private static ImmutableArray<MetadataReference> CreateReferences()
     {
         string trustedAssemblies = (string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!;
+        string toukiAssembly = typeof(Touki.Io.TextWriterExtensions).Assembly.Location;
 
         return
         [
             .. trustedAssemblies
                 .Split(Path.PathSeparator)
                 .Where(path => path.Length > 0)
+                .Where(path => !string.Equals(path, toukiAssembly, StringComparison.OrdinalIgnoreCase))
                 .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
         ];
     }

--- a/touki.analyzers.tests/UseTextWriterWriteFormattedAnalyzerTests.cs
+++ b/touki.analyzers.tests/UseTextWriterWriteFormattedAnalyzerTests.cs
@@ -1,0 +1,538 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class UseTextWriterWriteFormattedAnalyzerTests
+{
+    private static readonly MetadataReference s_toukiReference =
+        MetadataReference.CreateFromFile(typeof(Touki.Io.TextWriterExtensions).Assembly.Location);
+
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source) =>
+        await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            source,
+            additionalReferences: [s_toukiReference])
+            .ConfigureAwait(false);
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_TextWriterWriteInterpolatedString_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UseTextWriterWriteFormattedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_DerivedWriterWriteInterpolatedString_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(int value)
+                {
+                    StringWriter writer = new();
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UseTextWriterWriteFormattedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_InterpolatedString_ReportsAtMethodName()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        Location location = diagnostics.Should().ContainSingle().Subject.Location;
+        location.SourceTree!.GetText().ToString(location.SourceSpan).Should().Be("Write");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_ParenthesizedInterpolatedString_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write(($"Value: {value}"));
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UseTextWriterWriteFormattedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_WriteLineInterpolatedString_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.WriteLine($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_ConditionalAccess_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter? writer, int value)
+                {
+                    writer?.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_UnrelatedWriteMethod_ReportsNothing()
+    {
+        const string source = """
+            class Writer
+            {
+                public void Write(string value) { }
+            }
+
+            class Sample
+            {
+                void WriteValue(Writer writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_StringArgument_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, string value)
+                {
+                    writer.Write(value);
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_ConstantInterpolatedString_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer)
+                {
+                    writer.Write($"Value");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_BaseWriteInterpolatedString_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample : StringWriter
+            {
+                void WriteValue(int value)
+                {
+                    base.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_HiddenWriteMethod_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class CustomWriter : StringWriter
+            {
+                public new void Write(string value) { }
+            }
+
+            class Sample
+            {
+                void WriteValue(CustomWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_InstanceWriteFormattedMethod_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class CustomWriter : StringWriter
+            {
+                public void WriteFormatted(string value) { }
+            }
+
+            class Sample
+            {
+                void WriteValue(CustomWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_UnrelatedInstanceWriteFormattedMethod_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class CustomWriter : StringWriter
+            {
+                public void WriteFormatted() { }
+            }
+
+            class Sample
+            {
+                void WriteValue(CustomWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_RefInstanceWriteFormattedMethod_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class CustomWriter : StringWriter
+            {
+                public void WriteFormatted(ref string value) { }
+            }
+
+            class Sample
+            {
+                void WriteValue(CustomWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_ExtensionApiUnavailable_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_ExtensionHandlerOverloadUnavailable_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            namespace Touki.Io
+            {
+                public static class TextWriterExtensions
+                {
+                    public static void WriteFormatted(this TextWriter writer, string value) { }
+                }
+            }
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_CSharp9_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            source,
+            parseOptions: new CSharpParseOptions(LanguageVersion.CSharp9),
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_CSharp10_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            source,
+            parseOptions: new CSharpParseOptions(LanguageVersion.CSharp10),
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UseTextWriterWriteFormattedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_InsideExpressionTree_ReportsNothing()
+    {
+        const string source = """
+            using System;
+            using System.IO;
+            using System.Linq.Expressions;
+
+            class Sample
+            {
+                Expression<Action<TextWriter, int>> Create()
+                    => (writer, value) => writer.Write($"Value: {value}");
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_AwaitedInterpolation_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+            using System.Threading.Tasks;
+
+            class Sample
+            {
+                async Task WriteValue(TextWriter writer)
+                {
+                    writer.Write($"Value: {await Task.FromResult(42)}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UseTextWriterWriteFormattedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_TypeParameterConstrainedToCustomWriter_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class CustomWriter : StringWriter
+            {
+            }
+
+            class Sample
+            {
+                void WriteValue<TWriter>(TWriter writer, int value) where TWriter : CustomWriter
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_TypeParameterConstrainedToTextWriter_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue<TWriter>(TWriter writer, int value) where TWriter : TextWriter
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UseTextWriterWriteFormattedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_ConditionalWriteFormatted_Compiles()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter? writer, int value)
+                {
+                    writer?.WriteFormatted($"Value: {value}");
+                }
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/UseTextWriterWriteFormattedCodeFixTests.cs
+++ b/touki.analyzers.tests/UseTextWriterWriteFormattedCodeFixTests.cs
@@ -1,0 +1,485 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class UseTextWriterWriteFormattedCodeFixTests
+{
+    private static readonly MetadataReference s_toukiReference =
+        MetadataReference.CreateFromFile(typeof(Touki.Io.TextWriterExtensions).Assembly.Location);
+
+    private static async Task<string> FixAsync(string source) =>
+        await CodeFixTestHarness.ApplyFixAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            source,
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+    [TestMethod]
+    public async Task UseWriteFormatted_MissingNamespaceImport_AddsImportAndRenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+        string expected = source
+            .Replace(
+                "using System.IO;",
+                $"using System.IO;{Environment.NewLine}using Touki.Io;")
+            .Replace("writer.Write(", "writer.WriteFormatted(");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_NamespaceAlreadyImported_DoesNotDuplicateImport()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+        string expected = source.Replace("writer.Write(", "writer.WriteFormatted(");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_NamedArgument_RenamesParameter()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write(value: $"Value: {value}");
+                }
+            }
+            """;
+        string expected = source.Replace(
+            "writer.Write(value:",
+            "writer.WriteFormatted(builder:");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_ConditionalAccess_LeavesSourceUnchanged()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter? writer, int value)
+                {
+                    writer?.Write($"Value: {value}");
+                }
+            }
+            """;
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_FixAll_RewritesEveryCall()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValues(TextWriter writer, int first, int second)
+                {
+                    writer.Write($"First: {first}");
+                    writer.Write($"Second: {second}");
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            [("Test.cs", "Test.cs", source)],
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            fixAll: true,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        string fixedSource = result.Documents.Should().ContainSingle().Subject.Source;
+        fixedSource.Should().Contain("writer.WriteFormatted($\"First: {first}\");");
+        fixedSource.Should().Contain("writer.WriteFormatted($\"Second: {second}\");");
+        fixedSource.Split(["using Touki.Io;"], StringSplitOptions.None).Should().HaveCount(2);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_CompetingExtension_WithholdsFix()
+    {
+        const string source = """
+            global using Other;
+
+            using System.IO;
+
+            namespace Other
+            {
+                public static class OtherTextWriterExtensions
+                {
+                    public static void WriteFormatted(
+                        this TextWriter writer,
+                        ref System.Runtime.CompilerServices.DefaultInterpolatedStringHandler builder)
+                    {
+                    }
+                }
+            }
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_GlobalUsing_DoesNotAddLocalImport()
+    {
+        const string globalUsings = "global using Touki.Io;";
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            [
+                ("GlobalUsings.cs", "GlobalUsings.cs", globalUsings),
+                ("Test.cs", "Test.cs", source)
+            ],
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            fixAll: false,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        CodeFixTestDocument fixedDocument = result.Documents.Single(document => document.Name == "Test.cs");
+        fixedDocument.Source.Should().Contain("writer.WriteFormatted($\"Value: {value}\");");
+        fixedDocument.Source.Should().NotContain("using Touki.Io;");
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_ImportIntroducesAmbiguity_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+            using Other;
+
+            namespace Other
+            {
+                public class MSBuildSpecification
+                {
+                }
+            }
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    MSBuildSpecification specification = new();
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_ImportIntroducesInterpolationAmbiguity_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+            using Other;
+
+            namespace Other
+            {
+                public class Result
+                {
+                }
+            }
+
+            namespace Touki.Io
+            {
+                public class Result
+                {
+                }
+            }
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer)
+                {
+                    writer.Write($"Result type: {typeof(Result)}");
+                }
+            }
+            """;
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_ExpressionTree_WithholdsStaleFix()
+    {
+        const string source = """
+            using System;
+            using System.IO;
+            using System.Linq.Expressions;
+            using Touki.Io;
+
+            class Sample
+            {
+                Expression<Action<TextWriter, int>> Create()
+                    => (writer, value) => writer.Write($"Value: {value}");
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new ForcedWriteAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            source,
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_FixAllWithExpressionTree_RewritesOnlySafeCall()
+    {
+        const string source = """
+            using System;
+            using System.IO;
+            using System.Linq.Expressions;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Immediate: {value}");
+                }
+
+                Expression<Action<TextWriter, int>> Create()
+                    => (writer, value) => writer.Write($"Expression: {value}");
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new ForcedWriteAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            [("Test.cs", "Test.cs", source)],
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            fixAll: true,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        string fixedSource = result.Documents.Should().ContainSingle().Subject.Source;
+        fixedSource.Should().Contain("writer.WriteFormatted($\"Immediate: {value}\");");
+        fixedSource.Should().Contain("writer.Write($\"Expression: {value}\");");
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_AwaitedInterpolation_RenamesAndCompiles()
+    {
+        const string source = """
+            using System.IO;
+            using System.Threading.Tasks;
+            using Touki.Io;
+
+            class Sample
+            {
+                async Task WriteValue(TextWriter writer)
+                {
+                    writer.Write($"Value: {await Task.FromResult(42)}");
+                }
+            }
+            """;
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Contain(
+            "writer.WriteFormatted($\"Value: {await Task.FromResult(42)}\");");
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_StaleWriteLineDiagnostic_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.WriteLine($"Value: {value}");
+                }
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new ForcedWriteAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            source,
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_StaleCustomWriteDiagnostic_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class CustomWriter : StringWriter
+            {
+                public new void Write(string value) { }
+            }
+
+            class Sample
+            {
+                void WriteValue(CustomWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new ForcedWriteAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            source,
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            additionalReferences: [s_toukiReference]).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UseWriteFormatted_CSharp10_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+            using Touki.Io;
+
+            class Sample
+            {
+                void WriteValue(TextWriter writer, int value)
+                {
+                    writer.Write($"Value: {value}");
+                }
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UseTextWriterWriteFormattedAnalyzer(),
+            new UseTextWriterWriteFormattedCodeFixProvider(),
+            source,
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            additionalReferences: [s_toukiReference],
+            parseOptions: new CSharpParseOptions(LanguageVersion.CSharp10)).ConfigureAwait(false);
+
+        fixedSource.Should().Contain("writer.WriteFormatted($\"Value: {value}\");");
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class ForcedWriteAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor s_rule = new(
+            UseTextWriterWriteFormattedAnalyzer.DiagnosticId,
+            "Forced Write diagnostic",
+            "Forced Write diagnostic",
+            "Test",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(
+                static syntaxContext =>
+                {
+                    if (syntaxContext.Node is InvocationExpressionSyntax
+                        {
+                            Expression: MemberAccessExpressionSyntax memberAccess
+                        }
+                        && memberAccess.Name.Identifier.ValueText is "Write" or "WriteLine")
+                    {
+                        syntaxContext.ReportDiagnostic(
+                            Diagnostic.Create(s_rule, memberAccess.Name.GetLocation()));
+                    }
+                },
+                SyntaxKind.InvocationExpression);
+        }
+    }
+}

--- a/touki.analyzers.tests/touki.analyzers.tests.csproj
+++ b/touki.analyzers.tests/touki.analyzers.tests.csproj
@@ -40,6 +40,10 @@
   <ItemGroup>
     <ProjectReference Include="..\touki.analyzers\touki.analyzers.csproj" />
     <ProjectReference Include="..\touki.analyzers.codefixes\touki.analyzers.codefixes.csproj" />
+    <!-- Used by consumer-style analyzer tests that bind against the real public API metadata. -->
+    <ProjectReference Include="..\touki\touki.csproj"
+                      AdditionalProperties="TargetFramework=$(DotNetCoreVersion)"
+                      PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,4 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TOUKI0012 | Reliability | Disabled | Disposable class does not derive from Touki.DisposableBase
 TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML
+TOUKI0031 | Performance | Warning | Use WriteFormatted for TextWriter interpolated strings

--- a/touki.analyzers/UseTextWriterWriteFormattedAnalyzer.cs
+++ b/touki.analyzers/UseTextWriterWriteFormattedAnalyzer.cs
@@ -103,7 +103,7 @@ public sealed class UseTextWriterWriteFormattedAnalyzer : DiagnosticAnalyzer
         IInvocationOperation invocation = (IInvocationOperation)context.Operation;
         if (invocation.Syntax is not InvocationExpressionSyntax syntax
             || syntax.ArgumentList.Arguments.Count != 1
-            || GetInterpolatedString(syntax.ArgumentList.Arguments[0].Expression) is not { } interpolatedString
+            || GetInterpolatedString(syntax.ArgumentList.Arguments[0].Expression) is null
             || syntax.SyntaxTree.Options is not CSharpParseOptions parseOptions
             || parseOptions.LanguageVersion < LanguageVersion.CSharp10)
         {

--- a/touki.analyzers/UseTextWriterWriteFormattedAnalyzer.cs
+++ b/touki.analyzers/UseTextWriterWriteFormattedAnalyzer.cs
@@ -1,0 +1,282 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports interpolated strings passed to <see cref="TextWriter.Write(string)"/>, where
+///  <c>Touki.Io.TextWriterExtensions.WriteFormatted</c> can write the formatted content without an intermediate
+///  string when the writer supports direct copying.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UseTextWriterWriteFormattedAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0031";
+
+    /// <summary>
+    ///  The CLR metadata name of <see cref="TextWriter"/>.
+    /// </summary>
+    public const string TextWriterMetadataName = "System.IO.TextWriter";
+
+    /// <summary>
+    ///  The CLR metadata name of the extension type that provides <c>WriteFormatted</c>.
+    /// </summary>
+    public const string TextWriterExtensionsMetadataName = "Touki.Io.TextWriterExtensions";
+
+    /// <summary>
+    ///  The CLR metadata name of the attribute that identifies an interpolated string handler.
+    /// </summary>
+    public const string InterpolatedStringHandlerAttributeMetadataName =
+        "System.Runtime.CompilerServices.InterpolatedStringHandlerAttribute";
+
+    /// <summary>
+    ///  The CLR metadata name of expression trees, which cannot contain interpolated string handler conversions.
+    /// </summary>
+    public const string ExpressionMetadataName = "System.Linq.Expressions.Expression`1";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Use WriteFormatted for interpolated strings",
+        messageFormat: "Use 'WriteFormatted' to avoid an intermediate string on supported writers",
+        category: "Performance",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "TextWriter.Write converts an interpolated string to a string before writing it. "
+            + "Touki.Io.TextWriterExtensions.WriteFormatted uses an interpolated string handler and writes "
+            + "directly to supported framework writers without that intermediate allocation.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static start =>
+        {
+            if (start.Compilation.GetTypeByMetadataName(TextWriterMetadataName) is not { } textWriter
+                || start.Compilation.GetTypeByMetadataName("System.IO.StringWriter") is not { } stringWriter
+                || start.Compilation.GetTypeByMetadataName("System.IO.StreamWriter") is not { } streamWriter
+                || start.Compilation.GetTypeByMetadataName(TextWriterExtensionsMetadataName) is not { } extensions
+                || start.Compilation.GetTypeByMetadataName(InterpolatedStringHandlerAttributeMetadataName)
+                    is not { } handlerAttribute
+                || !HasWriteFormattedExtension(extensions, textWriter, handlerAttribute))
+            {
+                return;
+            }
+
+            INamedTypeSymbol? expression = start.Compilation.GetTypeByMetadataName(ExpressionMetadataName);
+            start.RegisterOperationAction(
+                operationContext => AnalyzeInvocation(
+                    operationContext,
+                    textWriter,
+                    stringWriter,
+                    streamWriter,
+                    expression),
+                OperationKind.Invocation);
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        OperationAnalysisContext context,
+        INamedTypeSymbol textWriter,
+        INamedTypeSymbol stringWriter,
+        INamedTypeSymbol streamWriter,
+        INamedTypeSymbol? expression)
+    {
+        IInvocationOperation invocation = (IInvocationOperation)context.Operation;
+        if (invocation.Syntax is not InvocationExpressionSyntax syntax
+            || syntax.ArgumentList.Arguments.Count != 1
+            || GetInterpolatedString(syntax.ArgumentList.Arguments[0].Expression) is not { } interpolatedString
+            || syntax.SyntaxTree.Options is not CSharpParseOptions parseOptions
+            || parseOptions.LanguageVersion < LanguageVersion.CSharp10)
+        {
+            return;
+        }
+
+        SimpleNameSyntax? methodName = syntax.Expression switch
+        {
+            MemberAccessExpressionSyntax { Expression: not BaseExpressionSyntax } memberAccess => memberAccess.Name,
+            _ => null
+        };
+
+        if (methodName?.Identifier.ValueText != nameof(TextWriter.Write)
+            || invocation.Arguments.Length != 1
+            || invocation.Arguments[0].Value.ConstantValue.HasValue
+            || !CanUseOptimizedWriter(invocation.Instance?.Type, textWriter, stringWriter, streamWriter)
+            || IsInsideExpressionTree(invocation, expression))
+        {
+            return;
+        }
+
+        IMethodSymbol method = invocation.TargetMethod;
+        if (method.IsStatic
+            || method.Name != nameof(TextWriter.Write)
+            || method.Parameters.Length != 1
+            || method.Parameters[0].Type.SpecialType != SpecialType.System_String
+            || !IsTextWriterWrite(method, textWriter))
+        {
+            return;
+        }
+
+        if (invocation.SemanticModel is not { } semanticModel
+            || BindsToInstanceWriteFormatted(semanticModel, syntax, methodName))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(s_rule, methodName.GetLocation()));
+    }
+
+    private static bool CanUseOptimizedWriter(
+        ITypeSymbol? receiverType,
+        INamedTypeSymbol textWriter,
+        INamedTypeSymbol stringWriter,
+        INamedTypeSymbol streamWriter)
+    {
+        if (SymbolEqualityComparer.Default.Equals(receiverType, textWriter)
+            || SymbolEqualityComparer.Default.Equals(receiverType, stringWriter)
+            || SymbolEqualityComparer.Default.Equals(receiverType, streamWriter))
+        {
+            return true;
+        }
+
+        if (receiverType is ITypeParameterSymbol typeParameter)
+        {
+            foreach (ITypeSymbol constraint in typeParameter.ConstraintTypes)
+            {
+                if (SymbolEqualityComparer.Default.Equals(constraint, textWriter)
+                    || SymbolEqualityComparer.Default.Equals(constraint, stringWriter)
+                    || SymbolEqualityComparer.Default.Equals(constraint, streamWriter))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasWriteFormattedExtension(
+        INamedTypeSymbol extensions,
+        INamedTypeSymbol textWriter,
+        INamedTypeSymbol handlerAttribute)
+    {
+        foreach (ISymbol member in extensions.GetMembers("WriteFormatted"))
+        {
+            if (member is not IMethodSymbol
+                {
+                    IsExtensionMethod: true,
+                    IsStatic: true,
+                    ReturnsVoid: true,
+                    DeclaredAccessibility: Accessibility.Public,
+                    Parameters.Length: 2
+                } method
+                || method.Parameters[0].RefKind != RefKind.None
+                || !SymbolEqualityComparer.Default.Equals(method.Parameters[0].Type, textWriter)
+                || method.Parameters[1].RefKind != RefKind.Ref)
+            {
+                continue;
+            }
+
+            foreach (AttributeData attribute in method.Parameters[1].Type.GetAttributes())
+            {
+                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, handlerAttribute))
+                {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsTextWriterWrite(IMethodSymbol method, INamedTypeSymbol textWriter)
+    {
+        for (IMethodSymbol? current = method; current is not null; current = current.OverriddenMethod)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current.ContainingType, textWriter))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool BindsToInstanceWriteFormatted(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocation,
+        SimpleNameSyntax methodName)
+    {
+        SyntaxToken replacementIdentifier = SyntaxFactory.Identifier(
+            methodName.Identifier.LeadingTrivia,
+            "WriteFormatted",
+            methodName.Identifier.TrailingTrivia);
+        InvocationExpressionSyntax candidate = invocation.ReplaceToken(
+            methodName.Identifier,
+            replacementIdentifier);
+
+        ArgumentSyntax argument = candidate.ArgumentList.Arguments[0];
+        if (argument.NameColon is { } nameColon)
+        {
+            IdentifierNameSyntax builderName = SyntaxFactory.IdentifierName(
+                SyntaxFactory.Identifier(
+                    nameColon.Name.Identifier.LeadingTrivia,
+                    "builder",
+                    nameColon.Name.Identifier.TrailingTrivia));
+            candidate = candidate.ReplaceNode(argument, argument.WithNameColon(nameColon.WithName(builderName)));
+        }
+
+        SymbolInfo symbolInfo = semanticModel.GetSpeculativeSymbolInfo(
+            invocation.SpanStart,
+            candidate,
+            SpeculativeBindingOption.BindAsExpression);
+        return symbolInfo.Symbol is IMethodSymbol { IsStatic: false, ReducedFrom: null };
+    }
+
+    private static InterpolatedStringExpressionSyntax? GetInterpolatedString(ExpressionSyntax expression)
+    {
+        while (expression is ParenthesizedExpressionSyntax parenthesized)
+        {
+            expression = parenthesized.Expression;
+        }
+
+        return expression as InterpolatedStringExpressionSyntax;
+    }
+
+    private static bool IsInsideExpressionTree(IOperation operation, INamedTypeSymbol? expression)
+    {
+        if (expression is null)
+        {
+            return false;
+        }
+
+        for (IOperation? current = operation.Parent; current is not null; current = current.Parent)
+        {
+            if (current is IConversionOperation { Type: INamedTypeSymbol convertedType }
+                && SymbolEqualityComparer.Default.Equals(convertedType.OriginalDefinition, expression))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/touki.tests/Touki/Io/TextWriterExtensionsTests.cs
+++ b/touki.tests/Touki/Io/TextWriterExtensionsTests.cs
@@ -157,6 +157,35 @@ public class TextWriterExtensionsTests
     }
 
     [TestMethod]
+    public void WriteFormatted_NullWriter_ThrowsAndDisposesBuilder()
+    {
+        System.IO.TextWriter writer = null!;
+        ValueStringBuilder builder = new(initialCapacity: 32);
+        ArgumentNullException? exception = null;
+        try
+        {
+            builder.Append("Hello");
+
+            try
+            {
+                writer.WriteFormatted(ref builder);
+            }
+            catch (ArgumentNullException caught)
+            {
+                exception = caught;
+            }
+
+            exception.Should().NotBeNull();
+            exception!.ParamName.Should().Be("writer");
+            builder.Capacity.Should().Be(0);
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [TestMethod]
     public void WriteFormatted_CustomWriter_UsesVirtualStringOverload()
     {
         using RecordingTextWriter writer = new();

--- a/touki.tests/Touki/Io/TextWriterExtensionsTests.cs
+++ b/touki.tests/Touki/Io/TextWriterExtensionsTests.cs
@@ -108,6 +108,247 @@ public class TextWriterExtensionsTests
         stream.Length.Should().Be(length);
     }
 
+    [TestMethod]
+    public void WriteFormatted_RentedBuilder_DisposesBuilder()
+    {
+        using System.IO.StringWriter writer = new();
+        ValueStringBuilder builder = new(initialCapacity: 32);
+        try
+        {
+            builder.Append("Hello");
+
+            writer.WriteFormatted(ref builder);
+
+            builder.Capacity.Should().Be(0);
+            writer.ToString().Should().Be("Hello");
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void WriteFormatted_WriterThrows_DisposesBuilder()
+    {
+        using ThrowingTextWriter writer = new();
+        ValueStringBuilder builder = new(initialCapacity: 32);
+        InvalidOperationException? exception = null;
+        try
+        {
+            builder.Append("Hello");
+
+            try
+            {
+                writer.WriteFormatted(ref builder);
+            }
+            catch (InvalidOperationException caught)
+            {
+                exception = caught;
+            }
+
+            builder.Capacity.Should().Be(0);
+            exception.Should().NotBeNull();
+        }
+        finally
+        {
+            builder.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void WriteFormatted_CustomWriter_UsesVirtualStringOverload()
+    {
+        using RecordingTextWriter writer = new();
+        int value = 42;
+
+        writer.WriteFormatted($"Value: {value}");
+
+        writer.StringOverloadCalled.Should().BeTrue();
+        writer.Captured.Should().Be("Value: 42");
+    }
+
+    [TestMethod]
+    public void WriteFormatted_DisposedStringWriterWithContent_Throws()
+    {
+        System.IO.StringWriter writer = new();
+        try
+        {
+            writer.Dispose();
+            int value = 42;
+            ObjectDisposedException? exception = null;
+
+            try
+            {
+                writer.WriteFormatted($"Value: {value}");
+            }
+            catch (ObjectDisposedException caught)
+            {
+                exception = caught;
+            }
+
+            exception.Should().NotBeNull();
+        }
+        finally
+        {
+            writer.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void WriteFormatted_DisposedStringWriterWithEmptyContent_Throws()
+    {
+        System.IO.StringWriter writer = new();
+        try
+        {
+            writer.Dispose();
+            string value = string.Empty;
+            ObjectDisposedException? exception = null;
+
+            try
+            {
+                writer.WriteFormatted($"{value}");
+            }
+            catch (ObjectDisposedException caught)
+            {
+                exception = caught;
+            }
+
+            exception.Should().NotBeNull();
+        }
+        finally
+        {
+            writer.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public void WriteFormatted_DisposedStreamWriterWithContent_MatchesStringOverload()
+    {
+        (Type? ExceptionType, long StreamLength) expected =
+            WriteToDisposedStreamWriter("Value: 42", formatted: false);
+        (Type? ExceptionType, long StreamLength) actual =
+            WriteToDisposedStreamWriter("Value: 42", formatted: true);
+
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void WriteFormatted_DisposedStreamWriterWithEmptyContent_MatchesStringOverload()
+    {
+        (Type? ExceptionType, long StreamLength) expected =
+            WriteToDisposedStreamWriter(string.Empty, formatted: false);
+        (Type? ExceptionType, long StreamLength) actual =
+            WriteToDisposedStreamWriter(string.Empty, formatted: true);
+
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void WriteFormatted_StreamWriterAutoFlush_MatchesStringOverload()
+    {
+        (Type? ExceptionType, int FlushCount, string Content) expected =
+            WriteToAutoFlushStreamWriter("Value: 42", formatted: false, throwOnFlush: false);
+        (Type? ExceptionType, int FlushCount, string Content) actual =
+            WriteToAutoFlushStreamWriter("Value: 42", formatted: true, throwOnFlush: false);
+
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void WriteFormatted_StreamWriterThrowingFlush_MatchesStringOverload()
+    {
+        (Type? ExceptionType, int FlushCount, string Content) expected =
+            WriteToAutoFlushStreamWriter("Value: 42", formatted: false, throwOnFlush: true);
+        (Type? ExceptionType, int FlushCount, string Content) actual =
+            WriteToAutoFlushStreamWriter("Value: 42", formatted: true, throwOnFlush: true);
+
+        actual.Should().Be(expected);
+    }
+
+    private static (Type? ExceptionType, long StreamLength) WriteToDisposedStreamWriter(
+        string value,
+        bool formatted)
+    {
+        MemoryStream stream = new();
+        System.IO.StreamWriter writer = new(stream, Encoding.UTF8, 1024, leaveOpen: true);
+        try
+        {
+            writer.Dispose();
+            Exception? exception = null;
+
+            try
+            {
+                if (formatted)
+                {
+                    writer.WriteFormatted($"{value}");
+                }
+                else
+                {
+                    writer.Write(value);
+                }
+            }
+            catch (Exception caught)
+            {
+                exception = caught;
+            }
+
+            return (exception?.GetType(), stream.Length);
+        }
+        finally
+        {
+            writer.Dispose();
+            stream.Dispose();
+        }
+    }
+
+    private static (Type? ExceptionType, int FlushCount, string Content) WriteToAutoFlushStreamWriter(
+        string value,
+        bool formatted,
+        bool throwOnFlush)
+    {
+        TrackingMemoryStream stream = new();
+        System.IO.StreamWriter writer = new(
+            stream,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+            1024,
+            leaveOpen: true);
+        try
+        {
+            writer.AutoFlush = true;
+            stream.ResetFlushCount();
+            stream.ThrowOnFlush = throwOnFlush;
+            Exception? exception = null;
+
+            try
+            {
+                if (formatted)
+                {
+                    writer.WriteFormatted($"{value}");
+                }
+                else
+                {
+                    writer.Write(value);
+                }
+            }
+            catch (Exception caught)
+            {
+                exception = caught;
+            }
+
+            return (
+                exception?.GetType(),
+                stream.FlushCount,
+                Encoding.UTF8.GetString(stream.ToArray()));
+        }
+        finally
+        {
+            stream.ThrowOnFlush = false;
+            writer.Dispose();
+            stream.Dispose();
+        }
+    }
+
 #if NET
     [TestMethod]
     public void WriteFormatted_StringOverload_WritesLiteralWithoutBuilder()
@@ -117,6 +358,17 @@ public class TextWriterExtensionsTests
         writer.WriteFormatted("Hello");
 
         writer.ToString().Should().Be("Hello");
+    }
+
+    [TestMethod]
+    public void WriteFormatted_StringOverload_CustomWriterUsesVirtualStringOverload()
+    {
+        using RecordingTextWriter writer = new();
+
+        writer.WriteFormatted("Hello");
+
+        writer.StringOverloadCalled.Should().BeTrue();
+        writer.Captured.Should().Be("Hello");
     }
 #endif
 
@@ -140,5 +392,61 @@ public class TextWriterExtensionsTests
         TextWriterExtensions.WriteLine(writer, segment);
 
         writer.ToString().Should().Be($"Hello{Environment.NewLine}");
+    }
+
+    private sealed class ThrowingTextWriter : System.IO.TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(string? value) => throw new InvalidOperationException();
+
+#if NET
+        public override void Write(ReadOnlySpan<char> buffer) => throw new InvalidOperationException();
+#else
+        public override void Write(char[] buffer, int index, int count) => throw new InvalidOperationException();
+#endif
+    }
+
+    private sealed class RecordingTextWriter : System.IO.TextWriter
+    {
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public bool StringOverloadCalled { get; private set; }
+
+        public string? Captured { get; private set; }
+
+        public override void Write(string? value)
+        {
+            StringOverloadCalled = true;
+            Captured = value;
+        }
+
+#if NET
+        public override void Write(ReadOnlySpan<char> buffer) =>
+            throw new InvalidOperationException("The span overload should not be used for a custom writer.");
+#else
+        public override void Write(char[] buffer, int index, int count) =>
+            throw new InvalidOperationException("The buffer overload should not be used for a custom writer.");
+#endif
+    }
+
+    private sealed class TrackingMemoryStream : MemoryStream
+    {
+        public int FlushCount { get; private set; }
+
+        public bool ThrowOnFlush { get; set; }
+
+        public override void Flush()
+        {
+            FlushCount++;
+            if (ThrowOnFlush)
+            {
+                throw new InvalidOperationException();
+            }
+
+            base.Flush();
+        }
+
+        public void ResetFlushCount() => FlushCount = 0;
     }
 }

--- a/touki.tests/Touki/Io/TextWriterExtensionsTests.cs
+++ b/touki.tests/Touki/Io/TextWriterExtensionsTests.cs
@@ -399,6 +399,25 @@ public class TextWriterExtensionsTests
         writer.StringOverloadCalled.Should().BeTrue();
         writer.Captured.Should().Be("Hello");
     }
+
+    [TestMethod]
+    public void WriteFormatted_StringOverloadWithNullWriter_ThrowsArgumentNullException()
+    {
+        System.IO.TextWriter writer = null!;
+        ArgumentNullException? exception = null;
+
+        try
+        {
+            writer.WriteFormatted("Hello");
+        }
+        catch (ArgumentNullException caught)
+        {
+            exception = caught;
+        }
+
+        exception.Should().NotBeNull();
+        exception!.ParamName.Should().Be("writer");
+    }
 #endif
 
     [TestMethod]

--- a/touki/Touki/Io/TextWriterExtensions.cs
+++ b/touki/Touki/Io/TextWriterExtensions.cs
@@ -86,6 +86,8 @@ public static partial class TextWriterExtensions
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void WriteFormatted(string value)
         {
+            ArgumentNullException.ThrowIfNull(writer);
+
             Type writerType = writer.GetType();
             if (writerType == typeof(StringWriter) || writerType == typeof(StreamWriter))
             {

--- a/touki/Touki/Io/TextWriterExtensions.cs
+++ b/touki/Touki/Io/TextWriterExtensions.cs
@@ -26,14 +26,49 @@ public static partial class TextWriterExtensions
         }
 
         /// <summary>
-        ///  Writes an interpolated string directly to a <see cref="StreamWriter"/>.
+        ///  Writes an interpolated string to a <see cref="TextWriter"/>.
         /// </summary>
+        /// <remarks>
+        ///  <para>
+        ///   This method consumes and disposes <paramref name="builder"/>.
+        ///  </para>
+        ///  <para>
+        ///   Exact <see cref="StringWriter"/> and <see cref="StreamWriter"/> instances use an optimized direct
+        ///   copy. Custom writer types are passed a string through <see cref="TextWriter.Write(string)"/> so their
+        ///   virtual behavior is preserved.
+        ///  </para>
+        /// </remarks>
         public void WriteFormatted(ref ValueStringBuilder builder)
         {
-            if (builder.Length > 0)
+            try
             {
-                builder.CopyTo(writer);
-                builder.Clear();
+                Type writerType = writer.GetType();
+                if (writerType == typeof(StringWriter))
+                {
+                    // Preserve the state check and empty-write behavior of the original virtual string call.
+                    writer.Write(string.Empty);
+                    builder.CopyTo(writer);
+                }
+                else if (writerType == typeof(StreamWriter))
+                {
+                    if (builder.Length == 0)
+                    {
+                        writer.Write(string.Empty);
+                    }
+                    else
+                    {
+                        builder.CopyTo(writer);
+                    }
+                }
+                else
+                {
+                    // Preserve virtual Write(string) behavior for custom TextWriter implementations.
+                    writer.Write(builder.ToString());
+                }
+            }
+            finally
+            {
+                builder.Dispose();
             }
         }
 
@@ -49,9 +84,15 @@ public static partial class TextWriterExtensions
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void WriteFormatted(string value)
         {
-            // While it would be nice to have this for .NET Framework, the only method we have on
-            // StreamWriter takes a char[] buffer. We can't reinterpret the string as a char[].
-            writer.Write(value.AsSpan());
+            Type writerType = writer.GetType();
+            if (writerType == typeof(StringWriter) || writerType == typeof(StreamWriter))
+            {
+                writer.Write(value.AsSpan());
+            }
+            else
+            {
+                writer.Write(value);
+            }
         }
 #endif
     }

--- a/touki/Touki/Io/TextWriterExtensions.cs
+++ b/touki/Touki/Io/TextWriterExtensions.cs
@@ -42,6 +42,8 @@ public static partial class TextWriterExtensions
         {
             try
             {
+                ArgumentNullException.ThrowIfNull(writer);
+
                 Type writerType = writer.GetType();
                 if (writerType == typeof(StringWriter))
                 {


### PR DESCRIPTION
## Summary

- Add TOUKI0031 to identify non-constant interpolated strings passed to supported `TextWriter.Write(string)` calls.
- Add a semantics-aware `WriteFormatted` code fix with safe import handling, binding validation, stale-diagnostic checks, and Fix All support.
- Harden `TextWriter.WriteFormatted` handler disposal and preserve writer dispatch/state behavior across modern .NET and .NET Framework; update analyzer and I/O documentation.

## Validation

- Analyzer/code-fix tests, Debug: 444 passed
- Analyzer/code-fix tests, Release: 444 passed
- Runtime tests, Debug net10.0: 7,133 passed, 119 skipped, 0 failed
- Runtime tests, Debug net481: 8,460 passed, 22 skipped, 0 failed
- Runtime tests, Release net10.0: 7,140 passed, 119 skipped, 0 failed
- Runtime tests, Release net481: 8,468 passed, 22 skipped, 0 failed
- Shipping build: net10.0 and net472 succeeded

Local validation used SDK 10.0.400 with `DotNetCoreNextVersion=net10.0` because the pinned .NET 11 preview SDK is not installed locally; CI will exercise the pinned toolchain.