### PR TITLE
Add Path.Join analyzer

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -7,8 +7,9 @@ ship disabled unless a project opts in.
 
 The analyzers encode the conventions this library is built on: avoid hidden struct
 copies, release resources deterministically, keep scratch buffers off the stack once
-they get large, write formatted text without temporary strings, keep types easy to find
-by file name, keep whitespace out of the way, and name a field for what it actually is.
+they get large, write formatted text without temporary strings, compose paths without
+silently discarding segments, keep types easy to find by file name, keep whitespace out
+of the way, and name a field for what it actually is.
 
 ## Rules
 
@@ -28,6 +29,7 @@ by file name, keep whitespace out of the way, and name a field for what it actua
 | [TOUKI0024](#touki0024) | Format XML documentation as nested XML | Maintainability | **Disabled** | Yes | - |
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
 | [TOUKI0031](#touki0031) | Use `WriteFormatted` for interpolated strings | Performance | Warning | - | C# 10, `TextWriterExtensions` |
+| [TOUKI0032](#touki0032) | Use `Path.Join` instead of `Path.Combine` | Reliability | Warning | - | - |
 | [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
 Rules that require an attribute only fire on code that applies it. TOUKI0012 requires
@@ -459,6 +461,55 @@ conditional access; and calls without an explicit receiver. Those forms cannot b
 converted by the same behavior-preserving local edit or cannot use the optimized writer
 path.
 
+## TOUKI0032
+
+**Use `Path.Join` instead of `Path.Combine`.** Reports calls bound to either
+`System.IO.Path.Combine` or the downlevel `Microsoft.IO.Path.Combine` from the
+strong-named `Microsoft.IO.Redist` assembly. `Combine` treats a rooted later argument as
+a replacement for everything accumulated before it. That behavior is easy to miss when
+a segment comes from configuration, an environment variable, or another operating
+system's path syntax: a leading `/` is meaningful to both Unix and WSL tooling and may
+unexpectedly discard a Windows-side prefix.
+
+`Path.Join` never interprets a later segment as replacing the preceding path:
+
+```csharp
+string path = Path.Combine(root, segment); // TOUKI0032
+string path = Path.Join(root, segment);
+```
+
+The change is intentional semantic hardening, not merely style. Code that specifically
+wants rooted segments to replace earlier segments should make that branch explicit rather
+than relying on `Combine` to do it implicitly.
+
+Adopting `Join` also adopts its other argument semantics:
+
+- null segments are treated as empty rather than rejected by overloads that validate them;
+- on Windows, drive-relative forms change - for example, `Combine("C:", "child")`
+  produces `C:child`, while `Join("C:", "child")` produces `C:\child`;
+- the .NET Framework implementation from `Microsoft.IO.Redist` does not perform the legacy
+  invalid-path-character validation that `Path.Combine` performs.
+
+These differences are why the rule is in the Reliability category. Suppress TOUKI0032 at
+an individual call only when the `Combine` behavior is deliberate and documented.
+
+The code fix preserves the existing `Path` spelling, alias, or static import when
+`System.IO.Path.Join` is available. Calls already bound to `Microsoft.IO.Path.Combine`
+retain that type and are renamed to its `Join` member. On .NET Framework, where the BCL
+member does not exist, calls to `System.IO.Path.Combine` are rewritten to the fully
+qualified `global::Microsoft.IO.Path.Join` provided by `Microsoft.IO.Redist`. Touki
+already references that package for its `net472` target. The fix is offered only when
+Roslyn proves that the rewritten overload binds successfully.
+
+Multi-targeted projects are analyzed once per target, so a shared source file can receive
+the diagnostic in both its modern .NET and .NET Framework project contexts. The fix is
+withheld when that physical source file appears in more than one project context: no
+single replacement is portable when one target exposes `System.IO.Path.Join` and another
+requires `Microsoft.IO.Path.Join`. TFM-specific files can be fixed normally. A downlevel
+fix is also withheld when comments or directives appear inside the original qualified
+method access, where replacing the qualifier would discard that trivia. Fix All is
+supported.
+
 ## TOUKI0041
 
 **Naming rule violation** - a name does not follow the configured naming rules. A
@@ -668,6 +719,10 @@ computed by the analyzer from the file's options. It supports Fix All.
 `UseTextWriterWriteFormattedCodeFixProvider` fixes TOUKI0031 by renaming the diagnosed
 `Write` call and importing `Touki.Io` when necessary. It supports Fix All.
 
+`UsePathJoinCodeFixProvider` fixes TOUKI0032 by selecting `System.IO.Path.Join` on modern
+.NET or `Microsoft.IO.Path.Join` from `Microsoft.IO.Redist` on .NET Framework. It
+preserves existing aliases and static imports where possible and supports Fix All.
+
 ## Relationship to IDE0055
 
 The .NET SDK's `IDE0055` ([Fix formatting](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0055))
@@ -699,7 +754,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 | 0.7.0 | TOUKI0022, TOUKI0023 |
-| Unshipped | TOUKI0012, TOUKI0024, TOUKI0031 |
+| Unshipped | TOUKI0012, TOUKI0024, TOUKI0031, TOUKI0032 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/touki.analyzers.codefixes/UsePathJoinCodeFixProvider.cs
+++ b/touki.analyzers.codefixes/UsePathJoinCodeFixProvider.cs
@@ -1,0 +1,337 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Offers a "Use Path.Join" fix for <c>TOUKI0032</c>.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(UsePathJoinCodeFixProvider))]
+[Shared]
+public sealed class UsePathJoinCodeFixProvider : CodeFixProvider
+{
+    // Hardcoded to avoid a dependency on the analyzer assembly; this is a stable public contract.
+    private const string UsePathJoinId = "TOUKI0032";
+    private const string SystemPathMetadataName = "System.IO.Path";
+    private const string RedistPathMetadataName = "Microsoft.IO.Path";
+    private const string RedistAssemblyName = "Microsoft.IO.Redist";
+
+    private static readonly ImmutableArray<string> s_fixableDiagnosticIds = [UsePathJoinId];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<string> FixableDiagnosticIds => s_fixableDiagnosticIds;
+
+    /// <inheritdoc/>
+    public override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc/>
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null
+            || context.Document.FilePath is not null
+                && DocumentFileUtilities.HasSharedFilePath(context.Document.Project.Solution, context.Document))
+        {
+            return;
+        }
+
+        foreach (Diagnostic diagnostic in context.Diagnostics)
+        {
+            if (diagnostic.Location.SourceTree != root.SyntaxTree)
+            {
+                continue;
+            }
+
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            InvocationExpressionSyntax? invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            SimpleNameSyntax? methodName = invocation is null ? null : GetMethodName(invocation.Expression);
+            if (invocation is null || methodName is null || diagnostic.Location.SourceSpan != methodName.Span)
+            {
+                continue;
+            }
+
+            Document? changedDocument = await TryUsePathJoinAsync(
+                context.Document,
+                invocation.Span,
+                context.CancellationToken).ConfigureAwait(false);
+            if (changedDocument is null)
+            {
+                continue;
+            }
+
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Use Path.Join",
+                    createChangedDocument: _ => Task.FromResult(changedDocument),
+                    equivalenceKey: nameof(UsePathJoinCodeFixProvider)),
+                diagnostic);
+        }
+    }
+
+    private static async Task<Document?> TryUsePathJoinAsync(
+        Document document,
+        TextSpan invocationSpan,
+        CancellationToken cancellationToken)
+    {
+        SyntaxNode? root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null || semanticModel is null)
+        {
+            return null;
+        }
+
+        SyntaxNode node = root.FindNode(invocationSpan, getInnermostNodeForTie: true);
+        InvocationExpressionSyntax? invocation = node as InvocationExpressionSyntax
+            ?? node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        if (invocation is null
+            || invocation.Span != invocationSpan
+            || semanticModel.GetOperation(invocation, cancellationToken) is not IInvocationOperation operation
+            || operation.TargetMethod.Name != "Combine"
+            || !operation.TargetMethod.IsStatic
+            || semanticModel.Compilation.GetTypeByMetadataName(SystemPathMetadataName) is not { } systemPath)
+        {
+            return null;
+        }
+
+        INamedTypeSymbol? redistPath = semanticModel.Compilation.GetTypeByMetadataName(RedistPathMetadataName);
+        if (redistPath is not null && !IsRedistPath(redistPath))
+        {
+            redistPath = null;
+        }
+
+        bool combinesWithSystemPath =
+            SymbolEqualityComparer.Default.Equals(operation.TargetMethod.ContainingType, systemPath);
+        bool combinesWithRedistPath =
+            SymbolEqualityComparer.Default.Equals(operation.TargetMethod.ContainingType, redistPath);
+        if (!combinesWithSystemPath && !combinesWithRedistPath)
+        {
+            return null;
+        }
+
+        if (combinesWithRedistPath)
+        {
+            if (redistPath is null || !HasPublicJoin(redistPath))
+            {
+                return null;
+            }
+
+            ExpressionSyntax? redistExpression = RenameMethod(invocation.Expression);
+            if (redistExpression is not null)
+            {
+                Document? renamedDocument = await TryRewriteAsync(
+                    document,
+                    root,
+                    invocation,
+                    redistExpression,
+                    RedistPathMetadataName,
+                    cancellationToken).ConfigureAwait(false);
+                if (renamedDocument is not null)
+                {
+                    return renamedDocument;
+                }
+            }
+
+            if (ContainsSignificantTrivia(invocation.Expression))
+            {
+                return null;
+            }
+
+            return await TryRewriteAsync(
+                document,
+                root,
+                invocation,
+                SyntaxFactory.ParseExpression("global::Microsoft.IO.Path.Join")
+                    .WithTriviaFrom(invocation.Expression),
+                RedistPathMetadataName,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        bool systemPathHasJoin = HasPublicJoin(systemPath);
+        if (!systemPathHasJoin
+            && redistPath is not null
+            && HasPublicJoin(redistPath)
+            && !ContainsSignificantTrivia(invocation.Expression))
+        {
+            Document? redistDocument = await TryRewriteAsync(
+                document,
+                root,
+                invocation,
+                SyntaxFactory.ParseExpression("global::Microsoft.IO.Path.Join").WithTriviaFrom(invocation.Expression),
+                RedistPathMetadataName,
+                cancellationToken).ConfigureAwait(false);
+            if (redistDocument is not null)
+            {
+                return redistDocument;
+            }
+        }
+
+        if (!systemPathHasJoin)
+        {
+            return null;
+        }
+
+        ExpressionSyntax? renamedExpression = RenameMethod(invocation.Expression);
+        if (renamedExpression is not null)
+        {
+            Document? renamedDocument = await TryRewriteAsync(
+                document,
+                root,
+                invocation,
+                renamedExpression,
+                SystemPathMetadataName,
+                cancellationToken).ConfigureAwait(false);
+            if (renamedDocument is not null)
+            {
+                return renamedDocument;
+            }
+        }
+
+        if (ContainsSignificantTrivia(invocation.Expression))
+        {
+            return null;
+        }
+
+        return await TryRewriteAsync(
+            document,
+            root,
+            invocation,
+            SyntaxFactory.ParseExpression("global::System.IO.Path.Join").WithTriviaFrom(invocation.Expression),
+            SystemPathMetadataName,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<Document?> TryRewriteAsync(
+        Document document,
+        SyntaxNode root,
+        InvocationExpressionSyntax invocation,
+        ExpressionSyntax replacementExpression,
+        string expectedPathMetadataName,
+        CancellationToken cancellationToken)
+    {
+        SyntaxAnnotation annotation = new();
+        InvocationExpressionSyntax replacement = invocation
+            .WithExpression(replacementExpression)
+            .WithAdditionalAnnotations(annotation);
+        Document changedDocument = document.WithSyntaxRoot(root.ReplaceNode(invocation, replacement));
+        SyntaxNode? changedRoot = await changedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        SemanticModel? changedSemanticModel =
+            await changedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (changedRoot is null || changedSemanticModel is null)
+        {
+            return null;
+        }
+
+        InvocationExpressionSyntax? changedInvocation = null;
+        foreach (SyntaxNode annotatedNode in changedRoot.GetAnnotatedNodes(annotation))
+        {
+            if (annotatedNode is InvocationExpressionSyntax candidate)
+            {
+                changedInvocation = candidate;
+                break;
+            }
+        }
+
+        if (changedInvocation is null
+            || changedSemanticModel.GetOperation(changedInvocation, cancellationToken)
+                is not IInvocationOperation changedOperation
+            || changedSemanticModel.Compilation.GetTypeByMetadataName(expectedPathMetadataName)
+                is not { } expectedPath
+            || expectedPathMetadataName == RedistPathMetadataName && !IsRedistPath(expectedPath)
+            || changedOperation.TargetMethod.Name != "Join"
+            || !changedOperation.TargetMethod.IsStatic
+            || !SymbolEqualityComparer.Default.Equals(changedOperation.TargetMethod.ContainingType, expectedPath))
+        {
+            return null;
+        }
+
+        return changedDocument;
+    }
+
+    private static ExpressionSyntax? RenameMethod(ExpressionSyntax expression)
+    {
+        switch (expression)
+        {
+            case SimpleNameSyntax simpleName:
+                return SyntaxFactory.IdentifierName(
+                    SyntaxFactory.Identifier(
+                        simpleName.Identifier.LeadingTrivia,
+                        "Join",
+                        simpleName.Identifier.TrailingTrivia));
+            case MemberAccessExpressionSyntax memberAccess:
+                IdentifierNameSyntax join = SyntaxFactory.IdentifierName(
+                    SyntaxFactory.Identifier(
+                        memberAccess.Name.Identifier.LeadingTrivia,
+                        "Join",
+                        memberAccess.Name.Identifier.TrailingTrivia));
+                return memberAccess.WithName(join);
+            default:
+                return null;
+        }
+    }
+
+    private static SimpleNameSyntax? GetMethodName(ExpressionSyntax expression) => expression switch
+    {
+        SimpleNameSyntax simpleName => simpleName,
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+        _ => null
+    };
+
+    private static bool IsRedistPath(INamedTypeSymbol path)
+    {
+        AssemblyIdentity identity = path.ContainingAssembly.Identity;
+        return identity.Name == RedistAssemblyName
+            && identity.PublicKeyToken.Length == 8
+            && identity.PublicKeyToken[0] == 0xcc
+            && identity.PublicKeyToken[1] == 0x7b
+            && identity.PublicKeyToken[2] == 0x13
+            && identity.PublicKeyToken[3] == 0xff
+            && identity.PublicKeyToken[4] == 0xcd
+            && identity.PublicKeyToken[5] == 0x2d
+            && identity.PublicKeyToken[6] == 0xdd
+            && identity.PublicKeyToken[7] == 0x51;
+    }
+
+    private static bool ContainsSignificantTrivia(ExpressionSyntax expression)
+    {
+        foreach (SyntaxTrivia trivia in expression.DescendantTrivia(descendIntoTrivia: true))
+        {
+            if (!trivia.IsKind(SyntaxKind.WhitespaceTrivia)
+                && !trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasPublicJoin(INamedTypeSymbol path)
+    {
+        foreach (ISymbol member in path.GetMembers("Join"))
+        {
+            if (member is IMethodSymbol
+                {
+                    IsStatic: true,
+                    DeclaredAccessibility: Accessibility.Public
+                })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/touki.analyzers.tests/AnalyzerTestHarness.cs
+++ b/touki.analyzers.tests/AnalyzerTestHarness.cs
@@ -40,14 +40,17 @@ internal static class AnalyzerTestHarness
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
         IReadOnlyCollection<string>? expectedCompilerDiagnosticIds = null,
         CSharpParseOptions? parseOptions = null,
-        IReadOnlyCollection<MetadataReference>? additionalReferences = null)
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null,
+        IReadOnlyCollection<MetadataReference>? metadataReferences = null)
     {
+        IReadOnlyCollection<MetadataReference> references =
+            metadataReferences ?? RoslynTestEnvironment.GetReferences(additionalReferences);
         CSharpCompilation compilation = parseOptions is null
-            ? CreateCompilation(source, fileName, additionalReferences)
+            ? CreateCompilation(source, fileName, references)
             : CSharpCompilation.Create(
                 assemblyName: "Touki.Analyzers.TestCompilation",
                 syntaxTrees: [CSharpSyntaxTree.ParseText(source, parseOptions, fileName ?? string.Empty)],
-                references: RoslynTestEnvironment.GetReferences(additionalReferences),
+                references: references,
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
 
         return await GetDiagnosticsAsync(
@@ -142,12 +145,12 @@ internal static class AnalyzerTestHarness
     private static CSharpCompilation CreateCompilation(
         string source,
         string? fileName,
-        IReadOnlyCollection<MetadataReference>? additionalReferences = null) =>
-        CreateCompilation([(source, fileName ?? string.Empty)], additionalReferences);
+        IReadOnlyCollection<MetadataReference>? metadataReferences = null)
+        => CreateCompilation([(source, fileName ?? string.Empty)], metadataReferences);
 
     private static CSharpCompilation CreateCompilation(
         IReadOnlyList<(string Source, string FileName)> sources,
-        IReadOnlyCollection<MetadataReference>? additionalReferences = null)
+        IReadOnlyCollection<MetadataReference>? metadataReferences = null)
     {
         SyntaxTree[] syntaxTrees = new SyntaxTree[sources.Count];
 
@@ -159,7 +162,7 @@ internal static class AnalyzerTestHarness
         return CSharpCompilation.Create(
             assemblyName: "Touki.Analyzers.TestCompilation",
             syntaxTrees: syntaxTrees,
-            references: RoslynTestEnvironment.GetReferences(additionalReferences),
+            references: metadataReferences ?? RoslynTestEnvironment.References,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
     }
 }

--- a/touki.analyzers.tests/CodeFixTestHarness.cs
+++ b/touki.analyzers.tests/CodeFixTestHarness.cs
@@ -37,12 +37,14 @@ internal static class CodeFixTestHarness
         IReadOnlyDictionary<string, string>? options = null,
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
         IReadOnlyCollection<MetadataReference>? additionalReferences = null,
-        CSharpParseOptions? parseOptions = null)
+        CSharpParseOptions? parseOptions = null,
+        IReadOnlyCollection<MetadataReference>? metadataReferences = null)
     {
         using AdhocWorkspace workspace = new();
         Project project = workspace
             .AddProject("TestProject", LanguageNames.CSharp)
-            .AddMetadataReferences(RoslynTestEnvironment.GetReferences(additionalReferences))
+            .AddMetadataReferences(
+                metadataReferences ?? RoslynTestEnvironment.GetReferences(additionalReferences))
             .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             .WithParseOptions(parseOptions ?? new CSharpParseOptions(LanguageVersion.Preview));
         Document document = project.AddDocument("Test.cs", source);
@@ -97,14 +99,16 @@ internal static class CodeFixTestHarness
         IReadOnlyDictionary<string, string>? options = null,
         IReadOnlyDictionary<string, ReportDiagnostic>? diagnosticOptions = null,
         string? workspaceKind = null,
-        IReadOnlyCollection<MetadataReference>? additionalReferences = null)
+        IReadOnlyCollection<MetadataReference>? additionalReferences = null,
+        IReadOnlyCollection<MetadataReference>? metadataReferences = null)
     {
         using AdhocWorkspace workspace = workspaceKind is null
             ? new AdhocWorkspace()
             : new AdhocWorkspace(MefHostServices.DefaultHost, workspaceKind);
         Project project = workspace
             .AddProject("TestProject", LanguageNames.CSharp)
-            .AddMetadataReferences(RoslynTestEnvironment.GetReferences(additionalReferences))
+            .AddMetadataReferences(
+                metadataReferences ?? RoslynTestEnvironment.GetReferences(additionalReferences))
             .WithCompilationOptions(new CSharpCompilationOptions(
                 OutputKind.DynamicallyLinkedLibrary,
                 allowUnsafe: true));

--- a/touki.analyzers.tests/RoslynTestEnvironment.cs
+++ b/touki.analyzers.tests/RoslynTestEnvironment.cs
@@ -9,6 +9,7 @@ namespace Touki.Analyzers;
 internal static class RoslynTestEnvironment
 {
     private static readonly Lazy<ImmutableArray<MetadataReference>> s_references = new(CreateReferences);
+    private static readonly Lazy<ImmutableArray<MetadataReference>> s_net472References = new(CreateNet472References);
 
     /// <summary>
     ///  Gets metadata references for the trusted platform assemblies of the current test process.
@@ -23,6 +24,11 @@ internal static class RoslynTestEnvironment
         additionalReferences is null || additionalReferences.Count == 0
             ? References
             : References.AddRange(additionalReferences);
+
+    /// <summary>
+    ///  Gets the real net472 reference assemblies and the Microsoft.IO.Redist dependency closure.
+    /// </summary>
+    public static ImmutableArray<MetadataReference> Net472References => s_net472References.Value;
 
     /// <summary>
     ///  Creates analyzer options backed by the supplied EditorConfig values.
@@ -59,5 +65,46 @@ internal static class RoslynTestEnvironment
                 .Where(path => !string.Equals(path, toukiAssembly, StringComparison.OrdinalIgnoreCase))
                 .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
         ];
+    }
+
+    private static ImmutableArray<MetadataReference> CreateNet472References()
+    {
+        string packages = typeof(RoslynTestEnvironment).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyMetadataAttribute), inherit: false)
+            .Cast<System.Reflection.AssemblyMetadataAttribute>()
+            .Single(attribute => attribute.Key == "NuGetPackageRoot")
+            .Value!;
+        string framework = Path.Join(
+            packages,
+            "microsoft.netframework.referenceassemblies.net472",
+            "1.0.3",
+            "build",
+            ".NETFramework",
+            "v4.7.2");
+        string[] paths =
+        [
+            Path.Join(framework, "mscorlib.dll"),
+            Path.Join(framework, "System.dll"),
+            Path.Join(framework, "System.Core.dll"),
+            Path.Join(packages, "microsoft.io.redist", "6.1.3", "lib", "net472", "Microsoft.IO.Redist.dll"),
+            Path.Join(packages, "system.buffers", "4.6.1", "lib", "net462", "System.Buffers.dll"),
+            Path.Join(packages, "system.memory", "4.6.3", "lib", "net462", "System.Memory.dll"),
+            Path.Join(
+                packages,
+                "system.numerics.vectors",
+                "4.6.1",
+                "lib",
+                "net462",
+                "System.Numerics.Vectors.dll"),
+            Path.Join(
+                packages,
+                "system.runtime.compilerservices.unsafe",
+                "6.1.2",
+                "lib",
+                "net462",
+                "System.Runtime.CompilerServices.Unsafe.dll")
+        ];
+
+        return [.. paths.Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))];
     }
 }

--- a/touki.analyzers.tests/UsePathJoinAnalyzerTests.cs
+++ b/touki.analyzers.tests/UsePathJoinAnalyzerTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class UsePathJoinAnalyzerTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source) =>
+        await AnalyzerTestHarness.GetDiagnosticsAsync(new UsePathJoinAnalyzer(), source).ConfigureAwait(false);
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_PathCombine_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UsePathJoinAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_AllPathCombineOverloads_ReportDiagnostics()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Two(string first, string second) => Path.Combine(first, second);
+                string Three(string first, string second, string third) => Path.Combine(first, second, third);
+                string Four(string first, string second, string third, string fourth)
+                    => Path.Combine(first, second, third, fourth);
+                string Array(string[] paths) => Path.Combine(paths);
+                string Span(System.ReadOnlySpan<string> paths) => Path.Combine(paths);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(5);
+        diagnostics.Should().OnlyContain(diagnostic => diagnostic.Id == UsePathJoinAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_FullyQualifiedPathCombine_ReportsAtMethodName()
+    {
+        const string source = """
+            class Sample
+            {
+                string Build(string first, string second) => System.IO.Path.Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        Location location = diagnostics.Should().ContainSingle().Subject.Location;
+        location.SourceTree!.GetText().ToString(location.SourceSpan).Should().Be("Combine");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_AliasedPathCombine_ReportsDiagnostic()
+    {
+        const string source = """
+            using FilePath = System.IO.Path;
+
+            class Sample
+            {
+                string Build(string first, string second) => FilePath.Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UsePathJoinAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_UsingStaticCombine_ReportsDiagnostic()
+    {
+        const string source = """
+            using static System.IO.Path;
+
+            class Sample
+            {
+                string Build(string first, string second) => Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(UsePathJoinAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_PathJoin_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Join(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_UnrelatedPathCombine_ReportsNothing()
+    {
+        const string source = """
+            static class Path
+            {
+                public static string Combine(string first, string second) => first + second;
+            }
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_Net472MicrosoftIoPathCombine_AllSpellingsReportDiagnostics()
+    {
+        const string source = """
+            using Microsoft.IO;
+            using RedistPath = Microsoft.IO.Path;
+            using static Microsoft.IO.Path;
+
+            class Sample
+            {
+                string Imported(string first, string second) => Path.Combine(first, second);
+                string Qualified(string first, string second) => Microsoft.IO.Path.Combine(first, second);
+                string Aliased(string first, string second) => RedistPath.Combine(first, second);
+                string Static(string first, string second) => Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new UsePathJoinAnalyzer(),
+            source,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(4);
+        diagnostics.Should().OnlyContain(diagnostic => diagnostic.Id == UsePathJoinAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_SourceDefinedMicrosoftIoPathCombine_ReportsNothing()
+    {
+        const string source = """
+            namespace Microsoft.IO
+            {
+                public static class Path
+                {
+                    public static string Combine(string first, string second) => first + second;
+                }
+            }
+
+            class Sample
+            {
+                string Build(string first, string second) => Microsoft.IO.Path.Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_GeneratedCode_ReportsNothing()
+    {
+        const string source = """
+            // <auto-generated/>
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers.tests/UsePathJoinCodeFixTests.cs
+++ b/touki.analyzers.tests/UsePathJoinCodeFixTests.cs
@@ -1,0 +1,696 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class UsePathJoinCodeFixTests
+{
+    private static async Task<string> FixAsync(string source) =>
+        await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId).ConfigureAwait(false);
+
+    [TestMethod]
+    public async Task UsePathJoin_PathCombine_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_FullyQualifiedPathCombine_RenamesMethod()
+    {
+        const string source = """
+            class Sample
+            {
+                string Build(string first, string second) => System.IO.Path.Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_ModernPathWithInternalComment_PreservesComment()
+    {
+        const string source = """
+            class Sample
+            {
+                string Build(string first, string second)
+                    => System.IO.Path /* keep */ .Combine(first, second);
+            }
+            """;
+        string expected = source.Replace(".Combine", ".Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_AliasedPathCombine_PreservesAlias()
+    {
+        const string source = """
+            using FilePath = System.IO.Path;
+
+            class Sample
+            {
+                string Build(string first, string second) => FilePath.Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("FilePath.Combine", "FilePath.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_UsingStaticCombine_PreservesStaticImport()
+    {
+        const string source = """
+            using static System.IO.Path;
+
+            class Sample
+            {
+                string Build(string first, string second) => Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("Combine(first", "Join(first");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_FourArguments_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second, string third, string fourth)
+                    => Path.Combine(first, second, third, fourth);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_ArrayArgument_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string[] paths) => Path.Combine(paths);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_SpanArgument_RenamesMethod()
+    {
+        const string source = """
+            using System;
+            using System.IO;
+
+            class Sample
+            {
+                string Build(ReadOnlySpan<string> paths) => Path.Combine(paths);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_NullSegment_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string root) => Path.Combine(root, null!);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_DriveRelativeSegment_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build() => Path.Combine("C:", "child");
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_NamedArguments_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second)
+                    => Path.Combine(path1: first, path2: second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_MicrosoftIoPathAvailableOnModernDotNet_UsesSystemPath()
+    {
+        const string source = """
+            using System.IO;
+
+            namespace Microsoft.IO
+            {
+                public static class Path
+                {
+                    public static string Join(string first, string second) => first + second;
+                }
+            }
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await FixAsync(source).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472_UsesMicrosoftIoRedistPath()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "global::Microsoft.IO.Path.Join");
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472MicrosoftIoPathCombine_RenamesMethod()
+    {
+        const string source = """
+            class Sample
+            {
+                string Build(string first, string second)
+                    => Microsoft.IO.Path.Combine(first, second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "Path.Join");
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472MicrosoftIoPathFixAll_PreservesEverySpelling()
+    {
+        const string source = """
+            using Microsoft.IO;
+            using RedistPath = Microsoft.IO.Path;
+            using static Microsoft.IO.Path;
+
+            class Sample
+            {
+                string Imported(string first, string second) => Path.Combine(first, second);
+                string Qualified(string first, string second) => Microsoft.IO.Path.Combine(first, second);
+                string Aliased(string first, string second) => RedistPath.Combine(first, second);
+                string Static(string first, string second) => Combine(first, second);
+            }
+            """;
+        string expected = source
+            .Replace(".Combine", ".Join")
+            .Replace("=> Combine(", "=> Join(");
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            [("Test.cs", "Test.cs", source)],
+            UsePathJoinAnalyzer.DiagnosticId,
+            fixAll: true,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        string fixedSource = result.Documents.Should().ContainSingle().Subject.Source;
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472NamedArguments_UsesMicrosoftIoRedistPath()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second)
+                    => Path.Combine(path1: first, path2: second);
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "global::Microsoft.IO.Path.Join");
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472FixAll_RewritesEveryOverload()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Two(string first, string second) => Path.Combine(first, second);
+                string Three(string first, string second, string third) => Path.Combine(first, second, third);
+                string Four(string first, string second, string third, string fourth)
+                    => Path.Combine(first, second, third, fourth);
+                string Array(string[] paths) => Path.Combine(paths);
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            [("Test.cs", "Test.cs", source)],
+            UsePathJoinAnalyzer.DiagnosticId,
+            fixAll: true,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        string fixedSource = result.Documents.Should().ContainSingle().Subject.Source;
+        fixedSource.Should().NotContain("Path.Combine");
+        fixedSource.Split(["global::Microsoft.IO.Path.Join"], StringSplitOptions.None).Should().HaveCount(5);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472SourceMicrosoftIoPathCollision_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+
+            namespace Microsoft.IO
+            {
+                public static class Path
+                {
+                    public static string Join(string first, string second) => first + second;
+                }
+            }
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472InvalidCharacter_RenamesMethod()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string root) => Path.Combine(root, "bad\0name");
+            }
+            """;
+        string expected = source.Replace("Path.Combine", "global::Microsoft.IO.Path.Join");
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472PathWithInternalComment_WithholdsFix()
+    {
+        const string source = """
+            class Sample
+            {
+                string Build(string first, string second)
+                    => System.IO.Path /* keep */ .Combine(first, second);
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_Net472PathWithDirective_WithholdsFix()
+    {
+        const string source = """
+            class Sample
+            {
+                string Build(string first, string second) => System.IO.Path
+            #if USE_FIRST
+                    .Combine(first, second);
+            #else
+                    .Combine(first, second);
+            #endif
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_FixAll_RewritesEveryCall()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string First(string root, string child) => Path.Combine(root, child);
+                string Second(string root, string child) => Path.Combine(root, "nested", child);
+            }
+            """;
+
+        CodeFixTestResult result = await CodeFixTestHarness.ApplyFixToSolutionAsync(
+            new UsePathJoinAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            [("Test.cs", "Test.cs", source)],
+            UsePathJoinAnalyzer.DiagnosticId,
+            fixAll: true).ConfigureAwait(false);
+
+        result.FixAllActionOffered.Should().BeTrue();
+        result.CompilerErrors.Should().BeEmpty();
+        result.AnalyzerDiagnostics.Should().BeEmpty();
+        string fixedSource = result.Documents.Should().ContainSingle().Subject.Source;
+        fixedSource.Should().NotContain("Path.Combine");
+        fixedSource.Split(["Path.Join"], StringSplitOptions.None).Should().HaveCount(3);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_StaleUnrelatedPathDiagnostic_WithholdsFix()
+    {
+        const string source = """
+            static class Path
+            {
+                public static string Combine(string first, string second) => first + second;
+            }
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new ForcedCombineAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_StaleJoinDiagnostic_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Join(first, second);
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new ForcedCombineAnalyzer(),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_ShiftedDiagnosticInsideCombine_WithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+
+        string fixedSource = await CodeFixTestHarness.ApplyFixAsync(
+            new ForcedCombineAnalyzer(reportArgument: true),
+            new UsePathJoinCodeFixProvider(),
+            source,
+            UsePathJoinAnalyzer.DiagnosticId).ConfigureAwait(false);
+
+        fixedSource.Should().Be(source);
+    }
+
+    [TestMethod]
+    public async Task UsePathJoin_MultiTargetedLinkedSource_ReportsBothAndWithholdsFix()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                string Build(string first, string second) => Path.Combine(first, second);
+            }
+            """;
+        using AdhocWorkspace workspace = new();
+        Project firstProject = workspace.AddProject("First", LanguageNames.CSharp)
+            .AddMetadataReferences(RoslynTestEnvironment.References)
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        workspace.TryApplyChanges(firstProject.Solution).Should().BeTrue();
+        Project secondProject = workspace.AddProject("Second", LanguageNames.CSharp)
+            .AddMetadataReferences(RoslynTestEnvironment.Net472References)
+            .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        workspace.TryApplyChanges(secondProject.Solution).Should().BeTrue();
+
+        string filePath = Path.Join(Path.GetTempPath(), "touki-linked", "Shared.cs");
+        firstProject = workspace.CurrentSolution.GetProject(firstProject.Id)!;
+        Document firstDocument = firstProject.AddDocument(
+            "Shared.cs",
+            SourceText.From(source),
+            filePath: filePath);
+        workspace.TryApplyChanges(firstDocument.Project.Solution).Should().BeTrue();
+        secondProject = workspace.CurrentSolution.GetProject(secondProject.Id)!;
+        Document secondDocument = secondProject.AddDocument(
+            "Shared.cs",
+            SourceText.From(source),
+            filePath: filePath);
+        workspace.TryApplyChanges(secondDocument.Project.Solution).Should().BeTrue();
+        firstDocument = workspace.CurrentSolution.GetDocument(firstDocument.Id)!;
+        secondDocument = workspace.CurrentSolution.GetDocument(secondDocument.Id)!;
+
+        Compilation firstCompilation = (await firstDocument.Project.GetCompilationAsync().ConfigureAwait(false))!;
+        Compilation secondCompilation = (await secondDocument.Project.GetCompilationAsync().ConfigureAwait(false))!;
+        firstCompilation.GetDiagnostics().Should().NotContain(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        secondCompilation.GetDiagnostics().Should().NotContain(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Diagnostic firstDiagnostic = (await firstCompilation
+            .WithAnalyzers([new UsePathJoinAnalyzer()])
+            .GetAnalyzerDiagnosticsAsync()
+            .ConfigureAwait(false))
+            .Should().ContainSingle().Subject;
+        Diagnostic secondDiagnostic = (await secondCompilation
+            .WithAnalyzers([new UsePathJoinAnalyzer()])
+            .GetAnalyzerDiagnosticsAsync()
+            .ConfigureAwait(false))
+            .Should().ContainSingle().Subject;
+        List<CodeAction> actions = [];
+        CodeFixContext firstContext = new(
+            firstDocument,
+            firstDiagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        UsePathJoinCodeFixProvider provider = new();
+        await provider.RegisterCodeFixesAsync(firstContext).ConfigureAwait(false);
+
+        actions.Should().BeEmpty();
+        CodeFixContext secondContext = new(
+            secondDocument,
+            secondDiagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+        await provider.RegisterCodeFixesAsync(secondContext).ConfigureAwait(false);
+
+        actions.Should().BeEmpty();
+    }
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    private sealed class ForcedCombineAnalyzer(bool reportArgument = false) : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor s_rule = new(
+            UsePathJoinAnalyzer.DiagnosticId,
+            "Forced path diagnostic",
+            "Forced path diagnostic",
+            "Test",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterSyntaxNodeAction(
+                syntaxContext =>
+                {
+                    if (syntaxContext.Node is InvocationExpressionSyntax invocation)
+                    {
+                        if (reportArgument && invocation.ArgumentList.Arguments.Count > 0)
+                        {
+                            syntaxContext.ReportDiagnostic(
+                                Diagnostic.Create(s_rule, invocation.ArgumentList.Arguments[0].GetLocation()));
+                            return;
+                        }
+
+                        SimpleNameSyntax? methodName = invocation.Expression switch
+                        {
+                            SimpleNameSyntax simpleName => simpleName,
+                            MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+                            _ => null
+                        };
+                        if (methodName is not null)
+                        {
+                            syntaxContext.ReportDiagnostic(
+                                Diagnostic.Create(s_rule, methodName.GetLocation()));
+                        }
+                    }
+                },
+                SyntaxKind.InvocationExpression);
+        }
+    }
+}

--- a/touki.analyzers.tests/touki.analyzers.tests.csproj
+++ b/touki.analyzers.tests/touki.analyzers.tests.csproj
@@ -38,6 +38,23 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Download-only inputs for Roslyn compilations that validate the real net472/Redist metadata surface. -->
+    <PackageDownload Include="Microsoft.IO.Redist" Version="[6.1.3]" />
+    <PackageDownload Include="Microsoft.NETFramework.ReferenceAssemblies.net472" Version="[1.0.3]" />
+    <PackageDownload Include="System.Buffers" Version="[4.6.1]" />
+    <PackageDownload Include="System.Memory" Version="[4.6.3]" />
+    <PackageDownload Include="System.Numerics.Vectors" Version="[4.6.1]" />
+    <PackageDownload Include="System.Runtime.CompilerServices.Unsafe" Version="[6.1.2]" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>NuGetPackageRoot</_Parameter1>
+      <_Parameter2>$(NuGetPackageRoot)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\touki.analyzers\touki.analyzers.csproj" />
     <ProjectReference Include="..\touki.analyzers.codefixes\touki.analyzers.codefixes.csproj" />
     <!-- Used by consumer-style analyzer tests that bind against the real public API metadata. -->

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 TOUKI0012 | Reliability | Disabled | Disposable class does not derive from Touki.DisposableBase
 TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML
 TOUKI0031 | Performance | Warning | Use WriteFormatted for TextWriter interpolated strings
+TOUKI0032 | Reliability | Warning | Use Path.Join instead of Path.Combine

--- a/touki.analyzers/UsePathJoinAnalyzer.cs
+++ b/touki.analyzers/UsePathJoinAnalyzer.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports calls to <c>System.IO.Path.Combine</c> and <c>Microsoft.IO.Path.Combine</c>, whose rooted-segment
+///  behavior is easy to misuse, and recommends <c>Path.Join</c>, which joins every segment without replacing the
+///  preceding path.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class UsePathJoinAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0032";
+
+    /// <summary>
+    ///  The CLR metadata name of <c>System.IO.Path</c>.
+    /// </summary>
+    public const string PathMetadataName = "System.IO.Path";
+
+    /// <summary>
+    ///  The CLR metadata name of the downlevel path implementation from <c>Microsoft.IO.Redist</c>.
+    /// </summary>
+    public const string RedistPathMetadataName = "Microsoft.IO.Path";
+
+    private const string RedistAssemblyName = "Microsoft.IO.Redist";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Use Path.Join instead of Path.Combine",
+        messageFormat: "Use 'Path.Join' instead of 'Path.Combine'",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Path.Combine replaces the preceding path when a later segment is rooted. Path.Join treats "
+            + "every argument as a segment, which avoids unexpected path replacement across Windows, Unix, and WSL.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static start =>
+        {
+            if (start.Compilation.GetTypeByMetadataName(PathMetadataName) is not { } path)
+            {
+                return;
+            }
+
+            INamedTypeSymbol? redistPath = start.Compilation.GetTypeByMetadataName(RedistPathMetadataName);
+            if (redistPath is not null && !IsRedistPath(redistPath))
+            {
+                redistPath = null;
+            }
+
+            start.RegisterSyntaxNodeAction(
+                syntaxContext => AnalyzeInvocation(syntaxContext, path, redistPath),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        SyntaxNodeAnalysisContext context,
+        INamedTypeSymbol path,
+        INamedTypeSymbol? redistPath)
+    {
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
+        if (GetMethodName(invocation.Expression) is not { Identifier.ValueText: "Combine" } methodName
+            || context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
+                is not IMethodSymbol { Name: "Combine", IsStatic: true } method
+            || !SymbolEqualityComparer.Default.Equals(method.ContainingType, path)
+                && !SymbolEqualityComparer.Default.Equals(method.ContainingType, redistPath))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(s_rule, methodName.GetLocation()));
+    }
+
+    private static SimpleNameSyntax? GetMethodName(ExpressionSyntax expression) => expression switch
+    {
+        SimpleNameSyntax simpleName => simpleName,
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+        _ => null
+    };
+
+    private static bool IsRedistPath(INamedTypeSymbol path)
+    {
+        AssemblyIdentity identity = path.ContainingAssembly.Identity;
+        return identity.Name == RedistAssemblyName
+            && identity.PublicKeyToken.Length == 8
+            && identity.PublicKeyToken[0] == 0xcc
+            && identity.PublicKeyToken[1] == 0x7b
+            && identity.PublicKeyToken[2] == 0x13
+            && identity.PublicKeyToken[3] == 0xff
+            && identity.PublicKeyToken[4] == 0xcd
+            && identity.PublicKeyToken[5] == 0x2d
+            && identity.PublicKeyToken[6] == 0xdd
+            && identity.PublicKeyToken[7] == 0x51;
+    }
+}


### PR DESCRIPTION
## Summary

- Add TOUKI0032 to flag `System.IO.Path.Combine` and trusted `Microsoft.IO.Path.Combine` calls whose rooted-segment behavior can silently discard earlier path portions.
- Add a symbol-validated `Path.Join` code fix with Fix All support, selecting `System.IO.Path.Join` on modern .NET and strong-named `Microsoft.IO.Redist` on .NET Framework.
- Handle multi-targeted linked source conservatively: diagnose each target context but withhold a one-sided fix when no replacement is portable across all project contexts.
- Document rooted, null-segment, drive-relative, and legacy invalid-character semantic differences.

## Validation

- Focused TOUKI0031 + TOUKI0032 tests: 74 passed
- Analyzer/code-fix tests, Debug: 480 passed
- Analyzer/code-fix tests, Release: 480 passed
- Runtime tests, Release net10.0: 7,142 passed, 119 skipped, 0 failed
- Runtime tests, Release net481: 8,469 passed, 22 skipped, 0 failed
- Shipping build: net10.0 and net472 succeeded

Local validation used SDK 10.0.400 with `DotNetCoreNextVersion=net10.0` because the pinned .NET 11 preview SDK is not installed locally; CI will exercise the pinned toolchain.