### PR TITLE
Add IsPathRooted analyzer

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -30,6 +30,7 @@ of the way, and name a field for what it actually is.
 | [TOUKI0030](#touki0030) | Use `ValueStringBuilder` to build strings | Performance | Warning | - | - |
 | [TOUKI0031](#touki0031) | Use `WriteFormatted` for interpolated strings | Performance | Warning | - | C# 10, `TextWriterExtensions` |
 | [TOUKI0032](#touki0032) | Use `Path.Join` instead of `Path.Combine` | Reliability | Warning | - | - |
+| [TOUKI0033](#touki0033) | Avoid `Path.IsPathRooted` | Reliability | Warning | - | - |
 | [TOUKI0041](#touki0041) | Naming rule violation | Naming | **Disabled** | Yes | - |
 
 Rules that require an attribute only fire on code that applies it. TOUKI0012 requires
@@ -510,6 +511,49 @@ fix is also withheld when comments or directives appear inside the original qual
 method access, where replacing the qualifier would discard that trivia. Fix All is
 supported.
 
+## TOUKI0033
+
+**Avoid `Path.IsPathRooted`.** Reports calls bound to either
+`System.IO.Path.IsPathRooted` or the downlevel `Microsoft.IO.Path.IsPathRooted` from the
+strong-named `Microsoft.IO.Redist` assembly. "Rooted" does not mean that a path resolves
+independently of working-directory state.
+
+On Windows, both drive-relative and root-relative paths are rooted but not fully
+qualified:
+
+```csharp
+Path.IsPathRooted("C:child");          // true
+Path.IsPathFullyQualified("C:child"); // false
+
+Path.IsPathRooted("\\child");          // true
+Path.IsPathFullyQualified("\\child"); // false
+```
+
+`C:child` resolves against the current directory recorded for drive `C:`, which can
+differ from the process current directory. `\child` resolves against the current drive.
+These distinctions are particularly easy to lose when paths cross Windows, Unix, and WSL
+boundaries.
+
+Use `Path.IsPathFullyQualified` when the question is whether resolving a path can be
+changed by current-directory state:
+
+```csharp
+bool resolutionIsIndependent = Path.IsPathFullyQualified(path);
+```
+
+For a `net472` caller using `System.IO.Path.IsPathRooted`, the corresponding downlevel
+API is `Microsoft.IO.Path.IsPathFullyQualified` from `Microsoft.IO.Redist`.
+
+Manual replacement must account for the string-overload contracts. `IsPathRooted(null)`
+returns `false`, while `IsPathFullyQualified(null)` throws `ArgumentNullException`.
+Moving a `net472` BCL call to `Microsoft.IO.Redist` also adopts modern path validation:
+the Redist API does not perform .NET Framework's legacy invalid-path-character check.
+
+No code fix is offered. Some code intentionally asks whether a path has a root marker or
+needs root-relative classification, and replacing that check would change its meaning.
+After confirming such intent, suppress TOUKI0033 at that individual call and document the
+classification being performed.
+
 ## TOUKI0041
 
 **Naming rule violation** - a name does not follow the configured naming rules. A
@@ -754,7 +798,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 | 0.7.0 | TOUKI0022, TOUKI0023 |
-| Unshipped | TOUKI0012, TOUKI0024, TOUKI0031, TOUKI0032 |
+| Unshipped | TOUKI0012, TOUKI0024, TOUKI0031, TOUKI0032, TOUKI0033 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/touki.analyzers.tests/AvoidPathIsPathRootedAnalyzerTests.cs
+++ b/touki.analyzers.tests/AvoidPathIsPathRootedAnalyzerTests.cs
@@ -207,7 +207,7 @@ public class AvoidPathIsPathRootedAnalyzerTests
     }
 
     [TestMethod]
-    public async Task AnalyzeInvocation_Net472SystemIoPath_RecommendsMicrosoftIoQualificationCheck()
+    public async Task AnalyzeInvocation_Net472SystemIoPathWithoutRedist_RecommendsMicrosoftIoQualificationCheck()
     {
         const string source = """
             class Sample
@@ -216,10 +216,18 @@ public class AvoidPathIsPathRootedAnalyzerTests
             }
             """;
 
+        ImmutableArray<MetadataReference> references =
+        [
+            .. RoslynTestEnvironment.Net472References.Where(reference =>
+                !string.Equals(
+                    Path.GetFileName(reference.Display),
+                    "Microsoft.IO.Redist.dll",
+                    StringComparison.OrdinalIgnoreCase))
+        ];
         ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
             new AvoidPathIsPathRootedAnalyzer(),
             source,
-            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+            metadataReferences: references).ConfigureAwait(false);
 
         diagnostics.Should().ContainSingle().Which.GetMessage()
             .Should().Contain("Microsoft.IO.Path.IsPathFullyQualified");

--- a/touki.analyzers.tests/AvoidPathIsPathRootedAnalyzerTests.cs
+++ b/touki.analyzers.tests/AvoidPathIsPathRootedAnalyzerTests.cs
@@ -1,0 +1,268 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+namespace Touki.Analyzers;
+
+[TestClass]
+public class AvoidPathIsPathRootedAnalyzerTests
+{
+    private static async Task<ImmutableArray<Diagnostic>> AnalyzeAsync(string source) =>
+        await AnalyzerTestHarness.GetDiagnosticsAsync(new AvoidPathIsPathRootedAnalyzer(), source)
+            .ConfigureAwait(false);
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_PathIsPathRooted_ReportsDiagnostic()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                bool Check(string path) => Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(AvoidPathIsPathRootedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_StringAndSpanOverloads_ReportDiagnostics()
+    {
+        const string source = """
+            using System;
+            using System.IO;
+
+            class Sample
+            {
+                bool String(string path) => Path.IsPathRooted(path);
+                bool Span(ReadOnlySpan<char> path) => Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(2);
+        diagnostics.Should().OnlyContain(diagnostic => diagnostic.Id == AvoidPathIsPathRootedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_AllSystemIoPathSpellings_ReportAtMethodName()
+    {
+        const string source = """
+            using System.IO;
+            using FilePath = System.IO.Path;
+            using static System.IO.Path;
+
+            class Sample
+            {
+                bool Imported(string path) => Path.IsPathRooted(path);
+                bool Qualified(string path) => System.IO.Path.IsPathRooted(path);
+                bool Aliased(string path) => FilePath.IsPathRooted(path);
+                bool Static(string path) => IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(4);
+        diagnostics.Should().OnlyContain(diagnostic =>
+            diagnostic.Location.SourceTree!.GetText().ToString(diagnostic.Location.SourceSpan) == "IsPathRooted");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_MessageRecommendsQualificationCheck()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                bool Check(string path) => Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle().Which.GetMessage()
+            .Should().Contain("Path.IsPathFullyQualified")
+            .And.Contain("working directory");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_PathIsPathFullyQualified_ReportsNothing()
+    {
+        const string source = """
+            using System.IO;
+
+            class Sample
+            {
+                bool Check(string path) => Path.IsPathFullyQualified(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_UnrelatedPathIsPathRooted_ReportsNothing()
+    {
+        const string source = """
+            static class Path
+            {
+                public static bool IsPathRooted(string path) => false;
+            }
+
+            class Sample
+            {
+                bool Check(string path) => Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_SourceDefinedSystemIoPath_ReportsNothing()
+    {
+        const string source = """
+            namespace System.IO
+            {
+                public static class Path
+                {
+                    public static bool IsPathRooted(string path) => false;
+                }
+            }
+
+            class Sample
+            {
+                bool Check(string path) => System.IO.Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_SourceSystemIoPathWithTrustedRedist_StillReportsRedistCall()
+    {
+        const string source = """
+            namespace System.IO
+            {
+                public static class Path
+                {
+                    public static bool IsPathRooted(string path) => false;
+                }
+            }
+
+            class Sample
+            {
+                bool Check(string path) => Microsoft.IO.Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new AvoidPathIsPathRootedAnalyzer(),
+            source,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle()
+            .Which.Id.Should().Be(AvoidPathIsPathRootedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_Net472MicrosoftIoPath_AllSpellingsAndOverloadsReportDiagnostics()
+    {
+        const string source = """
+            using System;
+            using Microsoft.IO;
+            using RedistPath = Microsoft.IO.Path;
+            using static Microsoft.IO.Path;
+
+            class Sample
+            {
+                bool Imported(string path) => Path.IsPathRooted(path);
+                bool Qualified(string path) => Microsoft.IO.Path.IsPathRooted(path);
+                bool Aliased(ReadOnlySpan<char> path) => RedistPath.IsPathRooted(path);
+                bool Static(string path) => IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new AvoidPathIsPathRootedAnalyzer(),
+            source,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        diagnostics.Should().HaveCount(4);
+        diagnostics.Should().OnlyContain(diagnostic => diagnostic.Id == AvoidPathIsPathRootedAnalyzer.DiagnosticId);
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_Net472SystemIoPath_RecommendsMicrosoftIoQualificationCheck()
+    {
+        const string source = """
+            class Sample
+            {
+                bool Check(string path) => System.IO.Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzerTestHarness.GetDiagnosticsAsync(
+            new AvoidPathIsPathRootedAnalyzer(),
+            source,
+            metadataReferences: RoslynTestEnvironment.Net472References).ConfigureAwait(false);
+
+        diagnostics.Should().ContainSingle().Which.GetMessage()
+            .Should().Contain("Microsoft.IO.Path.IsPathFullyQualified");
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_SourceDefinedMicrosoftIoPath_ReportsNothing()
+    {
+        const string source = """
+            namespace Microsoft.IO
+            {
+                public static class Path
+                {
+                    public static bool IsPathRooted(string path) => false;
+                }
+            }
+
+            class Sample
+            {
+                bool Check(string path) => Microsoft.IO.Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+
+    [TestMethod]
+    public async Task AnalyzeInvocation_GeneratedCode_ReportsNothing()
+    {
+        const string source = """
+            // <auto-generated/>
+            using System.IO;
+
+            class Sample
+            {
+                bool Check(string path) => Path.IsPathRooted(path);
+            }
+            """;
+
+        ImmutableArray<Diagnostic> diagnostics = await AnalyzeAsync(source).ConfigureAwait(false);
+
+        diagnostics.Should().BeEmpty();
+    }
+}

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -9,3 +9,4 @@ TOUKI0012 | Reliability | Disabled | Disposable class does not derive from Touki
 TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML
 TOUKI0031 | Performance | Warning | Use WriteFormatted for TextWriter interpolated strings
 TOUKI0032 | Reliability | Warning | Use Path.Join instead of Path.Combine
+TOUKI0033 | Reliability | Warning | Avoid Path.IsPathRooted for qualification checks

--- a/touki.analyzers/AvoidPathIsPathRootedAnalyzer.cs
+++ b/touki.analyzers/AvoidPathIsPathRootedAnalyzer.cs
@@ -1,0 +1,156 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Touki.Analyzers;
+
+/// <summary>
+///  Reports calls to <c>System.IO.Path.IsPathRooted</c> and <c>Microsoft.IO.Path.IsPathRooted</c>, which are
+///  commonly mistaken for checks that a path resolves independently of a working directory.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AvoidPathIsPathRootedAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    ///  The diagnostic identifier reported by this analyzer.
+    /// </summary>
+    public const string DiagnosticId = "TOUKI0033";
+
+    /// <summary>
+    ///  The CLR metadata name of <c>System.IO.Path</c>.
+    /// </summary>
+    public const string PathMetadataName = "System.IO.Path";
+
+    /// <summary>
+    ///  The CLR metadata name of the downlevel path implementation from <c>Microsoft.IO.Redist</c>.
+    /// </summary>
+    public const string RedistPathMetadataName = "Microsoft.IO.Path";
+
+    private const string RedistAssemblyName = "Microsoft.IO.Redist";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Avoid Path.IsPathRooted",
+        messageFormat: "Review 'Path.IsPathRooted'; use '{0}' when resolution must not depend on a working directory",
+        category: "Reliability",
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: "Path.IsPathRooted returns true for paths such as Windows drive-relative paths that still "
+            + "depend on a working directory. Path.IsPathFullyQualified determines whether path resolution is "
+            + "independent of the current or per-drive working directory.",
+        helpLinkUri: HelpLinks.ForRule(DiagnosticId));
+
+    private static readonly ImmutableArray<DiagnosticDescriptor> s_supportedDiagnostics = [s_rule];
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => s_supportedDiagnostics;
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterCompilationStartAction(static start =>
+        {
+            INamedTypeSymbol? path = start.Compilation.GetTypeByMetadataName(PathMetadataName);
+            if (path is not null
+                && SymbolEqualityComparer.Default.Equals(path.ContainingAssembly, start.Compilation.Assembly))
+            {
+                path = null;
+            }
+
+            INamedTypeSymbol? redistPath = start.Compilation.GetTypeByMetadataName(RedistPathMetadataName);
+            if (redistPath is not null && !IsRedistPath(redistPath))
+            {
+                redistPath = null;
+            }
+
+            if (path is null && redistPath is null)
+            {
+                return;
+            }
+
+            bool systemHasFullyQualified = path is not null && HasPublicFullyQualified(path);
+            bool redistHasFullyQualified = redistPath is not null && HasPublicFullyQualified(redistPath);
+
+            start.RegisterSyntaxNodeAction(
+                syntaxContext => AnalyzeInvocation(
+                    syntaxContext,
+                    path,
+                    redistPath,
+                    systemHasFullyQualified,
+                    redistHasFullyQualified),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void AnalyzeInvocation(
+        SyntaxNodeAnalysisContext context,
+        INamedTypeSymbol? path,
+        INamedTypeSymbol? redistPath,
+        bool systemHasFullyQualified,
+        bool redistHasFullyQualified)
+    {
+        InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
+        if (GetMethodName(invocation.Expression) is not { Identifier.ValueText: "IsPathRooted" } methodName
+            || context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol
+                is not IMethodSymbol { Name: "IsPathRooted", IsStatic: true } method
+            || !SymbolEqualityComparer.Default.Equals(method.ContainingType, path)
+                && !SymbolEqualityComparer.Default.Equals(method.ContainingType, redistPath))
+        {
+            return;
+        }
+
+        string recommendation =
+            SymbolEqualityComparer.Default.Equals(method.ContainingType, redistPath)
+                || !systemHasFullyQualified && redistHasFullyQualified
+                ? "Microsoft.IO.Path.IsPathFullyQualified"
+                : "Path.IsPathFullyQualified";
+        context.ReportDiagnostic(Diagnostic.Create(s_rule, methodName.GetLocation(), recommendation));
+    }
+
+    private static SimpleNameSyntax? GetMethodName(ExpressionSyntax expression) => expression switch
+    {
+        SimpleNameSyntax simpleName => simpleName,
+        MemberAccessExpressionSyntax memberAccess => memberAccess.Name,
+        _ => null
+    };
+
+    private static bool IsRedistPath(INamedTypeSymbol path)
+    {
+        AssemblyIdentity identity = path.ContainingAssembly.Identity;
+        return identity.Name == RedistAssemblyName
+            && identity.PublicKeyToken.Length == 8
+            && identity.PublicKeyToken[0] == 0xcc
+            && identity.PublicKeyToken[1] == 0x7b
+            && identity.PublicKeyToken[2] == 0x13
+            && identity.PublicKeyToken[3] == 0xff
+            && identity.PublicKeyToken[4] == 0xcd
+            && identity.PublicKeyToken[5] == 0x2d
+            && identity.PublicKeyToken[6] == 0xdd
+            && identity.PublicKeyToken[7] == 0x51;
+    }
+
+    private static bool HasPublicFullyQualified(INamedTypeSymbol path)
+    {
+        foreach (ISymbol member in path.GetMembers("IsPathFullyQualified"))
+        {
+            if (member is IMethodSymbol
+                {
+                    IsStatic: true,
+                    DeclaredAccessibility: Accessibility.Public
+                })
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/touki.analyzers/AvoidPathIsPathRootedAnalyzer.cs
+++ b/touki.analyzers/AvoidPathIsPathRootedAnalyzer.cs
@@ -77,15 +77,13 @@ public sealed class AvoidPathIsPathRootedAnalyzer : DiagnosticAnalyzer
             }
 
             bool systemHasFullyQualified = path is not null && HasPublicFullyQualified(path);
-            bool redistHasFullyQualified = redistPath is not null && HasPublicFullyQualified(redistPath);
 
             start.RegisterSyntaxNodeAction(
                 syntaxContext => AnalyzeInvocation(
                     syntaxContext,
                     path,
                     redistPath,
-                    systemHasFullyQualified,
-                    redistHasFullyQualified),
+                    systemHasFullyQualified),
                 SyntaxKind.InvocationExpression);
         });
     }
@@ -94,8 +92,7 @@ public sealed class AvoidPathIsPathRootedAnalyzer : DiagnosticAnalyzer
         SyntaxNodeAnalysisContext context,
         INamedTypeSymbol? path,
         INamedTypeSymbol? redistPath,
-        bool systemHasFullyQualified,
-        bool redistHasFullyQualified)
+        bool systemHasFullyQualified)
     {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
         if (GetMethodName(invocation.Expression) is not { Identifier.ValueText: "IsPathRooted" } methodName
@@ -109,7 +106,7 @@ public sealed class AvoidPathIsPathRootedAnalyzer : DiagnosticAnalyzer
 
         string recommendation =
             SymbolEqualityComparer.Default.Equals(method.ContainingType, redistPath)
-                || !systemHasFullyQualified && redistHasFullyQualified
+                || !systemHasFullyQualified
                 ? "Microsoft.IO.Path.IsPathFullyQualified"
                 : "Path.IsPathFullyQualified";
         context.ReportDiagnostic(Diagnostic.Create(s_rule, methodName.GetLocation(), recommendation));

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -100,8 +100,8 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
 
         IsFullyQualified = Path.IsPathFullyQualified(Normalized.AsSpan());
 
-    // Deliberately distinguish nested relative paths from root- and drive-relative paths after checking full
-    // qualification above. Resolution independence is not the question this second classification answers.
+        // Deliberately distinguish nested relative paths from root- and drive-relative paths after checking full
+        // qualification above. Resolution independence is not the question this second classification answers.
 #pragma warning disable TOUKI0033
         IsNestedRelative = !IsFullyQualified
             && !Path.IsPathRooted(Normalized.AsSpan())

--- a/touki/Touki/Io/MSBuildSpecification.cs
+++ b/touki/Touki/Io/MSBuildSpecification.cs
@@ -99,10 +99,15 @@ public class MSBuildSpecification : IEquatable<string>, IEquatable<StringSegment
         Debug.Assert(Normalized.Equals(Normalize(Original)));
 
         IsFullyQualified = Path.IsPathFullyQualified(Normalized.AsSpan());
+
+    // Deliberately distinguish nested relative paths from root- and drive-relative paths after checking full
+    // qualification above. Resolution independence is not the question this second classification answers.
+#pragma warning disable TOUKI0033
         IsNestedRelative = !IsFullyQualified
             && !Path.IsPathRooted(Normalized.AsSpan())
             && !(Normalized.StartsWith("..")
                 && (Normalized.Length == 2 || (Normalized.Length > 2 && Normalized[2] == Path.DirectorySeparatorChar)));
+#pragma warning restore TOUKI0033
 
         int lastSeparator = Normalized.LastIndexOf(Path.DirectorySeparatorChar);
         int firstWildCard = Normalized.IndexOfAny('*', '?');


### PR DESCRIPTION
## Summary

- Add TOUKI0033 to flag `System.IO.Path.IsPathRooted` and trusted `Microsoft.IO.Redist` `Microsoft.IO.Path.IsPathRooted` calls that can be mistaken for qualification checks.
- Recommend `Path.IsPathFullyQualified`, or `Microsoft.IO.Path.IsPathFullyQualified` for net472 BCL callers, when resolution must be independent of current or per-drive working directories.
- Deliberately provide no code fix because root-marker classification can be intentional; document targeted suppression and migration contract differences.
- Narrowly suppress Touki's intentional nested-relative classification after it separately checks full qualification.

## Validation

- Focused TOUKI0033 tests: 12 passed
- Analyzer/code-fix tests, Debug: 492 passed
- Analyzer/code-fix tests, Release: 492 passed
- Runtime tests, Release net10.0: 7,142 passed, 119 skipped, 0 failed
- Runtime tests, Release net481: 8,469 passed, 22 skipped, 0 failed
- Shipping build: net10.0 and net472 succeeded

Local validation used SDK 10.0.400 with `DotNetCoreNextVersion=net10.0` because the pinned .NET 11 preview SDK is not installed locally; CI will exercise the pinned toolchain.