### PR TITLE
Record Touki 0.8.0 release housekeeping

### DIFF
--- a/docs/analyzers.md
+++ b/docs/analyzers.md
@@ -798,7 +798,7 @@ Two rules are opt-in through public attributes in the `Touki` namespace:
 | 0.5.0 | TOUKI0020, TOUKI0030 |
 | 0.6.0 | TOUKI0011, TOUKI0021, TOUKI0041 |
 | 0.7.0 | TOUKI0022, TOUKI0023 |
-| Unshipped | TOUKI0012, TOUKI0024, TOUKI0031, TOUKI0032, TOUKI0033 |
+| 0.8.0 | TOUKI0012, TOUKI0024, TOUKI0031, TOUKI0032, TOUKI0033 |
 
 The authoritative list lives in
 [AnalyzerReleases.Shipped.md](../touki.analyzers/AnalyzerReleases.Shipped.md) and

--- a/touki.analyzers/AnalyzerReleases.Shipped.md
+++ b/touki.analyzers/AnalyzerReleases.Shipped.md
@@ -41,3 +41,14 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 TOUKI0022 | Maintainability | Disabled | Tab characters in source
 TOUKI0023 | Maintainability | Warning | Whitespace before a line break
+
+## Release 0.8.0
+
+### New Rules
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+TOUKI0012 | Reliability | Disabled | Disposable class does not derive from Touki.DisposableBase
+TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML
+TOUKI0031 | Performance | Warning | Use WriteFormatted for TextWriter interpolated strings
+TOUKI0032 | Reliability | Warning | Use Path.Join instead of Path.Combine
+TOUKI0033 | Reliability | Warning | Avoid Path.IsPathRooted for qualification checks

--- a/touki.analyzers/AnalyzerReleases.Unshipped.md
+++ b/touki.analyzers/AnalyzerReleases.Unshipped.md
@@ -1,12 +1,2 @@
 ; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### New Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-TOUKI0012 | Reliability | Disabled | Disposable class does not derive from Touki.DisposableBase
-TOUKI0024 | Maintainability | Disabled | Format XML documentation as nested XML
-TOUKI0031 | Performance | Warning | Use WriteFormatted for TextWriter interpolated strings
-TOUKI0032 | Reliability | Warning | Use Path.Join instead of Path.Combine
-TOUKI0033 | Reliability | Warning | Avoid Path.IsPathRooted for qualification checks


### PR DESCRIPTION
## Summary
- Promote TOUKI0012, TOUKI0024, TOUKI0031, TOUKI0032, and TOUKI0033 into the analyzer's 0.8.0 shipped release record.
- Update the public analyzer release history to match.
- Prepare the source tree for the separate `v0.8.0` tag and publish step after this PR merges.

## Release plan
- Ship stable `v0.8.0`, explicitly accepting the `GlobSpecification` binary break as a pre-1.0 Minor change; `AssemblyVersion` remains `0.0.0.0` and consumers of the changed API must rebuild.
- Keep `KlutzyNinja.Touki.TestSupport` at 0.7.0 because it has no source changes, does not bind to the changed APIs, and accepts Touki 0.8.0 through its dependency range.

## Validation
- `dotnet build touki.analyzers/touki.analyzers.csproj -c Release --nologo`
- `dotnet pack touki/touki.csproj -c Release -p:MinVerVersionOverride=0.8.0 -o artifacts/release-v0.8.0 --nologo`
- Package inspection: `net10.0`, `net11.0`, and `net472`; both analyzer assemblies; `AssemblyVersion 0.0.0.0`; `FileVersion 0.8.0.0`
- `dotnet test -c Release` (23,258 passed; 260 skipped; 0 failed)
- `dotnet test -c Debug` (23,236 passed; 260 skipped; 0 failed)
- Candidate tag `v0.8.0` is regex-valid and unused locally and remotely.