### PR TITLE
Add format provider overloads to FormatValues

### DIFF
--- a/touki.perf/FormatValuesProviderPerf.cs
+++ b/touki.perf/FormatValuesProviderPerf.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2025 Jeremy W Kuhne
+// SPDX-License-Identifier: MIT
+// See LICENSE file in the project root for full license information
+
+using System.Globalization;
+using Touki.Text;
+
+namespace touki.perf;
+
+[MemoryDiagnoser]
+public class FormatValuesProviderPerf
+{
+    private readonly CultureInfo _provider = CultureInfo.CurrentCulture;
+    private readonly Value _number = Value.Create(1234.5);
+    private readonly Value _percentage = Value.Create(0.25);
+
+    [Benchmark(Baseline = true)]
+    public string ExistingPath() =>
+        string.FormatValues("{0:N1} {1:P0}", _number, _percentage);
+
+    [Benchmark]
+    public string ExplicitProvider() =>
+        string.FormatValues(_provider, "{0:N1} {1:P0}", _number, _percentage);
+}

--- a/touki.tests/Touki/Text/StringExtensionsTests.cs
+++ b/touki.tests/Touki/Text/StringExtensionsTests.cs
@@ -44,6 +44,27 @@ public class StringExtensionsTests
     }
 
     [TestMethod]
+    public void FormatValues_ProviderWithSpanArgs_UsesProvider()
+    {
+        CultureInfo provider = CultureInfo.GetCultureInfo("fr-FR");
+        ReadOnlySpan<Value> args = [Value.Create(1234.5), Value.Create(0.25)];
+
+        string result = string.FormatValues(provider, "{0:N1} {1:P0}".AsSpan(), args);
+
+        result.Should().Be(string.Format(provider, "{0:N1} {1:P0}", 1234.5, 0.25));
+    }
+
+    [TestMethod]
+    public void FormatValues_NullProvider_UsesCurrentCulture()
+    {
+        ReadOnlySpan<Value> args = [Value.Create(1234.5), Value.Create(0.25)];
+
+        string result = string.FormatValues(null, "{0:N1} {1:P0}".AsSpan(), args);
+
+        result.Should().Be(string.Format(CultureInfo.CurrentCulture, "{0:N1} {1:P0}", 1234.5, 0.25));
+    }
+
+    [TestMethod]
     public void FormatValues_TwoArgs_FormatsBothPlaceholders()
     {
         string result = string.FormatValues(
@@ -51,6 +72,20 @@ public class StringExtensionsTests
             Value.Create("a"),
             Value.Create(1));
         result.Should().Be("a-1");
+    }
+
+    [TestMethod]
+    public void FormatValues_ProviderWithTwoArgs_UsesProvider()
+    {
+        CultureInfo provider = CultureInfo.GetCultureInfo("fr-FR");
+
+        string result = string.FormatValues(
+            provider,
+            "{0:N1} {1:P0}".AsSpan(),
+            Value.Create(1234.5),
+            Value.Create(0.25));
+
+        result.Should().Be(string.Format(provider, "{0:N1} {1:P0}", 1234.5, 0.25));
     }
 
     [TestMethod]
@@ -62,6 +97,21 @@ public class StringExtensionsTests
             Value.Create(5),
             Value.Create(10));
         result.Should().Be("2026/5/10");
+    }
+
+    [TestMethod]
+    public void FormatValues_ProviderWithThreeArgs_UsesProvider()
+    {
+        CultureInfo provider = CultureInfo.GetCultureInfo("fr-FR");
+
+        string result = string.FormatValues(
+            provider,
+            "{0:N1} {1:N1} {2:P0}".AsSpan(),
+            Value.Create(1234.5),
+            Value.Create(67.5),
+            Value.Create(0.25));
+
+        result.Should().Be(string.Format(provider, "{0:N1} {1:N1} {2:P0}", 1234.5, 67.5, 0.25));
     }
 
     [TestMethod]
@@ -77,6 +127,44 @@ public class StringExtensionsTests
     }
 
     [TestMethod]
+    public void FormatValues_ProviderWithFourArgs_UsesProvider()
+    {
+        CultureInfo provider = CultureInfo.GetCultureInfo("fr-FR");
+
+        string result = string.FormatValues(
+            provider,
+            "{0:N1} {1:N1} {2:N1} {3:P0}".AsSpan(),
+            Value.Create(1234.5),
+            Value.Create(67.5),
+            Value.Create(8.24),
+            Value.Create(0.25));
+
+        result.Should().Be(string.Format(provider, "{0:N1} {1:N1} {2:N1} {3:P0}", 1234.5, 67.5, 8.24, 0.25));
+    }
+
+    [TestMethod]
+    public void FormatValues_CustomFormatter_ReceivesUnderlyingValues()
+    {
+        UnderlyingTypeFormatProvider provider = new();
+        ReadOnlySpan<Value> args = [Value.Create(42), Value.Create("text"), Value.Create((object?)null)];
+
+        string result = string.FormatValues(provider, "{0}|{1}|{2}".AsSpan(), args);
+
+        result.Should().Be("[Int32:42]|[String:text]|[null]");
+    }
+
+    [TestMethod]
+    public void FormatValues_CustomFormatterReturnsNull_FallsBackToDefaultFormatting()
+    {
+        NullFormatProvider provider = new(CultureInfo.GetCultureInfo("fr-FR"));
+        ReadOnlySpan<Value> args = [Value.Create(1234.5), Value.Create("text"), Value.Create((object?)null)];
+
+        string result = string.FormatValues(provider, "{0:N1}|{1}|{2}".AsSpan(), args);
+
+        result.Should().Be(string.Format(provider, "{0:N1}|{1}|{2}", 1234.5, "text", null));
+    }
+
+    [TestMethod]
     public void FormatValues_FourArgs_LiteralFormat_NoPlaceholders_ReturnsLiteral()
     {
         string result = string.FormatValues(
@@ -86,5 +174,21 @@ public class StringExtensionsTests
             Value.Create(3),
             Value.Create(4));
         result.Should().Be("literal");
+    }
+
+    private sealed class UnderlyingTypeFormatProvider : IFormatProvider, ICustomFormatter
+    {
+        public object? GetFormat(Type? formatType) => formatType == typeof(ICustomFormatter) ? this : null;
+
+        public string Format(string? format, object? arg, IFormatProvider? formatProvider) =>
+            arg is null ? "[null]" : $"[{arg.GetType().Name}:{arg}]";
+    }
+
+    private sealed class NullFormatProvider(CultureInfo culture) : IFormatProvider, ICustomFormatter
+    {
+        public object? GetFormat(Type? formatType) =>
+            formatType == typeof(ICustomFormatter) ? this : culture.GetFormat(formatType);
+
+        public string Format(string? format, object? arg, IFormatProvider? formatProvider) => null!;
     }
 }

--- a/touki/Touki/Text/StringExtensions.cs
+++ b/touki/Touki/Text/StringExtensions.cs
@@ -54,31 +54,69 @@ public static partial class StringExtensions
 
         /// <inheritdoc cref="FormatValue{TArgument}(ReadOnlySpan{char}, TArgument)" />
         /// <param name="args">The arguments to format.</param>
+        public static string FormatValues(ReadOnlySpan<char> format, ReadOnlySpan<Value> args) =>
+            FormatValues(null, format, args);
+
+        /// <summary>
+        ///  Creates a formatted string using the specified format provider.
+        /// </summary>
+        /// <param name="provider">
+        ///  An object that supplies culture-specific formatting information, or <see langword="null"/> to use the
+        ///  current culture.
+        /// </param>
+        /// <param name="format">The format string.</param>
+        /// <param name="args">The arguments to format.</param>
+        /// <remarks>
+        ///  <para>
+        ///   Primitive values are formatted without boxing when <paramref name="provider"/> does not supply an
+        ///   <see cref="ICustomFormatter"/>. Custom formatters use an object-based contract and may box primitives.
+        ///  </para>
+        /// </remarks>
         [SkipLocalsInit]
-        public static string FormatValues(ReadOnlySpan<char> format, ReadOnlySpan<Value> args)
+        public static string FormatValues(
+            IFormatProvider? provider,
+            ReadOnlySpan<char> format,
+            ReadOnlySpan<Value> args)
         {
             Span<char> buffer = stackalloc char[256];
-            using ValueStringBuilder builder = new(buffer);
+            using ValueStringBuilder builder = new(buffer, provider);
             builder.AppendFormat(format, args);
             return builder.ToString();
         }
 
         /// <inheritdoc cref="FormatValues(ReadOnlySpan{char}, Value, Value, Value, Value)" />
+        public static string FormatValues(ReadOnlySpan<char> format, Value arg1, Value arg2) =>
+            FormatValues(null, format, arg1, arg2);
+
+        /// <inheritdoc cref="FormatValues(IFormatProvider, ReadOnlySpan{char}, Value, Value, Value, Value)" />
         [SkipLocalsInit]
-        public static string FormatValues(ReadOnlySpan<char> format, Value arg1, Value arg2)
+        public static string FormatValues(
+            IFormatProvider? provider,
+            ReadOnlySpan<char> format,
+            Value arg1,
+            Value arg2)
         {
             Span<char> buffer = stackalloc char[256];
-            using ValueStringBuilder builder = new(buffer);
+            using ValueStringBuilder builder = new(buffer, provider);
             builder.AppendFormat(format, arg1, arg2);
             return builder.ToString();
         }
 
         /// <inheritdoc cref="FormatValues(ReadOnlySpan{char}, Value, Value, Value, Value)" />
+        public static string FormatValues(ReadOnlySpan<char> format, Value arg1, Value arg2, Value arg3) =>
+            FormatValues(null, format, arg1, arg2, arg3);
+
+        /// <inheritdoc cref="FormatValues(IFormatProvider, ReadOnlySpan{char}, Value, Value, Value, Value)" />
         [SkipLocalsInit]
-        public static string FormatValues(ReadOnlySpan<char> format, Value arg1, Value arg2, Value arg3)
+        public static string FormatValues(
+            IFormatProvider? provider,
+            ReadOnlySpan<char> format,
+            Value arg1,
+            Value arg2,
+            Value arg3)
         {
             Span<char> buffer = stackalloc char[256];
-            using ValueStringBuilder builder = new(buffer);
+            using ValueStringBuilder builder = new(buffer, provider);
             builder.AppendFormat(format, arg1, arg2, arg3);
             return builder.ToString();
         }
@@ -88,11 +126,38 @@ public static partial class StringExtensions
         /// <param name="arg2">The second argument to format.</param>
         /// <param name="arg3">The third argument to format.</param>
         /// <param name="arg4">The fourth argument to format.</param>
+        public static string FormatValues(ReadOnlySpan<char> format, Value arg1, Value arg2, Value arg3, Value arg4) =>
+            FormatValues(null, format, arg1, arg2, arg3, arg4);
+
+        /// <summary>
+        ///  Creates a formatted string using the specified format provider.
+        /// </summary>
+        /// <param name="provider">
+        ///  An object that supplies culture-specific formatting information, or <see langword="null"/> to use the
+        ///  current culture.
+        /// </param>
+        /// <param name="format">The format string.</param>
+        /// <param name="arg1">The first argument to format.</param>
+        /// <param name="arg2">The second argument to format.</param>
+        /// <param name="arg3">The third argument to format.</param>
+        /// <param name="arg4">The fourth argument to format.</param>
+        /// <remarks>
+        ///  <para>
+        ///   Primitive values are formatted without boxing when <paramref name="provider"/> does not supply an
+        ///   <see cref="ICustomFormatter"/>. Custom formatters use an object-based contract and may box primitives.
+        ///  </para>
+        /// </remarks>
         [SkipLocalsInit]
-        public static string FormatValues(ReadOnlySpan<char> format, Value arg1, Value arg2, Value arg3, Value arg4)
+        public static string FormatValues(
+            IFormatProvider? provider,
+            ReadOnlySpan<char> format,
+            Value arg1,
+            Value arg2,
+            Value arg3,
+            Value arg4)
         {
             Span<char> buffer = stackalloc char[256];
-            using ValueStringBuilder builder = new(buffer);
+            using ValueStringBuilder builder = new(buffer, provider);
             builder.AppendFormat(format, arg1, arg2, arg3, arg4);
             return builder.ToString();
         }

--- a/touki/Touki/Text/ValueStringBuilder.Formatting.cs
+++ b/touki/Touki/Text/ValueStringBuilder.Formatting.cs
@@ -349,10 +349,8 @@ public ref partial struct ValueStringBuilder
     /// <inheritdoc cref="AppendFormatted(ReadOnlySpan{char}, int, string?)"/>
     public void AppendFormatted(string? value)
     {
-        if (_hasCustomFormatter)
+        if (_hasCustomFormatter && TryAppendCustomFormatter(value, format: null))
         {
-            // If there's a custom formatter, always use it.
-            AppendCustomFormatter(value, format: null);
             return;
         }
 
@@ -389,17 +387,7 @@ public ref partial struct ValueStringBuilder
     public void AppendFormatted(Value value, string? format) => AppendFormatted(value, (StringSpan)format);
 
     /// <inheritdoc cref="AppendFormatted(ReadOnlySpan{char}, int, string?)"/>
-    public void AppendFormatted(Value value, StringSpan format = default)
-    {
-        // If there's a custom formatter, always use it.
-        if (_hasCustomFormatter)
-        {
-            AppendCustomFormatter(value, format);
-            return;
-        }
-
-        value.Format(ref this, format);
-    }
+    public void AppendFormatted(Value value, StringSpan format = default) => value.Format(ref this, format);
 
     /// <inheritdoc cref="AppendFormatted(ReadOnlySpan{char}, int, string?)"/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -407,14 +395,16 @@ public ref partial struct ValueStringBuilder
     {
         if (value is null)
         {
-            // If the value is null, just leave it blank.
+            if (_hasCustomFormatter)
+            {
+                TryAppendCustomFormatter(value, format);
+            }
+
             return;
         }
 
-        // If there's a custom formatter, always use it.
-        if (_hasCustomFormatter)
+        if (_hasCustomFormatter && TryAppendCustomFormatter(value, format))
         {
-            AppendCustomFormatter(value, format);
             return;
         }
 
@@ -557,7 +547,7 @@ public ref partial struct ValueStringBuilder
     /// <param name="value">The value to write.</param>
     /// <param name="format">The format string.</param>
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private void AppendCustomFormatter<T>(T value, StringSpan format)
+    private bool TryAppendCustomFormatter<T>(T value, StringSpan format)
     {
         // This case is very rare, but we need to handle it prior to the other checks in case
         // a provider was used that supplied an ICustomFormatter which wanted to intercept the particular value.
@@ -574,7 +564,10 @@ public ref partial struct ValueStringBuilder
         if (formatter is not null && formatter.Format(format.ToStringOrNull(), value, _formatProvider) is string customFormatted)
         {
             AppendLiteral(customFormatted);
+            return true;
         }
+
+        return false;
     }
 
     /// <summary>

--- a/touki/Touki/Value.cs
+++ b/touki/Touki/Value.cs
@@ -1677,6 +1677,10 @@ public readonly partial struct Value
                 }
             }
         }
+        else
+        {
+            destination.AppendFormatted((object?)null, format);
+        }
     }
 
     private void FormatTypeFlagSlow(


### PR DESCRIPTION
## Summary

- Add nullable `IFormatProvider` overloads for every existing `string.FormatValues` shape and route provider-less overloads through them with `null`.
- Preserve non-boxing primitive formatting for ordinary providers.
- Match `string.Format` custom-formatter behavior by passing underlying `Value` contents to `ICustomFormatter` and falling back to normal formatting when it returns `null`.

## Validation

- `dotnet build -c Debug`
- `dotnet build -c Release`
- Formatter-focused tests in Debug and Release across net10, net11, and net481: 68 passed in each configuration.
- BenchmarkDotNet: both paths allocate 48 B/op on modern .NET RyuJIT and .NET Framework 4.8.1 RyuJIT; the explicit-provider path remained in the same throughput range as the existing path.

## Known validation gap

A full `dotnet test -c Release` run was attempted. The net481, analyzer, and AOT hosts passed, while the net10 and net11 hosts stalled late in the unrelated broader suite after more than 4,400 tests each; no failures were reported before the stall.